### PR TITLE
feat(BGE-164): Game Admin Page — Create & Manage Games

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
@@ -1,0 +1,122 @@
+@page "/admin/games"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+<h1>Game Admin</h1>
+
+<h2>Create Game</h2>
+
+<EditForm Model="@createModel" OnValidSubmit="HandleCreate">
+	<DataAnnotationsValidator />
+	<ValidationSummary />
+	<div>
+		<label>Name</label>
+		<InputText @bind-Value="createModel.Name" placeholder="Game name" />
+	</div>
+	<div>
+		<label>Tick Duration (HH:MM:SS)</label>
+		<InputText @bind-Value="createModel.TickDuration" placeholder="00:01:00" />
+	</div>
+	<div>
+		<label>Start Time</label>
+		<input type="datetime-local" value="@createModel.StartTime.ToString("yyyy-MM-ddTHH:mm")" @onchange="e => createModel.StartTime = ParseDateTime(e.Value?.ToString())" />
+	</div>
+	<div>
+		<label>End Time</label>
+		<input type="datetime-local" value="@createModel.EndTime.ToString("yyyy-MM-ddTHH:mm")" @onchange="e => createModel.EndTime = ParseDateTime(e.Value?.ToString())" />
+	</div>
+	<button type="submit">Create Game</button>
+</EditForm>
+
+@if (!string.IsNullOrEmpty(createError)) {
+	<p style="color:red">@createError</p>
+}
+@if (!string.IsNullOrEmpty(createSuccess)) {
+	<p style="color:green">@createSuccess</p>
+}
+
+<h2>Games</h2>
+
+@if (games == null) {
+	<p><em>Loading...</em></p>
+} else if (games.Count == 0) {
+	<p>No games found.</p>
+} else {
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Status</th>
+				<th>Players</th>
+				<th>Start Time</th>
+				<th>End Time</th>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var game in games) {
+				<tr>
+					<td>@game.Name</td>
+					<td>@game.Status</td>
+					<td>@game.PlayerCount</td>
+					<td>@game.StartTime.ToLocalTime().ToString("g")</td>
+					<td>@game.EndTime.ToLocalTime().ToString("g")</td>
+					<td><a href="/games/@game.GameId">View</a></td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+@code {
+	private List<GameSummaryViewModel>? games;
+	private CreateGameFormModel createModel = new();
+	private string? createError;
+	private string? createSuccess;
+
+	protected override async Task OnInitializedAsync() {
+		await LoadGames();
+	}
+
+	private async Task LoadGames() {
+		games = await Http.GetFromJsonAsync<List<GameSummaryViewModel>>("api/games") ?? new();
+	}
+
+	private async Task HandleCreate() {
+		createError = null;
+		createSuccess = null;
+
+		var request = new CreateGameRequest(
+			Name: createModel.Name,
+			GameDefType: "sco",
+			StartTime: createModel.StartTime.ToUniversalTime(),
+			EndTime: createModel.EndTime.ToUniversalTime(),
+			TickDuration: createModel.TickDuration
+		);
+
+		var response = await Http.PostAsJsonAsync("api/games", request);
+		if (response.IsSuccessStatusCode) {
+			createSuccess = $"Game '{createModel.Name}' created.";
+			createModel = new();
+			await LoadGames();
+		} else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) {
+			createError = "You must be logged in to create a game.";
+		} else {
+			var body = await response.Content.ReadAsStringAsync();
+			createError = $"Failed to create game: {body}";
+		}
+	}
+
+	private static DateTime ParseDateTime(string? value) {
+		if (DateTime.TryParse(value, out var dt)) return dt;
+		return DateTime.Now;
+	}
+
+	private class CreateGameFormModel {
+		public string Name { get; set; } = string.Empty;
+		public string TickDuration { get; set; } = "00:01:00";
+		public DateTime StartTime { get; set; } = DateTime.Now.AddHours(1);
+		public DateTime EndTime { get; set; } = DateTime.Now.AddDays(7);
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
@@ -1,5 +1,7 @@
 @page "/admin/games"
 @using BrowserGameEngine.Shared
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @inject HttpClient Http
 @inject NavigationManager Nav
 
@@ -51,6 +53,7 @@
 				<th>Players</th>
 				<th>Start Time</th>
 				<th>End Time</th>
+				<th>Created By</th>
 				<th></th>
 			</tr>
 		</thead>
@@ -62,6 +65,7 @@
 					<td>@game.PlayerCount</td>
 					<td>@game.StartTime.ToLocalTime().ToString("g")</td>
 					<td>@game.EndTime.ToLocalTime().ToString("g")</td>
+					<td>@game.CreatedBy</td>
 					<td><a href="/games/@game.GameId">View</a></td>
 				</tr>
 			}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
@@ -53,7 +53,6 @@
 				<th>Players</th>
 				<th>Start Time</th>
 				<th>End Time</th>
-				<th>Created By</th>
 				<th></th>
 			</tr>
 		</thead>
@@ -63,9 +62,8 @@
 					<td>@game.Name</td>
 					<td>@game.Status</td>
 					<td>@game.PlayerCount</td>
-					<td>@game.StartTime.ToLocalTime().ToString("g")</td>
-					<td>@game.EndTime.ToLocalTime().ToString("g")</td>
-					<td>@game.CreatedBy</td>
+					<td>@game.StartTime?.ToLocalTime().ToString("g")</td>
+					<td>@game.EndTime?.ToLocalTime().ToString("g")</td>
 					<td><a href="/games/@game.GameId">View</a></td>
 				</tr>
 			}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -75,6 +75,7 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Profile
             </NavLink>
         </li>
+        <AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="history">
                 <span class="oi oi-clock" aria-hidden="true"></span> My History
@@ -85,6 +86,7 @@
                 <span class="oi oi-cog" aria-hidden="true"></span> Admin: Games
             </NavLink>
         </li>
+        </AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="signout">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Logout

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -81,6 +81,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="admin/games">
+                <span class="oi oi-cog" aria-hidden="true"></span> Admin: Games
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="signout">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Logout
             </NavLink>

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -14,6 +14,7 @@ namespace BrowserGameEngine.GameModel {
 		DateTime EndTime,
 		TimeSpan TickDuration,
 		PlayerId? WinnerId = null,
-		DateTime? ActualEndTime = null
+		DateTime? ActualEndTime = null,
+		string? CreatedByUserId = null
 	);
 }


### PR DESCRIPTION
## Summary
- Adds `/admin/games` Blazor page with a Create Game form (name, tick duration, start/end time) that POSTs to `api/games`
- Game list table: name, status, player count, start/end time, View link
- Admin nav link in the sidebar

## Depends on
- Targets `feat/bge-156-game-lifecycle` branch (BGE-156 provides `POST /api/games`)

## Test plan
- [ ] Build passes (0 errors)
- [ ] All 137 tests pass
- [ ] Navigate to `/admin/games` — page renders with empty game list
- [ ] Fill in form and submit — game appears in the list
- [ ] View link navigates to `/games/{gameId}`