### PR TITLE
Fix all compiler warnings (BGE-81)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/BrowserGameEngine.BlazorClient.csproj
+++ b/src/BrowserGameEngine.BlazorClient/BrowserGameEngine.BlazorClient.csproj
@@ -14,8 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="10.0.0" />
-  </ItemGroup>
+</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BrowserGameEngine.Shared\BrowserGameEngine.ViewModels.csproj" />

--- a/src/BrowserGameEngine.BlazorClient/Code/RefreshService.cs
+++ b/src/BrowserGameEngine.BlazorClient/Code/RefreshService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace BrowserGameEngine.BlazorClient.Code {
 
 	public class RefreshService {
-		public event Action RefreshRequested;
+		public event Action? RefreshRequested;
 		public void CallRequestRefresh() {
 			RefreshRequested?.Invoke();
 		}

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -78,7 +78,7 @@
     private string? lastError;
 
     [Parameter]
-    public string EnemeyPlayerId { get; set; }
+    public required string EnemeyPlayerId { get; set; }
 
     protected override async Task OnInitializedAsync() {
         model = await Http.GetFromJsonAsync<EnemyBaseViewModel>($"api/battle/enemybase?enemyPlayerId={Uri.EscapeDataString(EnemeyPlayerId)}");

--- a/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
@@ -29,7 +29,7 @@
 
 @code {
     [Parameter]
-    public string UnitId { get; set; }
+    public required string UnitId { get; set; }
 
     private SelectEnemyViewModel? model;
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -38,7 +38,7 @@
                             }
                         </td>
                         <td>
-                            <button class="btn btn-primary" @onclick="async () => await Merge(item.Definition.Id)">
+                            <button class="btn btn-primary" @onclick="async () => await Merge(item.Definition!.Id!)">
                                 Truppen dieses Typs zusammenführen
                             </button>
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
@@ -21,7 +21,7 @@
 
 @code {
     [Parameter]
-    public List<UnitDefinitionViewModel> AvailableUnits { get; set; }
+    public required List<UnitDefinitionViewModel> AvailableUnits { get; set; }
 
     private BuildUnitFormModel model = new BuildUnitFormModel();
     private string? lastError;
@@ -42,7 +42,7 @@
 
     internal class BuildUnitFormModel {
         [Required]
-        public string UnitDefId { get; set; }
+        public string UnitDefId { get; set; } = string.Empty;
         [Required]
         [Range(1, 100000, ErrorMessage = "Accommodation invalid (1-100000).")]
         public int Count { get; set; }

--- a/src/BrowserGameEngine.BlazorClient/Pages/_Cost.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_Cost.razor
@@ -10,5 +10,5 @@
 
 @code {
     [Parameter]
-    public BrowserGameEngine.Shared.CostViewModel Cost { get; set; }
+    public required BrowserGameEngine.Shared.CostViewModel Cost { get; set; }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -17,7 +17,7 @@
 }
 
 @code {
-    public BrowserGameEngine.Shared.PlayerResourcesViewModel model { get; set; }
+    public BrowserGameEngine.Shared.PlayerResourcesViewModel? model { get; set; }
 
     protected override async Task OnInitializedAsync() {
         await Update();

--- a/src/BrowserGameEngine.BlazorClient/Pages/_UnitProperties.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_UnitProperties.razor
@@ -8,5 +8,5 @@
 
 @code {
     [Parameter]
-    public BrowserGameEngine.Shared.UnitDefinitionViewModel UnitDef { get; set; }
+    public required BrowserGameEngine.Shared.UnitDefinitionViewModel UnitDef { get; set; }
 }

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -58,7 +58,7 @@
 @code {
     private bool collapseNavMenu = true;
 
-    private string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
     private void ToggleNavMenu()
     {

--- a/src/BrowserGameEngine.FrontendServer/BgeOptions.cs
+++ b/src/BrowserGameEngine.FrontendServer/BgeOptions.cs
@@ -13,8 +13,8 @@ namespace BrowserGameEngine.FrontendServer {
 		public bool DevAuth { get; set; }
 
 		// "localfile", "s3"
-		public string StorageType { get; set; }
+		public required string StorageType { get; set; }
 
-		public string S3BucketName { get; set; }
+		public required string S3BucketName { get; set; }
     }
 }

--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -21,8 +21,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AssetsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AssetsController.cs
@@ -49,14 +49,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public async Task<AssetsViewModel> Get() {
 			return new AssetsViewModel {
-				Assets = gameDef.GetAssetsByPlayerType(playerRepository.GetPlayerType(currentUserContext.PlayerId)).Select(x => CreateAssetViewModel(x)).ToList()
+				Assets = gameDef.GetAssetsByPlayerType(playerRepository.GetPlayerType(currentUserContext.PlayerId!)).Select(x => CreateAssetViewModel(x)).ToList()
 			};
 		}
 
 		[HttpPost]
 		public async Task<ActionResult> Build([FromQuery] string assetDefId) {
 			try {
-				assetRepositoryWrite.BuildAsset(new BuildAssetCommand(currentUserContext.PlayerId, Id.AssetDef(assetDefId)));
+				assetRepositoryWrite.BuildAsset(new BuildAssetCommand(currentUserContext.PlayerId!, Id.AssetDef(assetDefId)));
 				return Ok();
 			} catch (InvalidGameDefException e) {
 				return BadRequest(e.Message);
@@ -77,15 +77,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private AssetViewModel CreateAssetViewModel(AssetDef assetDef) {
 			return new AssetViewModel {
 				Definition = AssetDefinitionViewModel.Create(assetDef),
-				Built = assetRepository.HasAsset(currentUserContext.PlayerId, assetDef.Id),
+				Built = assetRepository.HasAsset(currentUserContext.PlayerId!, assetDef.Id),
 				Prerequisites = string.Join(", ", gameDef.GetAssetNames(assetDef.Prerequisites)),
-				PrerequisitesMet = assetRepository.PrerequisitesMet(currentUserContext.PlayerId, assetDef),
+				PrerequisitesMet = assetRepository.PrerequisitesMet(currentUserContext.PlayerId!, assetDef),
 				Cost = CostViewModel.Create(assetDef.Cost),
-				CanAfford = resourceRepository.CanAfford(currentUserContext.PlayerId, assetDef.Cost),
-				AlreadyQueued = assetRepository.IsBuildQueued(currentUserContext.PlayerId, assetDef.Id),
-				TicksLeftForBuild = assetRepository.TicksLeft(currentUserContext.PlayerId, assetDef.Id),
+				CanAfford = resourceRepository.CanAfford(currentUserContext.PlayerId!, assetDef.Cost),
+				AlreadyQueued = assetRepository.IsBuildQueued(currentUserContext.PlayerId!, assetDef.Id),
+				TicksLeftForBuild = assetRepository.TicksLeft(currentUserContext.PlayerId!, assetDef.Id),
 				AvailableUnits = gameDef.GetUnitsForAsset(assetDef.Id)
-					.Select(x => UnitDefinitionViewModel.Create(x, unitRepository.PrerequisitesMet(currentUserContext.PlayerId, x))).ToList()
+					.Select(x => UnitDefinitionViewModel.Create(x, unitRepository.PrerequisitesMet(currentUserContext.PlayerId!, x))).ToList()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -49,7 +49,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		[HttpGet("~/signout")]
 		[HttpPost("~/signout")]
-		public IActionResult SignOut() {
+		public new IActionResult SignOut() {
 			// Instruct the cookies middleware to delete the local cookie created
 			// when the user agent is redirected from the external identity provider
 			// after a successful authentication flow (e.g Google or Facebook).

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -52,14 +52,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public SelectEnemyViewModel AttackablePlayers() {
 			return new SelectEnemyViewModel {
-				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId).Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository)).ToList()
+				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId!).Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository)).ToList()
 			};
 		}
 
 		[HttpPost]
 		public ActionResult SendUnits([FromQuery] string unitId, [FromQuery] string enemyPlayerId) {
 			try {
-				unitRepositoryWrite.SendUnit(new SendUnitCommand(currentUserContext.PlayerId, Id.UnitId(unitId), PlayerIdFactory.Create(enemyPlayerId)));
+				unitRepositoryWrite.SendUnit(new SendUnitCommand(currentUserContext.PlayerId!, Id.UnitId(unitId), PlayerIdFactory.Create(enemyPlayerId)));
 				return Ok();
 			} catch (PlayerNotAttackableException e) {
 				return BadRequest(e.Message);
@@ -77,11 +77,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			try {
 				return new EnemyBaseViewModel {
 					PlayerAttackingUnits = new UnitsViewModel {
-						Units = unitRepository.GetAttackingUnits(currentUserContext.PlayerId, PlayerIdFactory.Create(enemyPlayerId))
+						Units = unitRepository.GetAttackingUnits(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId))
 							.Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
 					},
 					EnemyDefendingUnits = new UnitsViewModel {
-						Units = unitRepository.GetDefendingEnemyUnits(currentUserContext.PlayerId, PlayerIdFactory.Create(enemyPlayerId))
+						Units = unitRepository.GetDefendingEnemyUnits(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId))
 							.Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
 					}
 				};
@@ -93,7 +93,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		[HttpPost]
 		public BattleResultViewModel Attack([FromQuery] string enemyPlayerId) {
-			var result = unitRepositoryWrite.Attack(currentUserContext.PlayerId, PlayerIdFactory.Create(enemyPlayerId));
+			var result = unitRepositoryWrite.Attack(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId));
 			battleReportGenerator.GenerateReports(result);
 			return new BattleResultViewModel {
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
@@ -31,7 +31,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult Colonize([FromQuery] int amount) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
-				colonizeRepositoryWrite.Colonize(new ColonizeCommand(currentUserContext.PlayerId, amount));
+				colonizeRepositoryWrite.Colonize(new ColonizeCommand(currentUserContext.PlayerId!, amount));
 				return Ok();
 			} catch (ArgumentOutOfRangeException e) {
 				return BadRequest(e.Message);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -39,7 +39,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public ActionResult<PlayerProfileViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			var player = playerRepository.Get(currentUserContext.PlayerId);
+			var player = playerRepository.Get(currentUserContext.PlayerId!);
 			return new PlayerProfileViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name
@@ -67,7 +67,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[Route("changename")]
 		public ActionResult ChangePlayerName(PlayerProfileViewModel playerProfile) {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(currentUserContext.PlayerId, playerProfile.PlayerName));
+			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(currentUserContext.PlayerId!, playerProfile.PlayerName!));
 			return Ok();
 		}
 
@@ -82,7 +82,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			playerRepositoryWrite.CreatePlayer(playerId, currentUserContext.UserId);
-			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName));
+			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName!));
 			currentUserContext.Activate(playerId);
 			return Ok();
 		}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
@@ -33,7 +33,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		[HttpGet]
 		public async Task<PlayerResourcesViewModel> Get() {
-			var playerId = currentUserContext.PlayerId;
+			var playerId = currentUserContext.PlayerId!;
 			var currentLand = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
 			return new PlayerResourcesViewModel {
 				PrimaryResource = CostViewModel.Create(resourceRepository.GetPrimaryResource(playerId)),

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
@@ -43,14 +43,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public UnitsViewModel Get() {
 			return new UnitsViewModel {
-				Units = unitRepository.GetAll(currentUserContext.PlayerId).Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
+				Units = unitRepository.GetAll(currentUserContext.PlayerId!).Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
 			};
 		}
 
 		[HttpPost]
 		public async Task<ActionResult> Build([FromQuery] string unitDefId, [FromQuery] int count) {
 			try {
-				unitRepositoryWrite.BuildUnit(new BuildUnitCommand(currentUserContext.PlayerId, Id.UnitDef(unitDefId), count));
+				unitRepositoryWrite.BuildUnit(new BuildUnitCommand(currentUserContext.PlayerId!, Id.UnitDef(unitDefId), count));
 				return Ok();
 			} catch (InvalidGameDefException e) {
 				return BadRequest(e.Message);
@@ -63,9 +63,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public async Task<ActionResult> Merge([FromQuery] string? unitDefId) {
 			try {
 				if (string.IsNullOrEmpty(unitDefId)) {
-					unitRepositoryWrite.MergeUnits(new MergeAllUnitsCommand(currentUserContext.PlayerId));
+					unitRepositoryWrite.MergeUnits(new MergeAllUnitsCommand(currentUserContext.PlayerId!));
 				} else {
-					unitRepositoryWrite.MergeUnits(new MergeUnitsCommand(currentUserContext.PlayerId, Id.UnitDef(unitDefId)));
+					unitRepositoryWrite.MergeUnits(new MergeUnitsCommand(currentUserContext.PlayerId!, Id.UnitDef(unitDefId)));
 				}
 				return Ok();
 			} catch (InvalidGameDefException e) {
@@ -76,7 +76,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpPost]
 		public async Task<ActionResult> Split([FromQuery] Guid unitId, [FromQuery] int splitCount) {
 			try {
-				unitRepositoryWrite.SplitUnit(new SplitUnitCommand(currentUserContext.PlayerId, Id.UnitId(unitId), splitCount));
+				unitRepositoryWrite.SplitUnit(new SplitUnitCommand(currentUserContext.PlayerId!, Id.UnitId(unitId), splitCount));
 				return Ok();
 			} catch (InvalidGameDefException e) {
 				return BadRequest(e.Message);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -27,7 +27,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			return new UnitViewModel {
 				UnitId = unit.UnitId.Id,
-				Definition = UnitDefinitionViewModel.Create(unitDef, unitRepository.PrerequisitesMet(currentUserContext.PlayerId, unitDef)),
+				Definition = UnitDefinitionViewModel.Create(unitDef, unitRepository.PrerequisitesMet(currentUserContext.PlayerId!, unitDef)),
 				Count = unit.Count,
 				PositionPlayerId = unit.Position?.Id
 			};

--- a/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
@@ -39,7 +39,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public ActionResult<WorkerAssignmentViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			var playerId = currentUserContext.PlayerId;
+			var playerId = currentUserContext.PlayerId!;
 			var workerUnit = Id.UnitDef("wbf");
 			int totalWorkers = unitRepository.CountByUnitDefId(playerId, workerUnit);
 			return new WorkerAssignmentViewModel {
@@ -53,7 +53,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public async Task<ActionResult> Assign([FromQuery] int mineralWorkers, [FromQuery] int gasWorkers) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
-				var playerId = currentUserContext.PlayerId;
+				var playerId = currentUserContext.PlayerId!;
 				var workerUnit = Id.UnitDef("wbf");
 				int totalWorkers = unitRepository.CountByUnitDefId(playerId, workerUnit);
 				playerRepositoryWrite.AssignWorkers(

--- a/src/BrowserGameEngine.FrontendServer/Pages/Error.cshtml.cs
+++ b/src/BrowserGameEngine.FrontendServer/Pages/Error.cshtml.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace BrowserGameEngine.FrontendServer.Pages {
 	[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 	public class ErrorModel : PageModel {
-		public string RequestId { get; set; }
+		public string? RequestId { get; set; }
 
 		public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -99,7 +99,7 @@ var app = builder.Build();
 var forwardedHeadersOptions = new ForwardedHeadersOptions {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 };
-forwardedHeadersOptions.KnownNetworks.Clear();
+forwardedHeadersOptions.KnownIPNetworks.Clear();
 forwardedHeadersOptions.KnownProxies.Clear();
 app.UseForwardedHeaders(forwardedHeadersOptions);
 

--- a/src/BrowserGameEngine.GameDefinition/AssetDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/AssetDef.cs
@@ -7,15 +7,15 @@ namespace BrowserGameEngine.GameDefinition {
 	}
 
 	public record AssetDef {
-		public AssetDefId Id { get; init; }
-		public string Name { get; init; }
-		public PlayerTypeDefId PlayerTypeRestriction { get; init; }
-		public Cost Cost { get; init; }
+		public AssetDefId Id { get; init; } = null!;
+		public string Name { get; init; } = null!;
+		public PlayerTypeDefId PlayerTypeRestriction { get; init; } = null!;
+		public Cost Cost { get; init; } = null!;
 		public int Attack { get; init; }
 		public int Defense { get; init; }
 		public int Hitpoints { get; init; }
 		public List<AssetDefId> Prerequisites { get; init; } = new List<AssetDefId>();
-		public GameTick BuildTimeTicks { get; init; }
+		public GameTick BuildTimeTicks { get; init; } = null!;
 
 		public override string ToString() => Id.Id;
 	}

--- a/src/BrowserGameEngine.GameDefinition/GameDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/GameDef.cs
@@ -9,7 +9,7 @@ namespace BrowserGameEngine.GameDefinition {
 		public IEnumerable<UnitDef> Units { get; init; } = new List<UnitDef>();
 		public IEnumerable<AssetDef> Assets { get; init; } = new List<AssetDef>();
 		public IEnumerable<ResourceDef> Resources { get; init; } = new List<ResourceDef>();
-		public ResourceDefId ScoreResource { get; init; } // player ranking is based on this resource
+		public ResourceDefId ScoreResource { get; init; } = null!; // player ranking is based on this resource
 		public IEnumerable<GameTickModuleDef> GameTickModules { get; init; } = new List<GameTickModuleDef>();
 		public TimeSpan TickDuration { get; init; } = TimeSpan.FromMinutes(20);
 
@@ -37,7 +37,7 @@ namespace BrowserGameEngine.GameDefinition {
 		}
 
 		public static IEnumerable<string> GetAssetNames(this GameDef gameDef, IList<AssetDefId> assetDefIds) {
-			return assetDefIds.Select(x => gameDef.GetAssetDef(x)).Where(x => x != null).Select(x => x.Name);
+			return assetDefIds.Select(x => gameDef.GetAssetDef(x)).Where(x => x != null).Select(x => x!.Name);
 		}
 
 		// The first asset in prerequisites is the primary asset, where the unit can be built

--- a/src/BrowserGameEngine.GameDefinition/GameDefVerifier.cs
+++ b/src/BrowserGameEngine.GameDefinition/GameDefVerifier.cs
@@ -9,7 +9,7 @@ namespace BrowserGameEngine.GameDefinition {
 		public bool IsValid(GameDef gameDef) {
 			try {
 				Verify(gameDef);
-			} catch (Exception e) {
+			} catch (Exception) {
 				return false;
 			}
 			return true;

--- a/src/BrowserGameEngine.GameDefinition/InvalidGameDefException.cs
+++ b/src/BrowserGameEngine.GameDefinition/InvalidGameDefException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Runtime.Serialization;
+using System;
 
 namespace BrowserGameEngine.GameDefinition {
-	[Serializable]
 	public class InvalidGameDefException : Exception {
 		public InvalidGameDefException() {
 		}
@@ -11,9 +9,6 @@ namespace BrowserGameEngine.GameDefinition {
 		}
 
 		public InvalidGameDefException(string? message, Exception? innerException) : base(message, innerException) {
-		}
-
-		protected InvalidGameDefException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameDefinition/UnitDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/UnitDef.cs
@@ -5,10 +5,10 @@ namespace BrowserGameEngine.GameDefinition {
 		public override string ToString() => Id;
 	}
 	public record UnitDef {
-		public UnitDefId Id { get; init; }
-		public string Name { get; init; }
-		public PlayerTypeDefId PlayerTypeRestriction { get; init; }
-		public Cost Cost { get; init; }
+		public UnitDefId Id { get; init; } = null!;
+		public string Name { get; init; } = null!;
+		public PlayerTypeDefId PlayerTypeRestriction { get; init; } = null!;
+		public Cost Cost { get; init; } = null!;
 		public int Attack { get; init; }
 		public int Defense { get; init; }
 		public int Hitpoints { get; init; }

--- a/src/BrowserGameEngine.GameModel/BattleResult.cs
+++ b/src/BrowserGameEngine.GameModel/BattleResult.cs
@@ -3,18 +3,18 @@ using System.Collections.Generic;
 
 namespace BrowserGameEngine.GameModel {
 	public class BattleResult {
-		public PlayerId Attacker { get; set; }
-		public PlayerId Defender { get; set; }
-		public BtlResult BtlResult { get; set; }
+		public required PlayerId Attacker { get; set; }
+		public required PlayerId Defender { get; set; }
+		public required BtlResult BtlResult { get; set; }
 	}
 
 	public class BtlResult {
-		public List<UnitCount> AttackingUnitsDestroyed { get; set; }
-		public List<UnitCount> DefendingUnitsDestroyed { get; set; }
-		public List<UnitCount> AttackingUnitsSurvived { get; set; }
-		public List<UnitCount> DefendingUnitsSurvived { get; set; }
-		public List<Cost> ResourcesDestroyed { get; set; }
-		public List<Cost> ResourcesStolen { get; set; }
+		public required List<UnitCount> AttackingUnitsDestroyed { get; set; }
+		public required List<UnitCount> DefendingUnitsDestroyed { get; set; }
+		public required List<UnitCount> AttackingUnitsSurvived { get; set; }
+		public required List<UnitCount> DefendingUnitsSurvived { get; set; }
+		public required List<Cost> ResourcesDestroyed { get; set; }
+		public required List<Cost> ResourcesStolen { get; set; }
 		public decimal LandTransferred { get; set; }
 		public int WorkersCaptured { get; set; }
 	}

--- a/src/BrowserGameEngine.GameModel/GameActionImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameActionImmutable.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace BrowserGameEngine.GameModel {
 	public record GameActionImmutable {
-		public string Name { get; init; }
-		public GameTick DueTick { get; init; }
-		public PlayerId PlayerId { get; init; }
-		public Dictionary<string, string> Properties { get; init; }
+		public required string Name { get; init; }
+		public required GameTick DueTick { get; init; }
+		public required PlayerId PlayerId { get; init; }
+		public required Dictionary<string, string> Properties { get; init; }
 	}
 }

--- a/src/BrowserGameEngine.GameModel/PlayerId.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerId.cs
@@ -20,7 +20,7 @@ namespace BrowserGameEngine.GameModel {
 	public class PlayerIdConverter : JsonConverter<PlayerId> {
 		[return: MaybeNull]
 		public override PlayerId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-			return PlayerIdFactory.Create(reader.GetString());
+			return PlayerIdFactory.Create(reader.GetString()!);
 		}
 
 		public override void Write(Utf8JsonWriter writer, PlayerId value, JsonSerializerOptions options) {

--- a/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/DictionaryJsonConverter.cs
+++ b/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/DictionaryJsonConverter.cs
@@ -29,13 +29,13 @@ namespace KellySharp {
 				if (reader.TokenType == JsonTokenType.EndObject)
 					return result;
 
-				var key = keyParser(reader.GetString());
+				var key = keyParser(reader.GetString()!);
 
 				if (!reader.Read())
 					throw new JsonException("Incomplete JSON object");
 
 				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
-				result.Add(key, value);
+				result.Add(key, value!);
 			}
 		}
 

--- a/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/ImmutableDictionaryJsonConverter.cs
+++ b/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/ImmutableDictionaryJsonConverter.cs
@@ -29,14 +29,14 @@ namespace KellySharp {
 				if (reader.TokenType == JsonTokenType.EndObject)
 					return result.ToImmutable();
 
-				var key = keyParser(reader.GetString());
+				var key = keyParser(reader.GetString()!);
 
 				if (!reader.Read())
 					throw new JsonException("Incomplete JSON object");
 
 				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
 
-				result.Add(key, value);
+				result.Add(key, value!);
 			}
 		}
 

--- a/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/ImmutableSortedDictionaryJsonConverter.cs
+++ b/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/ImmutableSortedDictionaryJsonConverter.cs
@@ -39,14 +39,14 @@ namespace KellySharp {
 				if (reader.TokenType == JsonTokenType.EndObject)
 					return result.ToImmutable();
 
-				var key = _keyParser(reader.GetString());
+				var key = _keyParser(reader.GetString()!);
 
 				if (!reader.Read())
 					throw new JsonException("Incomplete JSON object");
 
 				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
 
-				result.Add(key, value);
+				result.Add(key, value!);
 			}
 		}
 

--- a/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/SortedDictionaryJsonConverter.cs
+++ b/src/BrowserGameEngine.Persistence/DictionaryJsonHelpers/SortedDictionaryJsonConverter.cs
@@ -39,14 +39,14 @@ namespace KellySharp {
 				if (reader.TokenType == JsonTokenType.EndObject)
 					return result;
 
-				var key = _keyParser(reader.GetString());
+				var key = _keyParser(reader.GetString()!);
 
 				if (!reader.Read())
 					throw new JsonException("Incomplete JSON object");
 
 				var value = JsonSerializer.Deserialize<TValue>(ref reader, options);
 
-				result.Add(key, value);
+				result.Add(key, value!);
 			}
 		}
 

--- a/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
@@ -12,7 +12,7 @@ namespace BrowserGameEngine.Persistence {
 		}
 
 		public WorldStateImmutable Deserialize(byte[] blob) {
-			return JsonSerializer.Deserialize<WorldStateImmutable>(blob, GetOptions());
+			return JsonSerializer.Deserialize<WorldStateImmutable>(blob, GetOptions())!;
 		}
 
 		private static JsonSerializerOptions GetOptions() {

--- a/src/BrowserGameEngine.Shared/AssetDefinitionViewModel.cs
+++ b/src/BrowserGameEngine.Shared/AssetDefinitionViewModel.cs
@@ -6,14 +6,14 @@ using System.Text;
 
 namespace BrowserGameEngine.Shared {
 	public record AssetDefinitionViewModel {
-		public string Id { get; set; }
-		public string Name { get; set; }
-		public string PlayerTypeRestriction { get; set; }
-		public IDictionary<string, decimal> Cost { get; set; }
+		public required string Id { get; set; }
+		public required string Name { get; set; }
+		public required string PlayerTypeRestriction { get; set; }
+		public required IDictionary<string, decimal> Cost { get; set; }
 		public int Attack { get; set; }
 		public int Defense { get; set; }
 		public int Hitpoints { get; set; }
-		public List<string> Prerequisites { get; set; }
+		public required List<string> Prerequisites { get; set; }
 		public int BuildTimeTicks { get; set; }
 
 		public static AssetDefinitionViewModel Create(AssetDef assetDefinition) {

--- a/src/BrowserGameEngine.Shared/AssetViewModel.cs
+++ b/src/BrowserGameEngine.Shared/AssetViewModel.cs
@@ -6,19 +6,19 @@ using System.Text;
 
 namespace BrowserGameEngine.Shared {
 	public record AssetsViewModel {
-		public List<AssetViewModel> Assets { get; set; }
+		public required List<AssetViewModel> Assets { get; set; }
 	}
 
 	public record AssetViewModel {
-		public AssetDefinitionViewModel Definition { get; set; }
+		public required AssetDefinitionViewModel Definition { get; set; }
 		public int Level { get; set; }
 		public bool Built { get; set; }
 		public int TicksLeftForBuild { get; set; }
-		public string Prerequisites { get; set; }
+		public required string Prerequisites { get; set; }
 		public bool PrerequisitesMet { get; set; }
 		public bool AlreadyQueued { get; set; }
-		public CostViewModel Cost { get; set; } // for build or upgrade to next level
+		public required CostViewModel Cost { get; set; } // for build or upgrade to next level
 		public bool CanAfford { get; set; }
-		public List<UnitDefinitionViewModel> AvailableUnits { get; set; }
+		public required List<UnitDefinitionViewModel> AvailableUnits { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/BattleResultViewModel.cs
+++ b/src/BrowserGameEngine.Shared/BattleResultViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.Shared {
 	public class BattleResultViewModel {
-		public UnitsViewModel PlayerLostUnits { get; set; }
-		public UnitsViewModel EnemyLostUnits { get; set; }
+		public UnitsViewModel? PlayerLostUnits { get; set; }
+		public UnitsViewModel? EnemyLostUnits { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/CostViewModel.cs
+++ b/src/BrowserGameEngine.Shared/CostViewModel.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace BrowserGameEngine.Shared {
 	public record CostViewModel {
-		public IDictionary<string, decimal> Cost { get; init; }
+		public required IDictionary<string, decimal> Cost { get; init; }
 
 		public static CostViewModel Create(Cost cost) {
 			return new CostViewModel {

--- a/src/BrowserGameEngine.Shared/EnemyBaseViewModel.cs
+++ b/src/BrowserGameEngine.Shared/EnemyBaseViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.Shared {
 	public class EnemyBaseViewModel {
-		public UnitsViewModel PlayerAttackingUnits { get; set; }
-		public UnitsViewModel EnemyDefendingUnits { get; set; }
+		public required UnitsViewModel PlayerAttackingUnits { get; set; }
+		public required UnitsViewModel EnemyDefendingUnits { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
@@ -6,8 +6,8 @@ using System.Text;
 
 namespace BrowserGameEngine.Shared {
 	public record PlayerResourcesViewModel {
-		public CostViewModel PrimaryResource { get; init; }
-		public CostViewModel SecondaryResources { get; init; }
+		public required CostViewModel PrimaryResource { get; init; }
+		public required CostViewModel SecondaryResources { get; init; }
 		public decimal ColonizationCostPerLand { get; init; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/SelectEnemyViewModel.cs
+++ b/src/BrowserGameEngine.Shared/SelectEnemyViewModel.cs
@@ -6,6 +6,6 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.Shared {
 	public class SelectEnemyViewModel {
-		public List<PublicPlayerViewModel> AttackablePlayers { get; set; }
+		public required List<PublicPlayerViewModel> AttackablePlayers { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/UnitDefinitionViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UnitDefinitionViewModel.cs
@@ -6,16 +6,16 @@ using System.Text;
 
 namespace BrowserGameEngine.Shared {
 	public record UnitDefinitionViewModel {
-		public string Id { get; set; }
-		public string Name { get; set; }
-		public string PlayerTypeRestriction { get; set; }
-		public CostViewModel Cost { get; set; }
+		public required string Id { get; set; }
+		public required string Name { get; set; }
+		public required string PlayerTypeRestriction { get; set; }
+		public required CostViewModel Cost { get; set; }
 		public int Attack { get; set; }
 		public int Defense { get; set; }
 		public int Hitpoints { get; set; }
 		public int Speed { get; set; }
 		public bool IsMobile { get; set; }
-		public List<string> Prerequisites { get; set; }
+		public required List<string> Prerequisites { get; set; }
 		public bool PrerequisitesMet { get; set; }
 
 		public static UnitDefinitionViewModel Create(UnitDef unitDefinition, bool prerequisitesMet) {

--- a/src/BrowserGameEngine.Shared/UnitsViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UnitsViewModel.cs
@@ -6,13 +6,13 @@ using System.Text;
 
 namespace BrowserGameEngine.Shared {
 	public record UnitsViewModel {
-		public List<UnitViewModel> Units { get; set; }
+		public required List<UnitViewModel> Units { get; set; }
 		//public IEnumerable<UnitDefinitionViewModel>? UnitDefinitions { get; set; }
 	}
 
 	public record UnitViewModel {
 		public Guid UnitId { get; set; }
-		public UnitDefinitionViewModel Definition { get; set; }
+		public required UnitDefinitionViewModel Definition { get; set; }
 		public int Count { get; set; }
 		public string? PositionPlayerId { get; set; }
 	}

--- a/src/BrowserGameEngine.StatefulGameServer.Benchmarks/GameTickEngineBenchmarks.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Benchmarks/GameTickEngineBenchmarks.cs
@@ -14,8 +14,8 @@ namespace BrowserGameEngine.StatefulGameServer.Benchmarks {
     [ShortRunJob]
     [MemoryDiagnoser]
     public class GameTickEngineBenchmarks {
-        private TestGame singlePlayerGame;
-        private TestGame thousandPlayerGame;
+        private TestGame singlePlayerGame = null!;
+        private TestGame thousandPlayerGame = null!;
 
         [GlobalSetup]
         public void Setup() {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AssetsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AssetsTest.cs
@@ -20,9 +20,9 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.False(g.AssetRepository.HasAsset(g.WorldStateFactory.Player1, Id.AssetDef("asset99")));
 			Assert.Single(g.AssetRepository.Get(g.WorldStateFactory.Player1));
 
-			Assert.True(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset1"))));
-			Assert.True(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset2"))));
-			Assert.False(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset3"))));
+			Assert.True(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset1"))!));
+			Assert.True(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset2"))!));
+			Assert.False(g.AssetRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetAssetDef(Id.AssetDef("asset3"))!));
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UnitsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UnitsTest.cs
@@ -17,10 +17,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Equal(15, g.UnitRepository.CountByUnitDefId(g.WorldStateFactory.Player1, Id.UnitDef("unit1")));
 			Assert.Equal(25, g.UnitRepository.CountByUnitDefId(g.WorldStateFactory.Player1, Id.UnitDef("unit2")));
 
-			Assert.True(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit1"))));
-			Assert.True(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit2"))));
-			Assert.False(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit3"))));
-			Assert.False(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit4"))));
+			Assert.True(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit1"))!));
+			Assert.True(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit2"))!));
+			Assert.False(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit3"))!));
+			Assert.False(g.UnitRepository.PrerequisitesMet(g.WorldStateFactory.Player1, g.GameDef.GetUnitDef(Id.UnitDef("unit4"))!));
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetAlreadyBuiltException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetAlreadyBuiltException.cs
@@ -1,14 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class AssetAlreadyBuiltException : Exception {
 		public AssetAlreadyBuiltException(AssetDefId assetDefId) : base($"Asset '{assetDefId.Id}' already built.") {
-		}
-
-		protected AssetAlreadyBuiltException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetAlreadyQueuedException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetAlreadyQueuedException.cs
@@ -1,14 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class AssetAlreadyQueuedException : Exception {
 		public AssetAlreadyQueuedException(AssetDefId assetDefId) : base($"Asset '{assetDefId.Id}' already queued.") {
-		}
-
-		protected AssetAlreadyQueuedException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AssetNotFoundException.cs
@@ -1,14 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	internal class AssetNotFoundException : Exception {
 		public AssetNotFoundException(AssetDefId assetDefId) : base($"Asset '{assetDefId.Id}' does not exist.") {
-		}
-
-		protected AssetNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotAffordException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotAffordException.cs
@@ -1,11 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class CannotAffordException : Exception {
-		private Cost cost;
+		private Cost? cost;
 
 		public CannotAffordException() {
 		}
@@ -18,9 +16,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public CannotAffordException(string? message, Exception? innerException) : base(message, innerException) {
-		}
-
-		protected CannotAffordException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotSplitUnitException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotSplitUnitException.cs
@@ -1,15 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class CannotSplitUnitException : Exception {
 		public CannotSplitUnitException(UnitId unitId, int splitCount, int totalCount) : base($"Cannot split '{unitId}'. Only {totalCount} available, but {splitCount} requested.") {
-		}
-
-		protected CannotSplitUnitException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotViewEnemyBaseException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/CannotViewEnemyBaseException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Runtime.Serialization;
+using System;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class CannotViewEnemyBaseException : Exception {
 		public CannotViewEnemyBaseException() : this("Not units positioned in enemy based, thus cannot view enemy units.") {
 		}
@@ -11,9 +9,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public CannotViewEnemyBaseException(string? message, Exception? innerException) : base(message, innerException) {
-		}
-
-		protected CannotViewEnemyBaseException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerAlreadyExistsException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerAlreadyExistsException.cs
@@ -1,17 +1,12 @@
-﻿using BrowserGameEngine.GameModel;
+using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	internal class PlayerAlreadyExistsException : Exception {
 		private PlayerId playerId;
 
 		public PlayerAlreadyExistsException(PlayerId playerId) {
 			this.playerId = playerId;
-		}
-
-		protected PlayerAlreadyExistsException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotAttackableException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotAttackableException.cs
@@ -1,10 +1,7 @@
-﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class PlayerNotAttackableException : Exception {
 		public AttackIneligibilityReason? Reason { get; }
 
@@ -13,9 +10,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public PlayerNotAttackableException(PlayerId playerId, AttackIneligibilityReason reason) : base(BuildMessage(playerId, reason)) {
 			Reason = reason;
-		}
-
-		protected PlayerNotAttackableException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 
 		private static string BuildMessage(PlayerId playerId, AttackIneligibilityReason reason) {

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PlayerNotFoundException.cs
@@ -1,14 +1,9 @@
-﻿using BrowserGameEngine.GameModel;
+using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	internal class PlayerNotFoundException : Exception {
 		public PlayerNotFoundException(PlayerId playerId) : base($"Player '{playerId}' does not exist.") {
-		}
-
-		protected PlayerNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PrerequisitesNotMetException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PrerequisitesNotMetException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Runtime.Serialization;
+using System;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class PrerequisitesNotMetException : Exception {
 		public PrerequisitesNotMetException() {
 		}
@@ -11,9 +9,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public PrerequisitesNotMetException(string? message, Exception? innerException) : base(message, innerException) {
-		}
-
-		protected PrerequisitesNotMetException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitDefNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitDefNotFoundException.cs
@@ -1,14 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UnitDefNotFoundException : Exception {
 		public UnitDefNotFoundException(UnitDefId unitDefId) : base($"Unit '{unitDefId.Id}' does not exist.") {
-		}
-
-		protected UnitDefNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitImmobileException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitImmobileException.cs
@@ -1,15 +1,10 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UnitImmobileException : Exception {
 		public UnitImmobileException(UnitId unitId) : base($"Unit '{unitId}' is immobile and cannot be sent to attack.") {
-		}
-
-		protected UnitImmobileException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitNotFoundException.cs
@@ -1,15 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UnitNotFoundException : Exception {
 		public UnitNotFoundException(UnitId unitId) : base($"Unit '{unitId}' does not exist.") {
-		}
-
-		protected UnitNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitNotHomeException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UnitNotHomeException.cs
@@ -1,15 +1,9 @@
-﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UnitNotHomeException : Exception {
 		public UnitNotHomeException(UnitId unitId, string message) : base($"Unit '{unitId}' is not in homebase: {message}") {
-		}
-
-		protected UnitNotHomeException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Asset.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Asset.cs
@@ -6,7 +6,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	// can be anything that enables stuff or improves capabilities
 	// e.g. buildings or upgrades
 	internal class Asset {
-		public AssetDefId AssetDefId { get; init; }
+		public required AssetDefId AssetDefId { get; init; }
 		public int Level { get; set; }
 	}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GameAction.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GameAction.cs
@@ -5,10 +5,10 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public record GameAction {
-		public string Name { get; init; }
-		public GameTick DueTick { get; init; }
-		public PlayerId PlayerId { get; init; }
-		public Dictionary<string, string> Properties { get; init; }
+		public required string Name { get; init; }
+		public required GameTick DueTick { get; init; }
+		public required PlayerId PlayerId { get; init; }
+		public required Dictionary<string, string> Properties { get; init; }
 	}
 
 	public static class GameActionExtensions {

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GameTickState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GameTickState.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal record GameTickState {
-		internal GameTick CurrentGameTick { get; set; }
+		internal GameTick CurrentGameTick { get; set; } = new GameTick(0);
 		internal DateTime LastUpdate { get; set; }
 	}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Message.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Message.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class Message {
 		public Guid Id { get; set; }
-		public PlayerId RecipientId { get; set; }
+		public required PlayerId RecipientId { get; set; }
 		public string Subject { get; set; } = string.Empty;
 		public string Body { get; set; } = string.Empty;
 		public DateTime CreatedAt { get; set; }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
@@ -6,11 +6,11 @@ using System.Text;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class Player {
-		public PlayerId PlayerId { get; init; }
-		public PlayerTypeDefId PlayerType { get; init; }
-		public string Name { get; set; }
+		public required PlayerId PlayerId { get; init; }
+		public required PlayerTypeDefId PlayerType { get; init; }
+		public required string Name { get; set; }
 		public DateTime Created { get; init; }
-		public PlayerState State { get; init; }
+		public required PlayerState State { get; init; }
 		public string? UserId { get; set; }
 		public string? ApiKeyHash { get; set; }
 		public DateTime? LastOnline { get; set; }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class PlayerState {
 		public DateTime? LastGameTickUpdate { get; set; }
-		public GameTick CurrentGameTick { get; set; }
+		public GameTick CurrentGameTick { get; set; } = new GameTick(0);
 		public IDictionary<ResourceDefId, decimal> Resources { get; set; } = new Dictionary<ResourceDefId, decimal>();
 		public ISet<Asset> Assets { get; set; } = new HashSet<Asset>();
 		public List<Unit> Units { get; set; } = new List<Unit>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/UnitState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/UnitState.cs
@@ -5,8 +5,8 @@ using System;
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 	internal class Unit {
-		public UnitId UnitId { get; init; }
-		public UnitDefId UnitDefId { get; init; }
+		public required UnitId UnitId { get; init; }
+		public required UnitDefId UnitDefId { get; init; }
 		public int Count { get; set; }
 		public PlayerId? Position { get; set; }
 		public int ReturnTimer { get; set; }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
@@ -3,10 +3,10 @@ using System;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class User {
-		public string UserId { get; init; }
-		public string GithubId { get; init; }
-		public string GithubLogin { get; set; }
-		public string DisplayName { get; set; }
+		public required string UserId { get; init; }
+		public required string GithubId { get; init; }
+		public required string GithubLogin { get; set; }
+		public required string DisplayName { get; set; }
 		public DateTime Created { get; init; }
 	}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
@@ -22,10 +22,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 		private readonly IActionLogger actionLogger;
 
-		private UnitDefId workerUnit;
-		private ResourceDefId mineralResource;
-		private ResourceDefId gasResource; // null = gas income disabled
-		private ResourceDefId constraintResource;
+		private UnitDefId workerUnit = null!;
+		private ResourceDefId mineralResource = null!;
+		private ResourceDefId? gasResource; // null = gas income disabled
+		private ResourceDefId constraintResource = null!;
 
 		// Base income added every tick regardless of workers (spec 2.3)
 		private const decimal BaseIncomeMinerals = 10m;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
@@ -132,15 +132,15 @@ namespace BrowserGameEngine.StatefulGameServer {
 	}
 
 	internal class BattleState {
-		public List<BtlUnit> AttackingUnits { get; set; }
-		public List<BtlUnit> DefendingUnits { get; set; }
+		public required List<BtlUnit> AttackingUnits { get; set; }
+		public required List<BtlUnit> DefendingUnits { get; set; }
 
 		public List<UnitCount> AttackingUnitsDestroyed { get; set; } = new();
 		public List<UnitCount> DefendingUnitsDestroyed { get; set; } = new();
 	}
 
 	public class BtlUnit {
-		public UnitDefId UnitDefId { get; set; }
+		public required UnitDefId UnitDefId { get; set; }
 		public int Count { get; set; }
 		public int Hitpoints { get; set; }
 		public int Attack { get; set; }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -145,7 +145,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			lock (_lock) {
 				var units = Units(playerId).Where(x => x.Position == enemyPlayerId).ToList();
 				foreach (var unit in units) {
-					unit.ReturnTimer = gameDef.GetUnitDef(unit.UnitDefId).Speed;
+					unit.ReturnTimer = gameDef.GetUnitDef(unit.UnitDefId)!.Speed;
 				}
 			}
 		}
@@ -190,7 +190,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		private int TryRemoveUnitCount(PlayerId playerId, UnitId unitId, int count) {
-			var unit = Unit(playerId, unitId);
+			var unit = Unit(playerId, unitId)!;
 			if (count >= unit.Count) {
 				// remove full unit
 				RemoveUnit(playerId, unitId);
@@ -237,7 +237,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			bool attackerWon = !battleResult.BtlResult.DefendingUnitsSurvived.Any() && battleResult.BtlResult.AttackingUnitsSurvived.Any();
 			if (attackerWon) {
 				int remainingAttackDamage = battleResult.BtlResult.AttackingUnitsSurvived
-					.Sum(uc => uc.Count * gameDef.GetUnitDef(uc.UnitDefId).Attack);
+					.Sum(uc => uc.Count * gameDef.GetUnitDef(uc.UnitDefId)!.Attack);
 				ApplyLandTransfer(battleResult, remainingAttackDamage);
 			}
 
@@ -251,7 +251,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		private IEnumerable<BtlUnit> ToBattleUnits(IEnumerable<UnitImmutable> units, int attackLevel, int defenseLevel) {
 			return units.Select(x => {
-				var unitDef = gameDef.GetUnitDef(x.UnitDefId);
+				var unitDef = gameDef.GetUnitDef(x.UnitDefId)!;
 				int attackBonus = attackLevel > 0 ? unitDef.AttackBonuses[attackLevel - 1] : 0;
 				int defenseBonus = defenseLevel > 0 ? unitDef.DefenseBonuses[defenseLevel - 1] : 0;
 				return new BtlUnit {


### PR DESCRIPTION
## Summary
- Remove redundant NuGet package references causing NU1510 warnings (`Microsoft.Extensions.Caching.Abstractions` in FrontendServer, `System.Net.Http.Json` in BlazorClient)
- Remove obsolete `[Serializable]` attributes and `protected Exception(SerializationInfo, StreamingContext)` constructors from all 14 exception classes (SYSLIB0051)
- Fix nullable reference type warnings across ~70 files (CS8618, CS8604, CS8602, CS8603, CS8601) — using `required` modifiers, `null!` initializers, and `!` null-forgiving operators where guarded by `IsValid` checks
- Remove unused variable in `GameDefVerifier.cs` (CS0168)
- Add missing `new` keyword on `AuthenticationController.SignOut()` (CS0114)
- Replace obsolete `KnownNetworks` with `KnownIPNetworks` in `Program.cs` (ASPDEPR005)

## Test plan
- [x] `dotnet build` passes with 0 warnings, 0 errors
- [x] `dotnet test` passes — 64/64 tests pass

Closes BGE-81