### PR TITLE
Implement player deletion (BGE-70)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -72,9 +72,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var pid = PlayerIdFactory.Create(playerId);
 			var player = playerRepository.Get(pid);
 			if (player.UserId != currentUserContext.UserId) return Forbid();
-			// Soft-delete: revoke API key and mark player as deleted is out of scope.
-			// For now return not implemented.
-			return StatusCode(501, "Player deletion not yet implemented");
+			if (currentUserContext.PlayerId == pid) return Conflict("Cannot delete the player you are currently playing as.");
+			playerRepositoryWrite.DeletePlayer(pid);
+			return NoContent();
 		}
 
 		[HttpPost("{playerId}/apikey")]

--- a/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
@@ -1,9 +1,46 @@
 using BrowserGameEngine.GameModel;
+using System;
 using System.Linq;
 using Xunit;
 
 namespace BrowserGameEngine.StatefulGameServer.Test {
 	public class PlayerRepositoryTest {
+
+		[Fact]
+		public void DeletePlayer_RemovesPlayerFromWorld() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+			var userRepository = new UserRepository(game.World);
+
+			game.PlayerRepositoryWrite.DeletePlayer(playerId);
+
+			Assert.False(game.PlayerRepository.Exists(playerId));
+		}
+
+		[Fact]
+		public void DeletePlayer_NoLongerAppearsInGetPlayersForUser() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+			var userId = "testuser";
+			// Assign a userId to the player via creating a fresh player
+			game.PlayerRepositoryWrite.CreatePlayer(PlayerIdFactory.Create("newplayer"), userId);
+			var userRepository = new UserRepository(game.World);
+
+			game.PlayerRepositoryWrite.DeletePlayer(PlayerIdFactory.Create("newplayer"));
+
+			var players = userRepository.GetPlayersForUser(userId).ToList();
+			Assert.DoesNotContain(players, p => p.PlayerId == PlayerIdFactory.Create("newplayer"));
+		}
+
+		[Fact]
+		public void DeletePlayer_GetThrowsAfterDeletion() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+
+			game.PlayerRepositoryWrite.DeletePlayer(playerId);
+
+			Assert.ThrowsAny<Exception>(() => game.PlayerRepository.Get(playerId));
+		}
 
 		[Fact]
 		public void IsPlayerAttackable_SamePlayer_ReturnsFalse() {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -108,5 +108,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 				};
 			}
 		}
+
+		public void DeletePlayer(PlayerId playerId) {
+			lock (_lock) {
+				if (!world.PlayerExists(playerId)) return;
+				var player = world.Players[playerId];
+				player.ApiKeyHash = null;
+				world.Players.Remove(playerId);
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `PlayerRepositoryWrite.DeletePlayer`: clears `ApiKeyHash` then removes the player from `WorldState.Players` under lock
- Update `PlayerManagementController.DeletePlayer`: returns 409 if the player is the caller's active session player, otherwise calls `DeletePlayer` and returns 204
- Add three tests: removal verified via `Exists`, exclusion from `GetPlayersForUser`, and `Get` throwing after deletion

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (67/67)
- [x] `DELETE /api/players/{id}` returns 204 on valid owned player
- [x] `DELETE /api/players/{id}` returns 409 if deleting the active session player

Closes BGE-70