### PR TITLE
Add colonization command (BGE-28)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -10,6 +10,21 @@
 
     <_WorkerAssignment />
 
+    <div class="bge-colonize mt-3">
+        <h3>Kolonisieren</h3>
+        @if (resources != null) {
+            <div>Kosten: @resources.ColonizationCostPerLand Mineralien pro Land</div>
+            <div>
+                <input type="number" min="1" max="24" @bind="colonizeAmount" class="form-control d-inline-block" style="width:100px" />
+                <span class="ms-2">= @(colonizeAmount * resources.ColonizationCostPerLand) Mineralien</span>
+                <button class="btn btn-success ms-2" @onclick="Colonize">Kolonisieren</button>
+            </div>
+            @if (!string.IsNullOrEmpty(colonizeError)) {
+                <span class="error">@colonizeError</span>
+            }
+        }
+    </div>
+
     @if (model == null) {
         <p><em>Lade...</em></p>
     } else {
@@ -52,9 +67,11 @@
 
 @code {
 
-
     private AssetsViewModel? model;
+    private PlayerResourcesViewModel? resources;
     private string? lastError;
+    private string? colonizeError;
+    private int colonizeAmount = 1;
 
     protected override async Task OnInitializedAsync() {
         await Update();
@@ -70,8 +87,19 @@
         }
     }
 
+    private async Task Colonize() {
+        colonizeError = null;
+        var response = await Http.PostAsJsonAsync($"api/colonize/colonize?amount={colonizeAmount}", "");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            colonizeError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
     private async Task Update() {
         model = await Http.GetFromJsonAsync<AssetsViewModel>("api/assets");
+        resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
     }
 
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
@@ -1,0 +1,43 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}")]
+	public class ColonizeController : ControllerBase {
+		private readonly ILogger<ColonizeController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly ColonizeRepositoryWrite colonizeRepositoryWrite;
+
+		public ColonizeController(ILogger<ColonizeController> logger
+				, CurrentUserContext currentUserContext
+				, ColonizeRepositoryWrite colonizeRepositoryWrite
+			) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.colonizeRepositoryWrite = colonizeRepositoryWrite;
+		}
+
+		[HttpPost]
+		public ActionResult Colonize([FromQuery] int amount) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				colonizeRepositoryWrite.Colonize(new ColonizeCommand(currentUserContext.PlayerId, amount));
+				return Ok();
+			} catch (ArgumentOutOfRangeException e) {
+				return BadRequest(e.Message);
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
@@ -33,9 +33,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		[HttpGet]
 		public async Task<PlayerResourcesViewModel> Get() {
+			var playerId = currentUserContext.PlayerId;
+			var currentLand = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
 			return new PlayerResourcesViewModel {
-				PrimaryResource = CostViewModel.Create(resourceRepository.GetPrimaryResource(currentUserContext.PlayerId)),
-				SecondaryResources = CostViewModel.Create(resourceRepository.GetSecondaryResources(currentUserContext.PlayerId))
+				PrimaryResource = CostViewModel.Create(resourceRepository.GetPrimaryResource(playerId)),
+				SecondaryResources = CostViewModel.Create(resourceRepository.GetSecondaryResources(playerId)),
+				ColonizationCostPerLand = ColonizeRepositoryWrite.GetCostPerLand(currentLand)
 			};
 		}
 	}

--- a/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
@@ -8,5 +8,6 @@ namespace BrowserGameEngine.Shared {
 	public record PlayerResourcesViewModel {
 		public CostViewModel PrimaryResource { get; init; }
 		public CostViewModel SecondaryResources { get; init; }
+		public decimal ColonizationCostPerLand { get; init; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -15,4 +15,5 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record ChangePlayerNameCommand(PlayerId PlayerId, string NewName) : ICommand;
 	public record HarvestResourceCommand(PlayerId PlayerId, string ResourceId, int Count) : ICommand;
 	public record AssignWorkersCommand(PlayerId PlayerId, int MineralWorkers, int GasWorkers) : ICommand;
+	public record ColonizeCommand(PlayerId PlayerId, int Amount) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<AssetRepositoryWrite>();
 			services.AddSingleton<UnitRepository>();
 			services.AddSingleton<UnitRepositoryWrite>();
+			services.AddSingleton<ColonizeRepositoryWrite>();
 			services.AddSingleton<ActionQueueRepository>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ColonizeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ColonizeRepositoryWrite.cs
@@ -1,0 +1,38 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class ColonizeRepositoryWrite {
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+
+		public ColonizeRepositoryWrite(
+			ResourceRepository resourceRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite
+		) {
+			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+		}
+
+		public static decimal GetCostPerLand(decimal currentLand) {
+			return Math.Max(1, currentLand / 4);
+		}
+
+		public void Colonize(ColonizeCommand command) {
+			if (command.Amount < 1 || command.Amount > 24) {
+				throw new ArgumentOutOfRangeException(nameof(command.Amount), "Colonization amount must be between 1 and 24.");
+			}
+
+			var landId = Id.ResDef("land");
+			var mineralsId = Id.ResDef("minerals");
+			var currentLand = resourceRepository.GetAmount(command.PlayerId, landId);
+			var costPerLand = GetCostPerLand(currentLand);
+			var totalCost = command.Amount * costPerLand;
+
+			resourceRepositoryWrite.DeductCost(command.PlayerId, mineralsId, totalCost);
+			resourceRepositoryWrite.AddResources(command.PlayerId, landId, command.Amount);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ColonizeCommand` and `ColonizeRepositoryWrite` — players can spend minerals to acquire land directly
- Cost formula: `max(1, land/4)` minerals per land unit, capped at 24 land per action
- New `POST /api/colonize/colonize?amount=N` endpoint with validation and error handling
- `ColonizationCostPerLand` added to `PlayerResourcesViewModel` for cost preview
- Colonize UI section added to the Base page with amount input, live cost preview, and error display

## Test plan

- [ ] Build passes (`dotnet build`)
- [ ] All 64 tests pass (`dotnet test`)
- [ ] Colonize with valid amount (1-24) deducts correct minerals and adds land
- [ ] Colonize with amount < 1 or > 24 returns 400 Bad Request
- [ ] Colonize with insufficient minerals returns 400 Bad Request (CannotAffordException)
- [ ] Cost preview on Base page updates correctly as player's land grows