### PR TITLE
Add player management UI with API key management (BGE-68)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -1,0 +1,122 @@
+@page "/players"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+@inject IJSRuntime JS
+
+<h1>My Players</h1>
+
+@if (players == null) {
+	<p><em>Loading...</em></p>
+} else {
+	<h2>Create Player</h2>
+	<EditForm Model="@createModel" OnValidSubmit="HandleCreatePlayer">
+		<DataAnnotationsValidator />
+		<ValidationSummary />
+		<InputText id="PlayerName" @bind-Value="createModel.PlayerName" placeholder="Player name" />
+		<button type="submit">Create</button>
+	</EditForm>
+	@if (!string.IsNullOrEmpty(createError)) {
+		<p style="color:red">@createError</p>
+	}
+
+	<h2>Player List</h2>
+	@if (players.Count == 0) {
+		<p>No players yet.</p>
+	} else {
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>ID</th>
+					<th>API Key</th>
+					<th>Actions</th>
+				</tr>
+			</thead>
+			<tbody>
+				@foreach (var player in players) {
+					<tr>
+						<td>@player.PlayerName</td>
+						<td>@player.PlayerId</td>
+						<td>@(player.HasApiKey ? "Key active" : "No key")</td>
+						<td>
+							@if (players.Count > 1) {
+								<button @onclick="() => HandleSwitchPlayer(player.PlayerId)">Play as this player</button>
+															}
+							@if (player.HasApiKey) {
+								<button @onclick="() => HandleRevokeKey(player.PlayerId)">Revoke API Key</button>
+							} else {
+								<button @onclick="() => HandleGenerateKey(player.PlayerId)">Generate API Key</button>
+							}
+														<button disabled title="Not yet available">Delete</button>
+						</td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+}
+
+@if (!string.IsNullOrEmpty(newApiKey)) {
+	<div style="border:1px solid #ccc; padding:1em; margin-top:1em;">
+		<strong>New API Key (shown once — copy now):</strong><br />
+		<code>@newApiKey</code>
+		<br />
+		<button @onclick="() => CopyToClipboard(newApiKey)">Copy</button>
+		<button @onclick="() => newApiKey = null">Dismiss</button>
+	</div>
+}
+
+@code {
+	private List<PlayerSummaryViewModel>? players;
+	private CreatePlayerForUserViewModel createModel = new();
+	private string? createError;
+	private string? newApiKey;
+
+	protected override async Task OnInitializedAsync() {
+		await LoadPlayers();
+	}
+
+	private async Task LoadPlayers() {
+		var result = await Http.GetFromJsonAsync<PlayerListViewModel>("api/players");
+		players = result?.Players ?? new();
+	}
+
+	private async Task HandleCreatePlayer() {
+		createError = null;
+		var response = await Http.PostAsJsonAsync("api/players", createModel);
+		if (response.IsSuccessStatusCode) {
+			createModel = new();
+			await LoadPlayers();
+		} else {
+			createError = "Failed to create player.";
+		}
+	}
+
+	private async Task HandleGenerateKey(string playerId) {
+		var response = await Http.PostAsJsonAsync($"api/players/{playerId}/apikey", new { });
+		if (response.IsSuccessStatusCode) {
+			var keyVm = await response.Content.ReadFromJsonAsync<ApiKeyViewModel>();
+			newApiKey = keyVm?.ApiKey;
+			await LoadPlayers();
+		}
+	}
+
+	private async Task HandleRevokeKey(string playerId) {
+		var response = await Http.DeleteAsync($"api/players/{playerId}/apikey");
+		if (response.IsSuccessStatusCode) {
+			await LoadPlayers();
+		}
+	}
+
+	private async Task HandleSwitchPlayer(string playerId) {
+		var response = await Http.PostAsJsonAsync("api/playerprofile/switch", new SwitchPlayerViewModel { PlayerId = playerId });
+		if (response.IsSuccessStatusCode) {
+			Nav.NavigateTo("/", forceLoad: true);
+		}
+	}
+
+	private async Task CopyToClipboard(string text) {
+		await JS.InvokeVoidAsync("navigator.clipboard.writeText", text);
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -33,6 +33,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="players">
+                <span class="oi oi-people" aria-hidden="true"></span> My Players
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="profile">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Profile
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -86,5 +86,22 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			currentUserContext.Activate(playerId);
 			return Ok();
 		}
+
+		[HttpPost]
+		[Route("switch")]
+		public ActionResult SwitchPlayer(SwitchPlayerViewModel model) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var pid = PlayerIdFactory.Create(model.PlayerId);
+			var players = userRepository.GetPlayersForUser(currentUserContext.UserId).ToList();
+			if (!players.Any(p => p.PlayerId == pid)) return Forbid();
+
+			Response.Cookies.Append("BGE.SelectedPlayer", model.PlayerId, new Microsoft.AspNetCore.Http.CookieOptions {
+				HttpOnly = true,
+				Secure = true,
+				SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax,
+				MaxAge = TimeSpan.FromDays(30)
+			});
+			return Ok();
+		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -48,7 +48,15 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 					var players = userRepository.GetPlayersForUser(user.UserId).ToList();
 					if (players.Count > 0) {
 						var selectedPlayerId = players[0].PlayerId;
-						// Support X-Player-Id header for multi-player accounts
+						// Support BGE.SelectedPlayer cookie for multi-player accounts
+						var selectedPlayerCookie = context.Request.Cookies["BGE.SelectedPlayer"];
+						if (selectedPlayerCookie != null) {
+							var cookieId = PlayerIdFactory.Create(selectedPlayerCookie);
+							if (players.Any(p => p.PlayerId == cookieId)) {
+								selectedPlayerId = cookieId;
+							}
+						}
+						// Support X-Player-Id header (takes precedence over cookie)
 						var playerIdHeader = context.Request.Headers["X-Player-Id"].FirstOrDefault();
 						if (playerIdHeader != null) {
 							var requestedId = PlayerIdFactory.Create(playerIdHeader);

--- a/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
+++ b/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
@@ -18,4 +18,8 @@ namespace BrowserGameEngine.Shared {
 	public class ApiKeyViewModel {
 		public string ApiKey { get; set; } = "";
 	}
+
+	public class SwitchPlayerViewModel {
+		public string PlayerId { get; set; } = "";
+	}
 }


### PR DESCRIPTION
## Summary
- New `Players.razor` page at `/players`: lists players, create player form, generate/revoke API keys per player, shows newly generated key once in a dismissable panel with a copy button
- `POST api/playerprofile/switch` endpoint using a `BGE.SelectedPlayer` cookie for multi-player session switching; `CurrentUserMiddleware` respects this cookie when selecting the active player
- `SwitchPlayerViewModel` added to Shared
- "My Players" nav link added to NavMenu
- Delete player button is shown as disabled with "Not yet available" tooltip (pending BGE-69)

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes
- [ ] Navigate to `/players` — player list loads
- [ ] Create a player — appears in list
- [ ] Generate API key — raw key shown once, can be copied; refreshing shows "Key active"
- [ ] Revoke API key — shows "No key" after refresh
- [ ] With multiple players, "Play as this player" button appears; clicking it switches active player and redirects to home
- [ ] Delete button is disabled/grayed out

Closes BGE-68