### PR TITLE
Add alliance shared stats view (BGE-34, spec 9.3)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -50,6 +50,44 @@
         </tbody>
     </table>
 
+    @if (myStatus.IsMember && !myStatus.IsPending) {
+        <div class="card mb-3">
+            <div class="card-header">Alliance Stats</div>
+            <div class="card-body">
+                <div class="mb-2">
+                    <label>
+                        <input type="checkbox" checked="@shareMyStats" @onchange="ToggleStatShare" />
+                        Share my stats with this alliance
+                    </label>
+                </div>
+                @if (memberStats != null) {
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>Player</th>
+                                <th>Land</th>
+                                <th>Minerals</th>
+                                <th>Gas</th>
+                                <th>Army Size</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var s in memberStats) {
+                                <tr>
+                                    <td>@s.PlayerName</td>
+                                    <td>@(s.SharesStats ? s.Land?.ToString("N0") : "-")</td>
+                                    <td>@(s.SharesStats ? s.Minerals?.ToString("N0") : "-")</td>
+                                    <td>@(s.SharesStats ? s.Gas?.ToString("N0") : "-")</td>
+                                    <td>@(s.SharesStats ? s.ArmySize?.ToString("N0") : "-")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    }
+
     @if (myStatus.IsMember && myStatus.IsLeader) {
         <div class="card mb-3">
             <div class="card-header">Leader Controls</div>
@@ -74,6 +112,9 @@
 
     private AllianceDetailViewModel? detail;
     private MyAllianceStatusViewModel? myStatus;
+    private List<AllianceMemberStatsViewModel>? memberStats;
+    private bool shareMyStats;
+    private string? myPlayerId;
     private string newMessage = "";
     private string newPassword = "";
     private string? lastError;
@@ -85,7 +126,20 @@
     private async Task Update() {
         detail = await Http.GetFromJsonAsync<AllianceDetailViewModel>($"api/alliances/{AllianceId}");
         myStatus = await Http.GetFromJsonAsync<MyAllianceStatusViewModel>("api/alliances/my-status");
+        if (myStatus?.IsMember == true && myStatus.IsPending == false) {
+            var profile = await Http.GetFromJsonAsync<PlayerProfileViewModel>("api/playerprofile");
+            myPlayerId = profile?.PlayerId;
+            memberStats = await Http.GetFromJsonAsync<List<AllianceMemberStatsViewModel>>("api/alliances/members/stats");
+            shareMyStats = memberStats?.FirstOrDefault(s => s.PlayerId == myPlayerId)?.SharesStats ?? false;
+        }
         lastError = null;
+    }
+
+    private async Task ToggleStatShare(ChangeEventArgs e) {
+        shareMyStats = (bool)(e.Value ?? false);
+        var r = await Http.PostAsJsonAsync("api/alliances/my-stat-share", new SetAllianceStatShareRequest { ShareStats = shareMyStats });
+        if (r.IsSuccessStatusCode) await Update();
+        else lastError = await r.Content.ReadAsStringAsync();
     }
 
     private async Task Accept(string playerId) {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -17,17 +17,26 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly AllianceRepository allianceRepository;
 		private readonly AllianceRepositoryWrite allianceRepositoryWrite;
 		private readonly PlayerRepository playerRepository;
+		private readonly PlayerRepositoryWrite playerRepositoryWrite;
+		private readonly UnitRepository unitRepository;
+		private readonly ResourceRepository resourceRepository;
 
 		public AlliancesController(
 			CurrentUserContext currentUserContext,
 			AllianceRepository allianceRepository,
 			AllianceRepositoryWrite allianceRepositoryWrite,
-			PlayerRepository playerRepository
+			PlayerRepository playerRepository,
+			PlayerRepositoryWrite playerRepositoryWrite,
+			UnitRepository unitRepository,
+			ResourceRepository resourceRepository
 		) {
 			this.currentUserContext = currentUserContext;
 			this.allianceRepository = allianceRepository;
 			this.allianceRepositoryWrite = allianceRepositoryWrite;
 			this.playerRepository = playerRepository;
+			this.playerRepositoryWrite = playerRepositoryWrite;
+			this.unitRepository = unitRepository;
+			this.resourceRepository = resourceRepository;
 		}
 
 		[HttpGet]
@@ -56,6 +65,51 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				IsPending = member?.IsPending ?? false,
 				IsLeader = alliance.LeaderId == currentUserContext.PlayerId
 			});
+		}
+
+		[HttpGet("members/stats")]
+		public ActionResult<IEnumerable<AllianceMemberStatsViewModel>> GetMemberStats() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var alliance = allianceRepository.GetByPlayerId(currentUserContext.PlayerId);
+			if (alliance == null) return StatusCode(403, "Not in an alliance.");
+			var member = alliance.Members.FirstOrDefault(m => m.PlayerId == currentUserContext.PlayerId);
+			if (member == null || member.IsPending) return StatusCode(403, "Not an accepted alliance member.");
+
+			var stats = alliance.Members
+				.Where(m => !m.IsPending)
+				.Select(m => {
+					var player = playerRepository.Get(m.PlayerId);
+					if (player.State.ShareStatsWithAlliance) {
+						return new AllianceMemberStatsViewModel {
+							PlayerId = m.PlayerId.Id,
+							PlayerName = player.Name,
+							SharesStats = true,
+							Land = resourceRepository.GetAmount(m.PlayerId, Id.ResDef("land")),
+							Minerals = resourceRepository.GetAmount(m.PlayerId, Id.ResDef("minerals")),
+							Gas = resourceRepository.GetAmount(m.PlayerId, Id.ResDef("gas")),
+							ArmySize = unitRepository.GetTotalUnitCount(m.PlayerId)
+						};
+					}
+					return new AllianceMemberStatsViewModel {
+						PlayerId = m.PlayerId.Id,
+						PlayerName = player.Name,
+						SharesStats = false
+					};
+				});
+			return Ok(stats);
+		}
+
+		[HttpPost("my-stat-share")]
+		public ActionResult SetStatShare([FromBody] SetAllianceStatShareRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var alliance = allianceRepository.GetByPlayerId(currentUserContext.PlayerId);
+			if (alliance == null) return StatusCode(403, "Not in an alliance.");
+			var member = alliance.Members.FirstOrDefault(m => m.PlayerId == currentUserContext.PlayerId);
+			if (member == null || member.IsPending) return StatusCode(403, "Not an accepted alliance member.");
+
+			playerRepositoryWrite.SetAllianceStatShare(
+				new SetAllianceStatShareCommand(currentUserContext.PlayerId, request.ShareStats));
+			return Ok();
 		}
 
 		[HttpGet("{id}")]

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -16,6 +16,7 @@ namespace BrowserGameEngine.GameModel {
 		int AttackUpgradeLevel = 0,
 		int DefenseUpgradeLevel = 0,
 		int UpgradeResearchTimer = 0,
-		UpgradeType UpgradeBeingResearched = UpgradeType.None
+		UpgradeType UpgradeBeingResearched = UpgradeType.None,
+		bool ShareStatsWithAlliance = false
 	);
 }

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -56,4 +56,18 @@ namespace BrowserGameEngine.Shared {
 	public class SetAllianceMessageRequest {
 		public string Message { get; set; }
 	}
+
+	public class AllianceMemberStatsViewModel {
+		public string PlayerId { get; set; }
+		public string PlayerName { get; set; }
+		public bool SharesStats { get; set; }
+		public decimal? Land { get; set; }
+		public decimal? Minerals { get; set; }
+		public decimal? Gas { get; set; }
+		public int? ArmySize { get; set; }
+	}
+
+	public class SetAllianceStatShareRequest {
+		public bool ShareStats { get; set; }
+	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
@@ -182,5 +182,44 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Throws<AllianceNameTakenException>(() =>
 				game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player2, "TestAlliance", "secret")));
 		}
+
+		[Fact]
+		public void ShareStatsWithAlliance_Default_IsFalse() {
+			var game = new TestGame(playerCount: 1);
+			var player = game.PlayerRepository.Get(Player1);
+			Assert.False(player.State.ShareStatsWithAlliance);
+		}
+
+		[Fact]
+		public void SetAllianceStatShare_Enable_FlagPersists() {
+			var game = new TestGame(playerCount: 1);
+			game.PlayerRepositoryWrite.SetAllianceStatShare(new SetAllianceStatShareCommand(Player1, true));
+
+			var player = game.PlayerRepository.Get(Player1);
+			Assert.True(player.State.ShareStatsWithAlliance);
+		}
+
+		[Fact]
+		public void SetAllianceStatShare_Disable_FlagCleared() {
+			var game = new TestGame(playerCount: 1);
+			game.PlayerRepositoryWrite.SetAllianceStatShare(new SetAllianceStatShareCommand(Player1, true));
+			game.PlayerRepositoryWrite.SetAllianceStatShare(new SetAllianceStatShareCommand(Player1, false));
+
+			var player = game.PlayerRepository.Get(Player1);
+			Assert.False(player.State.ShareStatsWithAlliance);
+		}
+
+		[Fact]
+		public void ShareStatsWithAlliance_DeserializationBackcompat() {
+			// Simulate a PlayerStateImmutable deserialized without ShareStatsWithAlliance (defaults to false)
+			var state = new BrowserGameEngine.GameModel.PlayerStateImmutable(
+				LastGameTickUpdate: null,
+				CurrentGameTick: new BrowserGameEngine.GameDefinition.GameTick(0),
+				Resources: new System.Collections.Generic.Dictionary<BrowserGameEngine.GameDefinition.ResourceDefId, decimal>(),
+				Assets: new System.Collections.Generic.HashSet<BrowserGameEngine.GameModel.AssetImmutable>(),
+				Units: new System.Collections.Generic.List<BrowserGameEngine.GameModel.UnitImmutable>()
+			);
+			Assert.False(state.ShareStatsWithAlliance);
+		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -14,6 +14,7 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record VoteLeaderCommand(PlayerId PlayerId, PlayerId VoteePlayerId) : ICommand;
 	public record SetAlliancePasswordCommand(PlayerId PlayerId, string NewPassword) : ICommand;
 	public record SetAllianceMessageCommand(PlayerId PlayerId, string Message) : ICommand;
+	public record SetAllianceStatShareCommand(PlayerId PlayerId, bool ShareStats) : ICommand;
 
 	public record BuildAssetCommand(PlayerId PlayerId, AssetDefId AssetDefId) : ICommand;
 	public record BuildUnitCommand(PlayerId PlayerId, UnitDefId UnitDefId, int Count) : ICommand;

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -18,6 +18,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int DefenseUpgradeLevel { get; set; }
 		public int UpgradeResearchTimer { get; set; }
 		public UpgradeType UpgradeBeingResearched { get; set; }
+		public bool ShareStatsWithAlliance { get; set; }
 	}
 
 	internal static class PlayerStateExtensions {
@@ -34,7 +35,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				AttackUpgradeLevel: playerState.AttackUpgradeLevel,
 				DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
 				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
-				UpgradeBeingResearched: playerState.UpgradeBeingResearched
+				UpgradeBeingResearched: playerState.UpgradeBeingResearched,
+				ShareStatsWithAlliance: playerState.ShareStatsWithAlliance
 			);
 		}
 
@@ -51,7 +53,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				AttackUpgradeLevel = playerStateImmutable.AttackUpgradeLevel,
 				DefenseUpgradeLevel = playerStateImmutable.DefenseUpgradeLevel,
 				UpgradeResearchTimer = playerStateImmutable.UpgradeResearchTimer,
-				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched
+				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched,
+				ShareStatsWithAlliance = playerStateImmutable.ShareStatsWithAlliance
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -114,6 +114,13 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		public void SetAllianceStatShare(SetAllianceStatShareCommand command) {
+			lock (_lock) {
+				var state = world.GetPlayer(command.PlayerId).State;
+				state.ShareStatsWithAlliance = command.ShareStats;
+			}
+		}
+
 		public void DeletePlayer(PlayerId playerId) {
 			lock (_lock) {
 				if (!world.PlayerExists(playerId)) return;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepository.cs
@@ -73,6 +73,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 				.Select(x => x.ToImmutable());
 		}
 
+		public int GetTotalUnitCount(PlayerId playerId) {
+			world.ValidatePlayer(playerId);
+			return Units(playerId).Sum(x => x.Count);
+		}
+
 		public IEnumerable<UnitImmutable> GetDefendingEnemyUnits(PlayerId playerId, PlayerId enemyPlayerId) {
 			world.ValidatePlayer(playerId);
 			world.ValidatePlayer(enemyPlayerId);


### PR DESCRIPTION
## Summary
- Add `ShareStatsWithAlliance` (bool, default false) to player state — backward-compatible serialization
- New `SetAllianceStatShareCommand` + `PlayerRepositoryWrite.SetAllianceStatShare()` to toggle the flag
- New `UnitRepository.GetTotalUnitCount()` for army size
- New `AllianceMemberStatsViewModel` and `SetAllianceStatShareRequest` ViewModels in `Shared`
- `GET /api/alliances/members/stats` — returns full stats for opted-in members, name+land only for others; 403 if not accepted member
- `POST /api/alliances/my-stat-share` — toggles the stat sharing flag; 403 if not accepted member
- Alliance stats section added to `AllianceDetail.razor` with share toggle and member stats table

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (100 tests, 4 new)
- [ ] Join an alliance and verify stats section appears only for accepted members
- [ ] Toggle "Share my stats" — verify land/minerals/gas/army populate for sharing members
- [ ] Non-sharing member rows show dashes for private columns
- [ ] Non-member player gets 403 from both endpoints

**Note:** This PR targets `feat/BGE-33-alliance-system` (depends on BGE-33 files). Will rebase on master after BGE-33 merges.

Closes BGE-34