### PR TITLE
Add Cache-Control: no-store for index.html to prevent stale SPA caching

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -122,7 +122,13 @@ app.UseExceptionHandler("/Error");
 app.MapOpenApi();
 
 app.UseBlazorFrameworkFiles();
-app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions {
+	OnPrepareResponse = ctx => {
+		if (string.Equals(ctx.File.Name, "index.html", StringComparison.OrdinalIgnoreCase)) {
+			ctx.Context.Response.Headers.CacheControl = "no-store";
+		}
+	}
+});
 
 app.UseRouting();
 app.UseHttpMetrics();
@@ -147,7 +153,11 @@ app.MapDefaultControllerRoute();
 app.MapRazorPages();
 app.MapControllers();
 app.MapMetrics();
-app.MapFallbackToFile("index.html");
+app.MapFallbackToFile("index.html", new StaticFileOptions {
+	OnPrepareResponse = ctx => {
+		ctx.Context.Response.Headers.CacheControl = "no-store";
+	}
+});
 
 app.Run();
 


### PR DESCRIPTION
## Problem

In regular Chrome (non-incognito), navigating to `/signin` shows "Sorry, there's nothing at this address" instead of the server-side login page.

## Root Cause

The Blazor `index.html` was served by `MapFallbackToFile` without any `Cache-Control` header. The browser applied heuristic caching based on `ETag` and `Last-Modified` headers, disk-caching the SPA entry point for server-side routes like `/signin`. On subsequent visits, the browser serves the cached Blazor SPA HTML instead of hitting the server, so the Blazor client-side router shows its NotFound message.

Incognito worked because there's no disk cache.

## Fix

Sets `Cache-Control: no-store` on `index.html` served via both:
- `UseStaticFiles` (direct `/index.html` requests)
- `MapFallbackToFile` (SPA fallback for unmatched routes)

This prevents browsers from disk-caching the SPA entry point.