### PR TITLE
Fix critical bugs, race conditions, and code smells across codebase

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -51,11 +51,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpPost]
-		public async Task<ActionResult> SendUnits([FromQuery] string unitId, [FromQuery] string enemyPlayerId) {
+		public ActionResult SendUnits([FromQuery] string unitId, [FromQuery] string enemyPlayerId) {
 			try {
 				unitRepositoryWrite.SendUnit(new SendUnitCommand(currentUserContext.PlayerId, Id.UnitId(unitId), PlayerIdFactory.Create(enemyPlayerId)));
 				return Ok();
-			} catch (Exception e) {
+			} catch (PlayerNotAttackableException e) {
+				return BadRequest(e.Message);
+			} catch (UnitNotFoundException e) {
+				return BadRequest(e.Message);
+			} catch (UnitNotHomeException e) {
 				return BadRequest(e.Message);
 			}
 		}

--- a/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
@@ -28,14 +28,13 @@ namespace BrowserGameEngine.FrontendServer {
 		}
 
 		private void DoWork(object? state) {
-			if (isactive == 1) return; // avoid multipe timers at once. if old timer task is still running, just skip this time.
-			Interlocked.Increment(ref isactive);
+			if (Interlocked.CompareExchange(ref isactive, 1, 0) != 0) return;
 			try {
 				var count = Interlocked.Increment(ref executionCount);
 				logger.LogInformation("GameTickTimer #{Count}", count);
 				gameTickEngine.CheckAllTicks();
 			} finally {
-				Interlocked.Decrement(ref isactive);
+				Interlocked.Exchange(ref isactive, 0);
 			}
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Services/PersistenceHostedService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/PersistenceHostedService.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.Persistence;
+using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.GameModel;
 using Microsoft.Extensions.Hosting;
@@ -33,13 +33,14 @@ namespace BrowserGameEngine.FrontendServer {
 			return Task.CompletedTask;
 		}
 
-		private async void DoWork(object? state) {
-			if (isactive == 1) return; // avoid multipe timers at once. if old timer task is still running, just skip this time.
-			Interlocked.Increment(ref isactive);
+		private void DoWork(object? state) {
+			if (Interlocked.CompareExchange(ref isactive, 1, 0) != 0) return;
 			try {
-				await StoreGameState();
+				StoreGameState().GetAwaiter().GetResult();
+			} catch (Exception ex) {
+				logger.LogError(ex, "Failed to store game state");
 			} finally {
-				Interlocked.Decrement(ref isactive);
+				Interlocked.Exchange(ref isactive, 0);
 			}
 		}
 

--- a/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/DictionaryJsonConverterFactory.cs
+++ b/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/DictionaryJsonConverterFactory.cs
@@ -68,7 +68,7 @@ namespace KellySharp {
 				var obj = GetType()
 					.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic)?
 					.MakeGenericMethod(keyType)
-					.Invoke(null, null) ?? throw new NullReferenceException("Failed to invoke serializer maker");
+					.Invoke(null, null) ?? throw new InvalidOperationException("Failed to invoke serializer maker");
 				keySerializer = (Delegate)obj;
 			}
 
@@ -76,7 +76,7 @@ namespace KellySharp {
 			var result = Activator.CreateInstance(
 				converterType.MakeGenericType(typeToConvert.GenericTypeArguments),
 				keyParser,
-				keySerializer) ?? throw new NullReferenceException("Failed to create converter");
+				keySerializer) ?? throw new InvalidOperationException("Failed to create converter");
 
 			return (JsonConverter)result;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
@@ -1,0 +1,77 @@
+using BrowserGameEngine.GameModel;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class PlayerRepositoryTest {
+
+		[Fact]
+		public void IsPlayerAttackable_SamePlayer_ReturnsFalse() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+
+			Assert.False(game.PlayerRepository.IsPlayerAttackable(player1, player1));
+		}
+
+		[Fact]
+		public void IsPlayerAttackable_EqualScore_ReturnsTrue() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Both players start with the same resources (score=1000), so each is attackable by the other
+			Assert.True(game.PlayerRepository.IsPlayerAttackable(player1, player2));
+			Assert.True(game.PlayerRepository.IsPlayerAttackable(player2, player1));
+		}
+
+		[Fact]
+		public void IsPlayerAttackable_DefenderBelowMinScore_ReturnsFalse() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Give player1 a much higher score so player2 falls below 50% threshold
+			game.ResourceRepositoryWrite.AddResources(player1, Id.ResDef("res1"), 9000); // player1 score = 10000
+			// player2 score = 1000, which is < 10000 * 0.5 = 5000
+
+			Assert.False(game.PlayerRepository.IsPlayerAttackable(player1, player2));
+		}
+
+		[Fact]
+		public void IsPlayerAttackable_DefenderAboveMinScore_ReturnsTrue() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Give player1 a slightly higher score
+			game.ResourceRepositoryWrite.AddResources(player1, Id.ResDef("res1"), 500); // player1 score = 1500
+			// player2 score = 1000, which is >= 1500 * 0.5 = 750
+
+			Assert.True(game.PlayerRepository.IsPlayerAttackable(player1, player2));
+		}
+
+		[Fact]
+		public void GetAttackablePlayers_ExcludesSelf() {
+			var game = new TestGame(playerCount: 3);
+			var player1 = PlayerIdFactory.Create("player0");
+
+			var attackable = game.PlayerRepository.GetAttackablePlayers(player1).ToList();
+
+			Assert.DoesNotContain(attackable, p => p.PlayerId == player1);
+		}
+
+		[Fact]
+		public void GetAttackablePlayers_ExcludesPlayersBelowMinScore() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Make player1 much stronger
+			game.ResourceRepositoryWrite.AddResources(player1, Id.ResDef("res1"), 9000);
+
+			var attackable = game.PlayerRepository.GetAttackablePlayers(player1).ToList();
+
+			Assert.DoesNotContain(attackable, p => p.PlayerId == player2);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -3,14 +3,14 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public class WorldState {
-		private readonly object _lock = new();
-		internal IDictionary<PlayerId, Player> Players { get; set; } = new Dictionary<PlayerId, Player>();
+		internal IDictionary<PlayerId, Player> Players { get; set; } = new ConcurrentDictionary<PlayerId, Player>();
 
 		internal GameTickState GameTickState { get; set; } = new GameTickState();
 
@@ -32,9 +32,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		}
 
 		internal PlayerId[] GetPlayersForGameTick() {
-			lock (_lock) {
-				return Players.Where(x => x.Value.State.CurrentGameTick.Tick < this.GameTickState.CurrentGameTick.Tick).Select(x => x.Key).ToArray();
-			}
+			return Players.Where(x => x.Value.State.CurrentGameTick.Tick < this.GameTickState.CurrentGameTick.Tick).Select(x => x.Key).ToArray();
 		}
 
 		internal GameTick GetTargetGameTick(GameTick tickToAdd) {
@@ -60,7 +58,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 		public static WorldState ToMutable(this WorldStateImmutable worldStateImmutable) {
 			return new WorldState {
-				Players = worldStateImmutable.Players.ToDictionary(x => x.Key, y => y.Value.ToMutable()),
+				Players = new ConcurrentDictionary<PlayerId, Player>(worldStateImmutable.Players.ToDictionary(x => x.Key, y => y.Value.ToMutable())),
 				GameTickState = worldStateImmutable.GameTickState.ToMutable(),
 				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList()
 			};

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
@@ -45,7 +45,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				if (assetDef == null) throw new AssetNotFoundException(command.AssetDefId);
 				if (assetRepository.HasAsset(command.PlayerId, assetDef.Id)) throw new AssetAlreadyBuiltException(assetDef.Id);
 				if (assetRepository.IsBuildQueued(command.PlayerId, command.AssetDefId)) throw new AssetAlreadyQueuedException(assetDef.Id);
-				if (!assetRepository.PrerequisitesMet(command.PlayerId, assetDef)) throw new PrerequisitesNotMetException("too bad");
+				if (!assetRepository.PrerequisitesMet(command.PlayerId, assetDef)) throw new PrerequisitesNotMetException($"Prerequisites not met for asset '{command.AssetDefId}'.");
 				resourceRepositoryWrite.DeductCost(command.PlayerId, assetDef.Cost);
 				var dueTick = world.GetTargetGameTick(assetDef.BuildTimeTicks);
 				actionQueueRepository.AddAction(new GameAction {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class BattleBehaviorScoOriginal : IBattleBehavior {
+		private const int MaxBattleRounds = 8;
 		private readonly ILogger<IBattleBehavior> logger;
 
 		/// <summary>
@@ -40,7 +41,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				AttackingUnits = new List<BtlUnit>(attackingUnits),
 				DefendingUnits = new List<BtlUnit>(defendingUnits)
 			};
-			for (int i = 0; i < 8; i++) {
+			for (int i = 0; i < MaxBattleRounds; i++) {
 				logger.LogDebug("Round {RoundNr}", i);
 				battleState.DefendingUnits = Fight(battleState.AttackingUnits, battleState.DefendingUnits, FightMode.Attack, out var defendingUnitsDestroyed);
 				battleState.DefendingUnitsDestroyed.AddRange(defendingUnitsDestroyed);
@@ -119,7 +120,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 					logger.LogDebug("{DestroyedCount} {UnitDefId}'s destroyed. {RemainingHitPoints}/{HitPoints} hitpoints remain.",
 						destroyedCountExact, defendingUnit.UnitDefId, remainingHitpoints + remainderHitpoints, defendingUnit.TotalHitpoints);
 				}
-				if (attackPoints < 0) throw new Exception($"Here be dragons. attackPoints should never by below zero. {attackPoints}");
+				if (attackPoints < 0) throw new InvalidOperationException($"attackPoints should never be below zero. {attackPoints}");
 			}
 			return survivingDefendingUnits;
 		}
@@ -152,17 +153,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 	public static class ExtensionMethods {
 
-
 		public static IEnumerable<UnitCount> ToUnitCount(this IEnumerable<BtlUnit> btlUnits) => btlUnits.Select(x => new UnitCount(x.UnitDefId, x.Count));
-		public static IEnumerable<UnitCount> ToUnitCount(this List<BtlUnit> btlUnits) => ((IEnumerable<BtlUnit>)btlUnits).ToUnitCount();
 
 		public static IEnumerable<UnitCount> GroupByUnitDefId(this IEnumerable<UnitCount> units) {
 			return units.GroupBy(x => x.UnitDefId).Select(x => new UnitCount(x.First().UnitDefId, x.Sum(y => y.Count)));
 		}
 
 		public static IEnumerable<UnitCount> ToGroupedUnitCounts(this IEnumerable<BtlUnit> btlUnits) => btlUnits.ToUnitCount().GroupByUnitDefId();
-		public static IEnumerable<UnitCount> ToGroupedUnitCounts(this List<BtlUnit> btlUnits) => ((IEnumerable<BtlUnit>)btlUnits).ToGroupedUnitCounts();
-
-		
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
@@ -46,10 +46,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public bool IsPlayerAttackable(PlayerId attacker, PlayerId defender) {
 			var attackerScore = scoreRepository.GetScore(attacker);
-			var defenderScore = scoreRepository.GetScore(attacker);
+			var defenderScore = scoreRepository.GetScore(defender);
 			var minScore = GetMinScore(attackerScore);
 			return attacker != defender
-				&& defenderScore >= attackerScore
+				&& defenderScore >= minScore
 				// TODO: consider alliance members
 				;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -43,7 +43,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			lock (_lock) {
 				var playerRes = Res(playerId);
 				if (!playerRes.ContainsKey(resourceDefId)) {
-					playerRes.Add(resourceDefId, 0);
+					playerRes.Add(resourceDefId, value);
 				} else {
 					playerRes[resourceDefId] += value;
 				}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -53,7 +53,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			lock (_lock) {
 				var unitDef = gameDef.GetUnitDef(command.UnitDefId);
 				if (unitDef == null) throw new UnitDefNotFoundException(command.UnitDefId);
-				if (!unitRepository.PrerequisitesMet(command.PlayerId, unitDef)) throw new PrerequisitesNotMetException("too bad");
+				if (!unitRepository.PrerequisitesMet(command.PlayerId, unitDef)) throw new PrerequisitesNotMetException($"Prerequisites not met for unit '{command.UnitDefId}'.");
 
 				resourceRepositoryWrite.DeductCost(command.PlayerId, unitDef.Cost.Multiply(command.Count));
 				AddUnit(command.PlayerId, command.UnitDefId, command.Count);
@@ -208,7 +208,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			foreach (var unit in units) {
 				unitsToRemove -= TryRemoveUnitCount(playerId, unit.UnitId, unitsToRemove);
 				if (unitsToRemove == 0) return;
-				if (unitsToRemove < 0) throw new Exception("Here be dragons. unitsToRemove can never be less than zero.");
+				if (unitsToRemove < 0) throw new InvalidOperationException("unitsToRemove can never be less than zero.");
 			}
 		}
 	}


### PR DESCRIPTION
- Fix IsPlayerAttackable: wrong player ID passed to GetScore + unused minScore
- Fix AddResources: new resource key initialized to 0 instead of value
- Fix async void in PersistenceHostedService causing unhandled crash on error
- Fix race conditions in timer services using Interlocked.CompareExchange
- Use ConcurrentDictionary in WorldState for thread-safe player access
- Narrow blanket catch(Exception) in BattleController to specific types
- Replace generic Exception throws with InvalidOperationException
- Replace NullReferenceException throws with InvalidOperationException
- Fix unhelpful "too bad" error messages with descriptive text
- Extract magic battle rounds number to MaxBattleRounds constant
- Remove redundant List<BtlUnit> extension method overloads
- Add PlayerRepositoryTest with 6 tests for attackability logic

https://claude.ai/code/session_01XUPMcCAbKPahJmUvDjq6hA