### PR TITLE
Add alliance ranking leaderboard (BGE-38, spec 12.2)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
@@ -1,0 +1,45 @@
+@page "/allianceranking"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h1>Alliance Ranking</h1>
+
+@if (model == null) {
+    <p><em>Loading...</em></p>
+} else if (!model.Any()) {
+    <p>No alliances with 2 or more members yet.</p>
+} else {
+    <table class="table">
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Name</th>
+                <th>Members</th>
+                <th>Total Land</th>
+                <th>Avg Land</th>
+                <th>Score</th>
+            </tr>
+        </thead>
+        <tbody>
+            @for (int i = 0; i < model.Length; i++) {
+                var item = model[i];
+                <tr>
+                    <td>@(i + 1)</td>
+                    <td><a href="alliances/@item.AllianceId">@item.Name</a></td>
+                    <td>@item.MemberCount</td>
+                    <td>@item.TotalLand.ToString("N0")</td>
+                    <td>@item.AvgLand.ToString("N0")</td>
+                    <td>@item.Score.ToString("N1")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private AllianceRankingViewModel[]? model;
+
+    protected override async Task OnInitializedAsync() {
+        model = await Http.GetFromJsonAsync<AllianceRankingViewModel[]>("api/allianceranking");
+    }
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -43,6 +43,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="allianceranking">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Alliance Ranking
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="players">
                 <span class="oi oi-people" aria-hidden="true"></span> My Players
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AllianceRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AllianceRankingController.cs
@@ -1,0 +1,24 @@
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]")]
+	public class AllianceRankingController : ControllerBase {
+		private readonly AllianceScoreRepository allianceScoreRepository;
+
+		public AllianceRankingController(AllianceScoreRepository allianceScoreRepository) {
+			this.allianceScoreRepository = allianceScoreRepository;
+		}
+
+		[HttpGet]
+		public IEnumerable<AllianceRankingViewModel> Get() {
+			return allianceScoreRepository.GetRanked().Select(s => new AllianceRankingViewModel(
+				s.AllianceId, s.Name, s.MemberCount, s.TotalLand, s.AvgLand, s.Score));
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/AllianceRankingViewModel.cs
+++ b/src/BrowserGameEngine.Shared/AllianceRankingViewModel.cs
@@ -1,0 +1,10 @@
+namespace BrowserGameEngine.Shared {
+	public record AllianceRankingViewModel(
+		string AllianceId,
+		string Name,
+		int MemberCount,
+		decimal TotalLand,
+		decimal AvgLand,
+		decimal Score
+	);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceScoreRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceScoreRepositoryTest.cs
@@ -1,0 +1,118 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class AllianceScoreRepositoryTest {
+
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+		private static readonly PlayerId Player3 = PlayerIdFactory.Create("player2");
+
+		private static AllianceScoreRepository MakeRepo(TestGame game) =>
+			new AllianceScoreRepository(game.AllianceRepository, game.ScoreRepository);
+
+		[Fact]
+		public void GetRanked_NoAlliances_ReturnsEmpty() {
+			var game = new TestGame(playerCount: 2);
+			var repo = MakeRepo(game);
+
+			var result = repo.GetRanked().ToList();
+
+			Assert.Empty(result);
+		}
+
+		[Fact]
+		public void GetRanked_OnlyOneMember_ExcludesAlliance() {
+			var game = new TestGame(playerCount: 3);
+			var repo = MakeRepo(game);
+			game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "Solo", "pw"));
+			// Alliance has only 1 accepted member (Player1 is the leader, no one joined)
+
+			var result = repo.GetRanked().ToList();
+
+			Assert.Empty(result);
+		}
+
+		[Fact]
+		public void GetRanked_TwoAcceptedMembers_IncludesAlliance() {
+			var game = new TestGame(playerCount: 3);
+			var repo = MakeRepo(game);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "Team", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+
+			var result = repo.GetRanked().ToList();
+
+			Assert.Single(result);
+			Assert.Equal("Team", result[0].Name);
+			Assert.Equal(2, result[0].MemberCount);
+		}
+
+		[Fact]
+		public void GetRanked_ScoreFormula_Correct() {
+			var game = new TestGame(playerCount: 3);
+			var repo = MakeRepo(game);
+			// Each player starts with 1000 res1 (score). Set specific values.
+			game.ResourceRepositoryWrite.AddResources(Player1, Id.ResDef("res1"), 500);  // player1: 1500
+			game.ResourceRepositoryWrite.AddResources(Player2, Id.ResDef("res1"), 0);    // player2: 1000
+
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "Team", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+
+			var result = repo.GetRanked().Single();
+
+			// totalLand = 1500 + 1000 = 2500, avgLand = 1250, score = 1250 + 2500/12
+			Assert.Equal(2500m, result.TotalLand);
+			Assert.Equal(1250m, result.AvgLand);
+			Assert.Equal(1250m + 2500m / 12, result.Score);
+		}
+
+		[Fact]
+		public void GetRanked_SortedDescendingByScore() {
+			var game = new TestGame(playerCount: 4);
+			var repo = MakeRepo(game);
+			var player4 = PlayerIdFactory.Create("player3");
+
+			// Alliance 1: Player1 (1000) + Player2 (1000) → total=2000, avg=1000, score=1000+2000/12
+			var id1 = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "LowTeam", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, id1, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+
+			// Alliance 2: Player3 (5000) + player4 (5000) → higher score
+			game.ResourceRepositoryWrite.AddResources(Player3, Id.ResDef("res1"), 4000);
+			game.ResourceRepositoryWrite.AddResources(player4, Id.ResDef("res1"), 4000);
+			var id2 = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player3, "HighTeam", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(player4, id2, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player3, player4));
+
+			var result = repo.GetRanked().ToList();
+
+			Assert.Equal(2, result.Count);
+			Assert.Equal("HighTeam", result[0].Name);
+			Assert.Equal("LowTeam", result[1].Name);
+		}
+
+		[Fact]
+		public void GetRanked_PendingMember_DoesNotContributeToScore() {
+			var game = new TestGame(playerCount: 3);
+			var repo = MakeRepo(game);
+			// Player3 gets lots of land but stays pending
+			game.ResourceRepositoryWrite.AddResources(Player3, Id.ResDef("res1"), 99000);
+
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "Team", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			// Player3 joins but is NOT accepted
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "pw"));
+
+			var result = repo.GetRanked().Single();
+
+			// Only Player1 (1000) + Player2 (1000) count
+			Assert.Equal(2000m, result.TotalLand);
+			Assert.Equal(2, result.MemberCount);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<ScoreRepository>();
 			services.AddSingleton<AllianceRepository>();
 			services.AddSingleton<AllianceRepositoryWrite>();
+			services.AddSingleton<AllianceScoreRepository>();
 			services.AddSingleton<AssetRepository>();
 			services.AddSingleton<AssetRepositoryWrite>();
 			services.AddSingleton<UnitRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceScoreRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceScoreRepository.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public record AllianceScore(
+		string AllianceId,
+		string Name,
+		int MemberCount,
+		decimal TotalLand,
+		decimal AvgLand,
+		decimal Score
+	);
+
+	public class AllianceScoreRepository {
+		private readonly AllianceRepository allianceRepository;
+		private readonly ScoreRepository scoreRepository;
+
+		public AllianceScoreRepository(AllianceRepository allianceRepository, ScoreRepository scoreRepository) {
+			this.allianceRepository = allianceRepository;
+			this.scoreRepository = scoreRepository;
+		}
+
+		public IEnumerable<AllianceScore> GetRanked() {
+			return allianceRepository.GetAll()
+				.Select(alliance => {
+					var acceptedMembers = alliance.Members.Where(m => !m.IsPending).ToList();
+					return new { alliance, acceptedMembers };
+				})
+				.Where(x => x.acceptedMembers.Count >= 2)
+				.Select(x => {
+					decimal totalLand = x.acceptedMembers.Sum(m => scoreRepository.GetScore(m.PlayerId));
+					decimal avgLand = totalLand / x.acceptedMembers.Count;
+					decimal score = avgLand + totalLand / 12;
+					return new AllianceScore(
+						AllianceId: x.alliance.AllianceId.ToString(),
+						Name: x.alliance.Name,
+						MemberCount: x.acceptedMembers.Count,
+						TotalLand: totalLand,
+						AvgLand: avgLand,
+						Score: score
+					);
+				})
+				.OrderByDescending(vm => vm.Score);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `AllianceScoreRepository.GetRanked()` — computes `score = avg_land + total_land / 12` per alliance; filters to 2+ accepted members; returns sorted descending
- New `GET /api/allianceranking` endpoint returning `AllianceRankingViewModel[]`
- New `AllianceRanking.razor` Blazor page at `/allianceranking` with rank, name, members, total land, avg land, score columns
- Alliance Ranking link added to NavMenu

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (123 tests, 5 new)
- [ ] Alliance with 1 member doesn't appear in ranking
- [ ] Alliance with 2+ accepted members appears; pending members excluded
- [ ] Score formula `avg_land + total_land/12` is correct
- [ ] Alliances sorted by score descending

Closes BGE-38