### PR TITLE
Post-launch monitoring setup: CloudWatch dashboard, alarms, runbook (BGE-117)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,201 @@
+# BGE Production Runbook
+
+Region: `eu-central-1` | Cluster: `bge` | Service: `bge`
+
+---
+
+## Health Check
+
+Run all checks in one pass:
+
+```bash
+# ECS service status
+aws ecs describe-services --cluster bge --services bge \
+  --query 'services[0].{status:status,running:runningCount,desired:desiredCount,deployments:deployments[*].{state:rolloutState,running:runningCount,desired:desiredCount}}'
+
+# ALB target health
+TG_ARN=$(aws elbv2 describe-target-groups --names bge --query 'TargetGroups[0].TargetGroupArn' --output text)
+aws elbv2 describe-target-health --target-group-arn "$TG_ARN"
+
+# Recent stopped tasks (crashes)
+aws ecs list-tasks --cluster bge --desired-status STOPPED --max-items 5 \
+  --query 'taskArns' --output text | xargs -I{} \
+  aws ecs describe-tasks --cluster bge --tasks {} \
+    --query 'tasks[*].{status:lastStatus,reason:stoppedReason,exitCode:containers[0].exitCode}'
+
+# Recent application logs
+aws logs tail /ecs/bge --since 30m --format short
+
+# Game state — verify world is ticking (last S3 write < 30s ago)
+aws s3api list-object-versions --bucket bge-game-state --prefix "" --max-keys 5 \
+  --query 'Versions[*].{Key:Key,LastModified:LastModified,Size:Size}'
+```
+
+**Healthy indicators:**
+- `runningCount == desiredCount == 1`
+- ALB target `State.State == healthy`
+- No stopped tasks with non-zero exit codes
+- Game state bucket has writes within the last 30 seconds
+- No ERROR-level log lines in the last 30 minutes
+
+---
+
+## CloudWatch Dashboard
+
+Open the dashboard for a visual overview:
+
+```
+https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1#dashboards:name=bge
+```
+
+Widgets:
+- ECS Running Task Count
+- ECS CPU & Memory Utilization (%)
+- ALB Request Count
+- ALB 5xx / 4xx Error Count
+- ALB Target Response Time (p50 / p95 / p99)
+- ALB Target Health (healthy/unhealthy host count)
+
+---
+
+## Active Alarms
+
+| Alarm | Trigger | Action |
+|-------|---------|--------|
+| `bge-ecs-task-count-low` | Running tasks < 1 for 1 minute | See "Restart Service" below |
+| `bge-alb-5xx-rate-high` | 5xx error rate > 1% over 5 min | Check app logs; see "Investigate Errors" |
+| `bge-ecs-memory-high` | Memory > 80% for 2 consecutive 5-min periods | See "Scale Up" below |
+| `bge-ecs-cpu-high` | CPU > 80% for 2 consecutive 5-min periods | See "Scale Up" below |
+
+SNS topic: `bge-alarms` — email subscribers receive notifications on state changes.
+
+---
+
+## Restart Service
+
+Force a new ECS deployment (pulls latest image from ECR):
+
+```bash
+aws ecs update-service --cluster bge --service bge --force-new-deployment
+
+# Wait for the new task to become healthy
+aws ecs wait services-stable --cluster bge --services bge
+echo "Service is stable"
+```
+
+If the new task fails to start, check logs immediately:
+
+```bash
+aws logs tail /ecs/bge --since 5m --format short
+```
+
+---
+
+## Rollback to Previous Image
+
+```bash
+# Find the previous image tag in ECR
+aws ecr describe-images --repository-name bge \
+  --query 'sort_by(imageDetails, &imagePushedAt)[-5:].{tag:imageTags[0],pushed:imagePushedAt}' \
+  --output table
+
+# Get current task definition
+CURRENT_TD=$(aws ecs describe-services --cluster bge --services bge \
+  --query 'services[0].taskDefinition' --output text)
+
+# Register a new task definition with the previous image tag
+# (replace <previous-tag> with the desired SHA or tag)
+REPO_URL=$(aws ecr describe-repositories --repository-names bge \
+  --query 'repositories[0].repositoryUri' --output text)
+
+aws ecs register-task-definition \
+  --cli-input-json "$(aws ecs describe-task-definition \
+    --task-definition bge \
+    --query 'taskDefinition' | \
+    jq --arg img "$REPO_URL:<previous-tag>" \
+      '.containerDefinitions[0].image = $img | del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)')"
+
+# Deploy the new (rolled-back) task definition
+aws ecs update-service --cluster bge --service bge \
+  --task-definition bge  # uses latest registered revision
+
+aws ecs wait services-stable --cluster bge --services bge
+```
+
+---
+
+## Scale Up
+
+Increase task CPU/memory requires a new task definition (Fargate sizes are fixed).
+For quick relief, increase `desired_count` to run multiple tasks:
+
+```bash
+aws ecs update-service --cluster bge --service bge --desired-count 2
+aws ecs wait services-stable --cluster bge --services bge
+```
+
+> **Note:** BGE is a stateful server — world state is serialized to S3 every 10 seconds.
+> Running multiple tasks is safe for serving traffic (ALB load-balances), but each task
+> has its own in-memory world state. Only use multiple tasks as a temporary relief measure;
+> scale back to 1 once the root cause is addressed.
+
+To permanently increase CPU/memory, update the `aws_ecs_task_definition` resource in
+`infra/main.tf` and apply via Terraform.
+
+---
+
+## Investigate Errors
+
+```bash
+# Application error logs
+aws logs filter-log-events \
+  --log-group-name /ecs/bge \
+  --filter-pattern "ERROR" \
+  --start-time $(date -d '1 hour ago' +%s000) \
+  --query 'events[*].message' \
+  --output text
+
+# ALB access logs are in S3 (enabled, 30-day retention)
+aws s3 ls s3://bge-alb-logs/AWSLogs/ --recursive | sort | tail -20
+```
+
+---
+
+## Game State Recovery
+
+World state is serialized to S3 every 10 seconds with versioning enabled.
+
+```bash
+# List recent versions
+aws s3api list-object-versions --bucket bge-game-state \
+  --query 'Versions[*].{VersionId:VersionId,LastModified:LastModified,Key:Key}' \
+  --output table
+
+# Restore a specific version (download locally to inspect)
+aws s3api get-object \
+  --bucket bge-game-state \
+  --key <world-state-key> \
+  --version-id <version-id> \
+  world-state-backup.json
+```
+
+The service automatically loads the latest version from S3 on startup.
+
+---
+
+## CI/CD Pipeline
+
+Deployments are triggered by push to `master` via GitHub Actions.
+
+```bash
+# Check recent workflow runs
+gh run list --workflow=deploy.yml --limit 10
+
+# View a specific run
+gh run view <run-id>
+
+# Re-run a failed deployment
+gh run rerun <run-id>
+```
+
+Pipeline steps: test → build Docker image → push to ECR (tagged with commit SHA + `latest`) → force new ECS deployment.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -33,6 +33,11 @@ variable "github_client_secret" {
   sensitive = true
 }
 
+variable "alarm_email" {
+  description = "Email address to receive CloudWatch alarm notifications (leave empty to skip subscription)"
+  default     = ""
+}
+
 # --- VPC (default) ---
 
 data "aws_vpc" "default" {
@@ -212,6 +217,13 @@ resource "aws_lb" "app" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
   subnets            = data.aws_subnets.default.ids
+
+  access_logs {
+    bucket  = aws_s3_bucket.alb_logs.id
+    enabled = true
+  }
+
+  depends_on = [aws_s3_bucket_policy.alb_logs]
 }
 
 resource "aws_lb_target_group" "app" {
@@ -305,6 +317,293 @@ resource "aws_ecs_service" "app" {
   depends_on = [aws_lb_listener.http]
 }
 
+# --- ALB Access Logs ---
+
+# S3 bucket for ALB access logs
+resource "aws_s3_bucket" "alb_logs" {
+  bucket = "${var.app_name}-alb-logs"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# ELB service account for eu-central-1 needs s3:PutObject permission
+data "aws_elb_service_account" "main" {}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { AWS = data.aws_elb_service_account.main.arn }
+      Action    = "s3:PutObject"
+      Resource  = "${aws_s3_bucket.alb_logs.arn}/*"
+    }]
+  })
+}
+
+# --- SNS Topic for Alarms ---
+
+resource "aws_sns_topic" "alarms" {
+  name = "${var.app_name}-alarms"
+}
+
+resource "aws_sns_topic_subscription" "alarms_email" {
+  count     = var.alarm_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+# --- CloudWatch Alarms ---
+
+# Alarm: ECS service running task count drops below 1
+resource "aws_cloudwatch_metric_alarm" "ecs_task_count" {
+  alarm_name          = "${var.app_name}-ecs-task-count-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "RunningTaskCount"
+  namespace           = "ECS/ContainerInsights"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  alarm_description   = "ECS running task count dropped below 1 — service may be down"
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.app.name
+    ServiceName = aws_ecs_service.app.name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Alarm: ALB 5xx error rate > 1% over 5 minutes
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_rate" {
+  alarm_name          = "${var.app_name}-alb-5xx-rate-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  alarm_description   = "ALB 5xx error rate exceeded 1% over 5 minutes"
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "error_rate"
+    expression  = "IF(requests > 0, 100 * errors / requests, 0)"
+    label       = "5xx Error Rate (%)"
+    return_data = true
+  }
+
+  metric_query {
+    id = "errors"
+    metric {
+      metric_name = "HTTPCode_Target_5XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = aws_lb.app.arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id = "requests"
+    metric {
+      metric_name = "RequestCount"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = aws_lb.app.arn_suffix
+      }
+    }
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Alarm: ECS memory utilization > 80%
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "${var.app_name}-ecs-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS memory utilization exceeded 80%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.app.name
+    ServiceName = aws_ecs_service.app.name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Alarm: ECS CPU utilization > 80%
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "${var.app_name}-ecs-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS CPU utilization exceeded 80%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.app.name
+    ServiceName = aws_ecs_service.app.name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# --- CloudWatch Dashboard ---
+
+resource "aws_cloudwatch_dashboard" "app" {
+  dashboard_name = var.app_name
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 6
+        height = 6
+        properties = {
+          title  = "ECS Running Task Count"
+          region = var.aws_region
+          metrics = [[
+            "ECS/ContainerInsights", "RunningTaskCount",
+            "ClusterName", aws_ecs_cluster.app.name,
+            "ServiceName", aws_ecs_service.app.name
+          ]]
+          stat   = "Average"
+          period = 60
+          view   = "timeSeries"
+          yAxis  = { left = { min = 0 } }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 6
+        y      = 0
+        width  = 6
+        height = 6
+        properties = {
+          title  = "ECS CPU & Memory Utilization (%)"
+          region = var.aws_region
+          metrics = [
+            ["AWS/ECS", "CPUUtilization", "ClusterName", aws_ecs_cluster.app.name, "ServiceName", aws_ecs_service.app.name],
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", aws_ecs_cluster.app.name, "ServiceName", aws_ecs_service.app.name]
+          ]
+          stat   = "Average"
+          period = 300
+          view   = "timeSeries"
+          yAxis  = { left = { min = 0, max = 100 } }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 6
+        height = 6
+        properties = {
+          title  = "ALB Request Count"
+          region = var.aws_region
+          metrics = [[
+            "AWS/ApplicationELB", "RequestCount",
+            "LoadBalancer", aws_lb.app.arn_suffix
+          ]]
+          stat   = "Sum"
+          period = 60
+          view   = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 18
+        y      = 0
+        width  = 6
+        height = 6
+        properties = {
+          title  = "ALB 5xx / 4xx Error Count"
+          region = var.aws_region
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", aws_lb.app.arn_suffix],
+            ["AWS/ApplicationELB", "HTTPCode_Target_4XX_Count", "LoadBalancer", aws_lb.app.arn_suffix]
+          ]
+          stat   = "Sum"
+          period = 60
+          view   = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ALB Target Response Time (p50 / p95 / p99)"
+          region = var.aws_region
+          metrics = [
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.app.arn_suffix, { stat = "p50", label = "p50" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.app.arn_suffix, { stat = "p95", label = "p95" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", aws_lb.app.arn_suffix, { stat = "p99", label = "p99" }]
+          ]
+          period = 60
+          view   = "timeSeries"
+          yAxis  = { left = { min = 0 } }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ALB Target Health"
+          region = var.aws_region
+          metrics = [
+            ["AWS/ApplicationELB", "HealthyHostCount", "TargetGroup", aws_lb_target_group.app.arn_suffix, "LoadBalancer", aws_lb.app.arn_suffix],
+            ["AWS/ApplicationELB", "UnHealthyHostCount", "TargetGroup", aws_lb_target_group.app.arn_suffix, "LoadBalancer", aws_lb.app.arn_suffix]
+          ]
+          stat   = "Average"
+          period = 60
+          view   = "timeSeries"
+          yAxis  = { left = { min = 0 } }
+        }
+      }
+    ]
+  })
+}
+
 # --- Outputs ---
 
 output "alb_dns_name" {
@@ -313,4 +612,12 @@ output "alb_dns_name" {
 
 output "ecr_repository_url" {
   value = aws_ecr_repository.app.repository_url
+}
+
+output "cloudwatch_dashboard_url" {
+  value = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#dashboards:name=${var.app_name}"
+}
+
+output "sns_alarms_topic_arn" {
+  value = aws_sns_topic.alarms.arn
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -256,6 +256,11 @@ resource "aws_lb_listener" "http" {
 
 resource "aws_ecs_cluster" "app" {
   name = var.app_name
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_ecs_task_definition" "app" {


### PR DESCRIPTION
## Summary

- **CloudWatch dashboard** (`bge`): 6 widgets covering ECS task count, CPU/memory utilization, ALB request count, 5xx/4xx errors, p50/p95/p99 latency, and ALB target health
- **CloudWatch alarms** (all wired to SNS → email):
  - `bge-ecs-task-count-low` — running tasks drops below 1
  - `bge-alb-5xx-rate-high` — 5xx error rate > 1% over 5 min
  - `bge-ecs-memory-high` — memory > 80% (2 periods)
  - `bge-ecs-cpu-high` — CPU > 80% (2 periods)
- **SNS topic** `bge-alarms` with optional email subscription via `var.alarm_email`
- **ALB access logs** enabled → S3 bucket `bge-alb-logs` (30-day retention, ELB service account bucket policy)
- **`docs/runbook.md`**: health check commands, restart, rollback, scale-up, error investigation, game state recovery, CI/CD procedures

## Terraform variables added

| Variable | Default | Purpose |
|----------|---------|---------|
| `alarm_email` | `""` | Email for SNS alarm notifications. Leave empty to skip subscription. |

## Test plan

- [ ] `terraform plan` shows new resources without destroying existing ones
- [ ] After `terraform apply`: confirm dashboard visible in CloudWatch console
- [ ] Alarms appear in CloudWatch → Alarms with correct thresholds
- [ ] SNS topic created; if `alarm_email` provided, confirm subscription email arrives
- [ ] ALB access logs enabled: trigger a request and verify log file appears in `bge-alb-logs` bucket
- [ ] Runbook commands execute without error against the live cluster