### PR TITLE
Implement battle land transfer and troop return timer (BGE-42)

### DIFF
--- a/src/BrowserGameEngine.GameModel/BattleResult.cs
+++ b/src/BrowserGameEngine.GameModel/BattleResult.cs
@@ -15,5 +15,7 @@ namespace BrowserGameEngine.GameModel {
 		public List<UnitCount> DefendingUnitsSurvived { get; set; }
 		public List<Cost> ResourcesDestroyed { get; set; }
 		public List<Cost> ResourcesStolen { get; set; }
+		public decimal LandTransferred { get; set; }
+		public int WorkersCaptured { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.GameModel/UnitImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/UnitImmutable.cs
@@ -10,6 +10,7 @@ namespace BrowserGameEngine.GameModel {
 		UnitId UnitId,
 		UnitDefId UnitDefId,
 		int Count,
-		PlayerId? Position
+		PlayerId? Position,
+		int ReturnTimer = 0
 	);
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BattleLandTransferTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BattleLandTransferTest.cs
@@ -1,0 +1,91 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class BattleLandTransferTest {
+
+		private static PlayerId Player2 => PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void Attack_WinnerGainsLand() {
+			var game = new TestGame(playerCount: 2);
+			// Grant player1 overwhelming attack force
+			game.UnitRepositoryWrite.GrantUnits(game.Player1, Id.UnitDef("unit2"), 1000);
+			var bigStack = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.UnitDefId == Id.UnitDef("unit2") && u.Position == null && u.Count == 1000)
+				.Single();
+			game.UnitRepositoryWrite.SendUnit(new SendUnitCommand(game.Player1, bigStack.UnitId, Player2));
+
+			var result = game.UnitRepositoryWrite.Attack(game.Player1, Player2);
+
+			Assert.True(result.BtlResult.AttackingUnitsSurvived.Any(), "Attacker should have surviving units");
+			Assert.False(result.BtlResult.DefendingUnitsSurvived.Any(), "All defenders should be destroyed");
+			Assert.True(result.BtlResult.LandTransferred > 0, "Land should be transferred to attacker");
+			Assert.True(game.ResourceRepository.GetAmount(game.Player1, Id.ResDef("land")) > 50, "Attacker should gain land");
+			Assert.True(game.ResourceRepository.GetAmount(Player2, Id.ResDef("land")) < 50, "Defender should lose land");
+		}
+
+		[Fact]
+		public void Attack_AttackerLoses_NoLandTransfer() {
+			var game = new TestGame(playerCount: 2);
+			// Send only unit1 (Attack=0) — can't hurt defenders
+			var unit1Stacks = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.UnitDefId == Id.UnitDef("unit1") && u.Position == null)
+				.ToList();
+			foreach (var unit in unit1Stacks) {
+				game.UnitRepositoryWrite.SendUnit(new SendUnitCommand(game.Player1, unit.UnitId, Player2));
+			}
+
+			var result = game.UnitRepositoryWrite.Attack(game.Player1, Player2);
+
+			Assert.True(result.BtlResult.DefendingUnitsSurvived.Any(), "Defenders should survive");
+			Assert.Equal(0, result.BtlResult.LandTransferred);
+			Assert.Equal(0, result.BtlResult.WorkersCaptured);
+			Assert.Equal(50, game.ResourceRepository.GetAmount(game.Player1, Id.ResDef("land")));
+			Assert.Equal(50, game.ResourceRepository.GetAmount(Player2, Id.ResDef("land")));
+		}
+
+		[Fact]
+		public void ReturnTimer_SetAfterBattle() {
+			var game = new TestGame(playerCount: 2);
+			game.UnitRepositoryWrite.GrantUnits(game.Player1, Id.UnitDef("unit2"), 1000);
+			var bigStack = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.UnitDefId == Id.UnitDef("unit2") && u.Position == null && u.Count == 1000)
+				.Single();
+			game.UnitRepositoryWrite.SendUnit(new SendUnitCommand(game.Player1, bigStack.UnitId, Player2));
+
+			game.UnitRepositoryWrite.Attack(game.Player1, Player2);
+
+			var returningUnits = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.Position == Player2)
+				.ToList();
+			Assert.NotEmpty(returningUnits);
+			Assert.All(returningUnits, u => Assert.True(u.ReturnTimer > 0, $"Unit {u.UnitId} should have ReturnTimer > 0 after battle"));
+		}
+
+		[Fact]
+		public void ReturnTimer_UnitsReturnHomeAfterTicks() {
+			var game = new TestGame(playerCount: 2);
+			game.UnitRepositoryWrite.GrantUnits(game.Player1, Id.UnitDef("unit2"), 1000);
+			var bigStack = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.UnitDefId == Id.UnitDef("unit2") && u.Position == null && u.Count == 1000)
+				.Single();
+			game.UnitRepositoryWrite.SendUnit(new SendUnitCommand(game.Player1, bigStack.UnitId, Player2));
+			game.UnitRepositoryWrite.Attack(game.Player1, Player2);
+
+			// unit2 Speed = 7, so return takes 7 ticks
+			int unit2Speed = 7;
+			for (int i = 0; i < unit2Speed; i++) {
+				game.UnitRepositoryWrite.ProcessReturningUnits(game.Player1);
+			}
+
+			var stillAway = game.UnitRepository.GetAll(game.Player1)
+				.Where(u => u.Position == Player2)
+				.ToList();
+			Assert.Empty(stillAway);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -47,7 +47,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			AssetRepositoryWrite = new AssetRepositoryWrite(LoggerFactory.CreateLogger<AssetRepositoryWrite>(), World, AssetRepository, ResourceRepository, ResourceRepositoryWrite, ActionQueueRepository, GameDef);
 			UnitRepository = new UnitRepository(World, GameDef, PlayerRepository, AssetRepository);
 			BattleBehavior = new BattleBehaviorScoOriginal(LoggerFactory.CreateLogger<IBattleBehavior>());
-			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, PlayerRepository, BattleBehavior);
+			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
@@ -19,7 +19,8 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 				Resources = new List<ResourceDef> {
 					new ResourceDef(Id.ResDef("res1"), "res1"),
 					new ResourceDef(Id.ResDef("res2"), "res2"),
-					new ResourceDef(Id.ResDef("res3"), "res3")
+					new ResourceDef(Id.ResDef("res3"), "res3"),
+					new ResourceDef(Id.ResDef("land"), "land")
 				},
 
 				ScoreResource = Id.ResDef("res1"),

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestWorldStateFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestWorldStateFactory.cs
@@ -32,7 +32,8 @@ namespace BrowserGameEngine.GameDefinition.SCO {
                             CurrentGameTick: gameTick,
                             Resources: new Dictionary<ResourceDefId, decimal> {
                             { Id.ResDef("res1"), 1000 },
-                            { Id.ResDef("res2"), 2000 }
+                            { Id.ResDef("res2"), 2000 },
+                            { Id.ResDef("land"), 50 }
                             },
                             Assets: new HashSet<AssetImmutable> {
                             new AssetImmutable(

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/UnitState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/UnitState.cs
@@ -9,6 +9,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public UnitDefId UnitDefId { get; init; }
 		public int Count { get; set; }
 		public PlayerId? Position { get; set; }
+		public int ReturnTimer { get; set; }
 
 		internal bool IsHome() {
 			return Position == null;
@@ -21,7 +22,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UnitId: unitState.UnitId,
 				UnitDefId: unitState.UnitDefId,
 				Count: unitState.Count,
-				Position: unitState.Position
+				Position: unitState.Position,
+				ReturnTimer: unitState.ReturnTimer
 			);
 		}
 
@@ -30,7 +32,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UnitId = unitStateImmutable.UnitId,
 				UnitDefId = unitStateImmutable.UnitDefId,
 				Count = unitStateImmutable.Count,
-				Position = unitStateImmutable.Position
+				Position = unitStateImmutable.Position,
+				ReturnTimer = unitStateImmutable.ReturnTimer
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/UnitReturn.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/UnitReturn.cs
@@ -1,26 +1,14 @@
 ﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
-	/// <summary>
-	/// SCO: based on WBF's and existing "land", the resource "minerals" is increased.
-	///      in SCO, there was also an assignement of WBFs to minerals and gas.
-	/// </summary>
 	public class UnitReturn : IGameTickModule {
 		public string Name => "unitreturn:1";
-		private readonly GameDef gameDef;
-		private readonly UnitRepository unitRepository;
+		private readonly UnitRepositoryWrite unitRepositoryWrite;
 
-		public UnitReturn(GameDef gameDef
-				, UnitRepository unitRepository
-			) {
-			this.gameDef = gameDef;
-			this.unitRepository = unitRepository;
+		public UnitReturn(UnitRepositoryWrite unitRepositoryWrite) {
+			this.unitRepositoryWrite = unitRepositoryWrite;
 		}
 
 		public void SetProperty(string name, string value) {
@@ -29,9 +17,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 					throw new InvalidGameDefException($"Property '{name}' not valid for GameTickModule '{this.Name}'.");
 			}
 		}
-		
+
 		public void CalculateTick(PlayerId playerId) {
-			//Console.WriteLine("yay");
+			unitRepositoryWrite.ProcessReturningUnits(playerId);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
@@ -66,7 +66,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			defendingUnitsDestroyed = new List<UnitCount>();
 			if (attackPoints == 0) return new List<BtlUnit>(defenders); // all survived
 			var survivingDefendingUnits = new List<BtlUnit>();
-			foreach (var defendingUnit in defenders.OrderBy(x => x.Hitpoints).ThenBy(x => x.Defense).ThenBy(x => x.UnitDefId)) {
+			foreach (var defendingUnit in defenders.OrderBy(x => x.Hitpoints).ThenBy(x => x.Defense).ThenBy(x => x.UnitDefId.Id)) {
 				if (attackPoints == 0) {
 					// no more attack points left. unit survives
 					survivingDefendingUnits.Add(new BtlUnit {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -42,6 +42,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		public void CaptureWorkers(PlayerId playerId, int count) {
+			lock (_lock) {
+				var state = world.GetPlayer(playerId).State;
+				int mineralRemoved = Math.Min(count, state.MineralWorkers);
+				state.MineralWorkers -= mineralRemoved;
+				int remaining = count - mineralRemoved;
+				int gasRemoved = Math.Min(remaining, state.GasWorkers);
+				state.GasWorkers -= gasRemoved;
+			}
+		}
+
 		internal GameTick IncrementTick(PlayerId playerId) {
 			lock (_lock) {
 				var player = world.GetPlayer(playerId);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -16,7 +16,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly GameDef gameDef;
 		private readonly UnitRepository unitRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+		private readonly ResourceRepository resourceRepository;
 		private readonly PlayerRepository playerRepository;
+		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly IBattleBehavior battleBehavior;
 
 		public UnitRepositoryWrite(ILogger<UnitRepositoryWrite> logger
@@ -24,7 +26,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, GameDef gameDef
 				, UnitRepository unitRepository
 				, ResourceRepositoryWrite resourceRepositoryWrite
+				, ResourceRepository resourceRepository
 				, PlayerRepository playerRepository
+				, PlayerRepositoryWrite playerRepositoryWrite
 				, IBattleBehavior battleBehavior
 			) {
 			this.logger = logger;
@@ -32,7 +36,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.gameDef = gameDef;
 			this.unitRepository = unitRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
+			this.resourceRepository = resourceRepository;
 			this.playerRepository = playerRepository;
+			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.battleBehavior = battleBehavior;
 		}
 
@@ -125,9 +131,49 @@ namespace BrowserGameEngine.StatefulGameServer {
 				world.ValidatePlayer(command.EnemyPlayerId);
 				var units = Units(command.PlayerId).Where(x => x.Position == command.EnemyPlayerId);
 				foreach (var unit in units) {
-					unit.Position = null; // TODO: should not be immediate, but rather with some rounds delay
+					unit.Position = null;
 				}
 			}
+		}
+
+		private void SetReturnTimers(PlayerId playerId, PlayerId enemyPlayerId) {
+			lock (_lock) {
+				var units = Units(playerId).Where(x => x.Position == enemyPlayerId).ToList();
+				foreach (var unit in units) {
+					unit.ReturnTimer = gameDef.GetUnitDef(unit.UnitDefId).Speed;
+				}
+			}
+		}
+
+		public void ProcessReturningUnits(PlayerId playerId) {
+			lock (_lock) {
+				var units = Units(playerId).Where(x => x.ReturnTimer > 0).ToList();
+				foreach (var unit in units) {
+					unit.ReturnTimer--;
+					if (unit.ReturnTimer == 0) {
+						unit.Position = null;
+					}
+				}
+			}
+		}
+
+		private void ApplyLandTransfer(BattleResult battleResult, int remainingAttackDamage) {
+			var defenderLand = (int)resourceRepository.GetAmount(battleResult.Defender, Id.ResDef("land"));
+			if (defenderLand <= 0) return;
+
+			decimal percent = Math.Clamp(remainingAttackDamage / (decimal)defenderLand * 12, 1, 50);
+			decimal landToTransfer = Math.Round(defenderLand * percent / 100);
+
+			resourceRepositoryWrite.AddResources(battleResult.Defender, Id.ResDef("land"), -landToTransfer);
+			resourceRepositoryWrite.AddResources(battleResult.Attacker, Id.ResDef("land"), landToTransfer);
+
+			var defenderState = world.GetPlayer(battleResult.Defender).State;
+			int totalWorkers = defenderState.MineralWorkers + defenderState.GasWorkers;
+			int workersToCapture = (int)Math.Round(totalWorkers * percent / 100 / 2);
+			playerRepositoryWrite.CaptureWorkers(battleResult.Defender, workersToCapture);
+
+			battleResult.BtlResult.LandTransferred = landToTransfer;
+			battleResult.BtlResult.WorkersCaptured = workersToCapture;
 		}
 
 		private void RemoveUnitsOfType(PlayerId playerId, UnitDefId unitDefId) {
@@ -181,7 +227,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, StringifyUnitCounts(battleResult.BtlResult.AttackingUnitsSurvived)
 				);
 
-			ReturnUnitsHome(new ReturnUnitsHomeCommand(playerId, enemyPlayerId));
+			bool attackerWon = !battleResult.BtlResult.DefendingUnitsSurvived.Any() && battleResult.BtlResult.AttackingUnitsSurvived.Any();
+			if (attackerWon) {
+				int remainingAttackDamage = battleResult.BtlResult.AttackingUnitsSurvived
+					.Sum(uc => uc.Count * gameDef.GetUnitDef(uc.UnitDefId).Attack);
+				ApplyLandTransfer(battleResult, remainingAttackDamage);
+			}
+
+			SetReturnTimers(playerId, enemyPlayerId);
 			return battleResult;
 		}
 
@@ -212,7 +265,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		private void RemoveUnits(PlayerId playerId, PlayerId? position, UnitCount unitCount) {
-			var units = unitRepository.GetByUnitDefId(playerId, unitCount.UnitDefId).Where(x => x.Position == position);
+			var units = unitRepository.GetByUnitDefId(playerId, unitCount.UnitDefId).Where(x => x.Position == position).ToList();
 			int unitsToRemove = unitCount.Count;
 			foreach (var unit in units) {
 				unitsToRemove -= TryRemoveUnitCount(playerId, unit.UnitId, unitsToRemove);


### PR DESCRIPTION
## Summary
- Add `ReturnTimer` to `Unit`/`UnitImmutable`/`UnitState` so attacking units return home over multiple ticks rather than instantly
- Extend `BattleResult` with `LandTransferred` and `WorkersCaptured` fields
- Add `CaptureWorkers()` to `PlayerRepositoryWrite` with mineral-first assignment reduction
- Add `SetReturnTimers()` and `ProcessReturningUnits()` to `UnitRepositoryWrite`; wire `SetReturnTimers` into `Attack()` replacing the old `ReturnUnitsHome` call
- Add `ApplyLandTransfer()` implementing the spec 6.4 percent formula; victory condition is `!DefendingUnitsSurvived.Any() && AttackingUnitsSurvived.Any()`
- Implement `UnitReturn.CalculateTick()` to delegate to `ProcessReturningUnits`
- Add `land` resource to `TestGameDefFactory` and `TestWorldStateFactory` (50 units per player)
- Fix pre-existing `Collection was modified` bug in `RemoveUnits` (lazy LINQ over mutable `List<Unit>`)
- Fix pre-existing `UnitDefId` sort crash (records not `IComparable`) in battle ordering

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (54 tests, 0 failures)
- [x] `Attack_WinnerGainsLand` — attacker wins, land transferred, resource amounts updated
- [x] `Attack_AttackerLoses_NoLandTransfer` — attacker loses (Attack=0 units), no land/worker change
- [x] `ReturnTimer_SetAfterBattle` — surviving attacking units have `ReturnTimer > 0` after battle
- [x] `ReturnTimer_UnitsReturnHomeAfterTicks` — units return home after `Speed` ticks of `ProcessReturningUnits`

Closes BGE-42