### PR TITLE
Fix race condition in CurrentUserMiddleware user creation (BGE-49)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -38,14 +38,11 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 
 				if (githubIdClaim != null) {
 					var githubId = githubIdClaim.Value;
-					var user = userRepository.GetByGithubId(githubId);
-					if (user == null) {
-						user = userRepositoryWrite.CreateUser(
-							githubId: githubId,
-							githubLogin: githubLoginClaim?.Value ?? githubId,
-							displayName: displayNameClaim?.Value ?? githubId
-						);
-					}
+					var user = userRepositoryWrite.GetOrCreateUser(
+						githubId: githubId,
+						githubLogin: githubLoginClaim?.Value ?? githubId,
+						displayName: displayNameClaim?.Value ?? githubId
+					);
 
 					// Select active player: first player belonging to this user
 					var players = userRepository.GetPlayersForUser(user.UserId).ToList();

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
@@ -88,6 +88,50 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public void GetOrCreateUser_NewUser_CreatesAndReturnsUser() {
+			var game = new TestGame();
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var user = userRepoWrite.GetOrCreateUser("gh-new", "newuser", "New User");
+
+			Assert.NotNull(user);
+			Assert.Equal("gh-new", user.GithubId);
+			Assert.Equal("newuser", user.GithubLogin);
+			Assert.Equal("New User", user.DisplayName);
+		}
+
+		[Fact]
+		public void GetOrCreateUser_ExistingUser_ReturnsSameUser() {
+			var game = new TestGame();
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+
+			var first = userRepoWrite.GetOrCreateUser("gh-dup", "dupuser", "Dup User");
+			var second = userRepoWrite.GetOrCreateUser("gh-dup", "dupuser-2", "Dup User 2");
+
+			Assert.Equal(first.UserId, second.UserId);
+			Assert.Equal("dupuser", second.GithubLogin);
+		}
+
+		[Fact]
+		public void GetOrCreateUser_ConcurrentCalls_ReturnSameUser() {
+			var game = new TestGame();
+			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			UserImmutable? result1 = null;
+			UserImmutable? result2 = null;
+
+			var t1 = new System.Threading.Thread(() => result1 = userRepoWrite.GetOrCreateUser("gh-race", "racer", "Racer"));
+			var t2 = new System.Threading.Thread(() => result2 = userRepoWrite.GetOrCreateUser("gh-race", "racer", "Racer"));
+			t1.Start();
+			t2.Start();
+			t1.Join();
+			t2.Join();
+
+			Assert.NotNull(result1);
+			Assert.NotNull(result2);
+			Assert.Equal(result1!.UserId, result2!.UserId);
+		}
+
+		[Fact]
 		public void RevokeApiKey_ClearsHash() {
 			var game = new TestGame();
 			var userRepo = new UserRepository(game.World);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
@@ -29,6 +29,27 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		/// <summary>
+		/// Atomically returns the existing user for <paramref name="githubId"/>, or creates and
+		/// returns a new one. Safe for concurrent first-login requests from the same GitHub account.
+		/// </summary>
+		public UserImmutable GetOrCreateUser(string githubId, string githubLogin, string displayName) {
+			lock (_lock) {
+				if (world.Users.TryGetValue(githubId, out var existing)) {
+					return existing.ToImmutable();
+				}
+				var user = new User {
+					UserId = Guid.NewGuid().ToString(),
+					GithubId = githubId,
+					GithubLogin = githubLogin,
+					DisplayName = displayName,
+					Created = timeProvider.GetLocalNow().DateTime
+				};
+				world.Users[githubId] = user;
+				return user.ToImmutable();
+			}
+		}
+
 		public void SetApiKeyHash(PlayerId playerId, string? apiKeyHash) {
 			lock (_lock) {
 				world.Players[playerId].ApiKeyHash = apiKeyHash;


### PR DESCRIPTION
## Summary
- Add `GetOrCreateUser` to `UserRepositoryWrite` that atomically checks existence and creates under lock — eliminates the TOCTOU window where two concurrent first-login requests for the same GitHub account could both read `null` and both call `CreateUser`, causing the second to throw an unhandled `InvalidOperationException` (500).
- Update `CurrentUserMiddleware` to call `GetOrCreateUser` instead of the bare check-then-create pattern.
- Add three new tests: new user creation, idempotent call returning existing user, and a concurrent-thread test validating the same `UserId` is returned from both threads.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (60/60)
- [ ] Verify first login from two browser tabs simultaneously doesn't 500

Closes BGE-49