### PR TITLE
Fix rate limiting: GlobalLimiter + middleware ordering (BGE-48)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -49,7 +49,7 @@ builder.Services.AddOpenTelemetry()
     );
 
 builder.Services.AddRateLimiter(options => {
-    options.AddPolicy("api-key", context => {
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context => {
         var apiKeyHash = context.Items["ApiKeyHash"] as string;
         var partitionKey = apiKeyHash ?? context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ => new FixedWindowRateLimiterOptions {
@@ -116,7 +116,6 @@ app.UseStaticFiles();
 
 app.UseRouting();
 app.UseHttpMetrics();
-app.UseRateLimiter();
 
 IDisposable collector = DotNetRuntimeStatsBuilder
     .Customize()
@@ -129,6 +128,7 @@ IDisposable collector = DotNetRuntimeStatsBuilder
 
 app.UseAuthentication();
 app.UseMiddleware<BearerTokenMiddleware>();
+app.UseRateLimiter();
 app.UseMiddleware<CurrentUserMiddleware>();
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- **Bug 1 fixed:** `app.UseRateLimiter()` was called before `app.UseMiddleware<BearerTokenMiddleware>()`, so `context.Items["ApiKeyHash"]` was never populated when the limiter evaluated requests — all API key requests fell back to IP-based partitioning
- **Bug 2 fixed:** `options.AddPolicy("api-key", ...)` registers a named policy that only fires when endpoints have `[EnableRateLimiting("api-key")]`. No endpoints had this, and no `GlobalLimiter` was set, so the rate limiter did nothing for any request
- Both fixed with Option A: switch to `options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(...)` for global application, and move `app.UseRateLimiter()` to after `app.UseMiddleware<BearerTokenMiddleware>()`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (57 tests)
- [ ] Manual: API key requests are partitioned by `ApiKeyHash` (60 req/min)
- [ ] Manual: Non-API-key requests fall back to IP partitioning
- [ ] Manual: `UseRateLimiter()` is ordered after `BearerTokenMiddleware` (verify in pipeline)
- [ ] Manual: Requests beyond 60/min receive HTTP 429

Closes BGE-48