### PR TITLE
BGE-30: Add new player protection

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -13,6 +13,7 @@
                 <th>Id</th>
                 <th>Name</th>
                 <th>Punkte</th>
+                <th>Schutz</th>
             </tr>
         </thead>
         <tbody>
@@ -21,6 +22,7 @@
                 <td>@item.PlayerId</td>
                 <td>@item.PlayerName</td>
                 <td>@item.Score</td>
+                <td>@(item.ProtectionTicksRemaining > 0 ? $"🛡 {item.ProtectionTicksRemaining}" : "")</td>
             </tr>
             }
         </tbody>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -42,7 +42,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var player = playerRepository.Get(currentUserContext.PlayerId);
 			return new PlayerProfileViewModel {
 				PlayerId = player.PlayerId.Id,
-				PlayerName = player.Name
+				PlayerName = player.Name,
+				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -13,7 +13,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new PublicPlayerViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name,
-				Score = scoreRepository.GetScore(player.PlayerId)
+				Score = scoreRepository.GetScore(player.PlayerId),
+				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining
 			};
 		}
 

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -34,7 +34,8 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						{ "growth-resource", "minerals" },
 						{ "gas-resource", "gas" },
 						{ "constraint-resource", "land" },
-					}.ToFrozenDictionary())
+					}.ToFrozenDictionary()),
+					new GameTickModuleDef("protection:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
 
 				Assets = new List<AssetDef> {

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -11,6 +11,7 @@ namespace BrowserGameEngine.GameModel {
 		ISet<AssetImmutable> Assets,
 		List<UnitImmutable> Units,
 		int MineralWorkers = 0,
-		int GasWorkers = 0
+		int GasWorkers = 0,
+		int ProtectionTicksRemaining = 0
 	);
 }

--- a/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
@@ -9,5 +9,6 @@ namespace BrowserGameEngine.Shared {
 		public string? PlayerId { get; set; }
 		public string? PlayerName { get; set; }
 		public decimal Score { get; set; }
+		public int ProtectionTicksRemaining { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
@@ -9,5 +9,6 @@ namespace BrowserGameEngine.Shared {
 		public string? PlayerId { get; set; }
 		public string? PlayerName { get; set; }
 		public decimal Score { get; set; }
+		public int ProtectionTicksRemaining { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -13,6 +13,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<Unit> Units { get; set; } = new List<Unit>();
 		public int MineralWorkers { get; set; }
 		public int GasWorkers { get; set; }
+		public int ProtectionTicksRemaining { get; set; }
 	}
 
 	internal static class PlayerStateExtensions {
@@ -24,7 +25,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Assets: playerState.Assets.Select(x => x.ToImmutable()).ToHashSet(),
 				Units: playerState.Units.Select(x => x.ToImmutable()).ToList(),
 				MineralWorkers: playerState.MineralWorkers,
-				GasWorkers: playerState.GasWorkers
+				GasWorkers: playerState.GasWorkers,
+				ProtectionTicksRemaining: playerState.ProtectionTicksRemaining
 			);
 		}
 
@@ -36,7 +38,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Assets = playerStateImmutable.Assets.Select(x => x.ToMutable()).ToHashSet(),
 				Units = playerStateImmutable.Units.Select(x => x.ToMutable()).ToList(),
 				MineralWorkers = playerStateImmutable.MineralWorkers,
-				GasWorkers = playerStateImmutable.GasWorkers
+				GasWorkers = playerStateImmutable.GasWorkers,
+				ProtectionTicksRemaining = playerStateImmutable.ProtectionTicksRemaining
 		};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -32,6 +32,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
 			services.AddSingleton<IGameTickModule, UnitReturn>();
 			services.AddSingleton<IGameTickModule, ResourceGrowthSco>();
+			services.AddSingleton<IGameTickModule, NewPlayerProtectionModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/NewPlayerProtectionModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/NewPlayerProtectionModule.cs
@@ -1,0 +1,23 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class NewPlayerProtectionModule : IGameTickModule {
+		public string Name => "protection:1";
+
+		private readonly WorldState world;
+
+		public NewPlayerProtectionModule(WorldState world) {
+			this.world = world;
+		}
+
+		public void SetProperty(string name, string value) { }
+
+		public void CalculateTick(PlayerId playerId) {
+			var state = world.GetPlayer(playerId).State;
+			if (state.ProtectionTicksRemaining > 0) {
+				state.ProtectionTicksRemaining--;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
@@ -56,8 +56,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		private bool IsProtected(PlayerId id) {
-			// BGE-30: check player.State.Protection > 0 when protection field is added
-			return false;
+			return world.GetPlayer(id).State.ProtectionTicksRemaining > 0;
 		}
 
 		private bool AreAllied(PlayerId a, PlayerId b) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -103,7 +103,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 								AssetDefId = Id.AssetDef("commandcenter"),
 								Level = 1
 							},
-						}
+						},
+						ProtectionTicksRemaining = 32
 					}
 				};
 			}


### PR DESCRIPTION
## Summary
- Add `ProtectionTicksRemaining` (int) to player state (mutable + immutable + serialization)
- New players start with 32 protection ticks, initialized in `CreatePlayer()`
- `NewPlayerProtectionModule` implements `IGameTickModule`: decrements the counter each tick (stops at 0), registered in `GameServerExtensions` and `StarcraftOnlineGameDefFactory`
- `IsProtected()` in `PlayerRepository` now checks `ProtectionTicksRemaining > 0` — both attacker and defender protection block attacks via `GetIneligibilityReason()`
- `ProtectionTicksRemaining` exposed in `PublicPlayerViewModel` and `PlayerProfileViewModel` so clients know protection status
- `PlayerRanking` page shows a shield icon + remaining tick count for protected players

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (78 tests)
- [ ] Create a new player and verify `ProtectionTicksRemaining = 32`
- [ ] Verify protected player cannot be attacked (returns `DefenderProtected` reason)
- [ ] Verify attacking player under protection cannot attack (returns `AttackerProtected` reason)
- [ ] After 32 ticks, verify `ProtectionTicksRemaining = 0` and attacks succeed
- [ ] PlayerRanking page shows shield icon for new players, none for unprotected

Closes BGE-30