### PR TITLE
Add static defense structures: IsMobile flag + Missile Turret (BGE-24)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -59,6 +59,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				return BadRequest(e.Message);
 			} catch (UnitNotFoundException e) {
 				return BadRequest(e.Message);
+			} catch (UnitImmobileException e) {
+				return BadRequest(e.Message);
 			} catch (UnitNotHomeException e) {
 				return BadRequest(e.Message);
 			}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -377,6 +377,18 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Speed = 11,
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("spaceport") }
 					},
+					new UnitDef {
+						Id = Id.UnitDef("missileturret"),
+						Name = "Raketenturm",
+						PlayerTypeRestriction = Id.PlayerType("terran"),
+						Cost = CostHelper.Create(("minerals", 100)),
+						Attack = 0,
+						Defense = 12,
+						Hitpoints = 135,
+						Speed = 0,
+						IsMobile = false,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("commandcenter"), Id.AssetDef("academy") }
+					},
 
 					// Zerg units
 					new UnitDef {
@@ -476,6 +488,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 24,
 						Hitpoints = 180,
 						Speed = 0,
+						IsMobile = false,
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") }
 					},
 
@@ -588,6 +601,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 20,
 						Hitpoints = 200,
 						Speed = 0,
+						IsMobile = false,
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") }
 					}
 				}

--- a/src/BrowserGameEngine.GameDefinition/UnitDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/UnitDef.cs
@@ -13,6 +13,7 @@ namespace BrowserGameEngine.GameDefinition {
 		public int Defense { get; init; }
 		public int Hitpoints { get; init; }
 		public int Speed { get; init; }
+		public bool IsMobile { get; init; } = true;
 		public List<AssetDefId> Prerequisites { get; init; } = new List<AssetDefId>();
 
 		public override string ToString() => Id.Id;

--- a/src/BrowserGameEngine.Shared/UnitDefinitionViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UnitDefinitionViewModel.cs
@@ -14,6 +14,7 @@ namespace BrowserGameEngine.Shared {
 		public int Defense { get; set; }
 		public int Hitpoints { get; set; }
 		public int Speed { get; set; }
+		public bool IsMobile { get; set; }
 		public List<string> Prerequisites { get; set; }
 		public bool PrerequisitesMet { get; set; }
 
@@ -27,6 +28,7 @@ namespace BrowserGameEngine.Shared {
 				Defense = unitDefinition.Defense,
 				Hitpoints = unitDefinition.Hitpoints,
 				Speed = unitDefinition.Speed,
+				IsMobile = unitDefinition.IsMobile,
 				Prerequisites = unitDefinition.Prerequisites.Select(x => x.Id).ToList(),
 				PrerequisitesMet = prerequisitesMet
 			};

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
@@ -118,6 +118,18 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Hitpoints = 60,
 						Speed = 7,
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("asset3"), Id.AssetDef("asset2"), Id.AssetDef("asset1") }
+					},
+					new UnitDef {
+						Id = Id.UnitDef("staticunit1"),
+						Name = "staticunit1",
+						PlayerTypeRestriction = Id.PlayerType("type1"),
+						Cost = CostHelper.Create(("res1", 100)),
+						Attack = 0,
+						Defense = 10,
+						Hitpoints = 100,
+						Speed = 0,
+						IsMobile = false,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("asset1") }
 					}
 				}
 			};

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UnitsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UnitsTest.cs
@@ -65,7 +65,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var g = new TestGame();
 			Assert.Collection(g.GameDef.GetUnitsForAsset(Id.AssetDef("asset1")).Select(x => x.Id.Id),
 				item => Assert.Equal("unit1", item),
-				item => Assert.Equal("unit2", item)
+				item => Assert.Equal("unit2", item),
+				item => Assert.Equal("staticunit1", item)
 			);
 			Assert.Collection(g.GameDef.GetUnitsForAsset(Id.AssetDef("asset2")).Select(x => x.Id.Id),
 				item => Assert.Equal("unit3", item)
@@ -174,6 +175,34 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				g.UnitRepositoryWrite.SplitUnit(new Commands.SplitUnitCommand(g.Player1,
 					g.UnitRepository.GetByUnitDefId(g.Player1, Id.UnitDef("unit2")).Single().UnitId, 999))
 			);
+		}
+
+		[Fact]
+		public void SendUnit_WithImmobileUnit_Throws() {
+			var g = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			g.UnitRepositoryWrite.GrantUnits(player1, Id.UnitDef("staticunit1"), 5);
+			var staticUnit = g.UnitRepository.GetByUnitDefId(player1, Id.UnitDef("staticunit1")).Single();
+
+			Assert.Throws<UnitImmobileException>(() =>
+				g.UnitRepositoryWrite.SendUnit(new Commands.SendUnitCommand(player1, staticUnit.UnitId, player2))
+			);
+		}
+
+		[Fact]
+		public void SendUnit_WithMobileUnit_Succeeds() {
+			var g = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			var mobileUnit = g.UnitRepository.GetByUnitDefId(player1, Id.UnitDef("unit2")).Single();
+
+			g.UnitRepositoryWrite.SendUnit(new Commands.SendUnitCommand(player1, mobileUnit.UnitId, player2));
+
+			var sentUnit = g.UnitRepository.GetByUnitDefId(player1, Id.UnitDef("unit2")).Single();
+			Assert.Equal(player2, sentUnit.Position);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitImmobileException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitImmobileException.cs
@@ -1,0 +1,15 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System;
+using System.Runtime.Serialization;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	[Serializable]
+	public class UnitImmobileException : Exception {
+		public UnitImmobileException(UnitId unitId) : base($"Unit '{unitId}' is immobile and cannot be sent to attack.") {
+		}
+
+		protected UnitImmobileException(SerializationInfo info, StreamingContext context) : base(info, context) {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -118,6 +118,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			lock (_lock) {
 				var unit = Unit(command.PlayerId, command.UnitId);
 				if (unit == null) throw new UnitNotFoundException(command.UnitId);
+				if (!gameDef.GetUnitDef(unit.UnitDefId)!.IsMobile) throw new UnitImmobileException(command.UnitId);
 				if (!unit.IsHome()) throw new UnitNotHomeException(command.UnitId, "Cannot move unit.");
 				world.ValidatePlayer(command.EnemyPlayerId);
 				if (!playerRepository.IsPlayerAttackable(command.PlayerId, command.EnemyPlayerId)) throw new PlayerNotAttackableException(command.EnemyPlayerId);


### PR DESCRIPTION
## Summary

- Adds `IsMobile` bool (default `true`) to `UnitDef` — explicit flag for stationary defense structures
- Adds Terran Missile Turret (`missileturret` / Raketenturm): 100 min, 0 atk, 12 def, 135 HP, requires Command Center + Academy
- Marks existing Sunken Colony and Photon Cannon with `IsMobile = false`
- Enforces in `SendUnit`: throws `UnitImmobileException` (HTTP 400) if attempting to send a static unit
- Propagates `IsMobile` to `UnitDefinitionViewModel` for the client
- No combat changes needed — static units are always home and auto-participate as defenders via `GetDefendingEnemyUnits`

## Test plan

- [ ] All 66 existing tests pass
- [ ] `SendUnit_WithImmobileUnit_Throws` — sending a static unit throws `UnitImmobileException`
- [ ] `SendUnit_WithMobileUnit_Succeeds` — sending a mobile unit still works correctly
- [ ] Build passes with `dotnet build --configuration Release`

Closes BGE-24