### PR TITLE
Implement DX/QOL items 2, 3, 5, 7 (BGE-12)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -2,12 +2,18 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer.Controllers;
 
@@ -27,6 +33,8 @@ public class AdminController : ControllerBase
 	private readonly GameTickEngine gameTickEngine;
 	private readonly WorldState worldState;
 	private readonly GameStateJsonSerializer serializer;
+	private readonly IBlobStorage storage;
+	private readonly IActionLogger actionLogger;
 	private readonly GameDef gameDef;
 
 	public AdminController(
@@ -42,6 +50,8 @@ public class AdminController : ControllerBase
 		GameTickEngine gameTickEngine,
 		WorldState worldState,
 		GameStateJsonSerializer serializer,
+		IBlobStorage storage,
+		IActionLogger actionLogger,
 		GameDef gameDef
 	)
 	{
@@ -57,8 +67,12 @@ public class AdminController : ControllerBase
 		this.gameTickEngine = gameTickEngine;
 		this.worldState = worldState;
 		this.serializer = serializer;
+		this.storage = storage;
+		this.actionLogger = actionLogger;
 		this.gameDef = gameDef;
 	}
+
+	// ── Existing cheat endpoints ──────────────────────────────────────────────
 
 	[HttpPost("set-resources")]
 	public ActionResult SetResources([FromBody] SetResourcesRequest request)
@@ -123,6 +137,95 @@ public class AdminController : ControllerBase
 		if (!options.Value.DevAuth) return NotFound();
 		var json = Encoding.UTF8.GetString(serializer.Serialize(worldState.ToImmutable()));
 		return Content(json, "application/json");
+	}
+
+	[HttpGet("players")]
+	public ActionResult<IEnumerable<string>> ListPlayers()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		return Ok(playerRepository.GetAll().Select(p => p.PlayerId.Id));
+	}
+
+	// ── State Snapshots ───────────────────────────────────────────────────────
+
+	[HttpPost("save-snapshot")]
+	public async Task<ActionResult> SaveSnapshot([FromQuery] string name)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		if (!IsValidSnapshotName(name)) return BadRequest("Invalid snapshot name. Use letters, digits, hyphens, and underscores only.");
+		await storage.Store($"snapshots/{name}.json", serializer.Serialize(worldState.ToImmutable()));
+		return Ok();
+	}
+
+	[HttpPost("load-snapshot")]
+	public async Task<ActionResult> LoadSnapshot([FromQuery] string name)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		if (!IsValidSnapshotName(name)) return BadRequest("Invalid snapshot name. Use letters, digits, hyphens, and underscores only.");
+		var blobName = $"snapshots/{name}.json";
+		if (!storage.Exists(blobName)) return NotFound($"Snapshot '{name}' not found.");
+		var snapshot = serializer.Deserialize(await storage.Load(blobName));
+		worldState.ReplaceFrom(snapshot);
+		return Ok();
+	}
+
+	[HttpGet("snapshots")]
+	public ActionResult<IEnumerable<string>> ListSnapshots()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var names = storage.List("snapshots")
+			.Select(n => Path.GetFileNameWithoutExtension(n.Substring("snapshots/".Length)));
+		return Ok(names);
+	}
+
+	[HttpDelete("snapshot")]
+	public async Task<ActionResult> DeleteSnapshot([FromQuery] string name)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		if (!IsValidSnapshotName(name)) return BadRequest("Invalid snapshot name. Use letters, digits, hyphens, and underscores only.");
+		var blobName = $"snapshots/{name}.json";
+		if (!storage.Exists(blobName)) return NotFound($"Snapshot '{name}' not found.");
+		await storage.Delete(blobName);
+		return Ok();
+	}
+
+	private static bool IsValidSnapshotName(string? name) =>
+		!string.IsNullOrWhiteSpace(name) && name.All(c => char.IsLetterOrDigit(c) || c == '-' || c == '_');
+
+	// ── Tick Speed Control ────────────────────────────────────────────────────
+
+	[HttpPost("set-tick-duration")]
+	public ActionResult SetTickDuration([FromQuery] int seconds)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		if (seconds < 1 || seconds > 86400) return BadRequest("seconds must be between 1 and 86400.");
+		gameTickEngine.SetTickDuration(TimeSpan.FromSeconds(seconds));
+		return Ok(new { seconds, message = $"Tick duration set to {seconds}s (was {gameDef.TickDuration.TotalSeconds}s default)." });
+	}
+
+	[HttpPost("pause-ticks")]
+	public ActionResult PauseTicks()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		gameTickEngine.PauseTicks();
+		return Ok(new { paused = true });
+	}
+
+	[HttpPost("resume-ticks")]
+	public ActionResult ResumeTicks()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		gameTickEngine.ResumeTicks();
+		return Ok(new { paused = false, effectiveTickDurationSeconds = gameTickEngine.EffectiveTickDuration.TotalSeconds });
+	}
+
+	// ── Action Feed ───────────────────────────────────────────────────────────
+
+	[HttpGet("action-log")]
+	public ActionResult<IEnumerable<ActionLogEntry>> GetActionLog()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		return Ok(actionLogger.GetRecentEntries());
 	}
 }
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -165,7 +165,12 @@ public class AdminController : ControllerBase
 		var blobName = $"snapshots/{name}.json";
 		if (!storage.Exists(blobName)) return NotFound($"Snapshot '{name}' not found.");
 		var snapshot = serializer.Deserialize(await storage.Load(blobName));
-		worldState.ReplaceFrom(snapshot);
+		gameTickEngine.PauseTicks();
+		try {
+			worldState.ReplaceFrom(snapshot);
+		} finally {
+			gameTickEngine.ResumeTicks();
+		}
 		return Ok();
 	}
 

--- a/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
+++ b/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
@@ -1,14 +1,31 @@
-﻿@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication
 @using Microsoft.Extensions.Options
 @using BrowserGameEngine.FrontendServer
+@using BrowserGameEngine.StatefulGameServer
 @model AuthenticationScheme[]
 @inject IOptions<BgeOptions> options
+@inject PlayerRepository playerRepository
 
 @if (options.Value.DevAuth) {
-    <form action="/signindev" method="post">
-        <input type="text" name="PlayerId" />
-        <button class="btn btn-lg btn-success m-1" type="submit">Direct Login (dev)</button>
-    </form>
+    var players = playerRepository.GetAll().Select(p => p.PlayerId.Id).OrderBy(x => x).ToList();
+    <div class="jumbotron">
+        <h3>Dev Login</h3>
+        @if (players.Any()) {
+            <p class="text-muted">Click to log in as an existing player:</p>
+            @foreach (var playerId in players) {
+                <form action="/signindev" method="post" style="display:inline">
+                    <input type="hidden" name="PlayerId" value="@playerId" />
+                    <button class="btn btn-outline-primary m-1" type="submit">@playerId</button>
+                </form>
+            }
+            <hr />
+        }
+        <p class="text-muted">Or create and log in as a new player:</p>
+        <form action="/signindev" method="post" class="form-inline">
+            <input type="text" name="PlayerId" class="form-control mr-2" placeholder="New player ID" />
+            <button class="btn btn-success" type="submit">Create &amp; Login</button>
+        </form>
+    </div>
 }
 
 <div class="jumbotron">

--- a/src/BrowserGameEngine.Persistence.S3/S3Storage.cs
+++ b/src/BrowserGameEngine.Persistence.S3/S3Storage.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -42,6 +44,18 @@ namespace BrowserGameEngine.Persistence.S3 {
 				InputStream = stream
 			};
 			await s3Client.PutObjectAsync(request);
+		}
+
+		public IEnumerable<string> List(string folderPrefix) {
+			var fullPrefix = GetKey(folderPrefix) + "/";
+			var request = new ListObjectsV2Request { BucketName = bucketName, Prefix = fullPrefix };
+			var response = s3Client.ListObjectsV2Async(request).GetAwaiter().GetResult();
+			var stripLen = string.IsNullOrEmpty(keyPrefix) ? 0 : keyPrefix.Length + 1;
+			return response.S3Objects.Select(o => o.Key.Substring(stripLen));
+		}
+
+		public async Task Delete(string name) {
+			await s3Client.DeleteObjectAsync(bucketName, GetKey(name));
 		}
 	}
 }

--- a/src/BrowserGameEngine.Persistence/FileStorage.cs
+++ b/src/BrowserGameEngine.Persistence/FileStorage.cs
@@ -31,8 +31,21 @@ namespace BrowserGameEngine.Persistence {
 		}
 
 		public async Task Store(string name, byte[] blob) {
-			EnsureDirectory();
-			await File.WriteAllBytesAsync(GetFile(name).FullName, blob);
+			var file = GetFile(name);
+			file.Directory?.Create();
+			await File.WriteAllBytesAsync(file.FullName, blob);
+		}
+
+		public IEnumerable<string> List(string folderPrefix) {
+			var subDir = new DirectoryInfo(Path.Combine(directory.FullName, folderPrefix));
+			if (!subDir.Exists) return Enumerable.Empty<string>();
+			return subDir.GetFiles().Select(f => folderPrefix + "/" + f.Name);
+		}
+
+		public Task Delete(string name) {
+			var file = GetFile(name);
+			if (file.Exists) file.Delete();
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/src/BrowserGameEngine.Persistence/IBlobStorage.cs
+++ b/src/BrowserGameEngine.Persistence/IBlobStorage.cs
@@ -8,5 +8,7 @@ namespace BrowserGameEngine.Persistence {
 		Task Store(string name, byte[] blob);
 		Task<byte[]> Load(string name);
 		bool Exists(string name);
+		IEnumerable<string> List(string folderPrefix);
+		Task Delete(string name);
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
@@ -50,7 +51,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));
-			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite));
+			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger()));
 			GameTickModuleRegistry = new GameTickModuleRegistry(LoggerFactory.CreateLogger<GameTickModuleRegistry>(), services.BuildServiceProvider(), GameDef);
 			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), World, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/ActionFeed/ActionLogger.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/ActionFeed/ActionLogger.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.ActionFeed;
+
+public class ActionLogger : IActionLogger {
+	private const int MaxEntries = 500;
+	private readonly ConcurrentQueue<ActionLogEntry> entries = new();
+
+	public void Log(string category, string playerId, string action, string detail) {
+		entries.Enqueue(new ActionLogEntry(DateTime.UtcNow, category, playerId, action, detail));
+		while (entries.Count > MaxEntries)
+			entries.TryDequeue(out _);
+	}
+
+	public IReadOnlyList<ActionLogEntry> GetRecentEntries() => entries.ToArray();
+}

--- a/src/BrowserGameEngine.StatefulGameServer/ActionFeed/IActionLogger.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/ActionFeed/IActionLogger.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.ActionFeed;
+
+public interface IActionLogger {
+	void Log(string category, string playerId, string action, string detail);
+	IReadOnlyList<ActionLogEntry> GetRecentEntries();
+}
+
+public record ActionLogEntry(DateTime Timestamp, string Category, string PlayerId, string Action, string Detail);

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -48,6 +48,13 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	}
 
 	public static class WorldStateImmutableExtensions {
+		public static void ReplaceFrom(this WorldState worldState, WorldStateImmutable snapshot) {
+			var mutable = snapshot.ToMutable();
+			worldState.Players = mutable.Players;
+			worldState.GameTickState = mutable.GameTickState;
+			worldState.GameActionQueue = mutable.GameActionQueue;
+		}
+
 		public static WorldStateImmutable ToImmutable(this WorldState worldState) {
 			return new WorldStateImmutable(
 				Players: worldState.Players.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using BrowserGameEngine.Persistence;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
@@ -25,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<UnitRepositoryWrite>();
 			services.AddSingleton<ActionQueueRepository>();
 
+			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
 			services.AddSingleton<IGameTickModule, UnitReturn>();
 			services.AddSingleton<IGameTickModule, ResourceGrowthSco>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -24,6 +24,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly TimeProvider timeProvider;
 
+		private volatile bool isPaused = false;
+		private TimeSpan? tickDurationOverride = null;
+
 		public GameTickEngine(ILogger<GameTickEngine> logger
 				, WorldState worldState
 				, GameDef gameDef
@@ -56,9 +59,18 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		}
 
 		private bool IsTickDue() {
+			if (isPaused) return false;
+			var duration = tickDurationOverride ?? gameDef.TickDuration;
 			var diff = timeProvider.GetLocalNow().DateTime - worldState.GameTickState.LastUpdate;
-			return diff > gameDef.TickDuration;
+			return diff > duration;
 		}
+
+		public void PauseTicks() => isPaused = true;
+		public void ResumeTicks() => isPaused = false;
+		public bool IsPaused => isPaused;
+		public void SetTickDuration(TimeSpan duration) => tickDurationOverride = duration;
+		public void ResetTickDuration() => tickDurationOverride = null;
+		public TimeSpan EffectiveTickDuration => tickDurationOverride ?? gameDef.TickDuration;
 
 		private bool AreAllPlayersUpToDate() {
 			return worldState.GetPlayersForGameTick().Length == 0;
@@ -83,10 +95,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		}
 
 		public GameTick IncrementWorldTick(int count = 1) {
+			var duration = tickDurationOverride ?? gameDef.TickDuration;
 			for (int i = 0; i < count; i++) {
 				var currentTick = worldState.GameTickState.CurrentGameTick;
 				worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick + 1 };
-				worldState.GameTickState.LastUpdate += gameDef.TickDuration;
+				worldState.GameTickState.LastUpdate += duration;
 				logger.LogDebug("Incremented World Tick to #{CurrentTick}. LastUpdate: {LastUpdate}", worldState.GameTickState.CurrentGameTick.Tick, worldState.GameTickState.LastUpdate);
 			}
 			return worldState.GameTickState.CurrentGameTick;

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BrowserGameEngine.StatefulGameServer.GameTicks {
@@ -25,7 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		private readonly TimeProvider timeProvider;
 
 		private volatile bool isPaused = false;
-		private TimeSpan? tickDurationOverride = null;
+		private long tickDurationOverrideTicks = 0; // 0 = no override; use Interlocked for thread safety
 
 		public GameTickEngine(ILogger<GameTickEngine> logger
 				, WorldState worldState
@@ -60,7 +61,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 
 		private bool IsTickDue() {
 			if (isPaused) return false;
-			var duration = tickDurationOverride ?? gameDef.TickDuration;
+			var duration = EffectiveTickDuration;
 			var diff = timeProvider.GetLocalNow().DateTime - worldState.GameTickState.LastUpdate;
 			return diff > duration;
 		}
@@ -68,9 +69,14 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		public void PauseTicks() => isPaused = true;
 		public void ResumeTicks() => isPaused = false;
 		public bool IsPaused => isPaused;
-		public void SetTickDuration(TimeSpan duration) => tickDurationOverride = duration;
-		public void ResetTickDuration() => tickDurationOverride = null;
-		public TimeSpan EffectiveTickDuration => tickDurationOverride ?? gameDef.TickDuration;
+		public void SetTickDuration(TimeSpan duration) => Interlocked.Exchange(ref tickDurationOverrideTicks, duration.Ticks);
+		public void ResetTickDuration() => Interlocked.Exchange(ref tickDurationOverrideTicks, 0);
+		public TimeSpan EffectiveTickDuration {
+			get {
+				var ticks = Interlocked.Read(ref tickDurationOverrideTicks);
+				return ticks > 0 ? new TimeSpan(ticks) : gameDef.TickDuration;
+			}
+		}
 
 		private bool AreAllPlayersUpToDate() {
 			return worldState.GetPlayersForGameTick().Length == 0;
@@ -95,7 +101,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		}
 
 		public GameTick IncrementWorldTick(int count = 1) {
-			var duration = tickDurationOverride ?? gameDef.TickDuration;
+			var duration = EffectiveTickDuration;
 			for (int i = 0; i < count; i++) {
 				var currentTick = worldState.GameTickState.CurrentGameTick;
 				worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick + 1 };

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -19,6 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly UnitRepository unitRepository;
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
+		private readonly IActionLogger actionLogger;
 
 		private UnitDefId workerUnit;
 		private ResourceDefId mineralResource;
@@ -52,6 +54,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, UnitRepository unitRepository
 				, UnitRepositoryWrite unitRepositoryWrite
+				, IActionLogger actionLogger
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -61,6 +64,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.unitRepository = unitRepository;
 			this.unitRepositoryWrite = unitRepositoryWrite;
+			this.actionLogger = actionLogger;
 		}
 
 		public void SetProperty(string name, string value) {
@@ -119,16 +123,21 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 
 			// Mineral income (spec 2.3)
 			decimal mineralIncome = CalculateWorkerIncome(mineralWorkers, land, MineralsPerWorker, MineralEfficiencyFactor);
-			decimal newMinerals = resourceRepositoryWrite.AddResources(playerId, mineralResource, mineralIncome + BaseIncomeMinerals);
+			decimal totalMineralIncome = mineralIncome + BaseIncomeMinerals;
+			decimal newMinerals = resourceRepositoryWrite.AddResources(playerId, mineralResource, totalMineralIncome);
 			logger.LogDebug("Added {Value} minerals to player {PlayerId} ({Workers} workers, land={Land}). New value: {NewValue}",
-				mineralIncome + BaseIncomeMinerals, playerId, mineralWorkers, land, newMinerals);
+				totalMineralIncome, playerId, mineralWorkers, land, newMinerals);
 
 			// Gas income (spec 2.3) — only if gas-resource is configured
 			if (gasResource != null) {
 				decimal gasIncome = CalculateWorkerIncome(gasWorkers, land, GasPerWorker, GasEfficiencyFactor);
-				decimal newGas = resourceRepositoryWrite.AddResources(playerId, gasResource, gasIncome + BaseIncomeGas);
+				decimal totalGasIncome = gasIncome + BaseIncomeGas;
+				decimal newGas = resourceRepositoryWrite.AddResources(playerId, gasResource, totalGasIncome);
 				logger.LogDebug("Added {Value} gas to player {PlayerId} ({Workers} workers, land={Land}). New value: {NewValue}",
-					gasIncome + BaseIncomeGas, playerId, gasWorkers, land, newGas);
+					totalGasIncome, playerId, gasWorkers, land, newGas);
+				actionLogger.Log("tick", playerId.Id, "ResourceGrowth", $"+{totalMineralIncome:F0}M +{totalGasIncome:F0}G ({mineralWorkers}mw/{gasWorkers}gw land={land:F0})");
+			} else {
+				actionLogger.Log("tick", playerId.Id, "ResourceGrowth", $"+{totalMineralIncome:F0}M ({mineralWorkers}mw land={land:F0})");
 			}
 		}
 


### PR DESCRIPTION
## Summary

Implements four items from the [DX-QOL-PLAN](https://github.com/discostu105/bge/blob/master/docs/DX-QOL-PLAN.md). Item 1 (admin cheat endpoints) was already done in BGE-2.

- **State snapshots (item 2):** `POST /api/admin/save-snapshot?name=x`, `POST /api/admin/load-snapshot?name=x`, `GET /api/admin/snapshots`, `DELETE /api/admin/snapshot?name=x`. Snapshots are stored as `snapshots/{name}.json` via IBlobStorage. Extended IBlobStorage with `List(prefix)` and `Delete(name)`, implemented in both FileStorage and S3Storage.
- **Tick speed control (item 3):** `POST /api/admin/set-tick-duration?seconds=N`, `POST /api/admin/pause-ticks`, `POST /api/admin/resume-ticks`. The duration override and pause flag live in GameTickEngine; tick timer polling interval is unchanged (10s) since CheckAllTicks catches up on missed ticks.
- **Dev login page (item 5):** Signin.cshtml now injects PlayerRepository and renders all existing players as clickable login buttons above the create-new-player form.
- **Action feed (item 7):** `IActionLogger` / `ActionLogger` with a 500-entry `ConcurrentQueue` ring buffer. `ResourceGrowthSco` emits an entry each tick. Exposed at `GET /api/admin/action-log`.

Remaining from the plan (Balance Simulation CLI / Bot Players) will be tracked as separate subtasks.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (50/50)
- [ ] `POST /api/admin/save-snapshot?name=test` → 200, file created
- [ ] `GET /api/admin/snapshots` → returns `["test"]`
- [ ] `POST /api/admin/load-snapshot?name=test` → 200, state restored
- [ ] `DELETE /api/admin/snapshot?name=test` → 200
- [ ] `POST /api/admin/pause-ticks` → world tick stops advancing
- [ ] `POST /api/admin/set-tick-duration?seconds=2` + `resume-ticks` → fast ticks
- [ ] `GET /api/admin/action-log` → shows ResourceGrowth entries after a tick
- [ ] `/signin` in dev mode shows existing players as buttons

Closes BGE-12