### PR TITLE
Add build queue (todo system) [BGE-35]

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -1,4 +1,4 @@
-﻿@page "/base"
+@page "/base"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -42,7 +42,7 @@
                             <span>Bereits gebaut!</span>
 
                             <div class="bge-recruiting">
-                                <_BuildUnitsForm AvailableUnits="item.AvailableUnits" />
+                                <_BuildUnitsForm AvailableUnits="item.AvailableUnits" BuildQueue="buildQueue" OnQueueChanged="OnQueueChanged" />
                             </div>
 
                         } else if (item.AlreadyQueued) {
@@ -50,10 +50,15 @@
                         } else {
                             <div>Kosten: <_Cost Cost="@item.Cost" /></div>
                             <div>Benötigt: @item.Prerequisites </div>
-                            @if (item.PrerequisitesMet && item.CanAfford) {
+                            @if (item.PrerequisitesMet) {
                                 <div>
-                                    <button class="btn btn-primary" @onclick="(e) => BuildAsset(item)">
-                                        Bauen
+                                    @if (item.CanAfford) {
+                                        <button class="btn btn-primary" @onclick="(e) => BuildAsset(item)">
+                                            Bauen
+                                        </button>
+                                    }
+                                    <button class="btn btn-secondary" @onclick="(e) => QueueAsset(item)">
+                                        In Warteschlange
                                     </button>
                                 </div>
                             }
@@ -63,6 +68,9 @@
             </div>
         }
     }
+
+    <_BuildQueue @ref="buildQueue" />
+
 </div>
 
 @code {
@@ -72,6 +80,7 @@
     private string? lastError;
     private string? colonizeError;
     private int colonizeAmount = 1;
+    private _BuildQueue? buildQueue;
 
     protected override async Task OnInitializedAsync() {
         await Update();
@@ -95,6 +104,20 @@
         } else {
             colonizeError = await response.Content.ReadAsStringAsync();
         }
+    }
+
+    private async Task QueueAsset(AssetViewModel asset) {
+        var request = new AddToQueueRequest { Type = "asset", DefId = asset.Definition.Id, Count = 1 };
+        var response = await Http.PostAsJsonAsync("api/buildqueue/add", request);
+        if (response.IsSuccessStatusCode) {
+            if (buildQueue != null) await buildQueue.Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task OnQueueChanged() {
+        if (buildQueue != null) await buildQueue.Update();
     }
 
     private async Task Update() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -9,6 +9,8 @@
     <span class="error">@lastError</span>
 }
 
+<_BuildQueue />
+
 @if (model == null) {
     <p><em>Loading...</em></p>
 } else {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
@@ -1,0 +1,61 @@
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h3>Bauaufträge</h3>
+
+@if (!string.IsNullOrEmpty(lastError)) {
+    <span class="error">@lastError</span>
+}
+
+@if (model == null) {
+    <p><em>Lade...</em></p>
+} else if (!model.Entries.Any()) {
+    <p>Keine Bauaufträge in der Warteschlange.</p>
+} else {
+    <table class="table table-sm">
+        <thead>
+            <tr>
+                <th>Priorität</th>
+                <th>Typ</th>
+                <th>Name</th>
+                <th>Anzahl</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var entry in model.Entries.OrderBy(x => x.Priority)) {
+                <tr>
+                    <td>@entry.Priority</td>
+                    <td>@(entry.Type == "asset" ? "Gebäude" : "Einheit")</td>
+                    <td>@entry.Name</td>
+                    <td>@entry.Count</td>
+                    <td>
+                        <button class="btn btn-sm btn-danger" @onclick="() => RemoveEntry(entry.Id)">Entfernen</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private BuildQueueViewModel? model;
+    private string? lastError;
+
+    protected override async Task OnInitializedAsync() {
+        await Update();
+    }
+
+    public async Task Update() {
+        model = await Http.GetFromJsonAsync<BuildQueueViewModel>("api/buildqueue");
+    }
+
+    private async Task RemoveEntry(Guid entryId) {
+        var response = await Http.DeleteAsync($"api/buildqueue/remove?entryId={entryId}");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
@@ -1,4 +1,4 @@
-﻿@using BrowserGameEngine.Shared
+@using BrowserGameEngine.Shared
 @using System.ComponentModel.DataAnnotations
 @inject HttpClient Http
 @inject NavigationManager NavManager
@@ -16,12 +16,19 @@
             <option value="@x.Id">@x.Name</option>
         }
     </InputSelect>
-    <button type="submit">Submit</button>
+    <button type="submit">Bauen</button>
+    <button type="button" @onclick="QueueUnit">In Warteschlange</button>
 </EditForm>
 
 @code {
     [Parameter]
     public required List<UnitDefinitionViewModel> AvailableUnits { get; set; }
+
+    [Parameter]
+    public _BuildQueue? BuildQueue { get; set; }
+
+    [Parameter]
+    public EventCallback OnQueueChanged { get; set; }
 
     private BuildUnitFormModel model = new BuildUnitFormModel();
     private string? lastError;
@@ -37,6 +44,17 @@
         } else {
             var error = await response.Content.ReadAsStringAsync();
             lastError = error;
+        }
+    }
+
+    private async Task QueueUnit() {
+        var request = new AddToQueueRequest { Type = "unit", DefId = model.UnitDefId, Count = model.Count };
+        var response = await Http.PostAsJsonAsync("api/buildqueue/add", request);
+        if (response.IsSuccessStatusCode) {
+            if (BuildQueue != null) await BuildQueue.Update();
+            await OnQueueChanged.InvokeAsync();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
         }
     }
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
@@ -1,0 +1,95 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}/{id?}")]
+	public class BuildQueueController : ControllerBase {
+		private readonly ILogger<BuildQueueController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly BuildQueueRepository buildQueueRepository;
+		private readonly BuildQueueRepositoryWrite buildQueueRepositoryWrite;
+		private readonly GameDef gameDef;
+
+		public BuildQueueController(ILogger<BuildQueueController> logger
+				, CurrentUserContext currentUserContext
+				, BuildQueueRepository buildQueueRepository
+				, BuildQueueRepositoryWrite buildQueueRepositoryWrite
+				, GameDef gameDef
+			) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.buildQueueRepository = buildQueueRepository;
+			this.buildQueueRepositoryWrite = buildQueueRepositoryWrite;
+			this.gameDef = gameDef;
+		}
+
+		[HttpGet]
+		public BuildQueueViewModel Get() {
+			if (!currentUserContext.IsValid) return new BuildQueueViewModel();
+			var entries = buildQueueRepository.GetQueue(currentUserContext.PlayerId);
+			return new BuildQueueViewModel {
+				Entries = entries.Select(x => ToViewModel(x)).ToList()
+			};
+		}
+
+		[HttpPost]
+		public async Task<ActionResult> Add([FromBody] AddToQueueRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (request.Type != "unit" && request.Type != "asset") {
+				return BadRequest("Invalid type. Must be 'unit' or 'asset'.");
+			}
+			if (request.Count <= 0) return BadRequest("Count must be greater than 0.");
+			buildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(
+				currentUserContext.PlayerId,
+				request.Type,
+				request.DefId,
+				request.Count
+			));
+			return Ok();
+		}
+
+		[HttpDelete]
+		public async Task<ActionResult> Remove([FromQuery] Guid entryId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			buildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(currentUserContext.PlayerId, entryId));
+			return Ok();
+		}
+
+		[HttpPost]
+		public async Task<ActionResult> Reorder([FromBody] ReorderQueueRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			buildQueueRepositoryWrite.ReorderQueue(new ReorderQueueCommand(
+				currentUserContext.PlayerId,
+				request.EntryId,
+				request.NewPriority
+			));
+			return Ok();
+		}
+
+		private BuildQueueEntryViewModel ToViewModel(BuildQueueEntryImmutable entry) {
+			string name = entry.Type == "asset"
+				? gameDef.GetAssetDef(Id.AssetDef(entry.DefId))?.Name ?? entry.DefId
+				: gameDef.GetUnitDef(Id.UnitDef(entry.DefId))?.Name ?? entry.DefId;
+
+			return new BuildQueueEntryViewModel {
+				Id = entry.Id,
+				Type = entry.Type,
+				DefId = entry.DefId,
+				Name = name,
+				Count = entry.Count,
+				Priority = entry.Priority
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -35,8 +35,10 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						{ "gas-resource", "gas" },
 						{ "constraint-resource", "land" },
 					}.ToFrozenDictionary()),
+
 					new GameTickModuleDef("protection:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
-					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary())
+					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
+					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
 
 				Assets = new List<AssetDef> {

--- a/src/BrowserGameEngine.GameModel/BuildQueueEntryImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/BuildQueueEntryImmutable.cs
@@ -1,0 +1,12 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record BuildQueueEntryImmutable {
+		public Guid Id { get; init; }
+		public string Type { get; init; } // "unit" or "asset"
+		public string DefId { get; init; }
+		public int Count { get; init; }
+		public int Priority { get; init; }
+	}
+}

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -17,6 +17,7 @@ namespace BrowserGameEngine.GameModel {
 		int AttackUpgradeLevel = 0,
 		int DefenseUpgradeLevel = 0,
 		int UpgradeResearchTimer = 0,
-		UpgradeType UpgradeBeingResearched = UpgradeType.None
+		UpgradeType UpgradeBeingResearched = UpgradeType.None,
+		IList<BuildQueueEntryImmutable>? BuildQueue = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/BuildQueueViewModel.cs
+++ b/src/BrowserGameEngine.Shared/BuildQueueViewModel.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public record BuildQueueViewModel {
+		public List<BuildQueueEntryViewModel> Entries { get; set; } = new();
+	}
+
+	public record BuildQueueEntryViewModel {
+		public Guid Id { get; set; }
+		public string Type { get; set; } // "unit" or "asset"
+		public string DefId { get; set; }
+		public string Name { get; set; }
+		public int Count { get; set; }
+		public int Priority { get; set; }
+	}
+
+	public record AddToQueueRequest {
+		public string Type { get; set; } // "unit" or "asset"
+		public string DefId { get; set; }
+		public int Count { get; set; }
+	}
+
+	public record ReorderQueueRequest {
+		public Guid EntryId { get; set; }
+		public int NewPriority { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BuildQueueTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BuildQueueTest.cs
@@ -1,0 +1,181 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+
+	public class BuildQueueTest {
+		[Fact]
+		public void AddToQueue_Asset_AppearsInQueue() {
+			var g = new TestGame();
+
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			var queue = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Single(queue);
+			Assert.Equal("asset", queue[0].Type);
+			Assert.Equal("asset2", queue[0].DefId);
+		}
+
+		[Fact]
+		public void AddToQueue_Unit_AppearsInQueue() {
+			var g = new TestGame();
+
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 5));
+
+			var queue = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Single(queue);
+			Assert.Equal("unit", queue[0].Type);
+			Assert.Equal("unit1", queue[0].DefId);
+			Assert.Equal(5, queue[0].Count);
+		}
+
+		[Fact]
+		public void AddToQueue_MultipleEntries_AssignedFifoPriority() {
+			var g = new TestGame();
+
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 1));
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			var queue = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Equal(2, queue.Count);
+			Assert.Equal("unit1", queue[0].DefId);
+			Assert.Equal("asset2", queue[1].DefId);
+		}
+
+		[Fact]
+		public void RemoveFromQueue_RemovesEntry() {
+			var g = new TestGame();
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+			var entryId = g.BuildQueueRepository.GetQueue(g.Player1)[0].Id;
+
+			g.BuildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(g.Player1, entryId));
+
+			Assert.Empty(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void RemoveFromQueue_NonExistentId_DoesNothing() {
+			var g = new TestGame();
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 1));
+
+			g.BuildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(g.Player1, System.Guid.NewGuid()));
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_EmptyQueue_DoesNothing() {
+			var g = new TestGame();
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Empty(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Asset_SufficientResources_ExecutesAndDequeues() {
+			var g = new TestGame();
+			// asset2 requires asset1 (player has it) and costs res1=150, res2=300 (player has 1000/2000)
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Empty(g.BuildQueueRepository.GetQueue(g.Player1));
+			Assert.True(g.AssetRepository.IsBuildQueued(g.Player1, Id.AssetDef("asset2")));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Asset_InsufficientResources_StaysInQueue() {
+			var g = new TestGame();
+			// Drain res1 so asset2 (costs res1=150) is unaffordable
+			g.ResourceRepositoryWrite.DeductCost(g.Player1, Id.ResDef("res1"), 1000);
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+			Assert.False(g.AssetRepository.IsBuildQueued(g.Player1, Id.AssetDef("asset2")));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Asset_PrerequisitesNotMet_StaysInQueue() {
+			var g = new TestGame();
+			// asset3 requires asset1 AND asset2; player only has asset1
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset3", 1));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Unit_SufficientResources_ExecutesAndDequeues() {
+			var g = new TestGame();
+			int unitsBefore = g.UnitRepository.CountByUnitDefId(g.Player1, Id.UnitDef("unit1"));
+			// unit1 costs res1=50 each; requesting 10 = 500, player has 1000
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 10));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Empty(g.BuildQueueRepository.GetQueue(g.Player1));
+			Assert.Equal(unitsBefore + 10, g.UnitRepository.CountByUnitDefId(g.Player1, Id.UnitDef("unit1")));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Unit_InsufficientResources_StaysInQueue() {
+			var g = new TestGame();
+			// unit1 costs res1=50 each; 21 units = 1050 but player only has 1000
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 21));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_Unit_PrerequisitesNotMet_StaysInQueue() {
+			var g = new TestGame();
+			// unit3 requires asset1 AND asset2; player only has asset1
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit3", 1));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void ReorderQueue_ChangesExecutionOrder() {
+			var g = new TestGame();
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 5));
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			var queue = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Equal("unit1", queue[0].DefId); // unit1 first by FIFO
+
+			// Give asset2 entry a lower priority value (executes first)
+			var assetEntry = queue.First(x => x.DefId == "asset2");
+			g.BuildQueueRepositoryWrite.ReorderQueue(new ReorderQueueCommand(g.Player1, assetEntry.Id, -1));
+
+			var reordered = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Equal("asset2", reordered[0].DefId);
+			Assert.Equal("unit1", reordered[1].DefId);
+		}
+
+		[Fact]
+		public void TryExecuteAndDequeueFirst_ExecutesFrontEntry_LeavesRestInQueue() {
+			var g = new TestGame();
+			// Queue two units; player can afford both but TryExecuteAndDequeueFirst only processes the front
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 5));
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit2", 3));
+
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+
+			var remaining = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Single(remaining);
+			Assert.Equal("unit2", remaining[0].DefId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
@@ -29,6 +29,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public IBattleBehavior BattleBehavior { get; }
 		public UpgradeRepository UpgradeRepository { get; }
 		public UnitRepositoryWrite UnitRepositoryWrite { get; }
+		public BuildQueueRepository BuildQueueRepository { get; }
+		public BuildQueueRepositoryWrite BuildQueueRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -56,6 +58,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			BattleBehavior = new BattleBehaviorScoOriginal(LoggerFactory.CreateLogger<IBattleBehavior>());
 			UpgradeRepository = new UpgradeRepository(World);
 			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository);
+			BuildQueueRepository = new BuildQueueRepository(World);
+			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), World, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
 using System.Collections.Generic;
@@ -27,4 +27,7 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record AssignWorkersCommand(PlayerId PlayerId, int MineralWorkers, int GasWorkers) : ICommand;
 	public record ColonizeCommand(PlayerId PlayerId, int Amount) : ICommand;
 	public record ResearchUpgradeCommand(PlayerId PlayerId, UpgradeType UpgradeType) : ICommand;
+	public record AddToQueueCommand(PlayerId PlayerId, string Type, string DefId, int Count) : ICommand;
+	public record RemoveFromQueueCommand(PlayerId PlayerId, Guid EntryId) : ICommand;
+	public record ReorderQueueCommand(PlayerId PlayerId, Guid EntryId, int NewPriority) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BuildQueueEntry.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BuildQueueEntry.cs
@@ -1,0 +1,41 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class BuildQueueEntry {
+		public Guid Id { get; init; }
+		public string Type { get; init; } // "unit" or "asset"
+		public string DefId { get; init; }
+		public int Count { get; init; }
+		public int Priority { get; set; }
+	}
+
+	internal static class BuildQueueEntryConstants {
+		internal const string TypeUnit = "unit";
+		internal const string TypeAsset = "asset";
+	}
+
+	internal static class BuildQueueEntryExtensions {
+		internal static BuildQueueEntryImmutable ToImmutable(this BuildQueueEntry entry) {
+			return new BuildQueueEntryImmutable {
+				Id = entry.Id,
+				Type = entry.Type,
+				DefId = entry.DefId,
+				Count = entry.Count,
+				Priority = entry.Priority
+			};
+		}
+
+		internal static BuildQueueEntry ToMutable(this BuildQueueEntryImmutable entry) {
+			return new BuildQueueEntry {
+				Id = entry.Id,
+				Type = entry.Type,
+				DefId = entry.DefId,
+				Count = entry.Count,
+				Priority = entry.Priority
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
 using System.Collections.Generic;
@@ -19,6 +19,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int DefenseUpgradeLevel { get; set; }
 		public int UpgradeResearchTimer { get; set; }
 		public UpgradeType UpgradeBeingResearched { get; set; }
+		public List<BuildQueueEntry> BuildQueue { get; set; } = new List<BuildQueueEntry>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -36,7 +37,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				AttackUpgradeLevel: playerState.AttackUpgradeLevel,
 				DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
 				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
-				UpgradeBeingResearched: playerState.UpgradeBeingResearched
+				UpgradeBeingResearched: playerState.UpgradeBeingResearched,
+				BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList()
 			);
 		}
 
@@ -54,7 +56,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				AttackUpgradeLevel = playerStateImmutable.AttackUpgradeLevel,
 				DefenseUpgradeLevel = playerStateImmutable.DefenseUpgradeLevel,
 				UpgradeResearchTimer = playerStateImmutable.UpgradeResearchTimer,
-				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched
+				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched,
+				BuildQueue = (playerStateImmutable.BuildQueue ?? new List<BuildQueueEntryImmutable>())
+					.Select(x => x.ToMutable()).ToList()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.Persistence;
+using BrowserGameEngine.Persistence;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -35,6 +35,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<BattleReportGenerator>();
 			services.AddSingleton<UpgradeRepository>();
 			services.AddSingleton<UpgradeRepositoryWrite>();
+			services.AddSingleton<BuildQueueRepository>();
+			services.AddSingleton<BuildQueueRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
@@ -42,6 +44,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, ResourceGrowthSco>();
 			services.AddSingleton<IGameTickModule, NewPlayerProtectionModule>();
 			services.AddSingleton<IGameTickModule, UpgradeTimer>();
+			services.AddSingleton<IGameTickModule, BuildQueueModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/BuildQueueModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/BuildQueueModule.cs
@@ -1,0 +1,20 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class BuildQueueModule : IGameTickModule {
+		public string Name => "buildqueue:1";
+
+		public void SetProperty(string name, string value) { }
+
+		private readonly BuildQueueRepositoryWrite buildQueueRepositoryWrite;
+
+		public BuildQueueModule(BuildQueueRepositoryWrite buildQueueRepositoryWrite) {
+			this.buildQueueRepositoryWrite = buildQueueRepositoryWrite;
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			buildQueueRepositoryWrite.TryExecuteAndDequeueFirst(playerId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepository.cs
@@ -1,0 +1,31 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class BuildQueueRepository {
+		private readonly WorldState world;
+
+		public BuildQueueRepository(WorldState world) {
+			this.world = world;
+		}
+
+		private List<BuildQueueEntry> Queue(PlayerId playerId) => world.GetPlayer(playerId).State.BuildQueue;
+
+		public IList<BuildQueueEntryImmutable> GetQueue(PlayerId playerId) {
+			return Queue(playerId).OrderBy(x => x.Priority).Select(x => x.ToImmutable()).ToList();
+		}
+
+		internal BuildQueueEntry? GetEntryMutable(PlayerId playerId, Guid entryId) {
+			return Queue(playerId).SingleOrDefault(x => x.Id == entryId);
+		}
+
+		internal int GetNextPriority(PlayerId playerId) {
+			var queue = Queue(playerId);
+			if (!queue.Any()) return 0;
+			return queue.Max(x => x.Priority) + 1;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
@@ -1,0 +1,139 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class BuildQueueRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly ILogger<BuildQueueRepositoryWrite> logger;
+		private readonly WorldState world;
+		private readonly BuildQueueRepository buildQueueRepository;
+		private readonly AssetRepository assetRepository;
+		private readonly AssetRepositoryWrite assetRepositoryWrite;
+		private readonly UnitRepository unitRepository;
+		private readonly UnitRepositoryWrite unitRepositoryWrite;
+		private readonly ResourceRepository resourceRepository;
+		private readonly GameDef gameDef;
+
+		public BuildQueueRepositoryWrite(ILogger<BuildQueueRepositoryWrite> logger
+				, WorldState world
+				, BuildQueueRepository buildQueueRepository
+				, AssetRepository assetRepository
+				, AssetRepositoryWrite assetRepositoryWrite
+				, UnitRepository unitRepository
+				, UnitRepositoryWrite unitRepositoryWrite
+				, ResourceRepository resourceRepository
+				, GameDef gameDef
+			) {
+			this.logger = logger;
+			this.world = world;
+			this.buildQueueRepository = buildQueueRepository;
+			this.assetRepository = assetRepository;
+			this.assetRepositoryWrite = assetRepositoryWrite;
+			this.unitRepository = unitRepository;
+			this.unitRepositoryWrite = unitRepositoryWrite;
+			this.resourceRepository = resourceRepository;
+			this.gameDef = gameDef;
+		}
+
+		private List<BuildQueueEntry> Queue(PlayerId playerId) => world.GetPlayer(playerId).State.BuildQueue;
+
+		public void AddToQueue(AddToQueueCommand command) {
+			lock (_lock) {
+				var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
+				Queue(command.PlayerId).Add(new BuildQueueEntry {
+					Id = Guid.NewGuid(),
+					Type = command.Type,
+					DefId = command.DefId,
+					Count = command.Count,
+					Priority = priority
+				});
+			}
+		}
+
+		public void RemoveFromQueue(RemoveFromQueueCommand command) {
+			lock (_lock) {
+				var queue = Queue(command.PlayerId);
+				var entry = queue.SingleOrDefault(x => x.Id == command.EntryId);
+				if (entry != null) {
+					queue.Remove(entry);
+				}
+			}
+		}
+
+		public void ReorderQueue(ReorderQueueCommand command) {
+			lock (_lock) {
+				var entry = Queue(command.PlayerId).SingleOrDefault(x => x.Id == command.EntryId);
+				if (entry == null) return;
+				entry.Priority = command.NewPriority;
+			}
+		}
+
+		/// <summary>
+		/// Attempts to execute the front entry of the build queue. If resources/prerequisites
+		/// are met the entry is executed and dequeued. If not met, the entry stays.
+		/// </summary>
+		public void TryExecuteAndDequeueFirst(PlayerId playerId) {
+			lock (_lock) {
+				var queue = Queue(playerId);
+				var front = queue.OrderBy(x => x.Priority).FirstOrDefault();
+				if (front == null) return;
+
+				bool executed = false;
+				if (front.Type == BuildQueueEntryConstants.TypeAsset) {
+					executed = TryExecuteAsset(playerId, front);
+				} else if (front.Type == BuildQueueEntryConstants.TypeUnit) {
+					executed = TryExecuteUnit(playerId, front);
+				}
+
+				if (executed) {
+					queue.Remove(front);
+					logger.LogDebug("Build queue: executed and dequeued entry {EntryId} ({Type} {DefId}) for player {PlayerId}",
+						front.Id, front.Type, front.DefId, playerId);
+				}
+			}
+		}
+
+		private bool TryExecuteAsset(PlayerId playerId, BuildQueueEntry entry) {
+			var assetDefId = Id.AssetDef(entry.DefId);
+			var assetDef = gameDef.GetAssetDef(assetDefId);
+			if (assetDef == null) return true; // remove invalid entries
+			if (assetRepository.HasAsset(playerId, assetDefId)) return true; // already built, dequeue
+			if (assetRepository.IsBuildQueued(playerId, assetDefId)) return false; // already in timed queue, wait
+			if (!assetRepository.PrerequisitesMet(playerId, assetDef)) return false;
+			if (!resourceRepository.CanAfford(playerId, assetDef.Cost)) return false;
+
+			try {
+				assetRepositoryWrite.BuildAsset(new BuildAssetCommand(playerId, assetDefId));
+				return true;
+			} catch (Exception ex) {
+				logger.LogDebug("Build queue: failed to execute asset {DefId} for player {PlayerId}: {Message}",
+					entry.DefId, playerId, ex.Message);
+				return false;
+			}
+		}
+
+		private bool TryExecuteUnit(PlayerId playerId, BuildQueueEntry entry) {
+			var unitDefId = Id.UnitDef(entry.DefId);
+			var unitDef = gameDef.GetUnitDef(unitDefId);
+			if (unitDef == null) return true; // remove invalid entries
+			if (!unitRepository.PrerequisitesMet(playerId, unitDef)) return false;
+			if (!resourceRepository.CanAfford(playerId, unitDef.Cost.Multiply(entry.Count))) return false;
+
+			try {
+				unitRepositoryWrite.BuildUnit(new BuildUnitCommand(playerId, unitDefId, entry.Count));
+				return true;
+			} catch (Exception ex) {
+				logger.LogDebug("Build queue: failed to execute unit {DefId} for player {PlayerId}: {Message}",
+					entry.DefId, playerId, ex.Message);
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a per-player **build queue** where players can queue unit training and asset construction
- `BuildQueueModule` (new `IGameTickModule`) runs each tick: attempts the front queue entry, executes if resources + prerequisites are met, otherwise skips without dequeuing
- Players can reorder by priority; default order is FIFO

## What's included

- `BuildQueueEntry` mutable/immutable models stored in `PlayerState` (persisted in world state)
- `BuildQueueRepository` (read) + `BuildQueueRepositoryWrite` (write) with thread-safe locking
- `AddToQueueCommand`, `RemoveFromQueueCommand`, `ReorderQueueCommand`
- `BuildQueueModule` registered in `GameServerExtensions` and `StarcraftOnlineGameDefFactory` as `buildqueue:1`
- `BuildQueueController` — `GET /api/buildqueue`, `POST /api/buildqueue/add`, `DELETE /api/buildqueue/remove`, `POST /api/buildqueue/reorder`
- `BuildQueueViewModel`, `BuildQueueEntryViewModel`, `AddToQueueRequest`, `ReorderQueueRequest` in `Shared`
- `_BuildQueue.razor` component shown on both Base and Units pages
- "In Warteschlange" button added to asset build cards and unit recruit form

## Test plan

- [ ] Build and all 64 existing tests pass (`dotnet test`)
- [ ] Add a unit/asset to the queue via UI, verify it appears in `_BuildQueue`
- [ ] Verify queue entry executes on next tick when resources are sufficient
- [ ] Verify queue entry stays when resources are insufficient (skip, not dequeue)
- [ ] Remove an entry via UI, verify it disappears
- [ ] Verify world state serialization preserves build queue across server restart