### PR TITLE
BGE-32: Battle reports via in-game messaging

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly PlayerRepository playerRepository;
 		private readonly UnitRepository unitRepository;
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
+		private readonly BattleReportGenerator battleReportGenerator;
 
 		public BattleController(ILogger<PlayerRankingController> logger
 				, GameDef gameDef
@@ -33,6 +34,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, PlayerRepository playerRepository
 				, UnitRepository unitRepository
 				, UnitRepositoryWrite unitRepositoryWrite
+				, BattleReportGenerator battleReportGenerator
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -41,6 +43,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.playerRepository = playerRepository;
 			this.unitRepository = unitRepository;
 			this.unitRepositoryWrite = unitRepositoryWrite;
+			this.battleReportGenerator = battleReportGenerator;
 		}
 
 		[HttpGet]
@@ -86,6 +89,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpPost]
 		public BattleResultViewModel Attack([FromQuery] string enemyPlayerId) {
 			var result = unitRepositoryWrite.Attack(currentUserContext.PlayerId, PlayerIdFactory.Create(enemyPlayerId));
+			battleReportGenerator.GenerateReports(result);
 			return new BattleResultViewModel {
 
 			};

--- a/src/BrowserGameEngine.GameModel/MessageImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/MessageImmutable.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record MessageImmutable(
+		Guid Id,
+		PlayerId RecipientId,
+		string Subject,
+		string Body,
+		DateTime CreatedAt,
+		bool IsRead = false
+	);
+}

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -11,6 +11,7 @@ namespace BrowserGameEngine.GameModel {
 		ISet<AssetImmutable> Assets,
 		List<UnitImmutable> Units,
 		int MineralWorkers = 0,
-		int GasWorkers = 0
+		int GasWorkers = 0,
+		IList<MessageImmutable>? Messages = null
 	);
 }

--- a/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
@@ -1,0 +1,85 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class BattleReportGenerator {
+		private readonly PlayerRepository playerRepository;
+		private readonly MessageRepositoryWrite messageRepositoryWrite;
+		private readonly GameDef gameDef;
+
+		public BattleReportGenerator(
+			PlayerRepository playerRepository,
+			MessageRepositoryWrite messageRepositoryWrite,
+			GameDef gameDef
+		) {
+			this.playerRepository = playerRepository;
+			this.messageRepositoryWrite = messageRepositoryWrite;
+			this.gameDef = gameDef;
+		}
+
+		public void GenerateReports(BattleResult battleResult) {
+			var attacker = playerRepository.Get(battleResult.Attacker);
+			var defender = playerRepository.Get(battleResult.Defender);
+			var attackerRace = GetRaceName(attacker.PlayerType);
+			var defenderRace = GetRaceName(defender.PlayerType);
+
+			bool attackerWon = !battleResult.BtlResult.DefendingUnitsSurvived.Any()
+				&& battleResult.BtlResult.AttackingUnitsSurvived.Any();
+			string outcome = attackerWon ? "Attacker won" : "Defender won";
+
+			string body = BuildBody(
+				attacker.Name, attackerRace,
+				defender.Name, defenderRace,
+				outcome,
+				(int)battleResult.BtlResult.LandTransferred,
+				battleResult.BtlResult.AttackingUnitsDestroyed,
+				battleResult.BtlResult.DefendingUnitsDestroyed
+			);
+
+			messageRepositoryWrite.SendMessage(
+				battleResult.Attacker,
+				$"Battle Report vs {defender.Name}",
+				body
+			);
+			messageRepositoryWrite.SendMessage(
+				battleResult.Defender,
+				$"Battle Report vs {attacker.Name}",
+				body
+			);
+		}
+
+		private string GetRaceName(PlayerTypeDefId playerTypeDefId) {
+			return gameDef.PlayerTypes.SingleOrDefault(x => x.Id.Equals(playerTypeDefId))?.Name ?? playerTypeDefId.Id;
+		}
+
+		private string BuildBody(
+			string attackerName, string attackerRace,
+			string defenderName, string defenderRace,
+			string outcome,
+			int landTransferred,
+			List<UnitCount> attackerLosses,
+			List<UnitCount> defenderLosses
+		) {
+			var sb = new StringBuilder();
+			sb.AppendLine($"Attacker: {attackerName} ({attackerRace})");
+			sb.AppendLine($"Defender: {defenderName} ({defenderRace})");
+			sb.AppendLine($"Outcome: {outcome}");
+			sb.AppendLine($"Land transferred: {landTransferred}");
+			sb.AppendLine($"Attacker losses: {FormatUnitBreakdown(attackerLosses)}");
+			sb.AppendLine($"Defender losses: {FormatUnitBreakdown(defenderLosses)}");
+			return sb.ToString();
+		}
+
+		private string FormatUnitBreakdown(List<UnitCount> unitCounts) {
+			if (!unitCounts.Any()) return "none";
+			return string.Join(", ", unitCounts.Select(uc => {
+				var unitDef = gameDef.GetUnitDef(uc.UnitDefId);
+				var name = unitDef?.Name ?? uc.UnitDefId.Id;
+				return $"{uc.Count}x {name}";
+			}));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Message.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Message.cs
@@ -1,0 +1,39 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class Message {
+		public Guid Id { get; set; }
+		public PlayerId RecipientId { get; set; }
+		public string Subject { get; set; } = string.Empty;
+		public string Body { get; set; } = string.Empty;
+		public DateTime CreatedAt { get; set; }
+		public bool IsRead { get; set; }
+	}
+
+	internal static class MessageExtensions {
+		internal static MessageImmutable ToImmutable(this Message message) {
+			return new MessageImmutable(
+				Id: message.Id,
+				RecipientId: message.RecipientId,
+				Subject: message.Subject,
+				Body: message.Body,
+				CreatedAt: message.CreatedAt,
+				IsRead: message.IsRead
+			);
+		}
+
+		internal static Message ToMutable(this MessageImmutable message) {
+			return new Message {
+				Id = message.Id,
+				RecipientId = message.RecipientId,
+				Subject = message.Subject,
+				Body = message.Body,
+				CreatedAt = message.CreatedAt,
+				IsRead = message.IsRead
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -13,6 +13,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<Unit> Units { get; set; } = new List<Unit>();
 		public int MineralWorkers { get; set; }
 		public int GasWorkers { get; set; }
+		public List<Message> Messages { get; set; } = new List<Message>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -24,7 +25,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Assets: playerState.Assets.Select(x => x.ToImmutable()).ToHashSet(),
 				Units: playerState.Units.Select(x => x.ToImmutable()).ToList(),
 				MineralWorkers: playerState.MineralWorkers,
-				GasWorkers: playerState.GasWorkers
+				GasWorkers: playerState.GasWorkers,
+				Messages: playerState.Messages.Select(x => x.ToImmutable()).ToList()
 			);
 		}
 
@@ -36,7 +38,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Assets = playerStateImmutable.Assets.Select(x => x.ToMutable()).ToHashSet(),
 				Units = playerStateImmutable.Units.Select(x => x.ToMutable()).ToList(),
 				MineralWorkers = playerStateImmutable.MineralWorkers,
-				GasWorkers = playerStateImmutable.GasWorkers
+				GasWorkers = playerStateImmutable.GasWorkers,
+				Messages = (playerStateImmutable.Messages ?? new List<MessageImmutable>()).Select(x => x.ToMutable()).ToList()
 		};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -27,6 +27,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<UnitRepository>();
 			services.AddSingleton<UnitRepositoryWrite>();
 			services.AddSingleton<ActionQueueRepository>();
+			services.AddSingleton<MessageRepository>();
+			services.AddSingleton<MessageRepositoryWrite>();
+			services.AddSingleton<BattleReportGenerator>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
@@ -1,0 +1,21 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class MessageRepository {
+		private readonly WorldState world;
+
+		public MessageRepository(WorldState world) {
+			this.world = world;
+		}
+
+		public IList<MessageImmutable> GetMessages(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.Messages
+				.Select(x => x.ToImmutable())
+				.OrderByDescending(x => x.CreatedAt)
+				.ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
@@ -1,0 +1,30 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class MessageRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly WorldState world;
+		private readonly TimeProvider timeProvider;
+
+		public MessageRepositoryWrite(WorldState world, TimeProvider timeProvider) {
+			this.world = world;
+			this.timeProvider = timeProvider;
+		}
+
+		public void SendMessage(PlayerId recipientId, string subject, string body) {
+			lock (_lock) {
+				world.GetPlayer(recipientId).State.Messages.Add(new Message {
+					Id = Guid.NewGuid(),
+					RecipientId = recipientId,
+					Subject = subject,
+					Body = body,
+					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+					IsRead = false
+				});
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements [BGE-32](/BGE/issues/BGE-32) — battle reports delivered as in-game messages after each combat.

- **Message model**: `MessageImmutable` record in `GameModel`; mutable `Message` class in `GameModelInternal`. Persisted as part of `PlayerState`/`PlayerStateImmutable` (world state serialization).
- **Repositories**: `MessageRepository` (read, returns messages for a player ordered by date) and `MessageRepositoryWrite` (write, thread-safe with lock).
- **BattleReportGenerator**: Takes a `BattleResult`, looks up attacker/defender names and races from `PlayerRepository`/`GameDef`, builds a formatted report body, and sends one message to each side via `MessageRepositoryWrite`.
- **Integration**: `BattleController.Attack()` calls `battleReportGenerator.GenerateReports(result)` immediately after the attack and land transfer.

This also lays the infrastructure for [BGE-31](/BGE/issues/BGE-31) (private messages UI) — the message model, repository, and persistence are all in place.

## Report format

```
Subject: Battle Report vs [opponent]
Attacker: [name] ([race])
Defender: [name] ([race])
Outcome: [Attacker won/Defender won]
Land transferred: [N]
Attacker losses: [unit breakdown]
Defender losses: [unit breakdown]
```

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 64/64 passed
- [ ] Manually trigger an attack and verify both players have a message in their state