### PR TITLE
Fix Discord authentication for account creation and login

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/CreatePlayer.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/CreatePlayer.razor
@@ -1,6 +1,7 @@
 ﻿@page "/createplayer"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@inject NavigationManager Nav
 
 <h1>Create Player</h1>
 
@@ -28,7 +29,10 @@
 
     private async Task HandleValidSubmit() {
         if (model == null) return;
-        await Http.PostAsJsonAsync("api/playerprofile/create", model);
+        var response = await Http.PostAsJsonAsync("api/playerprofile/create", model);
+        if (response.IsSuccessStatusCode) {
+            Nav.NavigateTo("/", forceLoad: true);
+        }
     }
 
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
@@ -1,3 +1,14 @@
-﻿@page "/"
+@page "/"
+@inject HttpClient Http
+@inject NavigationManager Nav
 
 <h3>Hello</h3>
+
+@code {
+    protected override async Task OnInitializedAsync() {
+        var exists = await Http.GetFromJsonAsync<bool>("api/playerprofile/exists");
+        if (!exists) {
+            Nav.NavigateTo("/createplayer");
+        }
+    }
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer;
@@ -65,16 +66,22 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			// only works if DevAuth setting in appsettings is set (dev only!)
 			if (!options.Value.DevAuth) return BadRequest();
 			if (string.IsNullOrWhiteSpace(playerid)) return BadRequest();
-			return CreatePlayer(PlayerIdFactory.Create(playerid));
-		}
 
-		private IActionResult CreatePlayer(PlayerId playerId) {
+			var playerId = PlayerIdFactory.Create(playerid);
 			if (!playerRepository.Exists(playerId)) {
-				// create player
 				playerRepositoryWrite.CreatePlayer(playerId);
 			}
-			currentUserContext.PlayerId = playerId;
-			return Challenge();
+
+			// Create a claims identity so the cookie auth and CurrentUserMiddleware work correctly
+			var claims = new List<Claim> {
+				new Claim(ClaimTypes.NameIdentifier, playerid),
+				new Claim(ClaimTypes.Name, playerid)
+			};
+			var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+			var principal = new ClaimsPrincipal(identity);
+
+			await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+			return Redirect("/");
 		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.Shared;
+using BrowserGameEngine.Shared;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +11,7 @@ using BrowserGameEngine.StatefulGameServer.Commands;
 using Microsoft.AspNetCore.Authorization;
 using System.Security.Principal;
 using System.Security.Claims;
+using BrowserGameEngine.GameModel;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	[ApiController]
@@ -34,9 +35,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpGet]
-		public PlayerProfileViewModel Get() {
+		public ActionResult<PlayerProfileViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
 			var player = playerRepository.Get(currentUserContext.PlayerId);
-			return new PlayerProfileViewModel { 
+			return new PlayerProfileViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name
 			};
@@ -44,51 +46,53 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		[HttpGet]
 		[Route("init")]
-		public CreatePlayerViewModel Init() {
-			ClaimsPrincipal? user = User;
-			if (user == null) throw new Exception("TODO exception type not authenticated");
-			IIdentity? identity = user.Identity;
-			if (identity == null) throw new Exception("TODO exception type not authenticated");
-			if (!identity.IsAuthenticated) throw new Exception("TODO exception type not authenticated");
-			var name = identity.Name;
-			var id = user.Claims.First(x => x.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+		public ActionResult<CreatePlayerViewModel> Init() {
+			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+			if (id == null) return Unauthorized();
 
-			Console.WriteLine(id);
 			return new CreatePlayerViewModel {
-				PlayerName = name
+				PlayerName = User.Identity?.Name
 			};
 		}
 
-
-		/* Example:
+		/* Example claims from Discord:
 		  	http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier: 690094355519766528
-			http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name: Christoph Neumüller
+			http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name: Christoph Neumueller
 			urn:discord:user:discriminator: 0075
 			urn:discord:avatar:url: https://cdn.discordapp.com/avatars/690094355519766528/.png
 		*/
 
+		[HttpGet]
+		[Route("exists")]
+		public ActionResult<bool> Exists() {
+			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+			if (id == null) return Unauthorized();
+
+			var playerId = PlayerIdFactory.Create(id);
+			return playerRepository.Exists(playerId);
+		}
+
 		[HttpPost]
 		[Route("changename")]
-		public IActionResult ChangePlayerName(PlayerProfileViewModel playerProfile) {
+		public ActionResult ChangePlayerName(PlayerProfileViewModel playerProfile) {
+			if (!currentUserContext.IsValid) return Unauthorized();
 			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(currentUserContext.PlayerId, playerProfile.PlayerName));
 			return Ok();
 		}
 
 		[HttpPost]
 		[Route("create")]
-		public void Create(CreatePlayerViewModel model) {
-			ClaimsPrincipal? user = User;
-			if (user == null) throw new Exception("TODO exception type not authenticated");
-			IIdentity? identity = user.Identity;
-			if (identity == null) throw new Exception("TODO exception type not authenticated");
-			if (!identity.IsAuthenticated) throw new Exception("TODO exception type not authenticated");
-			var name = identity.Name;
-			var id = user.Claims.First(x => x.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier").Value;
+		public ActionResult Create(CreatePlayerViewModel model) {
+			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+			if (id == null) return Unauthorized();
 
-			var playerId = GameModel.PlayerIdFactory.Create(id);
+			var playerId = PlayerIdFactory.Create(id);
+			if (playerRepository.Exists(playerId)) return Conflict("Player already exists");
+
 			playerRepositoryWrite.CreatePlayer(playerId);
 			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName));
 			currentUserContext.Activate(playerId);
+			return Ok();
 		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer;
+
+namespace BrowserGameEngine.FrontendServer.Middleware {
+	/// <summary>
+	/// Middleware that populates CurrentUserContext from the authenticated user's claims.
+	/// Runs after UseAuthentication() so that HttpContext.User is available.
+	/// </summary>
+	public class CurrentUserMiddleware {
+		private readonly RequestDelegate _next;
+
+		public CurrentUserMiddleware(RequestDelegate next) {
+			_next = next;
+		}
+
+		public async Task InvokeAsync(HttpContext context, CurrentUserContext currentUserContext, PlayerRepository playerRepository) {
+			if (context.User.Identity?.IsAuthenticated == true) {
+				var idClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+				if (idClaim != null) {
+					var playerId = PlayerIdFactory.Create(idClaim.Value);
+					if (playerRepository.Exists(playerId)) {
+						currentUserContext.Activate(playerId);
+					}
+				}
+			}
+			await _next(context);
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.GameModel;
@@ -59,10 +60,6 @@ builder.Services.AddAuthentication(options => {
         options.ClientId = builder.Configuration["Discord:ClientId"] ?? throw new InvalidOperationException("Discord:ClientId not configured");
         options.ClientSecret = builder.Configuration["Discord:ClientSecret"] ?? throw new InvalidOperationException("Discord:ClientSecret not configured");
         options.SaveTokens = true;
-        options.Events.OnTicketReceived = ctx => {
-            Console.WriteLine("OnTicketReceived");
-            return Task.CompletedTask;
-        };
     });
 
 builder.Services.ConfigureApplicationCookie(options => {
@@ -106,6 +103,7 @@ IDisposable collector = DotNetRuntimeStatsBuilder
     .StartCollecting();
 
 app.UseAuthentication();
+app.UseMiddleware<CurrentUserMiddleware>();
 app.UseAuthorization();
 
 app.UseEndpoints(endpoints => {
@@ -133,8 +131,7 @@ async Task ConfigureGameServices(IServiceCollection services) {
 
     await services.AddGameServer(storage, worldState); // todo: init state for non-development
     
-    services.AddSingleton(CurrentUserContext.Create(playerId: "discostu#1")); // for dev purposes only.
-    //services.AddSingleton(CurrentUserContext.Inactive()); // for prod
+    services.AddScoped(_ => CurrentUserContext.Inactive());
 
     services.Configure<HostOptions>(opts =>
         opts.ShutdownTimeout = TimeSpan.FromMinutes(10) // large shutdown timeout to allow persistance to save gamestate


### PR DESCRIPTION
## Summary

Fixes all critical issues preventing Discord OAuth from working end-to-end. Users can now create accounts and log in via Discord authentication.

- **`CurrentUserContext` changed from hardcoded Singleton to Scoped** — was always set to `"discostu#1"`, meaning Discord-authenticated users were never recognized. Now each HTTP request gets its own context, populated from claims via new middleware.
- **Added `CurrentUserMiddleware`** — runs after `UseAuthentication()`, extracts Discord user ID from claims, and activates the user context if the player exists.
- **Removed stubbed `OnTicketReceived`** — the no-op `Console.WriteLine` handler is no longer needed; the middleware handles user context setup.
- **Fixed dev login (`/signindev`)** — was calling `Challenge()` without creating a claims identity, which didn't produce a valid auth cookie. Now creates proper `ClaimsIdentity` and signs in via cookie auth.
- **Replaced `throw new Exception("TODO...")` with HTTP 401 responses** — `PlayerProfileController` was throwing unhandled exceptions instead of returning proper status codes, breaking the Blazor client's auth redirect flow.
- **Added `api/playerprofile/exists` endpoint** — allows the Blazor client to check whether a player record exists for the authenticated user.
- **New user redirect flow** — `Index.razor` now checks if the player exists and redirects to `/createplayer` if not. `CreatePlayer.razor` redirects back to `/` after successful creation.

Fixes #7

## Test plan

- [ ] Configure Discord OAuth credentials (`Discord:ClientId`, `Discord:ClientSecret`)
- [ ] Click "Connect using Discord" on the sign-in page and complete OAuth flow
- [ ] Verify new user is redirected to `/createplayer` after first Discord login
- [ ] Submit player name and verify redirect to home page with active session
- [ ] Sign out and sign back in — verify existing player is recognized without re-creating
- [ ] Verify dev login (`/signindev` with `DevAuth: true`) still works correctly
- [ ] Verify all game API endpoints (resources, units, assets, battle) work with Discord-authenticated user

https://claude.ai/code/session_011zo8UXCbxauYjejvEdLxDx