### PR TITLE
feat: BGE-125 Phase 1 — multi-game foundation

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/HostedServices/GlobalPersistenceHostedService.cs
+++ b/src/BrowserGameEngine.FrontendServer/HostedServices/GlobalPersistenceHostedService.cs
@@ -1,0 +1,43 @@
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer {
+	public class GlobalPersistenceHostedService : IHostedService, IDisposable {
+		private readonly ILogger<GlobalPersistenceHostedService> logger;
+		private readonly GlobalPersistenceService globalPersistenceService;
+		private readonly GameRegistry gameRegistry;
+		private Timer? timer;
+
+		public GlobalPersistenceHostedService(ILogger<GlobalPersistenceHostedService> logger, GlobalPersistenceService globalPersistenceService, GameRegistry gameRegistry) {
+			this.logger = logger;
+			this.globalPersistenceService = globalPersistenceService;
+			this.gameRegistry = gameRegistry;
+		}
+
+		public Task StartAsync(CancellationToken stoppingToken) {
+			timer = new Timer(DoWork, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
+			return Task.CompletedTask;
+		}
+
+		private void DoWork(object? state) {
+			try {
+				_ = globalPersistenceService.StoreGlobalState(gameRegistry.GlobalState.ToImmutable());
+			} catch (Exception ex) {
+				logger.LogError(ex, "GlobalPersistenceHostedService: error storing global state");
+			}
+		}
+
+		public Task StopAsync(CancellationToken stoppingToken) {
+			timer?.Change(Timeout.Infinite, 0);
+			return Task.CompletedTask;
+		}
+
+		public void Dispose() => timer?.Dispose();
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/HostedServices/GlobalPersistenceHostedService.cs
+++ b/src/BrowserGameEngine.FrontendServer/HostedServices/GlobalPersistenceHostedService.cs
@@ -12,6 +12,7 @@ namespace BrowserGameEngine.FrontendServer {
 		private readonly ILogger<GlobalPersistenceHostedService> logger;
 		private readonly GlobalPersistenceService globalPersistenceService;
 		private readonly GameRegistry gameRegistry;
+		private int isactive = 0;
 		private Timer? timer;
 
 		public GlobalPersistenceHostedService(ILogger<GlobalPersistenceHostedService> logger, GlobalPersistenceService globalPersistenceService, GameRegistry gameRegistry) {
@@ -26,16 +27,22 @@ namespace BrowserGameEngine.FrontendServer {
 		}
 
 		private void DoWork(object? state) {
+			if (Interlocked.CompareExchange(ref isactive, 1, 0) != 0) return;
 			try {
-				_ = globalPersistenceService.StoreGlobalState(gameRegistry.GlobalState.ToImmutable());
+				SaveGlobalState().GetAwaiter().GetResult();
 			} catch (Exception ex) {
 				logger.LogError(ex, "GlobalPersistenceHostedService: error storing global state");
+			} finally {
+				Interlocked.Exchange(ref isactive, 0);
 			}
 		}
 
-		public Task StopAsync(CancellationToken stoppingToken) {
+		private async Task SaveGlobalState() =>
+			await globalPersistenceService.StoreGlobalState(gameRegistry.GlobalState.ToImmutable());
+
+		public async Task StopAsync(CancellationToken stoppingToken) {
 			timer?.Change(Timeout.Infinite, 0);
-			return Task.CompletedTask;
+			await SaveGlobalState();
 		}
 
 		public void Dispose() => timer?.Dispose();

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -1,20 +1,25 @@
 using Amazon.S3;
 using BrowserGameEngine.FrontendServer;
 using BrowserGameEngine.FrontendServer.Middleware;
+using BrowserGameEngine.FrontendServer.Services;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.Persistence.S3;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Trace;
 using Prometheus;
 using Prometheus.DotNetRuntime;
 using Serilog;
 using Serilog.Events;
+using System.Linq;
 using System.Threading.RateLimiting;
 
 Log.Logger = new LoggerConfiguration()
@@ -34,6 +39,7 @@ builder.Host.UseSerilog();
  */
 builder.Services.AddHostedService<GameTickTimerService>();
 builder.Services.AddHostedService<PersistenceHostedService>();
+builder.Services.AddHostedService<GlobalPersistenceHostedService>();
 
 builder.Services.Configure<BgeOptions>(builder.Configuration.GetSection(BgeOptions.Position));
 builder.Services.AddControllersWithViews();
@@ -103,6 +109,12 @@ await ConfigureGameServices(builder.Services);
  */
 var app = builder.Build();
 
+// Wire tick engine into game instances (Phase 1: single game)
+var tickEngine = app.Services.GetRequiredService<GameTickEngine>();
+foreach (var instance in app.Services.GetRequiredService<BrowserGameEngine.StatefulGameServer.GameRegistry.GameRegistry>().GetAllInstances()) {
+    instance.SetTickEngine(tickEngine);
+}
+
 var forwardedHeadersOptions = new ForwardedHeadersOptions {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 };
@@ -167,17 +179,56 @@ async Task ConfigureGameServices(IServiceCollection services) {
     var stateFactory = new StarcraftOnlineWorldStateFactory();
     var gameDef = gameDefFactory.CreateGameDef();
     new GameDefVerifier().Verify(gameDef);
-    services.AddSingleton<GameDef>(gameDef);
 
     var s3BucketName = builder.Configuration["Bge:S3BucketName"];
     IBlobStorage storage = !string.IsNullOrEmpty(s3BucketName)
         ? new S3Storage(new AmazonS3Client(), s3BucketName, builder.Configuration["Bge:S3KeyPrefix"] ?? "")
         : new FileStorage(new DirectoryInfo("storage"));
 
-    var worldState = stateFactory.CreateDevWorldState();
-    new WorldStateVerifier().Verify(gameDef, worldState); // todo: maybe make this more graceful.
+    var defaultWorldState = stateFactory.CreateDevWorldState();
+    new WorldStateVerifier().Verify(gameDef, defaultWorldState);
 
-    await services.AddGameServer(storage, worldState); // todo: init state for non-development
+    var serializer = new GameStateJsonSerializer();
+    var persistenceService = new PersistenceService(storage, serializer);
+    var globalSerializer = new GlobalStateJsonSerializer();
+    var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
+
+    var migrationLogger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<MigrationService>();
+    var migrationService = new MigrationService(storage, persistenceService, globalPersistenceService, migrationLogger);
+    await migrationService.MigrateIfNeeded();
+
+    GlobalState globalState;
+    if (globalPersistenceService.GlobalStateExists()) {
+        var globalStateImm = await globalPersistenceService.LoadGlobalState();
+        globalState = globalStateImm.ToMutable();
+    } else {
+        globalState = new GlobalState();
+    }
+
+    var gameRegistry = new BrowserGameEngine.StatefulGameServer.GameRegistry.GameRegistry(globalState);
+
+    foreach (var gameRecord in globalState.Games.Where(g => g.Status != GameStatus.Finished)) {
+        WorldStateImmutable wsImm;
+        if (persistenceService.GameStateExists(gameRecord.GameId)) {
+            wsImm = await persistenceService.LoadGameState(gameRecord.GameId);
+        } else {
+            wsImm = defaultWorldState;
+        }
+        var ws = wsImm.ToMutable();
+        var gd = new StarcraftOnlineGameDefFactory().CreateGameDef();
+        gameRegistry.Register(new BrowserGameEngine.StatefulGameServer.GameRegistry.GameInstance(gameRecord, ws, gd));
+    }
+
+    if (!gameRegistry.GetAllInstances().Any()) {
+        var ws = defaultWorldState.ToMutable();
+        var gameRecord = new GameRecordImmutable(
+            new GameId("default"), "Default Game", "sco", GameStatus.Active,
+            DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(3650), TimeSpan.FromSeconds(10));
+        var gd = new StarcraftOnlineGameDefFactory().CreateGameDef();
+        gameRegistry.Register(new BrowserGameEngine.StatefulGameServer.GameRegistry.GameInstance(gameRecord, ws, gd));
+    }
+
+    services.AddGameServer(storage, gameRegistry);
 
     services.AddScoped(_ => CurrentUserContext.Inactive());
 

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -112,7 +112,7 @@ var app = builder.Build();
 // Wire tick engine into game instances (Phase 1: single game)
 var tickEngine = app.Services.GetRequiredService<GameTickEngine>();
 foreach (var instance in app.Services.GetRequiredService<BrowserGameEngine.StatefulGameServer.GameRegistry.GameRegistry>().GetAllInstances()) {
-    instance.SetTickEngine(tickEngine);
+	instance.SetTickEngine(tickEngine);
 }
 
 var forwardedHeadersOptions = new ForwardedHeadersOptions {

--- a/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.StatefulGameServer.GameTicks;
+﻿using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -13,12 +13,12 @@ namespace BrowserGameEngine.FrontendServer {
 		private int executionCount = 0;
 		private int isactive = 0;
 		private readonly ILogger<GameTickTimerService> logger;
-		private readonly GameTickEngine gameTickEngine;
+		private readonly GameRegistry gameRegistry;
 		private Timer? timer;
 
-		public GameTickTimerService(ILogger<GameTickTimerService> logger, GameTickEngine gameTickEngine) {
+		public GameTickTimerService(ILogger<GameTickTimerService> logger, GameRegistry gameRegistry) {
 			this.logger = logger;
-			this.gameTickEngine = gameTickEngine;
+			this.gameRegistry = gameRegistry;
 		}
 
 		public Task StartAsync(CancellationToken stoppingToken) {
@@ -32,7 +32,9 @@ namespace BrowserGameEngine.FrontendServer {
 			try {
 				var count = Interlocked.Increment(ref executionCount);
 				logger.LogInformation("GameTickTimer #{Count}", count);
-				gameTickEngine.CheckAllTicks();
+				foreach (var instance in gameRegistry.GetAllInstances()) {
+					instance.TickEngine?.CheckAllTicks();
+				}
 			} finally {
 				Interlocked.Exchange(ref isactive, 0);
 			}

--- a/src/BrowserGameEngine.FrontendServer/Services/MigrationService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/MigrationService.cs
@@ -1,0 +1,83 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer.Services {
+	public class MigrationService {
+		private readonly IBlobStorage storage;
+		private readonly PersistenceService persistenceService;
+		private readonly GlobalPersistenceService globalPersistenceService;
+		private readonly ILogger<MigrationService> logger;
+
+		public MigrationService(IBlobStorage storage, PersistenceService persistenceService, GlobalPersistenceService globalPersistenceService, ILogger<MigrationService> logger) {
+			this.storage = storage;
+			this.persistenceService = persistenceService;
+			this.globalPersistenceService = globalPersistenceService;
+			this.logger = logger;
+		}
+
+		public async Task MigrateIfNeeded() {
+			if (globalPersistenceService.GlobalStateExists()) {
+				logger.LogInformation("Migration: already migrated, skipping.");
+				return;
+			}
+			if (!storage.Exists("latest.json")) {
+				logger.LogInformation("Migration: no legacy state found, fresh install.");
+				return;
+			}
+
+			logger.LogInformation("Migration: migrating legacy latest.json to multi-game layout.");
+
+			var legacyBytes = await storage.Load("latest.json");
+			var legacyJson = JsonDocument.Parse(legacyBytes);
+
+			var users = new Dictionary<string, UserImmutable>();
+			if (legacyJson.RootElement.TryGetProperty("Users", out var usersElement) &&
+				usersElement.ValueKind != JsonValueKind.Null) {
+				var usersDict = JsonSerializer.Deserialize<Dictionary<string, UserImmutable>>(usersElement.GetRawText());
+				if (usersDict != null) users = usersDict;
+			}
+
+			var worldState = persistenceService.DeserializeLegacy(legacyBytes);
+			var migratedGameId = new GameId("league-round-1");
+			var migratedWorldState = worldState with { GameId = migratedGameId };
+
+			await persistenceService.StoreGameState(migratedGameId, migratedWorldState);
+			logger.LogInformation("Migration: wrote games/league-round-1/state.json");
+
+			var gameRecord = new GameRecordImmutable(
+				GameId: migratedGameId,
+				Name: "BGE League — Round 1",
+				GameDefType: "sco",
+				Status: GameStatus.Active,
+				StartTime: DateTime.UtcNow - TimeSpan.FromDays(1),
+				EndTime: DateTime.UtcNow + TimeSpan.FromDays(3650),
+				TickDuration: TimeSpan.FromSeconds(10)
+			);
+
+			var globalState = new GlobalStateImmutable(
+				Users: users,
+				Games: new List<GameRecordImmutable> { gameRecord },
+				Achievements: new List<PlayerAchievementImmutable>()
+			);
+
+			await globalPersistenceService.StoreGlobalState(globalState);
+			logger.LogInformation("Migration: wrote global/state.json");
+
+			try {
+				var legacyCopy = await storage.Load("latest.json");
+				await storage.Store("latest.json.migrated", legacyCopy);
+				await storage.Delete("latest.json");
+				logger.LogInformation("Migration: renamed latest.json to latest.json.migrated");
+			} catch (Exception ex) {
+				logger.LogWarning(ex, "Migration: could not rename latest.json — continuing anyway");
+			}
+
+			logger.LogInformation("Migration: complete.");
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineWorldStateFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineWorldStateFactory.cs
@@ -75,9 +75,10 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 			}
 
 			return new WorldStateImmutable(
-				players.ToDictionary(x => x.PlayerId), 
-				new GameTickStateImmutable(gameTick, DateTime.Now - TimeSpan.FromMinutes(1)),
-				new List<GameActionImmutable>()
+				Players: players.ToDictionary(x => x.PlayerId),
+				GameTickState: new GameTickStateImmutable(gameTick, DateTime.Now - TimeSpan.FromMinutes(1)),
+				GameActionQueue: new List<GameActionImmutable>(),
+				GameId: new GameId("default")
 			);
 		}
 	}

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record GameId(string Id);
+
+	public enum GameStatus { Upcoming, Active, Finished }
+
+	public record GameRecordImmutable(
+		GameId GameId,
+		string Name,
+		string GameDefType,
+		GameStatus Status,
+		DateTime StartTime,
+		DateTime EndTime,
+		TimeSpan TickDuration,
+		PlayerId? WinnerId = null,
+		DateTime? ActualEndTime = null
+	);
+}

--- a/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameModel {
+	public record GlobalStateImmutable(
+		IDictionary<string, UserImmutable> Users,
+		IList<GameRecordImmutable> Games,
+		IList<PlayerAchievementImmutable> Achievements
+	);
+}

--- a/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record PlayerAchievementImmutable(
+		string UserId,
+		GameId GameId,
+		PlayerId PlayerId,
+		int FinalRank,
+		decimal FinalScore,
+		string GameDefType,
+		DateTime FinishedAt
+	);
+}

--- a/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
@@ -5,7 +5,7 @@ namespace BrowserGameEngine.GameModel {
 		IDictionary<PlayerId, PlayerImmutable> Players,
 		GameTickStateImmutable GameTickState,
 		IList<GameActionImmutable> GameActionQueue,
-		IDictionary<string, UserImmutable>? Users = null,
-		IDictionary<AllianceId, AllianceImmutable>? Alliances = null
+		IDictionary<AllianceId, AllianceImmutable>? Alliances = null,
+		GameId? GameId = null  // null = legacy JSON; treated as "default" in ToMutable()
 	);
 }

--- a/src/BrowserGameEngine.Persistence/GlobalPersistenceService.cs
+++ b/src/BrowserGameEngine.Persistence/GlobalPersistenceService.cs
@@ -1,0 +1,25 @@
+using BrowserGameEngine.GameModel;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.Persistence {
+	public class GlobalPersistenceService {
+		private const string filename = "global/state.json";
+		private readonly IBlobStorage storage;
+		private readonly GlobalStateJsonSerializer serializer;
+
+		public GlobalPersistenceService(IBlobStorage storage, GlobalStateJsonSerializer serializer) {
+			this.storage = storage;
+			this.serializer = serializer;
+		}
+
+		public async Task<GlobalStateImmutable> LoadGlobalState() {
+			return serializer.Deserialize(await storage.Load(filename));
+		}
+
+		public async Task StoreGlobalState(GlobalStateImmutable state) {
+			await storage.Store(filename, serializer.Serialize(state));
+		}
+
+		public bool GlobalStateExists() => storage.Exists(filename);
+	}
+}

--- a/src/BrowserGameEngine.Persistence/GlobalStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GlobalStateJsonSerializer.cs
@@ -1,0 +1,16 @@
+using BrowserGameEngine.GameModel;
+using System.Text.Json;
+
+namespace BrowserGameEngine.Persistence {
+	public class GlobalStateJsonSerializer {
+		public byte[] Serialize(GlobalStateImmutable state) {
+			return JsonSerializer.SerializeToUtf8Bytes(state, GetOptions());
+		}
+
+		public GlobalStateImmutable Deserialize(byte[] blob) {
+			return JsonSerializer.Deserialize<GlobalStateImmutable>(blob, GetOptions())!;
+		}
+
+		private static JsonSerializerOptions GetOptions() => new() { WriteIndented = true };
+	}
+}

--- a/src/BrowserGameEngine.Persistence/PersistenceService.cs
+++ b/src/BrowserGameEngine.Persistence/PersistenceService.cs
@@ -23,5 +23,19 @@ namespace BrowserGameEngine.Persistence {
 		public bool WorldStateExists() {
 			return storage.Exists(filename);
 		}
+
+		public async Task<WorldStateImmutable> LoadGameState(GameId gameId) {
+			return serializer.Deserialize(await storage.Load($"games/{gameId.Id}/state.json"));
+		}
+
+		public async Task StoreGameState(GameId gameId, WorldStateImmutable state) {
+			await storage.Store($"games/{gameId.Id}/state.json", serializer.Serialize(state));
+		}
+
+		public bool GameStateExists(GameId gameId) {
+			return storage.Exists($"games/{gameId.Id}/state.json");
+		}
+
+		public WorldStateImmutable DeserializeLegacy(byte[] blob) => serializer.Deserialize(blob);
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameRegistryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameRegistryTest.cs
@@ -1,0 +1,41 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class GameRegistryTest {
+		private static GameRegistryNs.GameInstance MakeInstance(string gameId) {
+			var game = new TestGame();
+			var record = new GameRecordImmutable(new GameId(gameId), "Test", "sco", GameStatus.Active,
+				DateTime.UtcNow, DateTime.UtcNow.AddDays(1), TimeSpan.FromSeconds(10));
+			return new GameRegistryNs.GameInstance(record, game.World, game.GameDef);
+		}
+
+		[Fact]
+		public void Register_ThenTryGet_ReturnsInstance() {
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			var instance = MakeInstance("test-1");
+			registry.Register(instance);
+			var found = registry.TryGetInstance(new GameId("test-1"));
+			Assert.NotNull(found);
+			Assert.Equal("test-1", found!.Record.GameId.Id);
+		}
+
+		[Fact]
+		public void GetDefaultInstance_WithOneRegistered_ReturnsThat() {
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			var instance = MakeInstance("default");
+			registry.Register(instance);
+			Assert.Equal(instance, registry.GetDefaultInstance());
+		}
+
+		[Fact]
+		public void TryGetInstance_NotFound_ReturnsNull() {
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			var result = registry.TryGetInstance(new GameId("nonexistent"));
+			Assert.Null(result);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
@@ -10,7 +10,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void DeletePlayer_RemovesPlayerFromWorld() {
 			var game = new TestGame(playerCount: 1);
 			var playerId = PlayerIdFactory.Create("player0");
-			var userRepository = new UserRepository(game.World);
+			var userRepository = new UserRepository(game.GlobalState, game.World);
 
 			game.PlayerRepositoryWrite.DeletePlayer(playerId);
 
@@ -24,7 +24,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var userId = "testuser";
 			// Assign a userId to the player via creating a fresh player
 			game.PlayerRepositoryWrite.CreatePlayer(PlayerIdFactory.Create("newplayer"), userId);
-			var userRepository = new UserRepository(game.World);
+			var userRepository = new UserRepository(game.GlobalState, game.World);
 
 			game.PlayerRepositoryWrite.DeletePlayer(PlayerIdFactory.Create("newplayer"));
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SingletonWorldStateAccessorTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SingletonWorldStateAccessorTest.cs
@@ -1,0 +1,13 @@
+using BrowserGameEngine.StatefulGameServer;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class SingletonWorldStateAccessorTest {
+		[Fact]
+		public void Accessor_ReturnsInjectedWorldState() {
+			var game = new TestGame();
+			var accessor = new SingletonWorldStateAccessor(game.World);
+			Assert.Same(game.World, accessor.WorldState);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -15,6 +15,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public NullLoggerFactory LoggerFactory { get; }
 		public WorldState World { get; }
 		public GameDef GameDef { get; }
+		public GlobalState GlobalState { get; }
+		public IWorldStateAccessor Accessor { get; }
 		public ScoreRepository ScoreRepository { get; }
 		public AllianceRepository AllianceRepository { get; }
 		public AllianceRepositoryWrite AllianceRepositoryWrite { get; }
@@ -46,30 +48,32 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			WorldStateFactory = new TestWorldStateFactory();
 			World = initialState.ToMutable();
 			GameDef = new TestGameDefFactory().CreateGameDef();
-			ScoreRepository = new ScoreRepository(GameDef, World);
-			AllianceRepository = new AllianceRepository(World);
-			AllianceRepositoryWrite = new AllianceRepositoryWrite(World, AllianceRepository);
-			PlayerRepository = new PlayerRepository(World, ScoreRepository, AllianceRepository);
-			PlayerRepositoryWrite = new PlayerRepositoryWrite(World, TimeProvider.System);
-			ResourceRepository = new ResourceRepository(World, GameDef);
-			ResourceRepositoryWrite = new ResourceRepositoryWrite(World, ResourceRepository);
-			ActionQueueRepository = new ActionQueueRepository(World);
-			AssetRepository = new AssetRepository(World, PlayerRepository, ActionQueueRepository);
-			AssetRepositoryWrite = new AssetRepositoryWrite(LoggerFactory.CreateLogger<AssetRepositoryWrite>(), World, AssetRepository, ResourceRepository, ResourceRepositoryWrite, ActionQueueRepository, GameDef);
-			UnitRepository = new UnitRepository(World, GameDef, PlayerRepository, AssetRepository);
+			GlobalState = new GlobalState();
+			Accessor = new SingletonWorldStateAccessor(World);
+			ScoreRepository = new ScoreRepository(GameDef, Accessor);
+			AllianceRepository = new AllianceRepository(Accessor);
+			AllianceRepositoryWrite = new AllianceRepositoryWrite(Accessor, AllianceRepository);
+			PlayerRepository = new PlayerRepository(Accessor, ScoreRepository, AllianceRepository);
+			PlayerRepositoryWrite = new PlayerRepositoryWrite(Accessor, TimeProvider.System);
+			ResourceRepository = new ResourceRepository(Accessor, GameDef);
+			ResourceRepositoryWrite = new ResourceRepositoryWrite(Accessor, ResourceRepository);
+			ActionQueueRepository = new ActionQueueRepository(Accessor);
+			AssetRepository = new AssetRepository(Accessor, PlayerRepository, ActionQueueRepository);
+			AssetRepositoryWrite = new AssetRepositoryWrite(LoggerFactory.CreateLogger<AssetRepositoryWrite>(), Accessor, AssetRepository, ResourceRepository, ResourceRepositoryWrite, ActionQueueRepository, GameDef);
+			UnitRepository = new UnitRepository(Accessor, GameDef, PlayerRepository, AssetRepository);
 			BattleBehavior = new BattleBehaviorScoOriginal(LoggerFactory.CreateLogger<IBattleBehavior>());
-			UpgradeRepository = new UpgradeRepository(World);
-			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), World, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository);
-			MessageRepository = new MessageRepository(World);
-			MessageRepositoryWrite = new MessageRepositoryWrite(World, TimeProvider.System);
-			BuildQueueRepository = new BuildQueueRepository(World);
-			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), World, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
+			UpgradeRepository = new UpgradeRepository(Accessor);
+			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), Accessor, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository);
+			MessageRepository = new MessageRepository(Accessor);
+			MessageRepositoryWrite = new MessageRepositoryWrite(Accessor, TimeProvider.System);
+			BuildQueueRepository = new BuildQueueRepository(Accessor);
+			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), Accessor, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));
 			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger()));
 			GameTickModuleRegistry = new GameTickModuleRegistry(LoggerFactory.CreateLogger<GameTickModuleRegistry>(), services.BuildServiceProvider(), GameDef);
-			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), World, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System);
+			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), Accessor, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
@@ -9,8 +9,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void CreateUser_NewGithubId_StoresUser() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var user = userRepoWrite.CreateUser("gh123", "octocat", "The Octocat");
 
@@ -24,8 +24,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetByGithubId_ExistingUser_ReturnsUser() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			userRepoWrite.CreateUser("gh456", "monalisa", "Mona Lisa");
 
@@ -37,7 +37,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetByGithubId_MissingUser_ReturnsNull() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
 
 			var result = userRepo.GetByGithubId("nonexistent");
 			Assert.Null(result);
@@ -46,7 +46,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void CreateUser_DuplicateGithubId_Throws() {
 			var game = new TestGame();
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 			userRepoWrite.CreateUser("dup123", "dup", "Dup");
 
 			Assert.Throws<InvalidOperationException>(() =>
@@ -56,8 +56,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetPlayersForUser_AfterCreatePlayer_ReturnsPlayer() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var user = userRepoWrite.CreateUser("gh789", "devuser", "Dev User");
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
@@ -72,8 +72,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void SetApiKeyHash_AndLookup_FindsPlayer() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var user = userRepoWrite.CreateUser("ghapikey", "apiuser", "API User");
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
@@ -90,7 +90,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetOrCreateUser_NewUser_CreatesAndReturnsUser() {
 			var game = new TestGame();
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var user = userRepoWrite.GetOrCreateUser("gh-new", "newuser", "New User");
 
@@ -103,7 +103,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetOrCreateUser_ExistingUser_ReturnsSameUser() {
 			var game = new TestGame();
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var first = userRepoWrite.GetOrCreateUser("gh-dup", "dupuser", "Dup User");
 			var second = userRepoWrite.GetOrCreateUser("gh-dup", "dupuser-2", "Dup User 2");
@@ -115,7 +115,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetOrCreateUser_ConcurrentCalls_ReturnSameUser() {
 			var game = new TestGame();
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 			UserImmutable? result1 = null;
 			UserImmutable? result2 = null;
 
@@ -134,8 +134,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void RevokeApiKey_ClearsHash() {
 			var game = new TestGame();
-			var userRepo = new UserRepository(game.World);
-			var userRepoWrite = new UserRepositoryWrite(game.World, TimeProvider.System);
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
 
 			var user = userRepoWrite.CreateUser("ghrevoke", "revokeuser", "Revoke User");
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
@@ -1,0 +1,31 @@
+using BrowserGameEngine.GameModel;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	public class GlobalState {
+		internal ConcurrentDictionary<string, User> Users { get; set; } = new();
+		public IList<GameRecordImmutable> Games { get; set; } = new List<GameRecordImmutable>();
+		public IList<PlayerAchievementImmutable> Achievements { get; set; } = new List<PlayerAchievementImmutable>();
+	}
+
+	public static class GlobalStateExtensions {
+		public static GlobalStateImmutable ToImmutable(this GlobalState globalState) {
+			return new GlobalStateImmutable(
+				Users: globalState.Users.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
+				Games: globalState.Games.ToList(),
+				Achievements: globalState.Achievements.ToList()
+			);
+		}
+
+		public static GlobalState ToMutable(this GlobalStateImmutable globalStateImmutable) {
+			return new GlobalState {
+				Users = new ConcurrentDictionary<string, User>(
+					globalStateImmutable.Users.ToDictionary(x => x.Key, y => y.Value.ToMutable())),
+				Games = globalStateImmutable.Games.ToList(),
+				Achievements = globalStateImmutable.Achievements.ToList()
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -1,8 +1,6 @@
-using BrowserGameEngine.Persistence;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,9 +8,9 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public class WorldState {
-		internal IDictionary<PlayerId, Player> Players { get; set; } = new ConcurrentDictionary<PlayerId, Player>();
+		internal GameId GameId { get; set; } = new GameId("default");
 
-		internal IDictionary<string, User> Users { get; set; } = new ConcurrentDictionary<string, User>();
+		internal IDictionary<PlayerId, Player> Players { get; set; } = new ConcurrentDictionary<PlayerId, Player>();
 
 		internal IDictionary<AllianceId, Alliance> Alliances { get; set; } = new ConcurrentDictionary<AllianceId, Alliance>();
 
@@ -60,27 +58,28 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public static class WorldStateImmutableExtensions {
 		public static void ReplaceFrom(this WorldState worldState, WorldStateImmutable snapshot) {
 			var mutable = snapshot.ToMutable();
+			worldState.GameId = mutable.GameId;
 			worldState.Players = mutable.Players;
-			worldState.Users = mutable.Users;
 			worldState.Alliances = mutable.Alliances;
 			worldState.GameTickState = mutable.GameTickState;
 			worldState.GameActionQueue = mutable.GameActionQueue;
 		}
+
 
 		public static WorldStateImmutable ToImmutable(this WorldState worldState) {
 			return new WorldStateImmutable(
 				Players: worldState.Players.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameTickState: worldState.GameTickState.ToImmutable(),
 				GameActionQueue: worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList(),
-				Users: worldState.Users.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
-				Alliances: worldState.Alliances.ToDictionary(x => x.Key, y => y.Value.ToImmutable())
+				Alliances: worldState.Alliances.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
+				GameId: worldState.GameId
 			);
 		}
 
 		public static WorldState ToMutable(this WorldStateImmutable worldStateImmutable) {
 			return new WorldState {
+				GameId = worldStateImmutable.GameId ?? new GameId("default"),
 				Players = new ConcurrentDictionary<PlayerId, Player>(worldStateImmutable.Players.ToDictionary(x => x.Key, y => y.Value.ToMutable())),
-				Users = new ConcurrentDictionary<string, User>(worldStateImmutable.Users?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<string, User>()),
 				Alliances = new ConcurrentDictionary<AllianceId, Alliance>(worldStateImmutable.Alliances?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<AllianceId, Alliance>()),
 				GameTickState = worldStateImmutable.GameTickState.ToMutable(),
 				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList()

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -1,0 +1,23 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
+
+namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
+	public class GameInstance {
+		public GameRecordImmutable Record { get; }
+		public WorldState WorldState { get; }
+		public IWorldStateAccessor WorldStateAccessor { get; }
+		public GameDef GameDef { get; }
+		public GameTickEngine? TickEngine { get; private set; }
+
+		public GameInstance(GameRecordImmutable record, WorldState worldState, GameDef gameDef) {
+			Record = record;
+			WorldState = worldState;
+			WorldStateAccessor = new SingletonWorldStateAccessor(worldState);
+			GameDef = gameDef;
+		}
+
+		public void SetTickEngine(GameTickEngine tickEngine) { TickEngine = tickEngine; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameRegistry.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameRegistry.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,8 +17,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		public GameInstance? TryGetInstance(GameId gameId) =>
 			_instances.TryGetValue(gameId.Id, out var i) ? i : null;
 
-		public IReadOnlyCollection<GameInstance> GetAllInstances() => (IReadOnlyCollection<GameInstance>)_instances.Values;
+		public IReadOnlyCollection<GameInstance> GetAllInstances() => _instances.Values.ToList();
 
-		public GameInstance GetDefaultInstance() => _instances.Values.First();
+		public GameInstance GetDefaultInstance() =>
+			_instances.Values.FirstOrDefault()
+			?? throw new InvalidOperationException("GameRegistry is empty — no game instances have been registered.");
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameRegistry.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameRegistry.cs
@@ -1,0 +1,23 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
+	public class GameRegistry {
+		public GlobalState GlobalState { get; }
+		private readonly ConcurrentDictionary<string, GameInstance> _instances = new();
+
+		public GameRegistry(GlobalState globalState) { GlobalState = globalState; }
+
+		public void Register(GameInstance instance) => _instances[instance.Record.GameId.Id] = instance;
+
+		public GameInstance? TryGetInstance(GameId gameId) =>
+			_instances.TryGetValue(gameId.Id, out var i) ? i : null;
+
+		public IReadOnlyCollection<GameInstance> GetAllInstances() => (IReadOnlyCollection<GameInstance>)_instances.Values;
+
+		public GameInstance GetDefaultInstance() => _instances.Values.First();
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -2,19 +2,25 @@ using BrowserGameEngine.Persistence;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public static class GameServerExtensions {
-		public static async Task AddGameServer(this IServiceCollection services, IBlobStorage storage, WorldStateImmutable defaultWorldState) {
-			await InitPersistenceAndGameState(services, storage, defaultWorldState);
+		public static void AddGameServer(this IServiceCollection services, IBlobStorage storage, BrowserGameEngine.StatefulGameServer.GameRegistry.GameRegistry gameRegistry) {
+			var defaultInstance = gameRegistry.GetDefaultInstance();
+			services.AddSingleton(gameRegistry);
+			services.AddSingleton(gameRegistry.GlobalState);
+			services.AddSingleton<IWorldStateAccessor>(defaultInstance.WorldStateAccessor);
+			services.AddSingleton(defaultInstance.WorldState);
+			services.AddSingleton(defaultInstance.GameDef);
 			services.AddSingleton(TimeProvider.System);
+
 			services.AddSingleton<UserRepository>();
 			services.AddSingleton<UserRepositoryWrite>();
 			services.AddSingleton<PlayerRepository>();
@@ -50,24 +56,16 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<GameTickEngine>();
 
 			services.AddSingleton<IBattleBehavior, BattleBehaviorScoOriginal>(); // TODO: make this configurable through GameDef
-		}
 
-		private static async Task InitPersistenceAndGameState(IServiceCollection services, IBlobStorage storage, WorldStateImmutable defaultWorldState) {
 			var serializer = new GameStateJsonSerializer();
 			var persistenceService = new PersistenceService(storage, serializer);
-			
+			var globalSerializer = new GlobalStateJsonSerializer();
+			var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
 			services.AddSingleton<IBlobStorage>(storage);
-			services.AddSingleton<GameStateJsonSerializer>(serializer);
-			services.AddSingleton<PersistenceService>(persistenceService);
-
-			if (persistenceService.WorldStateExists()) {
-				// state exists. use it. ignore default state.
-				var worldStateImmutable = await persistenceService.LoadWorldState();
-				services.AddSingleton<WorldState>(worldStateImmutable.ToMutable());
-			} else {
-				// no state stored yet. use default state.
-				services.AddSingleton<WorldState>(defaultWorldState.ToMutable());
-			}
+			services.AddSingleton(serializer);
+			services.AddSingleton(persistenceService);
+			services.AddSingleton(globalSerializer);
+			services.AddSingleton(globalPersistenceService);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -19,7 +19,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 	/// </summary>
 	public class GameTickEngine {
 		private readonly ILogger<GameTickEngine> logger;
-		private readonly WorldState worldState;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState worldState => worldStateAccessor.WorldState;
 		private readonly GameDef gameDef;
 		private readonly GameTickModuleRegistry gameTickModuleRegistry;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
@@ -29,14 +30,14 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		private long tickDurationOverrideTicks = 0; // 0 = no override; use Interlocked for thread safety
 
 		public GameTickEngine(ILogger<GameTickEngine> logger
-				, WorldState worldState
+				, IWorldStateAccessor worldStateAccessor
 				, GameDef gameDef
 				, GameTickModuleRegistry gameTickModuleRegistry
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, TimeProvider timeProvider
 			) {
 			this.logger = logger;
-			this.worldState = worldState;
+			this.worldStateAccessor = worldStateAccessor;
 			this.gameDef = gameDef;
 			this.gameTickModuleRegistry = gameTickModuleRegistry;
 			this.playerRepositoryWrite = playerRepositoryWrite;

--- a/src/BrowserGameEngine.StatefulGameServer/IWorldStateAccessor.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/IWorldStateAccessor.cs
@@ -1,0 +1,7 @@
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public interface IWorldStateAccessor {
+		WorldState WorldState { get; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/ActionQueue/ActionQueueRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/ActionQueue/ActionQueueRepository.cs
@@ -9,10 +9,11 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class ActionQueueRepository {
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public ActionQueueRepository(WorldState world) {
-			this.world = world;
+		public ActionQueueRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		private IList<GameAction> Actions => world.GameActionQueue;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepository.cs
@@ -5,10 +5,11 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class AllianceRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public AllianceRepository(WorldState world) {
-			this.world = world;
+		public AllianceRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public AllianceImmutable? Get(AllianceId allianceId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepositoryWrite.cs
@@ -10,11 +10,12 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class AllianceRepositoryWrite {
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly AllianceRepository allianceRepository;
 
-		public AllianceRepositoryWrite(WorldState world, AllianceRepository allianceRepository) {
-			this.world = world;
+		public AllianceRepositoryWrite(IWorldStateAccessor worldStateAccessor, AllianceRepository allianceRepository) {
+			this.worldStateAccessor = worldStateAccessor;
 			this.allianceRepository = allianceRepository;
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepository.cs
@@ -9,15 +9,16 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class AssetRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly PlayerRepository playerRepository;
 		private readonly ActionQueueRepository actionQueueRepository;
 
-		public AssetRepository(WorldState world
+		public AssetRepository(IWorldStateAccessor worldStateAccessor
 				, PlayerRepository playerRepository
 				, ActionQueueRepository actionQueueRepository
 			) {
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.playerRepository = playerRepository;
 			this.actionQueueRepository = actionQueueRepository;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
@@ -11,7 +11,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class AssetRepositoryWrite {
 		private readonly Lock _lock = new();
 		private readonly ILogger<AssetRepositoryWrite> logger;
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly AssetRepository assetRepository;
 		private readonly ResourceRepository resourceRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
@@ -19,7 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly GameDef gameDef;
 
 		public AssetRepositoryWrite(ILogger<AssetRepositoryWrite> logger
-				, WorldState world
+				, IWorldStateAccessor worldStateAccessor
 				, AssetRepository assetRepository
 				, ResourceRepository resourceRepository
 				, ResourceRepositoryWrite resourceRepositoryWrite
@@ -27,7 +28,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, GameDef gameDef
 			) {
 			this.logger = logger;
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.assetRepository = assetRepository;
 			this.resourceRepository = resourceRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepository.cs
@@ -6,10 +6,11 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class BuildQueueRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public BuildQueueRepository(WorldState world) {
-			this.world = world;
+		public BuildQueueRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		private List<BuildQueueEntry> Queue(PlayerId playerId) => world.GetPlayer(playerId).State.BuildQueue;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
@@ -12,7 +12,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class BuildQueueRepositoryWrite {
 		private readonly Lock _lock = new();
 		private readonly ILogger<BuildQueueRepositoryWrite> logger;
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly BuildQueueRepository buildQueueRepository;
 		private readonly AssetRepository assetRepository;
 		private readonly AssetRepositoryWrite assetRepositoryWrite;
@@ -22,7 +23,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly GameDef gameDef;
 
 		public BuildQueueRepositoryWrite(ILogger<BuildQueueRepositoryWrite> logger
-				, WorldState world
+				, IWorldStateAccessor worldStateAccessor
 				, BuildQueueRepository buildQueueRepository
 				, AssetRepository assetRepository
 				, AssetRepositoryWrite assetRepositoryWrite
@@ -32,7 +33,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, GameDef gameDef
 			) {
 			this.logger = logger;
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.buildQueueRepository = buildQueueRepository;
 			this.assetRepository = assetRepository;
 			this.assetRepositoryWrite = assetRepositoryWrite;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
@@ -6,10 +6,11 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class MessageRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public MessageRepository(WorldState world) {
-			this.world = world;
+		public MessageRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public IList<MessageImmutable> GetMessages(PlayerId playerId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
@@ -7,11 +7,12 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class MessageRepositoryWrite {
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
 
-		public MessageRepositoryWrite(WorldState world, TimeProvider timeProvider) {
-			this.world = world;
+		public MessageRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/OnlineStatusRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/OnlineStatusRepository.cs
@@ -6,10 +6,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class OnlineStatusRepository {
 		private static readonly TimeSpan OnlineThreshold = TimeSpan.FromMinutes(8);
 
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public OnlineStatusRepository(WorldState world) {
-			this.world = world;
+		public OnlineStatusRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public bool IsOnline(PlayerId playerId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepository.cs
@@ -7,16 +7,17 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class PlayerRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ScoreRepository scoreRepository;
 		private readonly AllianceRepository allianceRepository;
 
 		private IDictionary<PlayerId, Player> Players => world.Players;
 
-		public PlayerRepository(WorldState world
+		public PlayerRepository(IWorldStateAccessor worldStateAccessor
 			, ScoreRepository scoreRepository
 			, AllianceRepository allianceRepository) {
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.scoreRepository = scoreRepository;
 			this.allianceRepository = allianceRepository;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -9,12 +9,13 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class PlayerRepositoryWrite {
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
 		private IDictionary<PlayerId, Player> Players => world.Players;
 
-		public PlayerRepositoryWrite(WorldState world, TimeProvider timeProvider) {
-			this.world = world;
+		public PlayerRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepository.cs
@@ -7,11 +7,12 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class ResourceRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly GameDef gameDef;
 
-		public ResourceRepository(WorldState world, GameDef gameDef) {
-			this.world = world;
+		public ResourceRepository(IWorldStateAccessor worldStateAccessor, GameDef gameDef) {
+			this.worldStateAccessor = worldStateAccessor;
 			this.gameDef = gameDef;
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -9,13 +9,14 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class ResourceRepositoryWrite {
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ResourceRepository resourceRepository;
 
-		public ResourceRepositoryWrite(WorldState world
+		public ResourceRepositoryWrite(IWorldStateAccessor worldStateAccessor
 			, ResourceRepository resourceRepository
 			) {
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.resourceRepository = resourceRepository;
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/ScoreRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/ScoreRepository.cs
@@ -8,13 +8,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 	public class ScoreRepository {
 		private readonly GameDef gameDef;
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
 		private IDictionary<ResourceDefId, decimal> Res(PlayerId playerId) => world.GetPlayer(playerId).State.Resources;
 
-		public ScoreRepository(GameDef gameDef, WorldState world) {
+		public ScoreRepository(GameDef gameDef, IWorldStateAccessor worldStateAccessor) {
 			this.gameDef = gameDef;
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public decimal GetScore(PlayerId playerId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepository.cs
@@ -7,17 +7,18 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class UnitRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly GameDef gameDef;
 		private readonly PlayerRepository playerRepository;
 		private readonly AssetRepository assetRepository;
 
-		public UnitRepository(WorldState world
+		public UnitRepository(IWorldStateAccessor worldStateAccessor
 				, GameDef gameDef
 				, PlayerRepository playerRepository
 				, AssetRepository assetRepository
 			) {
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.gameDef = gameDef;
 			this.playerRepository = playerRepository;
 			this.assetRepository = assetRepository;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -12,7 +12,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class UnitRepositoryWrite {
 		private readonly Lock _lock = new();
 		private readonly ILogger<UnitRepositoryWrite> logger;
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly GameDef gameDef;
 		private readonly UnitRepository unitRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
@@ -23,7 +24,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly UpgradeRepository upgradeRepository;
 
 		public UnitRepositoryWrite(ILogger<UnitRepositoryWrite> logger
-				, WorldState world
+				, IWorldStateAccessor worldStateAccessor
 				, GameDef gameDef
 				, UnitRepository unitRepository
 				, ResourceRepositoryWrite resourceRepositoryWrite
@@ -34,7 +35,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, UpgradeRepository upgradeRepository
 			) {
 			this.logger = logger;
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.gameDef = gameDef;
 			this.unitRepository = unitRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepository.cs
@@ -3,10 +3,11 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class UpgradeRepository {
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 
-		public UpgradeRepository(WorldState world) {
-			this.world = world;
+		public UpgradeRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public int GetAttackUpgradeLevel(PlayerId playerId) => world.GetPlayer(playerId).State.AttackUpgradeLevel;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
@@ -12,7 +12,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private const int ResearchTimerTicks = 10;
 
 		private readonly Lock _lock = new();
-		private readonly WorldState world;
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ResourceRepository resourceRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
 
@@ -23,10 +24,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 		];
 
 		public UpgradeRepositoryWrite(
-			WorldState world,
+			IWorldStateAccessor worldStateAccessor,
 			ResourceRepository resourceRepository,
 			ResourceRepositoryWrite resourceRepositoryWrite) {
-			this.world = world;
+			this.worldStateAccessor = worldStateAccessor;
 			this.resourceRepository = resourceRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
@@ -5,24 +5,27 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class UserRepository {
+		private readonly GlobalState globalState;
 		private readonly WorldState world;
 
-		public UserRepository(WorldState world) {
+		public UserRepository(GlobalState globalState, WorldState world) {
+			this.globalState = globalState;
 			this.world = world;
 		}
 
 		public UserImmutable? GetByGithubId(string githubId) {
-			if (world.Users.TryGetValue(githubId, out var user)) {
+			if (globalState.Users.TryGetValue(githubId, out var user)) {
 				return user.ToImmutable();
 			}
 			return null;
 		}
 
 		public bool ExistsByGithubId(string githubId) {
-			return world.Users.ContainsKey(githubId);
+			return globalState.Users.ContainsKey(githubId);
 		}
 
 		public IEnumerable<PlayerImmutable> GetPlayersForUser(string userId) {
+			// TODO Phase 3: replace with game-scoped player lookup via ICurrentGameContext
 			return world.Players.Values
 				.Where(p => p.UserId == userId)
 				.Select(p => p.ToImmutable());
@@ -34,7 +37,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public string? GetDisplayNameByUserId(string userId) {
-			var user = world.Users.Values.FirstOrDefault(u => u.UserId == userId);
+			var user = globalState.Users.Values.FirstOrDefault(u => u.UserId == userId);
 			return user?.DisplayName;
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
@@ -6,17 +6,19 @@ using System.Threading;
 namespace BrowserGameEngine.StatefulGameServer {
 	public class UserRepositoryWrite {
 		private readonly Lock _lock = new();
+		private readonly GlobalState globalState;
 		private readonly WorldState world;
 		private readonly TimeProvider timeProvider;
 
-		public UserRepositoryWrite(WorldState world, TimeProvider timeProvider) {
+		public UserRepositoryWrite(GlobalState globalState, WorldState world, TimeProvider timeProvider) {
+			this.globalState = globalState;
 			this.world = world;
 			this.timeProvider = timeProvider;
 		}
 
 		public UserImmutable CreateUser(string githubId, string githubLogin, string displayName) {
 			lock (_lock) {
-				if (world.Users.ContainsKey(githubId)) throw new InvalidOperationException($"User with githubId {githubId} already exists");
+				if (globalState.Users.ContainsKey(githubId)) throw new InvalidOperationException($"User with githubId {githubId} already exists");
 				var user = new User {
 					UserId = Guid.NewGuid().ToString(),
 					GithubId = githubId,
@@ -24,7 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 					DisplayName = displayName,
 					Created = timeProvider.GetLocalNow().DateTime
 				};
-				world.Users[githubId] = user;
+				globalState.Users[githubId] = user;
 				return user.ToImmutable();
 			}
 		}
@@ -35,7 +37,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		/// </summary>
 		public UserImmutable GetOrCreateUser(string githubId, string githubLogin, string displayName) {
 			lock (_lock) {
-				if (world.Users.TryGetValue(githubId, out var existing)) {
+				if (globalState.Users.TryGetValue(githubId, out var existing)) {
 					return existing.ToImmutable();
 				}
 				var user = new User {
@@ -45,7 +47,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 					DisplayName = displayName,
 					Created = timeProvider.GetLocalNow().DateTime
 				};
-				world.Users[githubId] = user;
+				globalState.Users[githubId] = user;
 				return user.ToImmutable();
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/SingletonWorldStateAccessor.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/SingletonWorldStateAccessor.cs
@@ -1,0 +1,11 @@
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SingletonWorldStateAccessor : IWorldStateAccessor {
+		public WorldState WorldState { get; }
+
+		public SingletonWorldStateAccessor(WorldState worldState) {
+			WorldState = worldState;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `IWorldStateAccessor` abstraction and `SingletonWorldStateAccessor`; ports all 21 game-scoped repositories and `GameTickEngine` to use it instead of `WorldState` directly
- Introduces `GameInstance` + `GameRegistry` to manage multiple game worlds; adds `GlobalState` (mutable) and `GlobalStateImmutable` to hold cross-game user/achievement data
- Adds `MigrationService` to transparently upgrade existing `latest.json` to the new `games/{id}/state.json` + `global/state.json` layout on first boot; adds `GlobalPersistenceHostedService` for periodic global state saves
- Updates `Program.cs` and `GameServerExtensions` to build a `GameRegistry` at startup and wire tick engines per-game instance

## Test plan

- [ ] All 121 tests pass (`dotnet test`)
- [ ] Build succeeds with `dotnet build --configuration Release`
- [ ] Verify migration: start server with existing `latest.json`; confirm `games/league-round-1/state.json` and `global/state.json` are created and `latest.json` is renamed
- [ ] Verify fresh install: start server with empty storage; confirms single default game is created
- [ ] Confirm game ticks still fire and game play is functional end-to-end