### PR TITLE
Add full UI header (BGE-37, spec 15.1)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -1,30 +1,55 @@
-﻿@inject HttpClient Http
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject BrowserGameEngine.BlazorClient.Code.RefreshService RefreshService
+@implements IDisposable
 
-<span>Resourcen</span>
-@if (model != null) {
-    <div>
-        <span>@model.PrimaryResource.Cost.Single().Key</span>: <span>@model.PrimaryResource.Cost.Single().Value</span>
-    </div>
-
-    <div>
-
-        @foreach (var res in model.SecondaryResources.Cost) {
-            <div>
-                <span>@res.Key</span>: <span>@res.Value</span>
-            </div>
+@if (resources != null) {
+    <div class="d-flex flex-wrap gap-3 align-items-center small text-muted">
+        <span><strong>@resources.PrimaryResource.Cost.Single().Key</strong>: @resources.PrimaryResource.Cost.Single().Value</span>
+        @foreach (var res in resources.SecondaryResources.Cost) {
+            <span><strong>@res.Key</strong>: @res.Value</span>
+        }
+        @if (tickInfo != null) {
+            <span><strong>Server:</strong> @tickInfo.ServerTime.ToString("HH:mm:ss") UTC</span>
+            <span><strong>Next tick:</strong> @FormatCountdown(tickInfo.NextTickAt)</span>
+            @if (tickInfo.UnreadMessageCount > 0) {
+                <span class="badge bg-danger">@tickInfo.UnreadMessageCount unread</span>
+            }
         }
     </div>
 }
 
 @code {
-    public BrowserGameEngine.Shared.PlayerResourcesViewModel? model { get; set; }
+    private PlayerResourcesViewModel? resources;
+    private TickInfoViewModel? tickInfo;
+    private System.Threading.Timer? countdownTimer;
 
     protected override async Task OnInitializedAsync() {
+        RefreshService.RefreshRequested += OnRefresh;
         await Update();
+        countdownTimer = new System.Threading.Timer(async _ => {
+            await InvokeAsync(StateHasChanged);
+        }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    private async void OnRefresh() {
+        await Update();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task Update() {
-        model = await Http.GetFromJsonAsync<BrowserGameEngine.Shared.PlayerResourcesViewModel>("api/resources");
+        resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
+        tickInfo = await Http.GetFromJsonAsync<TickInfoViewModel>("api/game/tick-info");
     }
 
+    private string FormatCountdown(DateTime nextTickAt) {
+        var remaining = nextTickAt - DateTime.UtcNow;
+        if (remaining <= TimeSpan.Zero) return "now";
+        return $"{(int)remaining.TotalSeconds}s";
+    }
+
+    public void Dispose() {
+        RefreshService.RefreshRequested -= OnRefresh;
+        countdownTimer?.Dispose();
+    }
 }

--- a/src/BrowserGameEngine.BlazorClient/Program.cs
+++ b/src/BrowserGameEngine.BlazorClient/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddHttpClient("ServerAPI", client => {
     .AddHttpMessageHandler<RedirectIfUnauthorizedHandler>();
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ServerAPI"));
+builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.RefreshService>();
 
 await builder.Build().RunAsync();
 

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -5,7 +5,8 @@
 </div>
 
 <div class="main">
-    <div class="top-row px-4">
+    <div class="top-row px-4 d-flex align-items-center justify-content-between">
+        <_PlayerResources />
         <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
     </div>
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
@@ -1,0 +1,43 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/game")]
+	public class GameInfoController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly GameTickEngine gameTickEngine;
+		private readonly MessageRepository messageRepository;
+		private readonly TimeProvider timeProvider;
+
+		public GameInfoController(
+			CurrentUserContext currentUserContext,
+			GameTickEngine gameTickEngine,
+			MessageRepository messageRepository,
+			TimeProvider timeProvider
+		) {
+			this.currentUserContext = currentUserContext;
+			this.gameTickEngine = gameTickEngine;
+			this.messageRepository = messageRepository;
+			this.timeProvider = timeProvider;
+		}
+
+		[HttpGet("tick-info")]
+		public ActionResult<TickInfoViewModel> GetTickInfo() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			int unreadCount = messageRepository.GetUnreadCount(currentUserContext.PlayerId);
+			return Ok(new TickInfoViewModel {
+				ServerTime = timeProvider.GetUtcNow().UtcDateTime,
+				NextTickAt = gameTickEngine.NextTickAt,
+				UnreadMessageCount = unreadCount
+			});
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/TickInfoViewModel.cs
+++ b/src/BrowserGameEngine.Shared/TickInfoViewModel.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public class TickInfoViewModel {
+		public DateTime ServerTime { get; set; }
+		public DateTime NextTickAt { get; set; }
+		public int UnreadMessageCount { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -78,6 +78,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 			}
 		}
 
+		public DateTime NextTickAt => worldState.GameTickState.LastUpdate + EffectiveTickDuration;
+
 		private bool AreAllPlayersUpToDate() {
 			return worldState.GetPlayersForGameTick().Length == 0;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
@@ -17,5 +17,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 				.OrderByDescending(x => x.CreatedAt)
 				.ToList();
 		}
+
+		public int GetUnreadCount(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.Messages.Count(x => !x.IsRead);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- New `GET /api/game/tick-info` endpoint returning `ServerTime` (UTC), `NextTickAt`, and `UnreadMessageCount`
- `NextTickAt` computed as `lastTickUpdate + effectiveTickDuration` via new `GameTickEngine.NextTickAt` property
- `GetUnreadCount()` added to `MessageRepository` (counts messages with `IsRead == false`)
- `_PlayerResources.razor` now shows resources, server time (UTC), next-tick countdown (live, 1s timer), and unread message badge
- `_PlayerResources` added to `MainLayout.razor` top-row so it appears on every page
- `RefreshService` registered as singleton in Blazor DI

**Unread message count** depends on BGE-31 (mark-as-read) for full accuracy; badge already shows correctly for battle report messages which are delivered unread.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (96 tests)
- [ ] Header visible on all pages after login
- [ ] Server time displayed in UTC, updates on refresh
- [ ] Tick countdown counts down to 0 and resets
- [ ] Unread badge appears when messages are present

Closes BGE-37