### PR TITLE
Game Lobby UI — Browse and Join Games (BGE-136)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/GameLobby.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/GameLobby.razor
@@ -1,0 +1,102 @@
+@page "/lobby"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h1>Game Lobby</h1>
+
+@if (!string.IsNullOrEmpty(successMessage)) {
+    <div class="alert alert-success">@successMessage</div>
+}
+
+@if (!string.IsNullOrEmpty(lastError)) {
+    <div class="alert alert-danger">@lastError</div>
+}
+
+@if (games == null) {
+    <p><em>Loading...</em></p>
+} else if (games.Count == 0) {
+    <p>No games available.</p>
+} else {
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th>Game</th>
+                    <th>Status</th>
+                    <th>Players</th>
+                    <th>Start Time</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var game in games) {
+                    <tr>
+                        <td><strong>@game.Name</strong></td>
+                        <td>
+                            <span class="badge @GetStatusBadgeClass(game.Status)">
+                                @GetStatusLabel(game.Status)
+                            </span>
+                        </td>
+                        <td>@game.PlayerCount / @game.MaxPlayers</td>
+                        <td>
+                            @if (game.StartTime.HasValue) {
+                                @game.StartTime.Value.ToString("yyyy-MM-dd HH:mm")
+                                <span class="text-muted"> UTC</span>
+                            } else {
+                                <span class="text-muted">TBD</span>
+                            }
+                        </td>
+                        <td>
+                            @if (game.CanJoin) {
+                                <button class="btn btn-sm btn-primary" @onclick="() => JoinGame(game)">
+                                    Join
+                                </button>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<GameSummaryViewModel>? games;
+    private string? lastError;
+    private string? successMessage;
+
+    protected override async Task OnInitializedAsync() {
+        await LoadGames();
+    }
+
+    private async Task LoadGames() {
+        var result = await Http.GetFromJsonAsync<GameListViewModel>("api/games");
+        games = result?.Games ?? new();
+    }
+
+    private async Task JoinGame(GameSummaryViewModel game) {
+        lastError = null;
+        successMessage = null;
+        var response = await Http.PostAsJsonAsync($"api/games/{game.GameId}/join", new { });
+        if (response.IsSuccessStatusCode) {
+            successMessage = $"You have joined \"{game.Name}\"!";
+            await LoadGames();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private static string GetStatusBadgeClass(string status) => status switch {
+        "upcoming" => "bg-warning text-dark",
+        "active"   => "bg-success",
+        "finished" => "bg-secondary",
+        _          => "bg-light text-dark"
+    };
+
+    private static string GetStatusLabel(string status) => status switch {
+        "upcoming" => "Upcoming",
+        "active"   => "Active",
+        "finished" => "Finished",
+        _          => status
+    };
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -13,6 +13,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="lobby">
+                <span class="oi oi-globe" aria-hidden="true"></span> Game Lobby
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="base">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Basis
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -3,7 +3,6 @@ using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Linq;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
@@ -23,17 +22,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpGet]
+		[AllowAnonymous]
 		public ActionResult<GameListViewModel> GetAll() {
-			var games = gameRepository.GetAll().Select(g => new GameSummaryViewModel {
-				GameId = g.GameId,
-				Name = g.Name,
-				Status = g.Status.ToString().ToLowerInvariant(),
-				PlayerCount = g.PlayerCount,
-				MaxPlayers = g.MaxPlayers,
-				StartTime = g.StartTime,
-				CanJoin = g.Status == GameStatus.Upcoming
-			}).ToList();
-			return Ok(new GameListViewModel { Games = games });
+			var games = gameRepository.GetAll().Select(g => new GameSummaryViewModel(
+				g.GameId,
+				g.Name,
+				g.GameDefType,
+				g.Status.ToString().ToLowerInvariant(),
+				g.PlayerCount,
+				g.MaxPlayers,
+				g.StartTime,
+				g.EndTime,
+				g.Status == GameStatus.Upcoming
+			)).ToList();
+			return Ok(new GameListViewModel(games));
 		}
 
 		[HttpPost("{gameId}/join")]
@@ -42,7 +44,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var game = gameRepository.Get(gameId);
 			if (game == null) return NotFound();
 			if (game.Status != GameStatus.Upcoming) return BadRequest("This game is not open for joining.");
-			gameRepository.AddPlayer(gameId, currentUserContext.PlayerId!.Id);
+			if (!gameRepository.AddPlayer(gameId, currentUserContext.PlayerId!.Id)) {
+				return Conflict("You have already joined this game.");
+			}
 			return Ok();
 		}
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -1,0 +1,49 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/games")]
+	public class GamesController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly GameRepository gameRepository;
+
+		public GamesController(
+			CurrentUserContext currentUserContext,
+			GameRepository gameRepository
+		) {
+			this.currentUserContext = currentUserContext;
+			this.gameRepository = gameRepository;
+		}
+
+		[HttpGet]
+		public ActionResult<GameListViewModel> GetAll() {
+			var games = gameRepository.GetAll().Select(g => new GameSummaryViewModel {
+				GameId = g.GameId,
+				Name = g.Name,
+				Status = g.Status.ToString().ToLowerInvariant(),
+				PlayerCount = g.PlayerCount,
+				MaxPlayers = g.MaxPlayers,
+				StartTime = g.StartTime,
+				CanJoin = g.Status == GameStatus.Upcoming
+			}).ToList();
+			return Ok(new GameListViewModel { Games = games });
+		}
+
+		[HttpPost("{gameId}/join")]
+		public ActionResult Join(string gameId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var game = gameRepository.Get(gameId);
+			if (game == null) return NotFound();
+			if (game.Status != GameStatus.Upcoming) return BadRequest("This game is not open for joining.");
+			gameRepository.AddPlayer(gameId, currentUserContext.PlayerId!.Id);
+			return Ok();
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -23,8 +23,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpGet]
+		[AllowAnonymous]
 		public ActionResult<GameListViewModel> GetAll() {
-			if (!currentUserContext.IsValid) return Unauthorized();
 			var games = gameRepository.GetAll().Select(g => new GameSummaryViewModel(
 				g.GameId,
 				g.Name,

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -22,8 +22,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpGet]
-		[AllowAnonymous]
 		public ActionResult<GameListViewModel> GetAll() {
+			if (!currentUserContext.IsValid) return Unauthorized();
 			var games = gameRepository.GetAll().Select(g => new GameSummaryViewModel(
 				g.GameId,
 				g.Name,

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class GameListViewModel {
+		public List<GameSummaryViewModel> Games { get; set; } = new();
+	}
+
+	public class GameSummaryViewModel {
+		public string GameId { get; set; } = "";
+		public string Name { get; set; } = "";
+		public string Status { get; set; } = "";
+		public int PlayerCount { get; set; }
+		public int MaxPlayers { get; set; }
+		public DateTime? StartTime { get; set; }
+		public bool CanJoin { get; set; }
+	}
+
+	public class JoinGameRequest {
+		public string GameId { get; set; } = "";
+	}
+}

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -2,21 +2,19 @@ using System;
 using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
-	public class GameListViewModel {
-		public List<GameSummaryViewModel> Games { get; set; } = new();
-	}
+	public record GameSummaryViewModel(
+		string GameId,
+		string Name,
+		string GameDefType,
+		string Status,
+		int PlayerCount,
+		int MaxPlayers,
+		DateTime? StartTime,
+		DateTime? EndTime,
+		bool CanJoin
+	);
 
-	public class GameSummaryViewModel {
-		public string GameId { get; set; } = "";
-		public string Name { get; set; } = "";
-		public string Status { get; set; } = "";
-		public int PlayerCount { get; set; }
-		public int MaxPlayers { get; set; }
-		public DateTime? StartTime { get; set; }
-		public bool CanJoin { get; set; }
-	}
+	public record GameListViewModel(List<GameSummaryViewModel> Games);
 
-	public class JoinGameRequest {
-		public string GameId { get; set; } = "";
-	}
+	public record JoinGameRequest(string GameId);
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -15,6 +15,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public static async Task AddGameServer(this IServiceCollection services, IBlobStorage storage, WorldStateImmutable defaultWorldState) {
 			await InitPersistenceAndGameState(services, storage, defaultWorldState);
 			services.AddSingleton(TimeProvider.System);
+			services.AddSingleton<GameRepository>();
 			services.AddSingleton<UserRepository>();
 			services.AddSingleton<UserRepositoryWrite>();
 			services.AddSingleton<PlayerRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameInfo.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameInfo.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public enum GameStatus {
+		Upcoming,
+		Active,
+		Finished
+	}
+
+	public class GameInfo {
+		public string GameId { get; set; } = "";
+		public string Name { get; set; } = "";
+		public GameStatus Status { get; set; }
+		public int PlayerCount { get; set; }
+		public int MaxPlayers { get; set; }
+		public DateTime? StartTime { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameInfo.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameInfo.cs
@@ -10,9 +10,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class GameInfo {
 		public string GameId { get; set; } = "";
 		public string Name { get; set; } = "";
+		public string GameDefType { get; set; } = "sco";
 		public GameStatus Status { get; set; }
 		public int PlayerCount { get; set; }
 		public int MaxPlayers { get; set; }
 		public DateTime? StartTime { get; set; }
+		public DateTime? EndTime { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameRepository.cs
@@ -27,14 +27,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 			return playersByGame.TryGetValue(gameId, out var players) && players.Contains(playerId);
 		}
 
-		public void AddPlayer(string gameId, string playerId) {
+		public bool AddPlayer(string gameId, string playerId) {
 			var players = playersByGame.GetOrAdd(gameId, _ => new HashSet<string>());
 			lock (players) {
-				players.Add(playerId);
+				if (!players.Add(playerId)) {
+					return false;
+				}
+				if (games.TryGetValue(gameId, out var game)) {
+					game.PlayerCount = players.Count;
+				}
 			}
-			if (games.TryGetValue(gameId, out var game)) {
-				game.PlayerCount = playersByGame.TryGetValue(gameId, out var p) ? p.Count : 0;
-			}
+			return true;
 		}
 
 		private void SeedDefaultGames() {
@@ -45,7 +48,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				Status = GameStatus.Upcoming,
 				PlayerCount = 0,
 				MaxPlayers = 50,
-				StartTime = now.AddDays(2)
+				StartTime = now.AddDays(2),
+				EndTime = now.AddDays(16)
 			};
 			var active1 = new GameInfo {
 				GameId = "game-beta",
@@ -53,7 +57,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				Status = GameStatus.Active,
 				PlayerCount = 12,
 				MaxPlayers = 50,
-				StartTime = now.AddDays(-5)
+				StartTime = now.AddDays(-5),
+				EndTime = now.AddDays(9)
 			};
 			var finished1 = new GameInfo {
 				GameId = "game-s1",
@@ -61,7 +66,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				Status = GameStatus.Finished,
 				PlayerCount = 38,
 				MaxPlayers = 50,
-				StartTime = now.AddDays(-30)
+				StartTime = now.AddDays(-30),
+				EndTime = now.AddDays(-16)
 			};
 			games[upcoming1.GameId] = upcoming1;
 			games[active1.GameId] = active1;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameRepository.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	// Stub game registry. Holds the list of game instances that users can browse and join.
+	// This will be replaced by the full multi-game infrastructure in BGE-131.
+	public class GameRepository {
+		private readonly ConcurrentDictionary<string, GameInfo> games = new();
+		private readonly ConcurrentDictionary<string, HashSet<string>> playersByGame = new();
+
+		public GameRepository() {
+			SeedDefaultGames();
+		}
+
+		public IEnumerable<GameInfo> GetAll() {
+			return games.Values.OrderBy(g => g.StartTime);
+		}
+
+		public GameInfo? Get(string gameId) {
+			games.TryGetValue(gameId, out var game);
+			return game;
+		}
+
+		public bool IsPlayerInGame(string gameId, string playerId) {
+			return playersByGame.TryGetValue(gameId, out var players) && players.Contains(playerId);
+		}
+
+		public void AddPlayer(string gameId, string playerId) {
+			var players = playersByGame.GetOrAdd(gameId, _ => new HashSet<string>());
+			lock (players) {
+				players.Add(playerId);
+			}
+			if (games.TryGetValue(gameId, out var game)) {
+				game.PlayerCount = playersByGame.TryGetValue(gameId, out var p) ? p.Count : 0;
+			}
+		}
+
+		private void SeedDefaultGames() {
+			var now = DateTime.UtcNow;
+			var upcoming1 = new GameInfo {
+				GameId = "game-alpha",
+				Name = "Alpha Season",
+				Status = GameStatus.Upcoming,
+				PlayerCount = 0,
+				MaxPlayers = 50,
+				StartTime = now.AddDays(2)
+			};
+			var active1 = new GameInfo {
+				GameId = "game-beta",
+				Name = "Beta Season",
+				Status = GameStatus.Active,
+				PlayerCount = 12,
+				MaxPlayers = 50,
+				StartTime = now.AddDays(-5)
+			};
+			var finished1 = new GameInfo {
+				GameId = "game-s1",
+				Name = "Season 1",
+				Status = GameStatus.Finished,
+				PlayerCount = 38,
+				MaxPlayers = 50,
+				StartTime = now.AddDays(-30)
+			};
+			games[upcoming1.GameId] = upcoming1;
+			games[active1.GameId] = active1;
+			games[finished1.GameId] = finished1;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a **Game Lobby** page at `/lobby` where users can browse available games by status (upcoming / active / finished) and join upcoming ones
- New `GameLobbyViewModels` DTO contract in `Shared` (`GameListViewModel`, `GameSummaryViewModel`, `JoinGameRequest`)
- `GameRepository` stub in `StatefulGameServer` (seeded with sample upcoming/active/finished games; designed as a foundation for the full multi-game architecture from [BGE-131])
- `GamesController` with `GET /api/games` and `POST /api/games/{id}/join`
- **NavMenu** updated with a "Game Lobby" link (globe icon, immediately after Home)

## Test plan
- [ ] Build passes (`dotnet build --configuration Release`)
- [ ] All 117 existing tests pass (`dotnet test`)
- [ ] Verify `/lobby` page loads and shows game list with correct status badges
- [ ] Verify "Join" button appears only for upcoming games
- [ ] Verify joining an upcoming game posts successfully and refreshes the list
- [ ] Verify mobile layout renders cleanly (table-responsive wrapper)
- [ ] Verify Nav link highlights when on `/lobby`