### PR TITLE
Leaderboard: group by user, human/agent filter, online status (BGE-71)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -1,37 +1,66 @@
-﻿@page "/ranking"
+@page "/ranking"
 @using BrowserGameEngine.Shared
+@using System.Linq
 @inject HttpClient Http
 
 <h1>Ranking</h1>
 
+<div class="mb-3">
+    <button class="btn @(filter == "all" ? "btn-primary" : "btn-outline-secondary") me-1" @onclick='() => filter = "all"'>All</button>
+    <button class="btn @(filter == "human" ? "btn-primary" : "btn-outline-secondary") me-1" @onclick='() => filter = "human"'>Human</button>
+    <button class="btn @(filter == "agent" ? "btn-primary" : "btn-outline-secondary")" @onclick='() => filter = "agent"'>Agent</button>
+</div>
+
 @if (model == null) {
     <p><em>Loading...</em></p>
 } else {
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Id</th>
-                <th>Name</th>
-                <th>Punkte</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var item in model.OrderByDescending(x => x.Score)) {
-            <tr>
-                <td>@item.PlayerId</td>
-                <td>@item.PlayerName</td>
-                <td>@item.Score</td>
-            </tr>
-            }
-        </tbody>
-    </table>
+    @foreach (var group in FilteredAndGrouped()) {
+        <h5 class="mt-3">@(group.displayName ?? group.userId ?? "(unknown)")</h5>
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Score</th>
+                    <th>Type</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in group.players) {
+                <tr>
+                    <td>@item.PlayerName</td>
+                    <td>@item.Score</td>
+                    <td>@(item.IsAgent ? "[Bot]" : "Human")</td>
+                    <td>@(IsOnline(item) ? "Online" : "Offline")</td>
+                </tr>
+                }
+            </tbody>
+        </table>
+    }
 }
 
 @code {
     private PublicPlayerViewModel[]? model;
+    private string filter = "all";
 
     protected override async Task OnInitializedAsync() {
         model = await Http.GetFromJsonAsync<PublicPlayerViewModel[]>("api/playerranking");
     }
 
+    private IEnumerable<(string? userId, string? displayName, IEnumerable<PublicPlayerViewModel> players)> FilteredAndGrouped() {
+        if (model == null) return Enumerable.Empty<(string?, string?, IEnumerable<PublicPlayerViewModel>)>();
+        IEnumerable<PublicPlayerViewModel> filtered = filter switch {
+            "human" => model.Where(p => !p.IsAgent),
+            "agent" => model.Where(p => p.IsAgent),
+            _ => model
+        };
+        return filtered
+            .OrderByDescending(x => x.Score)
+            .GroupBy(p => p.UserId)
+            .Select(g => (g.Key, g.First().UserDisplayName, (IEnumerable<PublicPlayerViewModel>)g));
+    }
+
+    private bool IsOnline(PublicPlayerViewModel p) {
+        return p.LastOnline.HasValue && (DateTime.UtcNow - p.LastOnline.Value).TotalMinutes < 8;
+    }
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -23,6 +23,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly ScoreRepository scoreRepository;
 		private readonly PlayerRepository playerRepository;
+		private readonly UserRepository userRepository;
 		private readonly UnitRepository unitRepository;
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 
@@ -31,6 +32,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, CurrentUserContext currentUserContext
 				, ScoreRepository scoreRepository
 				, PlayerRepository playerRepository
+				, UserRepository userRepository
 				, UnitRepository unitRepository
 				, UnitRepositoryWrite unitRepositoryWrite
 			) {
@@ -39,6 +41,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.currentUserContext = currentUserContext;
 			this.scoreRepository = scoreRepository;
 			this.playerRepository = playerRepository;
+			this.userRepository = userRepository;
 			this.unitRepository = unitRepository;
 			this.unitRepositoryWrite = unitRepositoryWrite;
 		}
@@ -46,7 +49,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public SelectEnemyViewModel AttackablePlayers() {
 			return new SelectEnemyViewModel {
-				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId).Select(p => p.ToPublicPlayerViewModel(scoreRepository)).ToList()
+				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId).Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository)).ToList()
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -16,19 +16,22 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ILogger<PlayerRankingController> logger;
 		private readonly ScoreRepository scoreRepository;
 		private readonly PlayerRepository playerRepository;
+		private readonly UserRepository userRepository;
 
 		public PlayerRankingController(ILogger<PlayerRankingController> logger
 				, ScoreRepository scoreRepository
 				, PlayerRepository playerRepository
+				, UserRepository userRepository
 			) {
 			this.logger = logger;
 			this.scoreRepository = scoreRepository;
 			this.playerRepository = playerRepository;
+			this.userRepository = userRepository;
 		}
 
 		[HttpGet]
 		public IEnumerable<PublicPlayerViewModel> Get() {
-			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository));
+			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository));
 		}
 
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -9,11 +9,15 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	public static class ViewModelExtensions {
-		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository) {
+		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository, UserRepository userRepository) {
 			return new PublicPlayerViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name,
-				Score = scoreRepository.GetScore(player.PlayerId)
+				Score = scoreRepository.GetScore(player.PlayerId),
+				UserId = player.UserId,
+				UserDisplayName = player.UserId != null ? userRepository.GetDisplayNameByUserId(player.UserId) : null,
+				IsAgent = player.ApiKeyHash != null,
+				LastOnline = player.LastOnline
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -19,11 +19,13 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 			CurrentUserContext currentUserContext,
 			UserRepository userRepository,
 			UserRepositoryWrite userRepositoryWrite,
-			PlayerRepository playerRepository) {
+			PlayerRepository playerRepository,
+			PlayerRepositoryWrite playerRepositoryWrite) {
 			// Bearer token path: BearerTokenMiddleware already resolved the PlayerId
 			if (context.Items.TryGetValue("BearerPlayerId", out var bearerPlayerId) && bearerPlayerId is string bearerPlayerIdStr) {
 				var playerId = PlayerIdFactory.Create(bearerPlayerIdStr);
 				currentUserContext.Activate(playerId);
+				playerRepositoryWrite.UpdateLastOnline(playerId, DateTime.UtcNow);
 				await _next(context);
 				return;
 			}
@@ -66,6 +68,7 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 						}
 						currentUserContext.Activate(selectedPlayerId);
 						currentUserContext.UserId = user.UserId;
+						playerRepositoryWrite.UpdateLastOnline(selectedPlayerId, DateTime.UtcNow);
 					} else {
 						// Authenticated but no player yet; store UserId so create endpoint can use it
 						currentUserContext.UserId = user.UserId;

--- a/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
@@ -11,6 +11,7 @@ namespace BrowserGameEngine.GameModel {
 		DateTime Created,
 		PlayerStateImmutable State,
 		string? UserId = null,
-		string? ApiKeyHash = null
+		string? ApiKeyHash = null,
+		DateTime? LastOnline = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
@@ -9,5 +9,9 @@ namespace BrowserGameEngine.Shared {
 		public string? PlayerId { get; set; }
 		public string? PlayerName { get; set; }
 		public decimal Score { get; set; }
+		public string? UserId { get; set; }
+		public string? UserDisplayName { get; set; }
+		public bool IsAgent { get; set; }
+		public DateTime? LastOnline { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
@@ -13,6 +13,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public PlayerState State { get; init; }
 		public string? UserId { get; set; }
 		public string? ApiKeyHash { get; set; }
+		public DateTime? LastOnline { get; set; }
 	}
 
 	internal static class PlayerExtensions {
@@ -24,7 +25,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created: player.Created,
 				State: player.State.ToImmutable(),
 				UserId: player.UserId,
-				ApiKeyHash: player.ApiKeyHash
+				ApiKeyHash: player.ApiKeyHash,
+				LastOnline: player.LastOnline
 			);
 		}
 
@@ -36,7 +38,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created = playerImmutable.Created,
 				State = playerImmutable.State.ToMutable(),
 				UserId = playerImmutable.UserId,
-				ApiKeyHash = playerImmutable.ApiKeyHash
+				ApiKeyHash = playerImmutable.ApiKeyHash,
+				LastOnline = playerImmutable.LastOnline
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -81,6 +81,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		public void UpdateLastOnline(PlayerId playerId, DateTime time) {
+			if (!world.PlayerExists(playerId)) return;
+			world.Players[playerId].LastOnline = time;
+		}
+
 		public void CreatePlayer(PlayerId playerId, string? userId = null) {
 			lock (_lock) {
 				if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
@@ -32,5 +32,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 			var player = world.Players.Values.FirstOrDefault(p => p.ApiKeyHash == apiKeyHash);
 			return player?.ToImmutable();
 		}
+
+		public string? GetDisplayNameByUserId(string userId) {
+			var user = world.Users.Values.FirstOrDefault(u => u.UserId == userId);
+			return user?.DisplayName;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `Player.LastOnline` (`DateTime?`) to mutable/immutable player models; `CurrentUserMiddleware` updates it on every request
- Add `UserRepository.GetDisplayNameByUserId` to look up human-readable names
- Extend `PublicPlayerViewModel` with `UserId`, `UserDisplayName`, `IsAgent` (derived from `ApiKeyHash != null`), and `LastOnline`
- Update `PlayerRankingController` and `BattleController` to inject `UserRepository` and populate enriched fields
- Rewrite `PlayerRanking.razor` with:
  - Filter toggle: All / Human / Agent (client-side)
  - User grouping: sub-header per user when multiple players share the same `UserId`
  - Online/offline indicator (online = active within 8 minutes)
  - `[Bot]` badge for agent players
  - Sort-by-score preserved within each group

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes — 64/64 tests pass
- [ ] Navigate to `/playerranking` — verify players grouped by user, filter toggle works, online status shown
- [ ] Create an agent player (API key) — verify `[Bot]` badge appears
- [ ] Verify `UserDisplayName` shows GitHub login name for human players

Closes BGE-71