### PR TITLE
Add missing income formula tests and update PLAN.md (BGE-66)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -13,7 +13,8 @@ These features exist and are functional in the current codebase.
 | 1.1 | Tick-based game world | Per-player tick engine with pluggable modules. 30s ticks (configurable). |
 | 1.2 | Race selection at registration | Terran/Zerg/Protoss choice, permanent. Terran fully defined; Zerg & Protoss partially defined. |
 | 2.1 | Two resource types (Minerals, Gas) | Tracked per player. Land is the score resource. |
-| 2.3 | Resource income per round | `ResourceGrowthSco` tick module. Current formula is a simple stub (workers x 1.2), not the full spec formula. |
+| 2.3 | Resource income per round | `ResourceGrowthSco` tick module. Full efficiency formula implemented: `efficiency = clamp(land / (workers * factor), 0.2, 100)`. |
+| 2.5 | Emergency respawn | `ResourceGrowthSco` tick module. If 0 workers and low resources, auto-grants 1 mineral + 1 gas worker. |
 | 3.1-3.2 | Building construction | `BuildAssetCommand` with resource cost, build time countdown, prerequisites. Terran buildings defined. |
 | 3.3 | Tech tree prerequisites | Prerequisite chain enforced before building. |
 | 4.1 | Instant unit training | `BuildUnitCommand` — costs resources, requires building, no build time. |
@@ -39,8 +40,6 @@ These features are specified, not yet implemented, and slot cleanly into the exi
 | Spec Section | Feature | What to Build |
 |---|---|---|
 | 2.2 | Worker roles (mineral / gas / idle) | Add `MineralWorkers` and `GasWorkers` fields to player state. Build a worker-assignment command. Workers are already units; this adds role tracking. |
-| 2.3 | Full resource income formula | Replace the `ResourceGrowthSco` stub with the real formula: efficiency = land / (workers * factor), clamped. This is the heart of the economic tension. |
-| 2.5 | Emergency respawn | If a player has 0 workers and low resources, auto-grant 1 mineral + 1 gas worker. Add to tick processing. |
 | 6.4 | Land transfer on victory | After `BattleBehaviorScoOriginal` resolves, calculate percent from remaining attacker damage, transfer land. Also capture/destroy defender workers. |
 | 4.1 | Static defense structures | Missile Turret / Sunken Colony / Photon Cannon: units with `is_mobile = false`, 0 attack, participate in defense only. The unit framework supports this; just needs a flag and combat filter. |
 | 4.1 | Troop return timer | `UnitReturn` tick module exists as a stub. Implement: after battle, surviving attackers get `return_timer = speed`, decremented each tick, unavailable for defense until home. |

--- a/src/BrowserGameEngine.StatefulGameServer.Test/WorkerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/WorkerTest.cs
@@ -105,5 +105,45 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			Assert.Equal(gasBefore + 30m, gasAfter);
 		}
+
+		[Fact]
+		public void ResourceIncome_MixedWorkers_EarnsCorrectIncome() {
+			// 5 mineral workers + 3 gas workers, res2 (constraint) = 2000
+			// mineral efficiency = clamp(2000/(5*0.03), 0.2, 100) = clamp(13333, ...) = 100
+			// mineral income = 5 * 4 * 100/100 + 10 base = 30
+			// gas efficiency = clamp(2000/(3*0.06), 0.2, 100) = clamp(11111, ...) = 100
+			// gas income = 3 * 4 * 100/100 + 10 base = 22
+			var g = new TestGame();
+			var playerId = g.Player1;
+			g.PlayerRepositoryWrite.AssignWorkers(new AssignWorkersCommand(playerId, 5, 3), 15);
+
+			decimal mineralsBefore = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+			decimal gasBefore = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res3"));
+			g.TickEngine.IncrementWorldTick(1);
+			g.TickEngine.CheckAllTicks();
+			decimal mineralsAfter = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+			decimal gasAfter = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res3"));
+
+			Assert.Equal(mineralsBefore + 30m, mineralsAfter);
+			Assert.Equal(gasBefore + 22m, gasAfter);
+		}
+
+		[Fact]
+		public void ResourceIncome_LowEfficiency_ClampedAtMinimum() {
+			// Reduce res2 (constraint) to 0, assign 10 mineral workers
+			// efficiency = clamp(0/(10*0.03), 0.2, 100) = 0.2
+			// income = 10 * 4 * 0.2/100 + 10 base = 0.08 + 10 = 10.08
+			var g = new TestGame();
+			var playerId = g.Player1;
+			g.ResourceRepositoryWrite.DeductCost(playerId, Id.ResDef("res2"), 2000m);
+			g.PlayerRepositoryWrite.AssignWorkers(new AssignWorkersCommand(playerId, 10, 0), 15);
+
+			decimal mineralsBefore = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+			g.TickEngine.IncrementWorldTick(1);
+			g.TickEngine.CheckAllTicks();
+			decimal mineralsAfter = g.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+
+			Assert.Equal(mineralsBefore + 10.08m, mineralsAfter);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `ResourceIncome_MixedWorkers_EarnsCorrectIncome`: assigns 5 mineral + 3 gas workers (res2=2000), both efficiencies clamp to 100, asserts +30m minerals and +22m gas per tick
- Add `ResourceIncome_LowEfficiency_ClampedAtMinimum`: reduces res2 to 0, assigns 10 mineral workers, efficiency clamps to 0.2, asserts +10.08m minerals per tick
- Update `docs/PLAN.md` spec 2.3 row: remove stale "stub" note, document that full efficiency formula is implemented
- Move spec 2.5 (emergency respawn) from "Planned Phase 1" to "Already Implemented"

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test --filter "FullyQualifiedName~WorkerTest"` passes (10/10 tests)
- [x] Two new tests cover mixed-worker and low-efficiency clamping paths in `ResourceGrowthSco`

Closes BGE-66