### PR TITLE
Add worker assignment UI on Base page (BGE-41)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -8,6 +8,8 @@
 
     <_PlayerResources />
 
+    <_WorkerAssignment />
+
     @if (model == null) {
         <p><em>Lade...</em></p>
     } else {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
@@ -1,0 +1,49 @@
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+@if (!string.IsNullOrEmpty(lastError)) {
+	<span class="error">@lastError</span>
+}
+@if (model != null) {
+	<div>
+		<h3>Arbeiter</h3>
+		<div>Gesamt: @model.TotalWorkers</div>
+		<div>Untätig: @(model.TotalWorkers - mineralWorkers - gasWorkers)</div>
+		<div>
+			<label>Mineralien: <InputNumber @bind-Value="mineralWorkers" /></label>
+		</div>
+		<div>
+			<label>Gas: <InputNumber @bind-Value="gasWorkers" /></label>
+		</div>
+		<button @onclick="Assign">Zuweisen</button>
+	</div>
+}
+
+@code {
+	private WorkerAssignmentViewModel? model;
+	private string? lastError;
+	private int mineralWorkers;
+	private int gasWorkers;
+
+	protected override async Task OnInitializedAsync() {
+		await Load();
+	}
+
+	private async Task Load() {
+		model = await Http.GetFromJsonAsync<WorkerAssignmentViewModel>("api/workers");
+		if (model != null) {
+			mineralWorkers = model.MineralWorkers;
+			gasWorkers = model.GasWorkers;
+		}
+	}
+
+	private async Task Assign() {
+		lastError = null;
+		var response = await Http.PostAsJsonAsync($"api/workers/assign?mineralWorkers={mineralWorkers}&gasWorkers={gasWorkers}", "");
+		if (response.IsSuccessStatusCode) {
+			await Load();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `_WorkerAssignment.razor` component: loads worker data from `GET /api/workers`, renders total/mineral/gas/idle counts, allows user to update mineral/gas worker allocation and submit via `POST /api/workers/assign`
- Embed `<_WorkerAssignment />` in `Base.razor` after `<_PlayerResources />` and before the assets section

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (50/50)
- [ ] Navigate to `/base`, verify worker counts are displayed
- [ ] Change mineral/gas inputs and click "Zuweisen", verify values update
- [ ] Enter invalid values (e.g. exceeding total workers), verify error message shown

Closes BGE-41