### PR TITLE
Add resource trading feature (BGE-36, spec 2.4)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -10,6 +10,22 @@
 
     <_WorkerAssignment />
 
+    <div class="bge-trade mt-3">
+        <h3>Handel</h3>
+        <div>
+            <select @bind="tradeFromResource" class="form-select d-inline-block" style="width:150px">
+                <option value="minerals">Mineralien → Gas</option>
+                <option value="gas">Gas → Mineralien</option>
+            </select>
+            <input type="number" min="1" @bind="tradeAmount" class="form-control d-inline-block ms-2" style="width:100px" />
+            <span class="ms-2">Kosten: @(tradeAmount * 2) → erhalten: @tradeAmount</span>
+            <button class="btn btn-warning ms-2" @onclick="Trade">Handeln</button>
+        </div>
+        @if (!string.IsNullOrEmpty(tradeError)) {
+            <span class="text-danger">@tradeError</span>
+        }
+    </div>
+
     <div class="bge-colonize mt-3">
         <h3>Kolonisieren</h3>
         @if (resources != null) {
@@ -80,6 +96,9 @@
     private string? lastError;
     private string? colonizeError;
     private int colonizeAmount = 1;
+    private string tradeFromResource = "minerals";
+    private int tradeAmount = 1;
+    private string? tradeError;
     private _BuildQueue? buildQueue;
 
     protected override async Task OnInitializedAsync() {
@@ -93,6 +112,17 @@
         } else {
             var error = await response.Content.ReadAsStringAsync();
             lastError = error;
+        }
+    }
+
+    private async Task Trade() {
+        tradeError = null;
+        var request = new TradeResourceRequest { FromResource = tradeFromResource, Amount = tradeAmount };
+        var response = await Http.PostAsJsonAsync("api/resources/trade", request);
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            tradeError = await response.Content.ReadAsStringAsync();
         }
     }
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
@@ -21,14 +21,17 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ILogger<ResourcesController> logger;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
 
 		public ResourcesController(ILogger<ResourcesController> logger
 				, CurrentUserContext currentUserContext
 				, ResourceRepository resourceRepository
+				, ResourceRepositoryWrite resourceRepositoryWrite
 			) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
 		}
 
 		[HttpGet]
@@ -41,6 +44,25 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				SecondaryResources = CostViewModel.Create(resourceRepository.GetSecondaryResources(playerId)),
 				ColonizationCostPerLand = ColonizeRepositoryWrite.GetCostPerLand(currentLand)
 			};
+		}
+
+		[HttpPost]
+		public ActionResult Trade([FromBody] TradeResourceRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (request.FromResource == null || request.Amount <= 0)
+				return BadRequest("Invalid trade request.");
+			try {
+				resourceRepositoryWrite.TradeResource(new TradeResourceCommand(
+					currentUserContext.PlayerId!,
+					Id.ResDef(request.FromResource),
+					request.Amount
+				));
+				return Ok();
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			} catch (InvalidOperationException e) {
+				return BadRequest(e.Message);
+			}
 		}
 	}
 }

--- a/src/BrowserGameEngine.Shared/TradeResourceRequest.cs
+++ b/src/BrowserGameEngine.Shared/TradeResourceRequest.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public record TradeResourceRequest {
+		public string? FromResource { get; set; }
+		public int Amount { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ResourcesTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ResourcesTest.cs
@@ -1,5 +1,6 @@
 ﻿using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
@@ -66,5 +67,40 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Throws<ArgumentOutOfRangeException>( () => g.ResourceRepository.CanAfford(g.WorldStateFactory.Player1,
 				new Cost(new Dictionary<ResourceDefId, decimal> { { Id.ResDef("res1"), 1000 }, { Id.ResDef("res2"), 2000 }, { Id.ResDef("res3"), -1 } }.ToFrozenDictionary())));
 		}
-    }
+
+		[Fact]
+		public void TradeResource_Res2ToRes3_DeductsTwiceAndAddsOnce() {
+			var g = new TestGame();
+			// Player1 starts with res2=2000, res3=0
+			g.ResourceRepositoryWrite.TradeResource(new TradeResourceCommand(g.Player1, Id.ResDef("res2"), 100));
+			Assert.Equal(1800, g.ResourceRepository.GetAmount(g.Player1, Id.ResDef("res2")));
+			Assert.Equal(100, g.ResourceRepository.GetAmount(g.Player1, Id.ResDef("res3")));
+		}
+
+		[Fact]
+		public void TradeResource_Res3ToRes2_DeductsTwiceAndAddsOnce() {
+			var g = new TestGame();
+			// Seed some res3 first
+			g.ResourceRepositoryWrite.AddResources(g.Player1, Id.ResDef("res3"), 200);
+			g.ResourceRepositoryWrite.TradeResource(new TradeResourceCommand(g.Player1, Id.ResDef("res3"), 50));
+			Assert.Equal(100, g.ResourceRepository.GetAmount(g.Player1, Id.ResDef("res3")));
+			Assert.Equal(2050, g.ResourceRepository.GetAmount(g.Player1, Id.ResDef("res2")));
+		}
+
+		[Fact]
+		public void TradeResource_InsufficientFunds_ThrowsCannotAffordException() {
+			var g = new TestGame();
+			// Player1 has res2=2000; trading 1500 costs 3000, which exceeds the balance
+			Assert.Throws<CannotAffordException>(() =>
+				g.ResourceRepositoryWrite.TradeResource(new TradeResourceCommand(g.Player1, Id.ResDef("res2"), 1500)));
+		}
+
+		[Fact]
+		public void TradeResource_ScoreResource_ThrowsInvalidOperationException() {
+			var g = new TestGame();
+			// res1 is the score resource and must not be tradeable
+			Assert.Throws<InvalidOperationException>(() =>
+				g.ResourceRepositoryWrite.TradeResource(new TradeResourceCommand(g.Player1, Id.ResDef("res1"), 10)));
+		}
+	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -52,7 +52,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			PlayerRepository = new PlayerRepository(World, ScoreRepository, AllianceRepository);
 			PlayerRepositoryWrite = new PlayerRepositoryWrite(World, TimeProvider.System);
 			ResourceRepository = new ResourceRepository(World, GameDef);
-			ResourceRepositoryWrite = new ResourceRepositoryWrite(World, ResourceRepository);
+			ResourceRepositoryWrite = new ResourceRepositoryWrite(World, ResourceRepository, GameDef);
 			ActionQueueRepository = new ActionQueueRepository(World);
 			AssetRepository = new AssetRepository(World, PlayerRepository, ActionQueueRepository);
 			AssetRepositoryWrite = new AssetRepositoryWrite(LoggerFactory.CreateLogger<AssetRepositoryWrite>(), World, AssetRepository, ResourceRepository, ResourceRepositoryWrite, ActionQueueRepository, GameDef);

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -32,4 +32,5 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record AddToQueueCommand(PlayerId PlayerId, string Type, string DefId, int Count) : ICommand;
 	public record RemoveFromQueueCommand(PlayerId PlayerId, Guid EntryId) : ICommand;
 	public record ReorderQueueCommand(PlayerId PlayerId, Guid EntryId, int NewPriority) : ICommand;
+	public record TradeResourceCommand(PlayerId PlayerId, ResourceDefId FromResource, int Amount) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -66,6 +66,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				if (!tradeableResources.Contains(cmd.FromResource))
 					throw new InvalidOperationException($"Resource '{cmd.FromResource.Id}' is not tradeable.");
 
+				// NOTE: assumes exactly 2 tradeable resources; correct for SCO but would break if the game def ever adds a third
 				var toResource = tradeableResources.First(r => r != cmd.FromResource);
 				var cost = Cost.FromSingle(cmd.FromResource, 2m * cmd.Amount);
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -4,6 +4,7 @@ using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
@@ -11,12 +12,15 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly Lock _lock = new();
 		private readonly WorldState world;
 		private readonly ResourceRepository resourceRepository;
+		private readonly GameDef gameDef;
 
 		public ResourceRepositoryWrite(WorldState world
 			, ResourceRepository resourceRepository
+			, GameDef gameDef
 			) {
 			this.world = world;
 			this.resourceRepository = resourceRepository;
+			this.gameDef = gameDef;
 		}
 
 		private IDictionary<ResourceDefId, decimal> Res(PlayerId playerId) => world.GetPlayer(playerId).State.Resources;
@@ -49,6 +53,31 @@ namespace BrowserGameEngine.StatefulGameServer {
 					playerRes[resourceDefId] += value;
 				}
 				return playerRes[resourceDefId];
+			}
+		}
+
+		public void TradeResource(TradeResourceCommand cmd) {
+			lock (_lock) {
+				var tradeableResources = gameDef.Resources
+					.Where(r => r.Id != gameDef.ScoreResource)
+					.Select(r => r.Id)
+					.ToList();
+
+				if (!tradeableResources.Contains(cmd.FromResource))
+					throw new InvalidOperationException($"Resource '{cmd.FromResource.Id}' is not tradeable.");
+
+				var toResource = tradeableResources.First(r => r != cmd.FromResource);
+				var cost = Cost.FromSingle(cmd.FromResource, 2m * cmd.Amount);
+
+				if (!resourceRepository.CanAfford(cmd.PlayerId, cost)) throw new CannotAffordException(cost);
+
+				DeductResourceUnchecked(cmd.PlayerId, cmd.FromResource, 2m * cmd.Amount);
+				var playerRes = Res(cmd.PlayerId);
+				if (!playerRes.ContainsKey(toResource)) {
+					playerRes.Add(toResource, cmd.Amount);
+				} else {
+					playerRes[toResource] += cmd.Amount;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `TradeResourceCommand(PlayerId, FromResource, Amount)` to the command records
- Add `TradeResource` handler in `ResourceRepositoryWrite`: validates the player has enough, deducts `2 × Amount` of the source resource, adds `Amount` of the target resource (2:1 rate)
- Tradeable resources are any non-score resources (minerals ↔ gas in SCO)
- Add `POST /api/resources/trade` endpoint with error handling for `CannotAffordException` and invalid resource
- Add `TradeResourceRequest` ViewModel in Shared
- Add trade form on the Base page: dropdown to select direction, amount input, cost preview

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (117/117)
- [ ] Visit `/base` — trade section should appear with resource dropdown and amount field
- [ ] Trade minerals → gas: entering amount 50 should deduct 100 minerals, add 50 gas
- [ ] Trade gas → minerals: entering amount 25 should deduct 50 gas, add 25 minerals
- [ ] Insufficient funds returns an error message

Closes BGE-36