### PR TITLE
Replace Discord OAuth with GitHub OAuth and add API key auth (BGE-6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ dotnet test --filter "FullyQualifiedName~BattleTest.AttackEnemy_WithUnits_Return
 dotnet run --project BrowserGameEngine.StatefulGameServer.Benchmarks  # Run benchmarks
 ```
 
-Local dev with Docker (requires `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` env vars):
+Local dev with Docker (requires `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` env vars):
 ```bash
 docker-compose up
 ```
@@ -83,8 +83,8 @@ Governed by `.editorconfig`:
 | `Bge:DevAuth` | Enable password-less dev login (default: `true`) |
 | `Bge:S3BucketName` | S3 bucket; empty = local `FileStorage` |
 | `Bge:S3KeyPrefix` | S3 key prefix |
-| `Discord:ClientId` | Discord OAuth client ID |
-| `Discord:ClientSecret` | Discord OAuth client secret |
+| `GitHub:ClientId` | GitHub OAuth client ID |
+| `GitHub:ClientSecret` | GitHub OAuth client secret |
 
 ## Testing
 

--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNet.Security.OAuth.Discord" Version="10.0.0" />
+		<PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using BrowserGameEngine.FrontendServer.Middleware;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/players")]
+	public class PlayerManagementController : ControllerBase {
+		private readonly ILogger<PlayerManagementController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly UserRepository userRepository;
+		private readonly PlayerRepository playerRepository;
+		private readonly PlayerRepositoryWrite playerRepositoryWrite;
+		private readonly UserRepositoryWrite userRepositoryWrite;
+
+		public PlayerManagementController(
+			ILogger<PlayerManagementController> logger,
+			CurrentUserContext currentUserContext,
+			UserRepository userRepository,
+			PlayerRepository playerRepository,
+			PlayerRepositoryWrite playerRepositoryWrite,
+			UserRepositoryWrite userRepositoryWrite) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.userRepository = userRepository;
+			this.playerRepository = playerRepository;
+			this.playerRepositoryWrite = playerRepositoryWrite;
+			this.userRepositoryWrite = userRepositoryWrite;
+		}
+
+		[HttpGet]
+		public ActionResult<PlayerListViewModel> GetMyPlayers() {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var players = userRepository.GetPlayersForUser(currentUserContext.UserId).ToList();
+			return new PlayerListViewModel {
+				Players = players.Select(p => new PlayerSummaryViewModel {
+					PlayerId = p.PlayerId.Id,
+					PlayerName = p.Name,
+					HasApiKey = p.ApiKeyHash != null
+				}).ToList()
+			};
+		}
+
+		[HttpPost]
+		public ActionResult<PlayerSummaryViewModel> CreatePlayer(CreatePlayerForUserViewModel model) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			if (string.IsNullOrWhiteSpace(model.PlayerName)) return BadRequest("PlayerName is required");
+
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			playerRepositoryWrite.CreatePlayer(playerId, currentUserContext.UserId);
+			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName));
+
+			return new PlayerSummaryViewModel {
+				PlayerId = playerId.Id,
+				PlayerName = model.PlayerName,
+				HasApiKey = false
+			};
+		}
+
+		[HttpDelete("{playerId}")]
+		public ActionResult DeletePlayer(string playerId) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var pid = PlayerIdFactory.Create(playerId);
+			var player = playerRepository.Get(pid);
+			if (player.UserId != currentUserContext.UserId) return Forbid();
+			// Soft-delete: revoke API key and mark player as deleted is out of scope.
+			// For now return not implemented.
+			return StatusCode(501, "Player deletion not yet implemented");
+		}
+
+		[HttpPost("{playerId}/apikey")]
+		public ActionResult<ApiKeyViewModel> GenerateApiKey(string playerId) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var pid = PlayerIdFactory.Create(playerId);
+			var player = playerRepository.Get(pid);
+			if (player.UserId != currentUserContext.UserId) return Forbid();
+
+			var rawKey = "bge_k_" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+				.Replace("+", "-").Replace("/", "_").TrimEnd('=');
+			var hash = BearerTokenMiddleware.HashApiKey(rawKey);
+			userRepositoryWrite.SetApiKeyHash(pid, hash);
+
+			return new ApiKeyViewModel { ApiKey = rawKey };
+		}
+
+		[HttpDelete("{playerId}/apikey")]
+		public ActionResult RevokeApiKey(string playerId) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var pid = PlayerIdFactory.Create(playerId);
+			var player = playerRepository.Get(pid);
+			if (player.UserId != currentUserContext.UserId) return Forbid();
+
+			userRepositoryWrite.SetApiKeyHash(pid, null);
+			return NoContent();
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.Shared;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -9,8 +10,6 @@ using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.FrontendServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using Microsoft.AspNetCore.Authorization;
-using System.Security.Principal;
-using System.Security.Claims;
 using BrowserGameEngine.GameModel;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
@@ -22,16 +21,19 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly PlayerRepository playerRepository;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
+		private readonly UserRepository userRepository;
 
 		public PlayerProfileController(ILogger<PlayerProfileController> logger
 				, CurrentUserContext currentUserContext
 				, PlayerRepository playerRepository
 				, PlayerRepositoryWrite playerRepositoryWrite
+				, UserRepository userRepository
 			) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.playerRepository = playerRepository;
 			this.playerRepositoryWrite = playerRepositoryWrite;
+			this.userRepository = userRepository;
 		}
 
 		[HttpGet]
@@ -47,29 +49,18 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		[Route("init")]
 		public ActionResult<CreatePlayerViewModel> Init() {
-			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (id == null) return Unauthorized();
-
+			if (currentUserContext.UserId == null) return Unauthorized();
 			return new CreatePlayerViewModel {
 				PlayerName = User.Identity?.Name
 			};
 		}
 
-		/* Example claims from Discord:
-		  	http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier: 690094355519766528
-			http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name: Christoph Neumueller
-			urn:discord:user:discriminator: 0075
-			urn:discord:avatar:url: https://cdn.discordapp.com/avatars/690094355519766528/.png
-		*/
-
 		[HttpGet]
 		[Route("exists")]
 		public ActionResult<bool> Exists() {
-			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (id == null) return Unauthorized();
-
-			var playerId = PlayerIdFactory.Create(id);
-			return playerRepository.Exists(playerId);
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var players = userRepository.GetPlayersForUser(currentUserContext.UserId);
+			return players.Any();
 		}
 
 		[HttpPost]
@@ -83,13 +74,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpPost]
 		[Route("create")]
 		public ActionResult Create(CreatePlayerViewModel model) {
-			var id = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-			if (id == null) return Unauthorized();
+			if (currentUserContext.UserId == null) return Unauthorized();
 
-			var playerId = PlayerIdFactory.Create(id);
-			if (playerRepository.Exists(playerId)) return Conflict("Player already exists");
+			// Prevent duplicate creation
+			var existingPlayers = userRepository.GetPlayersForUser(currentUserContext.UserId);
+			if (existingPlayers.Any()) return Conflict("Player already exists");
 
-			playerRepositoryWrite.CreatePlayer(playerId);
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			playerRepositoryWrite.CreatePlayer(playerId, currentUserContext.UserId);
 			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName));
 			currentUserContext.Activate(playerId);
 			return Ok();

--- a/src/BrowserGameEngine.FrontendServer/CurrentUserContext.cs
+++ b/src/BrowserGameEngine.FrontendServer/CurrentUserContext.cs
@@ -9,6 +9,8 @@ namespace BrowserGameEngine.FrontendServer {
 	public class CurrentUserContext {
 		public PlayerId? PlayerId { get; set; }
 
+		public string? UserId { get; set; }
+
 		public bool IsValid { get; set; } = false;
 
 		public static CurrentUserContext Create(string playerId) {

--- a/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Text;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.Net.Http.Headers;
+
+namespace BrowserGameEngine.FrontendServer.Middleware {
+	/// <summary>
+	/// Middleware that authenticates API requests using a Bearer token in the format bge_k_...
+	/// Resolves the token to a Player and stores the PlayerId in HttpContext.Items for CurrentUserMiddleware.
+	/// Must run after UseAuthentication() but before CurrentUserMiddleware.
+	/// </summary>
+	public class BearerTokenMiddleware {
+		private const string ApiKeyPrefix = "bge_k_";
+		private readonly RequestDelegate _next;
+
+		public BearerTokenMiddleware(RequestDelegate next) {
+			_next = next;
+		}
+
+		public async Task InvokeAsync(HttpContext context, UserRepository userRepository) {
+			var authHeader = context.Request.Headers[HeaderNames.Authorization].FirstOrDefault();
+			if (authHeader != null && authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) {
+				var token = authHeader["Bearer ".Length..].Trim();
+				if (token.StartsWith(ApiKeyPrefix, StringComparison.Ordinal)) {
+					var hash = HashApiKey(token);
+					context.Items["ApiKeyHash"] = hash;
+					var player = userRepository.GetPlayerByApiKeyHash(hash);
+					if (player != null) {
+						context.Items["BearerPlayerId"] = player.PlayerId.Id;
+					}
+				}
+			}
+			await _next(context);
+		}
+
+		internal static string HashApiKey(string apiKey) {
+			var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(apiKey));
+			return Convert.ToHexStringLower(bytes);
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -4,8 +4,8 @@ using BrowserGameEngine.StatefulGameServer;
 
 namespace BrowserGameEngine.FrontendServer.Middleware {
 	/// <summary>
-	/// Middleware that populates CurrentUserContext from the authenticated user's claims.
-	/// Runs after UseAuthentication() so that HttpContext.User is available.
+	/// Middleware that populates CurrentUserContext from the authenticated user's claims or
+	/// from a bearer token set by BearerTokenMiddleware. Runs after UseAuthentication().
 	/// </summary>
 	public class CurrentUserMiddleware {
 		private readonly RequestDelegate _next;
@@ -14,16 +14,60 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 			_next = next;
 		}
 
-		public async Task InvokeAsync(HttpContext context, CurrentUserContext currentUserContext, PlayerRepository playerRepository) {
+		public async Task InvokeAsync(
+			HttpContext context,
+			CurrentUserContext currentUserContext,
+			UserRepository userRepository,
+			UserRepositoryWrite userRepositoryWrite,
+			PlayerRepository playerRepository) {
+			// Bearer token path: BearerTokenMiddleware already resolved the PlayerId
+			if (context.Items.TryGetValue("BearerPlayerId", out var bearerPlayerId) && bearerPlayerId is string bearerPlayerIdStr) {
+				var playerId = PlayerIdFactory.Create(bearerPlayerIdStr);
+				currentUserContext.Activate(playerId);
+				await _next(context);
+				return;
+			}
+
+			// Cookie/OAuth path: resolve User from GitHub claims
 			if (context.User.Identity?.IsAuthenticated == true) {
-				var idClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
-				if (idClaim != null) {
-					var playerId = PlayerIdFactory.Create(idClaim.Value);
-					if (playerRepository.Exists(playerId)) {
-						currentUserContext.Activate(playerId);
+				var githubIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+				var githubLoginClaim = context.User.FindFirst("urn:github:login")
+					?? context.User.FindFirst(ClaimTypes.Name);
+				var displayNameClaim = context.User.FindFirst(ClaimTypes.Name)
+					?? githubLoginClaim;
+
+				if (githubIdClaim != null) {
+					var githubId = githubIdClaim.Value;
+					var user = userRepository.GetByGithubId(githubId);
+					if (user == null) {
+						user = userRepositoryWrite.CreateUser(
+							githubId: githubId,
+							githubLogin: githubLoginClaim?.Value ?? githubId,
+							displayName: displayNameClaim?.Value ?? githubId
+						);
+					}
+
+					// Select active player: first player belonging to this user
+					var players = userRepository.GetPlayersForUser(user.UserId).ToList();
+					if (players.Count > 0) {
+						var selectedPlayerId = players[0].PlayerId;
+						// Support X-Player-Id header for multi-player accounts
+						var playerIdHeader = context.Request.Headers["X-Player-Id"].FirstOrDefault();
+						if (playerIdHeader != null) {
+							var requestedId = PlayerIdFactory.Create(playerIdHeader);
+							if (players.Any(p => p.PlayerId == requestedId)) {
+								selectedPlayerId = requestedId;
+							}
+						}
+						currentUserContext.Activate(selectedPlayerId);
+						currentUserContext.UserId = user.UserId;
+					} else {
+						// Authenticated but no player yet; store UserId so create endpoint can use it
+						currentUserContext.UserId = user.UserId;
 					}
 				}
 			}
+
 			await _next(context);
 		}
 	}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.S3;
+using Amazon.S3;
 using BrowserGameEngine.FrontendServer;
 using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.GameDefinition;
@@ -9,12 +9,13 @@ using BrowserGameEngine.Persistence.S3;
 using BrowserGameEngine.StatefulGameServer;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.AspNetCore.RateLimiting;
 using OpenTelemetry.Trace;
 using Prometheus;
 using Prometheus.DotNetRuntime;
 using Serilog;
 using Serilog.Events;
+using System.Threading.RateLimiting;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Information()
@@ -47,6 +48,20 @@ builder.Services.AddOpenTelemetry()
         .AddOtlpExporter()
     );
 
+builder.Services.AddRateLimiter(options => {
+    options.AddPolicy("api-key", context => {
+        var apiKeyHash = context.Items["ApiKeyHash"] as string;
+        var partitionKey = apiKeyHash ?? context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ => new FixedWindowRateLimiterOptions {
+            PermitLimit = 60,
+            Window = TimeSpan.FromMinutes(1),
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = 0
+        });
+    });
+    options.RejectionStatusCode = 429;
+});
+
 builder.Services.AddAuthentication(options => {
     options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
     options.RequireAuthenticatedSignIn = true;
@@ -65,9 +80,9 @@ builder.Services.AddAuthentication(options => {
             return Task.CompletedTask;
         };
     })
-    .AddDiscord(options => {
-        options.ClientId = builder.Configuration["Discord:ClientId"] ?? throw new InvalidOperationException("Discord:ClientId not configured");
-        options.ClientSecret = builder.Configuration["Discord:ClientSecret"] ?? throw new InvalidOperationException("Discord:ClientSecret not configured");
+    .AddGitHub(options => {
+        options.ClientId = builder.Configuration["GitHub:ClientId"] ?? throw new InvalidOperationException("GitHub:ClientId not configured");
+        options.ClientSecret = builder.Configuration["GitHub:ClientSecret"] ?? throw new InvalidOperationException("GitHub:ClientSecret not configured");
         options.SaveTokens = true;
         options.CorrelationCookie.SameSite = SameSiteMode.Lax;
         options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
@@ -91,16 +106,17 @@ app.UseForwardedHeaders(forwardedHeadersOptions);
 if (app.Environment.IsDevelopment()) {
     app.UseDeveloperExceptionPage();
     app.UseWebAssemblyDebugging();
-    app.MapOpenApi();
     app.UseHttpsRedirection();
-} else {
-    app.UseExceptionHandler("/Error");
 }
+app.UseExceptionHandler("/Error");
+app.MapOpenApi();
+
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
 app.UseHttpMetrics();
+app.UseRateLimiter();
 
 IDisposable collector = DotNetRuntimeStatsBuilder
     .Customize()
@@ -112,6 +128,7 @@ IDisposable collector = DotNetRuntimeStatsBuilder
     .StartCollecting();
 
 app.UseAuthentication();
+app.UseMiddleware<BearerTokenMiddleware>();
 app.UseMiddleware<CurrentUserMiddleware>();
 app.UseAuthorization();
 
@@ -141,7 +158,7 @@ async Task ConfigureGameServices(IServiceCollection services) {
     new WorldStateVerifier().Verify(gameDef, worldState); // todo: maybe make this more graceful.
 
     await services.AddGameServer(storage, worldState); // todo: init state for non-development
-    
+
     services.AddScoped(_ => CurrentUserContext.Inactive());
 
     services.Configure<HostOptions>(opts =>

--- a/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
+++ b/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
@@ -29,15 +29,17 @@
 }
 
 <div class="jumbotron">
-    <h1>Authentication</h1>
-    <p class="lead text-left">Sign in using one of these external providers:</p>
+    <h1>Sign In</h1>
+    <p class="lead text-left">Sign in with GitHub to play:</p>
 
     @foreach (var scheme in Model.OrderBy(p => p.DisplayName)) {
         <form action="/signin" method="post">
             <input type="hidden" name="Provider" value="@scheme.Name" />
             <input type="hidden" name="ReturnUrl" value="@ViewBag.ReturnUrl" />
 
-            <button class="btn btn-lg btn-success m-1" type="submit">Connect using @scheme.DisplayName</button>
+            <button class="btn btn-lg btn-dark m-1" type="submit">
+                Sign in with @scheme.DisplayName
+            </button>
         </form>
     }
 </div>
@@ -45,13 +47,6 @@
 <div class="jumbotron">
     @if (User?.Identity?.IsAuthenticated ?? false) {
         <h1>Welcome, @User.Identity.Name</h1>
-
-        <p>
-            @foreach (var claim in Context.User.Claims) {
-                <div><code>@claim.Type</code>: <strong>@claim.Value</strong></div>
-            }
-        </p>
-
         <a class="btn btn-lg btn-danger" href="/signout?returnUrl=%2F">Sign out</a>
     } else {
         <h1>Welcome, anonymous</h1>

--- a/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
@@ -9,6 +9,8 @@ namespace BrowserGameEngine.GameModel {
 		PlayerTypeDefId PlayerType,
 		string Name,
 		DateTime Created,
-		PlayerStateImmutable State
+		PlayerStateImmutable State,
+		string? UserId = null,
+		string? ApiKeyHash = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/UserImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/UserImmutable.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record UserImmutable(
+		string UserId,
+		string GithubId,
+		string GithubLogin,
+		string DisplayName,
+		DateTime Created
+	);
+}

--- a/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
@@ -4,6 +4,7 @@ namespace BrowserGameEngine.GameModel {
 	public record WorldStateImmutable(
 		IDictionary<PlayerId, PlayerImmutable> Players,
 		GameTickStateImmutable GameTickState,
-		IList<GameActionImmutable> GameActionQueue
+		IList<GameActionImmutable> GameActionQueue,
+		IDictionary<string, UserImmutable>? Users = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
+++ b/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class PlayerListViewModel {
+		public List<PlayerSummaryViewModel> Players { get; set; } = new();
+	}
+
+	public class PlayerSummaryViewModel {
+		public string PlayerId { get; set; } = "";
+		public string PlayerName { get; set; } = "";
+		public bool HasApiKey { get; set; }
+	}
+
+	public class CreatePlayerForUserViewModel {
+		public string PlayerName { get; set; } = "";
+	}
+
+	public class ApiKeyViewModel {
+		public string ApiKey { get; set; } = "";
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
@@ -1,0 +1,107 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Test;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class UserRepositoryTest {
+		[Fact]
+		public void CreateUser_NewGithubId_StoresUser() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("gh123", "octocat", "The Octocat");
+
+			Assert.NotNull(user);
+			Assert.Equal("gh123", user.GithubId);
+			Assert.Equal("octocat", user.GithubLogin);
+			Assert.Equal("The Octocat", user.DisplayName);
+			Assert.False(string.IsNullOrEmpty(user.UserId));
+		}
+
+		[Fact]
+		public void GetByGithubId_ExistingUser_ReturnsUser() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			userRepoWrite.CreateUser("gh456", "monalisa", "Mona Lisa");
+
+			var found = userRepo.GetByGithubId("gh456");
+			Assert.NotNull(found);
+			Assert.Equal("monalisa", found!.GithubLogin);
+		}
+
+		[Fact]
+		public void GetByGithubId_MissingUser_ReturnsNull() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+
+			var result = userRepo.GetByGithubId("nonexistent");
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void CreateUser_DuplicateGithubId_Throws() {
+			var game = new TestGame();
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			userRepoWrite.CreateUser("dup123", "dup", "Dup");
+
+			Assert.Throws<InvalidOperationException>(() =>
+				userRepoWrite.CreateUser("dup123", "dup2", "Dup2"));
+		}
+
+		[Fact]
+		public void GetPlayersForUser_AfterCreatePlayer_ReturnsPlayer() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("gh789", "devuser", "Dev User");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			var players = userRepo.GetPlayersForUser(user.UserId).ToList();
+			Assert.Single(players);
+			Assert.Equal(playerId, players[0].PlayerId);
+			Assert.Equal(user.UserId, players[0].UserId);
+		}
+
+		[Fact]
+		public void SetApiKeyHash_AndLookup_FindsPlayer() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("ghapikey", "apiuser", "API User");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			const string testHash = "abc123hash";
+			userRepoWrite.SetApiKeyHash(playerId, testHash);
+
+			var found = userRepo.GetPlayerByApiKeyHash(testHash);
+			Assert.NotNull(found);
+			Assert.Equal(playerId, found!.PlayerId);
+		}
+
+		[Fact]
+		public void RevokeApiKey_ClearsHash() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("ghrevoke", "revokeuser", "Revoke User");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			userRepoWrite.SetApiKeyHash(playerId, "somehash");
+			userRepoWrite.SetApiKeyHash(playerId, null);
+
+			var found = userRepo.GetPlayerByApiKeyHash("somehash");
+			Assert.Null(found);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
@@ -11,6 +11,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public string Name { get; set; }
 		public DateTime Created { get; init; }
 		public PlayerState State { get; init; }
+		public string? UserId { get; set; }
+		public string? ApiKeyHash { get; set; }
 	}
 
 	internal static class PlayerExtensions {
@@ -20,7 +22,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				PlayerType: player.PlayerType,
 				Name: player.Name,
 				Created: player.Created,
-				State: player.State.ToImmutable()
+				State: player.State.ToImmutable(),
+				UserId: player.UserId,
+				ApiKeyHash: player.ApiKeyHash
 			);
 		}
 
@@ -30,7 +34,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				PlayerType = playerImmutable.PlayerType,
 				Name = playerImmutable.Name,
 				Created = playerImmutable.Created,
-				State = playerImmutable.State.ToMutable()
+				State = playerImmutable.State.ToMutable(),
+				UserId = playerImmutable.UserId,
+				ApiKeyHash = playerImmutable.ApiKeyHash
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
@@ -1,0 +1,34 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class User {
+		public string UserId { get; init; }
+		public string GithubId { get; init; }
+		public string GithubLogin { get; set; }
+		public string DisplayName { get; set; }
+		public DateTime Created { get; init; }
+	}
+
+	internal static class UserExtensions {
+		internal static UserImmutable ToImmutable(this User user) {
+			return new UserImmutable(
+				UserId: user.UserId,
+				GithubId: user.GithubId,
+				GithubLogin: user.GithubLogin,
+				DisplayName: user.DisplayName,
+				Created: user.Created
+			);
+		}
+
+		internal static User ToMutable(this UserImmutable userImmutable) {
+			return new User {
+				UserId = userImmutable.UserId,
+				GithubId = userImmutable.GithubId,
+				GithubLogin = userImmutable.GithubLogin,
+				DisplayName = userImmutable.DisplayName,
+				Created = userImmutable.Created
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -12,6 +12,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public class WorldState {
 		internal IDictionary<PlayerId, Player> Players { get; set; } = new ConcurrentDictionary<PlayerId, Player>();
 
+		internal IDictionary<string, User> Users { get; set; } = new ConcurrentDictionary<string, User>();
+
 		internal GameTickState GameTickState { get; set; } = new GameTickState();
 
 		internal IList<GameAction> GameActionQueue { get; set; } = new List<GameAction>();
@@ -51,6 +53,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public static void ReplaceFrom(this WorldState worldState, WorldStateImmutable snapshot) {
 			var mutable = snapshot.ToMutable();
 			worldState.Players = mutable.Players;
+			worldState.Users = mutable.Users;
 			worldState.GameTickState = mutable.GameTickState;
 			worldState.GameActionQueue = mutable.GameActionQueue;
 		}
@@ -59,13 +62,15 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			return new WorldStateImmutable(
 				Players: worldState.Players.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameTickState: worldState.GameTickState.ToImmutable(),
-				GameActionQueue: worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList()
+				GameActionQueue: worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList(),
+				Users: worldState.Users.ToDictionary(x => x.Key, y => y.Value.ToImmutable())
 			);
 		}
 
 		public static WorldState ToMutable(this WorldStateImmutable worldStateImmutable) {
 			return new WorldState {
 				Players = new ConcurrentDictionary<PlayerId, Player>(worldStateImmutable.Players.ToDictionary(x => x.Key, y => y.Value.ToMutable())),
+				Users = new ConcurrentDictionary<string, User>(worldStateImmutable.Users?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<string, User>()),
 				GameTickState = worldStateImmutable.GameTickState.ToMutable(),
 				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList()
 			};

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -15,6 +15,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public static async Task AddGameServer(this IServiceCollection services, IBlobStorage storage, WorldStateImmutable defaultWorldState) {
 			await InitPersistenceAndGameState(services, storage, defaultWorldState);
 			services.AddSingleton(TimeProvider.System);
+			services.AddSingleton<UserRepository>();
+			services.AddSingleton<UserRepositoryWrite>();
 			services.AddSingleton<PlayerRepository>();
 			services.AddSingleton<PlayerRepositoryWrite>();
 			services.AddSingleton<ResourceRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -70,7 +70,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
-		public void CreatePlayer(PlayerId playerId) {
+		public void CreatePlayer(PlayerId playerId, string? userId = null) {
 			lock (_lock) {
 				if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);
 				world.Players[playerId] = new Player() {
@@ -78,6 +78,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 					PlayerId = playerId,
 					Name = playerId.Id,
 					PlayerType = Id.PlayerType("terran"),
+					UserId = userId,
 					State = new PlayerState {
 						LastGameTickUpdate = timeProvider.GetLocalNow().DateTime,
 						CurrentGameTick = world.GameTickState.CurrentGameTick,

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
@@ -1,0 +1,36 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class UserRepository {
+		private readonly WorldState world;
+
+		public UserRepository(WorldState world) {
+			this.world = world;
+		}
+
+		public UserImmutable? GetByGithubId(string githubId) {
+			if (world.Users.TryGetValue(githubId, out var user)) {
+				return user.ToImmutable();
+			}
+			return null;
+		}
+
+		public bool ExistsByGithubId(string githubId) {
+			return world.Users.ContainsKey(githubId);
+		}
+
+		public IEnumerable<PlayerImmutable> GetPlayersForUser(string userId) {
+			return world.Players.Values
+				.Where(p => p.UserId == userId)
+				.Select(p => p.ToImmutable());
+		}
+
+		public PlayerImmutable? GetPlayerByApiKeyHash(string apiKeyHash) {
+			var player = world.Players.Values.FirstOrDefault(p => p.ApiKeyHash == apiKeyHash);
+			return player?.ToImmutable();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
@@ -1,0 +1,38 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class UserRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly WorldState world;
+		private readonly TimeProvider timeProvider;
+
+		public UserRepositoryWrite(WorldState world, TimeProvider timeProvider) {
+			this.world = world;
+			this.timeProvider = timeProvider;
+		}
+
+		public UserImmutable CreateUser(string githubId, string githubLogin, string displayName) {
+			lock (_lock) {
+				if (world.Users.ContainsKey(githubId)) throw new InvalidOperationException($"User with githubId {githubId} already exists");
+				var user = new User {
+					UserId = Guid.NewGuid().ToString(),
+					GithubId = githubId,
+					GithubLogin = githubLogin,
+					DisplayName = displayName,
+					Created = timeProvider.GetLocalNow().DateTime
+				};
+				world.Users[githubId] = user;
+				return user.ToImmutable();
+			}
+		}
+
+		public void SetApiKeyHash(PlayerId playerId, string? apiKeyHash) {
+			lock (_lock) {
+				world.Players[playerId].ApiKeyHash = apiKeyHash;
+			}
+		}
+	}
+}

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - Bge__DevAuth=true
-      - Discord__ClientId=${DISCORD_CLIENT_ID}
-      - Discord__ClientSecret=${DISCORD_CLIENT_SECRET}
+      - GitHub__ClientId=${GITHUB_CLIENT_ID}
+      - GitHub__ClientSecret=${GITHUB_CLIENT_SECRET}
       # To use S3 storage instead of local file storage:
       # - Bge__S3BucketName=my-bge-bucket
       # - AWS_REGION=eu-central-1


### PR DESCRIPTION
## Summary

- **Replace Discord OAuth with GitHub OAuth** — swaps `AspNet.Security.OAuth.Discord` for `AspNet.Security.OAuth.GitHub`; updates `Program.cs`, `docker-compose.yml`, and `CLAUDE.md`
- **Add `User` entity** — new `UserImmutable` / mutable `User` persisted in `WorldState`; keyed by GitHub ID so login auto-creates a User record on first OAuth callback
- **Decouple `Player` from auth identity** — `PlayerImmutable` and mutable `Player` gain optional `UserId` (link to User) and `ApiKeyHash` (SHA-256 of API key)
- **`BearerTokenMiddleware`** — intercepts `Authorization: Bearer bge_k_...` headers, hashes the token, and resolves a Player so agents can call the REST API without OAuth
- **`CurrentUserMiddleware` rewrite** — resolves User from GitHub claims (creating on first login), selects active Player (supports `X-Player-Id` header for multi-player accounts), and activates `CurrentUserContext`
- **`PlayerManagementController`** — `GET/POST /api/players`, `POST/DELETE /api/players/{id}/apikey` for in-game player management and API key lifecycle
- **`PlayerProfileController` updates** — `exists` and `create` now use the User/Player model instead of Discord claim → PlayerId
- **Rate limiting** — 60 req/min per API-key hash (or IP) via ASP.NET built-in rate limiter
- **OpenAPI in prod** — `/openapi/v1.json` now mapped in all environments
- **7 new tests** added for `UserRepository` / `UserRepositoryWrite`; all 57 tests pass

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (57/57)
- [ ] GitHub OAuth app configured with callback URL, manual login flow works
- [ ] `curl -H "Authorization: Bearer bge_k_..."` successfully authenticates after API key is generated via `/api/players/{id}/apikey`
- [ ] Rate limiting returns HTTP 429 after 60 requests/min per key

Closes BGE-6