### PR TITLE
BGE-29: Attack restrictions enforcement with reason codes

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
@@ -73,5 +73,49 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			Assert.DoesNotContain(attackable, p => p.PlayerId == player2);
 		}
+
+		[Fact]
+		public void GetIneligibilityReason_SamePlayer_ReturnsSelfAttack() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+
+			Assert.Equal(AttackIneligibilityReason.SelfAttack, game.PlayerRepository.GetIneligibilityReason(player1, player1));
+		}
+
+		[Fact]
+		public void GetIneligibilityReason_DefenderBelowMinScore_ReturnsLandTooSmall() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Give player1 a much higher score so player2 falls below 50% threshold
+			game.ResourceRepositoryWrite.AddResources(player1, Id.ResDef("res1"), 9000); // player1 score = 10000
+			// player2 score = 1000, which is < 10000 * 0.5 = 5000
+
+			Assert.Equal(AttackIneligibilityReason.LandTooSmall, game.PlayerRepository.GetIneligibilityReason(player1, player2));
+		}
+
+		[Fact]
+		public void GetIneligibilityReason_EqualScore_ReturnsNull() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Both players start with equal scores
+			Assert.Null(game.PlayerRepository.GetIneligibilityReason(player1, player2));
+		}
+
+		[Fact]
+		public void GetIneligibilityReason_DefenderAboveMinScore_ReturnsNull() {
+			var game = new TestGame(playerCount: 2);
+			var player1 = PlayerIdFactory.Create("player0");
+			var player2 = PlayerIdFactory.Create("player1");
+
+			// Give player1 a slightly higher score
+			game.ResourceRepositoryWrite.AddResources(player1, Id.ResDef("res1"), 500); // player1 score = 1500
+			// player2 score = 1000, which is >= 1500 * 0.5 = 750
+
+			Assert.Null(game.PlayerRepository.GetIneligibilityReason(player1, player2));
+		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/AttackIneligibilityReason.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/AttackIneligibilityReason.cs
@@ -1,0 +1,9 @@
+namespace BrowserGameEngine.StatefulGameServer {
+	public enum AttackIneligibilityReason {
+		SelfAttack,
+		LandTooSmall,
+		AttackerProtected,  // BGE-30: attacker has active new-player protection
+		DefenderProtected,  // BGE-30: defender has active new-player protection
+		SameAlliance,       // BGE-33: both players are in the same alliance
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotAttackableException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotAttackableException.cs
@@ -6,10 +6,27 @@ using System.Runtime.Serialization;
 namespace BrowserGameEngine.StatefulGameServer {
 	[Serializable]
 	public class PlayerNotAttackableException : Exception {
+		public AttackIneligibilityReason? Reason { get; }
+
 		public PlayerNotAttackableException(PlayerId playerId) : base($"Cannot attack player '{playerId}'") {
 		}
 
+		public PlayerNotAttackableException(PlayerId playerId, AttackIneligibilityReason reason) : base(BuildMessage(playerId, reason)) {
+			Reason = reason;
+		}
+
 		protected PlayerNotAttackableException(SerializationInfo info, StreamingContext context) : base(info, context) {
+		}
+
+		private static string BuildMessage(PlayerId playerId, AttackIneligibilityReason reason) {
+			return reason switch {
+				AttackIneligibilityReason.SelfAttack => $"Cannot attack player '{playerId}': cannot attack yourself",
+				AttackIneligibilityReason.LandTooSmall => $"Cannot attack player '{playerId}': their land is less than 50% of yours",
+				AttackIneligibilityReason.AttackerProtected => $"Cannot attack player '{playerId}': you have active new-player protection",
+				AttackIneligibilityReason.DefenderProtected => $"Cannot attack player '{playerId}': they have active new-player protection",
+				AttackIneligibilityReason.SameAlliance => $"Cannot attack player '{playerId}': you are in the same alliance",
+				_ => $"Cannot attack player '{playerId}'",
+			};
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
@@ -31,12 +31,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public IEnumerable<PlayerImmutable> GetAttackablePlayers(PlayerId playerId) {
-			var playerScore = scoreRepository.GetScore(playerId);
-			var minScore = GetMinScore(playerScore);
 			return Players
-				.Where(x => scoreRepository.GetScore(x.Key) >= minScore)
-				.Where(x => x.Key != playerId)
-				// TODO: consider alliance members here
+				.Where(x => GetIneligibilityReason(playerId, x.Key) == null)
 				.Select(x => x.Value.ToImmutable());
 		}
 
@@ -45,13 +41,28 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public bool IsPlayerAttackable(PlayerId attacker, PlayerId defender) {
+			return GetIneligibilityReason(attacker, defender) == null;
+		}
+
+		public AttackIneligibilityReason? GetIneligibilityReason(PlayerId attacker, PlayerId defender) {
+			if (attacker == defender) return AttackIneligibilityReason.SelfAttack;
+			if (IsProtected(attacker)) return AttackIneligibilityReason.AttackerProtected;
+			if (IsProtected(defender)) return AttackIneligibilityReason.DefenderProtected;
+			if (AreAllied(attacker, defender)) return AttackIneligibilityReason.SameAlliance;
 			var attackerScore = scoreRepository.GetScore(attacker);
 			var defenderScore = scoreRepository.GetScore(defender);
-			var minScore = GetMinScore(attackerScore);
-			return attacker != defender
-				&& defenderScore >= minScore
-				// TODO: consider alliance members
-				;
+			if (defenderScore < GetMinScore(attackerScore)) return AttackIneligibilityReason.LandTooSmall;
+			return null;
+		}
+
+		private bool IsProtected(PlayerId id) {
+			// BGE-30: check player.State.Protection > 0 when protection field is added
+			return false;
+		}
+
+		private bool AreAllied(PlayerId a, PlayerId b) {
+			// BGE-33: check alliance membership when alliances are implemented
+			return false;
 		}
 
 		public bool Exists(PlayerId playerId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -120,7 +120,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				if (unit == null) throw new UnitNotFoundException(command.UnitId);
 				if (!unit.IsHome()) throw new UnitNotHomeException(command.UnitId, "Cannot move unit.");
 				world.ValidatePlayer(command.EnemyPlayerId);
-				if (!playerRepository.IsPlayerAttackable(command.PlayerId, command.EnemyPlayerId)) throw new PlayerNotAttackableException(command.EnemyPlayerId);
+				var attackReason = playerRepository.GetIneligibilityReason(command.PlayerId, command.EnemyPlayerId);
+				if (attackReason != null) throw new PlayerNotAttackableException(command.EnemyPlayerId, attackReason.Value);
 
 				unit.Position = command.EnemyPlayerId;
 			}


### PR DESCRIPTION
## Summary

- Add `AttackIneligibilityReason` enum covering all spec 6.1 rules (plus stubs for BGE-30/BGE-33)
- Add `PlayerRepository.GetIneligibilityReason()` — single authoritative method for all attack eligibility checks
- Refactor `IsPlayerAttackable` and `GetAttackablePlayers` to delegate to `GetIneligibilityReason` (eliminates duplication and TODO comments)
- Update `PlayerNotAttackableException` with structured reason and human-readable messages
- Update `UnitRepositoryWrite.SendUnit` to throw with reason code (belt-and-suspenders enforcement)
- Add 4 tests for `GetIneligibilityReason` covering each active rule

Rules 1 (BGE-30: new-player protection) and 2 (BGE-33: alliances) are stubbed as private `IsProtected()`/`AreAllied()` returning `false` with integration markers — no data model changes needed.

## Test plan

- [x] All 68 existing tests pass
- [x] 4 new `GetIneligibilityReason` tests pass: SelfAttack, LandTooSmall, EqualScore (null), DefenderAboveMinScore (null)