### PR TITLE
Implement attack & defense upgrades (BGE-27)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -1,0 +1,90 @@
+@page "/upgrades"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h1>Forschung</h1>
+
+<div class="container">
+
+    <_PlayerResources />
+
+    @if (model == null) {
+        <p><em>Lade...</em></p>
+    } else {
+        if (!string.IsNullOrEmpty(lastError)) {
+            <span class="error">@lastError</span>
+        }
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Angriffs-Upgrades</h5>
+                        <p>Level: @model.AttackUpgradeLevel / @model.MaxUpgradeLevel</p>
+
+                        @if (model.UpgradeBeingResearched == "Attack") {
+                            <p>Wird erforscht... (@model.UpgradeResearchTimer Runden verbleibend)</p>
+                        } else if (model.AttackUpgradeLevel >= model.MaxUpgradeLevel) {
+                            <p>Maximales Level erreicht!</p>
+                        } else if (model.UpgradeBeingResearched != "None") {
+                            <p>Eine andere Forschung läuft gerade.</p>
+                        } else {
+                            <div>Kosten: <_Cost Cost="@model.NextAttackUpgradeCost" /></div>
+                            <button class="btn btn-danger mt-2" @onclick="ResearchAttack">
+                                Angriffs-Upgrade erforschen (Level @(model.AttackUpgradeLevel + 1))
+                            </button>
+                        }
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Verteidigungs-Upgrades</h5>
+                        <p>Level: @model.DefenseUpgradeLevel / @model.MaxUpgradeLevel</p>
+
+                        @if (model.UpgradeBeingResearched == "Defense") {
+                            <p>Wird erforscht... (@model.UpgradeResearchTimer Runden verbleibend)</p>
+                        } else if (model.DefenseUpgradeLevel >= model.MaxUpgradeLevel) {
+                            <p>Maximales Level erreicht!</p>
+                        } else if (model.UpgradeBeingResearched != "None") {
+                            <p>Eine andere Forschung läuft gerade.</p>
+                        } else {
+                            <div>Kosten: <_Cost Cost="@model.NextDefenseUpgradeCost" /></div>
+                            <button class="btn btn-primary mt-2" @onclick="ResearchDefense">
+                                Verteidigungs-Upgrade erforschen (Level @(model.DefenseUpgradeLevel + 1))
+                            </button>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private UpgradesViewModel? model;
+    private string? lastError;
+
+    protected override async Task OnInitializedAsync() {
+        await Update();
+    }
+
+    private async Task ResearchAttack() => await Research("Attack");
+    private async Task ResearchDefense() => await Research("Defense");
+
+    private async Task Research(string upgradeType) {
+        lastError = null;
+        var response = await Http.PostAsJsonAsync($"api/upgrades/research?upgradeType={upgradeType}", "");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task Update() {
+        model = await Http.GetFromJsonAsync<UpgradesViewModel>("api/upgrades");
+    }
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -28,6 +28,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="upgrades">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Forschung
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="ranking">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Ranking
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
@@ -1,0 +1,62 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}")]
+	public class UpgradesController : ControllerBase {
+		private readonly ILogger<UpgradesController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly UpgradeRepository upgradeRepository;
+		private readonly UpgradeRepositoryWrite upgradeRepositoryWrite;
+
+		public UpgradesController(
+			ILogger<UpgradesController> logger,
+			CurrentUserContext currentUserContext,
+			UpgradeRepository upgradeRepository,
+			UpgradeRepositoryWrite upgradeRepositoryWrite) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.upgradeRepository = upgradeRepository;
+			this.upgradeRepositoryWrite = upgradeRepositoryWrite;
+		}
+
+		[HttpGet]
+		public UpgradesViewModel Get() {
+			var playerId = currentUserContext.PlayerId;
+			int attackLevel = upgradeRepository.GetAttackUpgradeLevel(playerId);
+			int defenseLevel = upgradeRepository.GetDefenseUpgradeLevel(playerId);
+			return new UpgradesViewModel {
+				AttackUpgradeLevel = attackLevel,
+				DefenseUpgradeLevel = defenseLevel,
+				UpgradeResearchTimer = upgradeRepository.GetUpgradeResearchTimer(playerId),
+				UpgradeBeingResearched = upgradeRepository.GetUpgradeBeingResearched(playerId).ToString(),
+				NextAttackUpgradeCost = attackLevel < 3 ? CostViewModel.Create(upgradeRepositoryWrite.GetUpgradeCost(attackLevel + 1)) : null,
+				NextDefenseUpgradeCost = defenseLevel < 3 ? CostViewModel.Create(upgradeRepositoryWrite.GetUpgradeCost(defenseLevel + 1)) : null
+			};
+		}
+
+		[HttpPost]
+		public ActionResult Research([FromQuery] string upgradeType) {
+			if (!System.Enum.TryParse<UpgradeType>(upgradeType, ignoreCase: true, out var type) || type == UpgradeType.None) {
+				return BadRequest("Invalid upgradeType. Use 'Attack' or 'Defense'.");
+			}
+			try {
+				upgradeRepositoryWrite.ResearchUpgrade(new ResearchUpgradeCommand(currentUserContext.PlayerId, type));
+				return Ok();
+			} catch (UpgradeAlreadyMaxLevelException e) {
+				return BadRequest(e.Message);
+			} catch (UpgradeResearchInProgressException e) {
+				return BadRequest(e.Message);
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -34,7 +34,8 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						{ "growth-resource", "minerals" },
 						{ "gas-resource", "gas" },
 						{ "constraint-resource", "land" },
-					}.ToFrozenDictionary())
+					}.ToFrozenDictionary()),
+					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
 
 				Assets = new List<AssetDef> {
@@ -287,7 +288,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 1,
 						Hitpoints = 60,
 						Speed = 8,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("commandcenter") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("commandcenter") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [0, 0, 0]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("spacemarine"),
@@ -298,7 +301,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 4,
 						Hitpoints = 60,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("barracks") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("barracks") },
+						AttackBonuses = [1, 2, 3],
+						DefenseBonuses = [1, 2, 3]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("firebat"),
@@ -309,7 +314,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 6,
 						Hitpoints = 50,
 						Speed = 7,
-						Prerequisites =  new List<AssetDefId> { Id.AssetDef("barracks") }
+						Prerequisites =  new List<AssetDefId> { Id.AssetDef("barracks") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [1, 2, 3]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("siegetank"),
@@ -320,7 +327,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 40,
 						Hitpoints = 130,
 						Speed = 9,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("factory") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("factory") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [3, 6, 9]
 					},
 					//new UnitDef {
 					//	Id = Id.Unit("ghost",
@@ -342,7 +351,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 2,
 						Hitpoints = 70,
 						Speed = 5,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("armory") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("armory") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [1, 2, 3]
 					},
 					//new UnitDef {
 					//	Id = Id.Unit("goliath",
@@ -364,7 +375,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 14,
 						Hitpoints = 230,
 						Speed = 5,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("spaceport") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spaceport") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [2, 4, 6]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("battlecruiser"),
@@ -375,7 +388,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 45,
 						Hitpoints = 500,
 						Speed = 11,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("spaceport") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spaceport") },
+						AttackBonuses = [5, 10, 15],
+						DefenseBonuses = [4, 8, 12]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("missileturret"),
@@ -400,7 +415,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 1,
 						Hitpoints = 40,
 						Speed = 8,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("hive") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("hive") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [0, 0, 0]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("zergling"),
@@ -411,7 +428,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 1,
 						Hitpoints = 25,
 						Speed = 6,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("spawningpool") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spawningpool") },
+						AttackBonuses = [1, 2, 3],
+						DefenseBonuses = [1, 2, 3]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("hydralisk"),
@@ -422,7 +441,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 5,
 						Hitpoints = 80,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("hydraliskden") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("hydraliskden") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [1, 2, 3]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("lurker"),
@@ -433,7 +454,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 26,
 						Hitpoints = 195,
 						Speed = 10,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [2, 4, 6]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("ultralisk"),
@@ -444,7 +467,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 30,
 						Hitpoints = 450,
 						Speed = 10,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("ultraliskcavern") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("ultraliskcavern") },
+						AttackBonuses = [4, 8, 12],
+						DefenseBonuses = [3, 6, 9]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("mutalisk"),
@@ -455,7 +480,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 26,
 						Hitpoints = 120,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [2, 4, 6]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("guardian"),
@@ -466,7 +493,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 35,
 						Hitpoints = 200,
 						Speed = 12,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") },
+						AttackBonuses = [4, 8, 12],
+						DefenseBonuses = [3, 6, 9]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("devourer"),
@@ -477,7 +506,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 30,
 						Hitpoints = 295,
 						Speed = 9,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [3, 6, 9]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("sunkencolony"),
@@ -489,7 +520,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Hitpoints = 180,
 						Speed = 0,
 						IsMobile = false,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [2, 4, 6]
 					},
 
 					// Protoss units
@@ -502,7 +535,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 1,
 						Hitpoints = 40,
 						Speed = 8,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("nexus") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("nexus") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [0, 0, 0]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("zealot"),
@@ -513,7 +548,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 6,
 						Hitpoints = 130,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("gateway") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("gateway") },
+						AttackBonuses = [1, 2, 3],
+						DefenseBonuses = [1, 2, 3]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("dragoon"),
@@ -524,7 +561,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 18,
 						Hitpoints = 180,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("cyberneticscore") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("cyberneticscore") },
+						AttackBonuses = [2, 4, 6],
+						DefenseBonuses = [2, 4, 6]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("archon"),
@@ -535,7 +574,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 42,
 						Hitpoints = 380,
 						Speed = 8,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [4, 8, 12]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("darktemplar"),
@@ -546,7 +587,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 30,
 						Hitpoints = 80,
 						Speed = 6,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("templararchives") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("templararchives") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [3, 6, 9]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("reaver"),
@@ -557,7 +600,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 0,
 						Hitpoints = 160,
 						Speed = 12,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("roboticsfacility") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("roboticsfacility") },
+						AttackBonuses = [5, 10, 15],
+						DefenseBonuses = [0, 0, 0]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("observer"),
@@ -568,7 +613,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 0,
 						Hitpoints = 20,
 						Speed = 4,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("observatory") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("observatory") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [0, 0, 0]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("scout"),
@@ -579,7 +626,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 49,
 						Hitpoints = 310,
 						Speed = 6,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("stargate") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("stargate") },
+						AttackBonuses = [3, 6, 9],
+						DefenseBonuses = [4, 8, 12]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("carrier"),
@@ -590,7 +639,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 55,
 						Hitpoints = 600,
 						Speed = 12,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("stargate") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("stargate") },
+						AttackBonuses = [5, 10, 15],
+						DefenseBonuses = [4, 8, 12]
 					},
 					new UnitDef {
 						Id = Id.UnitDef("photoncannon"),
@@ -602,7 +653,9 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Hitpoints = 200,
 						Speed = 0,
 						IsMobile = false,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [2, 4, 6]
 					}
 				}
 			};

--- a/src/BrowserGameEngine.GameDefinition/UnitDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/UnitDef.cs
@@ -15,6 +15,10 @@ namespace BrowserGameEngine.GameDefinition {
 		public int Speed { get; init; }
 		public bool IsMobile { get; init; } = true;
 		public List<AssetDefId> Prerequisites { get; init; } = new List<AssetDefId>();
+		/// <summary>Attack bonus per upgrade level (index 0 = level 1, 1 = level 2, 2 = level 3).</summary>
+		public int[] AttackBonuses { get; init; } = new int[3];
+		/// <summary>Defense bonus per upgrade level (index 0 = level 1, 1 = level 2, 2 = level 3).</summary>
+		public int[] DefenseBonuses { get; init; } = new int[3];
 
 		public override string ToString() => Id.Id;
 	}

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -12,6 +12,10 @@ namespace BrowserGameEngine.GameModel {
 		List<UnitImmutable> Units,
 		int MineralWorkers = 0,
 		int GasWorkers = 0,
-		IList<MessageImmutable>? Messages = null
+		IList<MessageImmutable>? Messages = null,
+		int AttackUpgradeLevel = 0,
+		int DefenseUpgradeLevel = 0,
+		int UpgradeResearchTimer = 0,
+		UpgradeType UpgradeBeingResearched = UpgradeType.None
 	);
 }

--- a/src/BrowserGameEngine.GameModel/UpgradeType.cs
+++ b/src/BrowserGameEngine.GameModel/UpgradeType.cs
@@ -1,0 +1,7 @@
+namespace BrowserGameEngine.GameModel {
+	public enum UpgradeType {
+		None,
+		Attack,
+		Defense
+	}
+}

--- a/src/BrowserGameEngine.Shared/UpgradesViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UpgradesViewModel.cs
@@ -1,0 +1,11 @@
+namespace BrowserGameEngine.Shared {
+	public class UpgradesViewModel {
+		public int AttackUpgradeLevel { get; set; }
+		public int DefenseUpgradeLevel { get; set; }
+		public int UpgradeResearchTimer { get; set; }
+		public string UpgradeBeingResearched { get; set; } = "None";
+		public int MaxUpgradeLevel { get; set; } = 3;
+		public CostViewModel? NextAttackUpgradeCost { get; set; }
+		public CostViewModel? NextDefenseUpgradeCost { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public AssetRepositoryWrite AssetRepositoryWrite { get; }
 		public UnitRepository UnitRepository { get; }
 		public IBattleBehavior BattleBehavior { get; }
+		public UpgradeRepository UpgradeRepository { get; }
 		public UnitRepositoryWrite UnitRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
@@ -49,7 +50,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			AssetRepositoryWrite = new AssetRepositoryWrite(LoggerFactory.CreateLogger<AssetRepositoryWrite>(), World, AssetRepository, ResourceRepository, ResourceRepositoryWrite, ActionQueueRepository, GameDef);
 			UnitRepository = new UnitRepository(World, GameDef, PlayerRepository, AssetRepository);
 			BattleBehavior = new BattleBehaviorScoOriginal(LoggerFactory.CreateLogger<IBattleBehavior>());
-			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior);
+			UpgradeRepository = new UpgradeRepository(World);
+			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -16,4 +16,5 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record HarvestResourceCommand(PlayerId PlayerId, string ResourceId, int Count) : ICommand;
 	public record AssignWorkersCommand(PlayerId PlayerId, int MineralWorkers, int GasWorkers) : ICommand;
 	public record ColonizeCommand(PlayerId PlayerId, int Amount) : ICommand;
+	public record ResearchUpgradeCommand(PlayerId PlayerId, UpgradeType UpgradeType) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeAlreadyMaxLevelException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeAlreadyMaxLevelException.cs
@@ -1,0 +1,14 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Runtime.Serialization;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	[Serializable]
+	public class UpgradeAlreadyMaxLevelException : Exception {
+		public UpgradeAlreadyMaxLevelException(UpgradeType upgradeType) : base($"Upgrade '{upgradeType}' is already at max level.") {
+		}
+
+		protected UpgradeAlreadyMaxLevelException(SerializationInfo info, StreamingContext context) : base(info, context) {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeResearchInProgressException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeResearchInProgressException.cs
@@ -1,0 +1,14 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Runtime.Serialization;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	[Serializable]
+	public class UpgradeResearchInProgressException : Exception {
+		public UpgradeResearchInProgressException(UpgradeType upgradeBeingResearched) : base($"Research already in progress: '{upgradeBeingResearched}'.") {
+		}
+
+		protected UpgradeResearchInProgressException(SerializationInfo info, StreamingContext context) : base(info, context) {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -14,6 +14,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int MineralWorkers { get; set; }
 		public int GasWorkers { get; set; }
 		public List<Message> Messages { get; set; } = new List<Message>();
+		public int AttackUpgradeLevel { get; set; }
+		public int DefenseUpgradeLevel { get; set; }
+		public int UpgradeResearchTimer { get; set; }
+		public UpgradeType UpgradeBeingResearched { get; set; }
 	}
 
 	internal static class PlayerStateExtensions {
@@ -26,7 +30,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Units: playerState.Units.Select(x => x.ToImmutable()).ToList(),
 				MineralWorkers: playerState.MineralWorkers,
 				GasWorkers: playerState.GasWorkers,
-				Messages: playerState.Messages.Select(x => x.ToImmutable()).ToList()
+				Messages: playerState.Messages.Select(x => x.ToImmutable()).ToList(),
+				AttackUpgradeLevel: playerState.AttackUpgradeLevel,
+				DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
+				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
+				UpgradeBeingResearched: playerState.UpgradeBeingResearched
 			);
 		}
 
@@ -39,8 +47,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Units = playerStateImmutable.Units.Select(x => x.ToMutable()).ToList(),
 				MineralWorkers = playerStateImmutable.MineralWorkers,
 				GasWorkers = playerStateImmutable.GasWorkers,
-				Messages = (playerStateImmutable.Messages ?? new List<MessageImmutable>()).Select(x => x.ToMutable()).ToList()
-		};
+				Messages = (playerStateImmutable.Messages ?? new List<MessageImmutable>()).Select(x => x.ToMutable()).ToList(),
+				AttackUpgradeLevel = playerStateImmutable.AttackUpgradeLevel,
+				DefenseUpgradeLevel = playerStateImmutable.DefenseUpgradeLevel,
+				UpgradeResearchTimer = playerStateImmutable.UpgradeResearchTimer,
+				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched
+			};
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -31,11 +31,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MessageRepository>();
 			services.AddSingleton<MessageRepositoryWrite>();
 			services.AddSingleton<BattleReportGenerator>();
+			services.AddSingleton<UpgradeRepository>();
+			services.AddSingleton<UpgradeRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
 			services.AddSingleton<IGameTickModule, UnitReturn>();
 			services.AddSingleton<IGameTickModule, ResourceGrowthSco>();
+			services.AddSingleton<IGameTickModule, UpgradeTimer>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/UpgradeTimer.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/UpgradeTimer.cs
@@ -1,0 +1,25 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class UpgradeTimer : IGameTickModule {
+		public string Name => "upgradetimer:1";
+		private readonly UpgradeRepositoryWrite upgradeRepositoryWrite;
+
+		public UpgradeTimer(UpgradeRepositoryWrite upgradeRepositoryWrite) {
+			this.upgradeRepositoryWrite = upgradeRepositoryWrite;
+		}
+
+		public void SetProperty(string name, string value) {
+			switch (name) {
+				default:
+					throw new InvalidGameDefException($"Property '{name}' not valid for GameTickModule '{this.Name}'.");
+			}
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			upgradeRepositoryWrite.ProcessResearchTimer(playerId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -20,6 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly PlayerRepository playerRepository;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly IBattleBehavior battleBehavior;
+		private readonly UpgradeRepository upgradeRepository;
 
 		public UnitRepositoryWrite(ILogger<UnitRepositoryWrite> logger
 				, WorldState world
@@ -30,6 +31,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, PlayerRepository playerRepository
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, IBattleBehavior battleBehavior
+				, UpgradeRepository upgradeRepository
 			) {
 			this.logger = logger;
 			this.world = world;
@@ -40,6 +42,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.playerRepository = playerRepository;
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.battleBehavior = battleBehavior;
+			this.upgradeRepository = upgradeRepository;
 		}
 
 		private List<Unit> Units(PlayerId playerId) => world.GetPlayer(playerId).State.Units;
@@ -199,8 +202,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public BattleResult Attack(PlayerId playerId, PlayerId enemyPlayerId) {
-			var attackingUnits = ToBattleUnits(unitRepository.GetAttackingUnits(playerId, enemyPlayerId)).ToList();
-			var defendingUnits = ToBattleUnits(unitRepository.GetDefendingEnemyUnits(playerId, enemyPlayerId)).ToList();
+			int attackerAttackLevel = upgradeRepository.GetAttackUpgradeLevel(playerId);
+			int defenderDefenseLevel = upgradeRepository.GetDefenseUpgradeLevel(enemyPlayerId);
+			var attackingUnits = ToBattleUnits(unitRepository.GetAttackingUnits(playerId, enemyPlayerId), attackerAttackLevel, 0).ToList();
+			var defendingUnits = ToBattleUnits(unitRepository.GetDefendingEnemyUnits(playerId, enemyPlayerId), 0, defenderDefenseLevel).ToList();
 
 			BattleResult battleResult = new BattleResult {
 				Attacker = playerId,
@@ -244,13 +249,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 			return string.Join(", ", attackingUnits.Select(x => $"({x.Count} × {x.UnitDefId})"));
 		}
 
-		private IEnumerable<BtlUnit> ToBattleUnits(IEnumerable<UnitImmutable> attackingUnits) {
-			return attackingUnits.Select(x => new BtlUnit {
-				UnitDefId = x.UnitDefId,
-				Count = x.Count,
-				Attack = gameDef.GetUnitDef(x.UnitDefId).Attack,
-				Defense = gameDef.GetUnitDef(x.UnitDefId).Defense,
-				Hitpoints = gameDef.GetUnitDef(x.UnitDefId).Hitpoints,
+		private IEnumerable<BtlUnit> ToBattleUnits(IEnumerable<UnitImmutable> units, int attackLevel, int defenseLevel) {
+			return units.Select(x => {
+				var unitDef = gameDef.GetUnitDef(x.UnitDefId);
+				int attackBonus = attackLevel > 0 ? unitDef.AttackBonuses[attackLevel - 1] : 0;
+				int defenseBonus = defenseLevel > 0 ? unitDef.DefenseBonuses[defenseLevel - 1] : 0;
+				return new BtlUnit {
+					UnitDefId = x.UnitDefId,
+					Count = x.Count,
+					Attack = unitDef.Attack + attackBonus,
+					Defense = unitDef.Defense + defenseBonus,
+					Hitpoints = unitDef.Hitpoints,
+				};
 			});
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepository.cs
@@ -1,0 +1,17 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class UpgradeRepository {
+		private readonly WorldState world;
+
+		public UpgradeRepository(WorldState world) {
+			this.world = world;
+		}
+
+		public int GetAttackUpgradeLevel(PlayerId playerId) => world.GetPlayer(playerId).State.AttackUpgradeLevel;
+		public int GetDefenseUpgradeLevel(PlayerId playerId) => world.GetPlayer(playerId).State.DefenseUpgradeLevel;
+		public int GetUpgradeResearchTimer(PlayerId playerId) => world.GetPlayer(playerId).State.UpgradeResearchTimer;
+		public UpgradeType GetUpgradeBeingResearched(PlayerId playerId) => world.GetPlayer(playerId).State.UpgradeBeingResearched;
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
@@ -1,0 +1,82 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class UpgradeRepositoryWrite {
+		private const int MaxUpgradeLevel = 3;
+		private const int ResearchTimerTicks = 10;
+
+		private readonly Lock _lock = new();
+		private readonly WorldState world;
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+
+		private static readonly Cost[] UpgradeCosts = [
+			CostHelper.Create(("minerals", 150), ("gas", 100)),  // level 1
+			CostHelper.Create(("minerals", 250), ("gas", 150)),  // level 2
+			CostHelper.Create(("minerals", 400), ("gas", 200)),  // level 3
+		];
+
+		public UpgradeRepositoryWrite(
+			WorldState world,
+			ResourceRepository resourceRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite) {
+			this.world = world;
+			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+		}
+
+		public Cost GetUpgradeCost(int nextLevel) => UpgradeCosts[nextLevel - 1];
+
+		public void ResearchUpgrade(ResearchUpgradeCommand command) {
+			lock (_lock) {
+				var state = world.GetPlayer(command.PlayerId).State;
+
+				if (state.UpgradeBeingResearched != UpgradeType.None) {
+					throw new UpgradeResearchInProgressException(state.UpgradeBeingResearched);
+				}
+
+				int currentLevel = command.UpgradeType == UpgradeType.Attack
+					? state.AttackUpgradeLevel
+					: state.DefenseUpgradeLevel;
+
+				if (currentLevel >= MaxUpgradeLevel) {
+					throw new UpgradeAlreadyMaxLevelException(command.UpgradeType);
+				}
+
+				var cost = GetUpgradeCost(currentLevel + 1);
+				if (!resourceRepository.CanAfford(command.PlayerId, cost)) {
+					throw new CannotAffordException(cost);
+				}
+
+				resourceRepositoryWrite.DeductCost(command.PlayerId, cost);
+				state.UpgradeBeingResearched = command.UpgradeType;
+				state.UpgradeResearchTimer = ResearchTimerTicks;
+			}
+		}
+
+		public void ProcessResearchTimer(PlayerId playerId) {
+			lock (_lock) {
+				var state = world.GetPlayer(playerId).State;
+				if (state.UpgradeBeingResearched == UpgradeType.None || state.UpgradeResearchTimer <= 0) {
+					return;
+				}
+
+				state.UpgradeResearchTimer--;
+				if (state.UpgradeResearchTimer == 0) {
+					if (state.UpgradeBeingResearched == UpgradeType.Attack) {
+						state.AttackUpgradeLevel++;
+					} else if (state.UpgradeBeingResearched == UpgradeType.Defense) {
+						state.DefenseUpgradeLevel++;
+					}
+					state.UpgradeBeingResearched = UpgradeType.None;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `AttackUpgradeLevel` (0–3) and `DefenseUpgradeLevel` (0–3) to player state, along with `UpgradeResearchTimer` and `UpgradeBeingResearched` (Attack/Defense/None)
- `ResearchUpgradeCommand` + `UpgradeRepositoryWrite` handles validation (max level, no concurrent research, resource cost deduction at tiered costs)
- `UpgradeTimerModule` (`IGameTickModule`, name `upgradetimer:1`) decrements research timer each tick and applies level on completion
- Per-unit `AttackBonuses[3]` and `DefenseBonuses[3]` added to `UnitDef`; all SCO units populated with tiered values
- `UnitRepositoryWrite.ToBattleUnits` applies attacker's attack bonus and defender's defense bonus to combat stats
- `UpgradesController` (GET + POST `/api/upgrades/research`) and `Upgrades.razor` Blazor page at `/upgrades` with nav link

## Test plan

- [x] All 64 existing tests pass
- [ ] Log in, navigate to `/upgrades` — verify level 0/0 shown with costs
- [ ] Initiate attack upgrade research — timer counts down over ticks, level increments to 1
- [ ] Verify concurrent research blocked (error shown)
- [ ] Verify max level 3 blocks further research
- [ ] Verify insufficient resources returns error
- [ ] Start a battle after attacker hits level 1 — confirm combat outcomes shift in attacker's favor