### PR TITLE
Add online status feature (BGE-39, spec 12.3)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
@@ -7,6 +7,12 @@
 @if (model == null) {
     <p><em>Loading...</em></p>
 } else {
+    <div class="mb-3">
+        <span>@(model.IsOnline ? "🟢 Online" : "⚫ Offline")</span>
+        @if (model.LastOnline.HasValue) {
+            <span class="text-muted ms-2">Last seen: @model.LastOnline.Value.ToLocalTime().ToString("g")</span>
+        }
+    </div>
     <div>
         <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
             <DataAnnotationsValidator />

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -32,7 +32,7 @@
                     <td>@item.PlayerName</td>
                     <td>@item.Score</td>
                     <td>@(item.IsAgent ? "[Bot]" : "Human")</td>
-                    <td>@(IsOnline(item) ? "Online" : "Offline")</td>
+                    <td>@(item.IsOnline ? "🟢 Online" : "⚫ Offline")</td>
                     <td>@(item.ProtectionTicksRemaining > 0 ? $"🛡 {item.ProtectionTicksRemaining}" : "")</td>
                 </tr>
                 }
@@ -62,7 +62,4 @@
             .Select(g => (g.Key, g.First().UserDisplayName, (IEnumerable<PublicPlayerViewModel>)g));
     }
 
-    private bool IsOnline(PublicPlayerViewModel p) {
-        return p.LastOnline.HasValue && (DateTime.UtcNow - p.LastOnline.Value).TotalMinutes < 8;
-    }
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -27,6 +27,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly UnitRepository unitRepository;
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 		private readonly BattleReportGenerator battleReportGenerator;
+		private readonly OnlineStatusRepository onlineStatusRepository;
 
 		public BattleController(ILogger<PlayerRankingController> logger
 				, GameDef gameDef
@@ -37,6 +38,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, UnitRepository unitRepository
 				, UnitRepositoryWrite unitRepositoryWrite
 				, BattleReportGenerator battleReportGenerator
+				, OnlineStatusRepository onlineStatusRepository
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -47,12 +49,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.unitRepository = unitRepository;
 			this.unitRepositoryWrite = unitRepositoryWrite;
 			this.battleReportGenerator = battleReportGenerator;
+			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
 		[HttpGet]
 		public SelectEnemyViewModel AttackablePlayers() {
 			return new SelectEnemyViewModel {
-				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId!).Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository)).ToList()
+				AttackablePlayers = playerRepository.GetAttackablePlayers(currentUserContext.PlayerId!).Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository)).ToList()
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -22,18 +22,24 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly PlayerRepository playerRepository;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly UserRepository userRepository;
+		private readonly ScoreRepository scoreRepository;
+		private readonly OnlineStatusRepository onlineStatusRepository;
 
 		public PlayerProfileController(ILogger<PlayerProfileController> logger
 				, CurrentUserContext currentUserContext
 				, PlayerRepository playerRepository
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, UserRepository userRepository
+				, ScoreRepository scoreRepository
+				, OnlineStatusRepository onlineStatusRepository
 			) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.playerRepository = playerRepository;
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.userRepository = userRepository;
+			this.scoreRepository = scoreRepository;
+			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
 		[HttpGet]
@@ -43,7 +49,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new PlayerProfileViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name,
-				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining
+				Score = scoreRepository.GetScore(player.PlayerId),
+				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining,
+				IsOnline = onlineStatusRepository.IsOnline(player.PlayerId),
+				LastOnline = player.LastOnline
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -17,21 +17,24 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ScoreRepository scoreRepository;
 		private readonly PlayerRepository playerRepository;
 		private readonly UserRepository userRepository;
+		private readonly OnlineStatusRepository onlineStatusRepository;
 
 		public PlayerRankingController(ILogger<PlayerRankingController> logger
 				, ScoreRepository scoreRepository
 				, PlayerRepository playerRepository
 				, UserRepository userRepository
+				, OnlineStatusRepository onlineStatusRepository
 			) {
 			this.logger = logger;
 			this.scoreRepository = scoreRepository;
 			this.playerRepository = playerRepository;
 			this.userRepository = userRepository;
+			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
 		[HttpGet]
 		public IEnumerable<PublicPlayerViewModel> Get() {
-			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository));
+			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository));
 		}
 
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	public static class ViewModelExtensions {
-		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository, UserRepository userRepository) {
+		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository, UserRepository userRepository, OnlineStatusRepository onlineStatusRepository) {
 			return new PublicPlayerViewModel {
 				PlayerId = player.PlayerId.Id,
 				PlayerName = player.Name,
@@ -18,7 +18,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				UserId = player.UserId,
 				UserDisplayName = player.UserId != null ? userRepository.GetDisplayNameByUserId(player.UserId) : null,
 				IsAgent = player.ApiKeyHash != null,
-				LastOnline = player.LastOnline
+				LastOnline = player.LastOnline,
+				IsOnline = onlineStatusRepository.IsOnline(player.PlayerId)
 			};
 		}
 

--- a/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
@@ -10,5 +10,7 @@ namespace BrowserGameEngine.Shared {
 		public string? PlayerName { get; set; }
 		public decimal Score { get; set; }
 		public int ProtectionTicksRemaining { get; set; }
+		public bool IsOnline { get; set; }
+		public DateTime? LastOnline { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
@@ -14,5 +14,6 @@ namespace BrowserGameEngine.Shared {
 		public string? UserDisplayName { get; set; }
 		public bool IsAgent { get; set; }
 		public DateTime? LastOnline { get; set; }
+		public bool IsOnline { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -19,6 +19,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<UserRepositoryWrite>();
 			services.AddSingleton<PlayerRepository>();
 			services.AddSingleton<PlayerRepositoryWrite>();
+			services.AddSingleton<OnlineStatusRepository>();
 			services.AddSingleton<ResourceRepository>();
 			services.AddSingleton<ResourceRepositoryWrite>();
 			services.AddSingleton<ScoreRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/OnlineStatusRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/OnlineStatusRepository.cs
@@ -1,0 +1,21 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class OnlineStatusRepository {
+		private static readonly TimeSpan OnlineThreshold = TimeSpan.FromMinutes(8);
+
+		private readonly WorldState world;
+
+		public OnlineStatusRepository(WorldState world) {
+			this.world = world;
+		}
+
+		public bool IsOnline(PlayerId playerId) {
+			var player = world.GetPlayer(playerId);
+			if (player.LastOnline == null) return false;
+			return DateTime.UtcNow - player.LastOnline.Value < OnlineThreshold;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `OnlineStatusRepository` with `IsOnline(playerId)` method using 8-minute threshold
- Add server-computed `IsOnline` bool to `PublicPlayerViewModel` and `PlayerProfileViewModel`
- Update `PlayerRanking` page to use server-computed IsOnline with 🟢/⚫ indicator
- Update `PlayerProfile` page to show online status and last seen time
- `LastOnline` stamping on every authenticated request was already in place via `CurrentUserMiddleware`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (96/96)
- [ ] Visit `/ranking` — players should show 🟢 Online or ⚫ Offline
- [ ] Visit `/profile` — should show current player's online status and last seen time

Closes BGE-39