### PR TITLE
feat: BGE-162 Phase 3 — game-scoped Blazor routing & in-game context

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
@@ -1,4 +1,5 @@
 @page "/allianceranking"
+@page "/games/{GameId}/allianceranking"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -37,6 +38,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private AllianceRankingViewModel[]? model;
 
     protected override async Task OnInitializedAsync() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -1,4 +1,5 @@
 @page "/alliances"
+@page "/games/{GameId}/alliances"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -75,6 +76,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private AllianceViewModel[]? alliances;
     private MyAllianceStatusViewModel? myStatus;
     private string createName = "";

--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -1,4 +1,5 @@
 @page "/base"
+@page "/games/{GameId}/base"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -90,6 +91,8 @@
 </div>
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
 
     private AssetsViewModel? model;
     private PlayerResourcesViewModel? resources;

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -1,4 +1,5 @@
 ﻿@page "/enemybase/{EnemeyPlayerId}"
+@page "/games/{GameId}/enemybase/{EnemeyPlayerId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -76,6 +77,9 @@
     private BattleResultViewModel? battleResult;
 
     private string? lastError;
+
+    [Parameter]
+    public string? GameId { get; set; }
 
     [Parameter]
     public required string EnemeyPlayerId { get; set; }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
@@ -41,7 +41,7 @@
 						} else if (game.Status == "Upcoming") {
 							<span class="text-muted">Upcoming</span>
 						} else {
-							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/ranking">Results</a>
+							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/results">Results</a>
 						}
 					</td>
 				</tr>

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
@@ -1,0 +1,72 @@
+@page "/games"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+<h1>Game Lobby</h1>
+
+@if (!string.IsNullOrEmpty(lastError)) {
+	<div class="alert alert-danger">@lastError</div>
+}
+
+@if (games == null) {
+	<p><em>Loading...</em></p>
+} else if (games.Length == 0) {
+	<p>No games available yet.</p>
+} else {
+	<table class="table table-hover">
+		<thead>
+			<tr>
+				<th>Game</th>
+				<th>Status</th>
+				<th>Players</th>
+				<th>Start</th>
+				<th>End</th>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var game in games) {
+				<tr>
+					<td><strong>@game.Name</strong></td>
+					<td>
+						<span class="badge @GetStatusBadge(game.Status)">@game.Status</span>
+					</td>
+					<td>@game.PlayerCount</td>
+					<td>@game.StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
+					<td>@game.EndTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
+					<td>
+						@if (game.Status == "Active") {
+							<a class="btn btn-sm btn-primary" href="games/@game.GameId/base">Play</a>
+						} else if (game.Status == "Upcoming") {
+							<span class="text-muted">Upcoming</span>
+						} else {
+							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/ranking">Results</a>
+						}
+					</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+@code {
+	private GameSummaryViewModel[]? games;
+	private string? lastError;
+
+	protected override async Task OnInitializedAsync() {
+		try {
+			games = await Http.GetFromJsonAsync<GameSummaryViewModel[]>("api/games");
+		} catch (Exception ex) {
+			lastError = ex.Message;
+			games = Array.Empty<GameSummaryViewModel>();
+		}
+	}
+
+	private static string GetStatusBadge(string status) => status switch {
+		"Active" => "bg-success",
+		"Upcoming" => "bg-warning text-dark",
+		"Finished" => "bg-secondary",
+		_ => "bg-light text-dark"
+	};
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
@@ -1,0 +1,87 @@
+@page "/games/{GameId}/results"
+@namespace BrowserGameEngine.BlazorClient.Pages.GameResults
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+@if (error != null) {
+	<div class="alert alert-danger">@error</div>
+}
+
+@if (model == null && error == null) {
+	<p><em>Loading...</em></p>
+} else if (model != null) {
+	<h1>@model.Name — Results</h1>
+
+	<p class="text-muted">
+		@{
+			var end = model.ActualEndTime ?? model.EndTime;
+			var duration = end - model.StartTime;
+		}
+		@model.StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @end.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
+		&nbsp;·&nbsp; Duration: @FormatDuration(duration)
+	</p>
+
+	@if (model.Standings.Count == 0) {
+		<p class="text-muted">No standings recorded for this game.</p>
+	} else {
+		<table class="table table-hover">
+			<thead>
+				<tr>
+					<th>Rank</th>
+					<th>Player</th>
+					<th>Score</th>
+				</tr>
+			</thead>
+			<tbody>
+				@foreach (var entry in model.Standings) {
+					<tr class="@(entry.IsWinner ? "table-warning" : "")">
+						<td>
+							@if (entry.IsWinner) {
+								<span>🏆 #@entry.Rank</span>
+							} else {
+								<span>#@entry.Rank</span>
+							}
+						</td>
+						<td>
+							@entry.PlayerName
+							@if (entry.IsWinner) {
+								<span class="badge bg-warning text-dark ms-2">Winner</span>
+							}
+						</td>
+						<td>@entry.Score.ToString("N0")</td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+
+	<div class="mt-4 d-flex gap-2">
+		<a class="btn btn-secondary" href="games">Browse Games</a>
+		<a class="btn btn-outline-secondary" href="leaderboard/alltime">View All-Time Leaderboard</a>
+	</div>
+}
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private GameResultsViewModel? model;
+	private string? error;
+
+	protected override async Task OnParametersSetAsync() {
+		model = null;
+		error = null;
+		try {
+			model = await Http.GetFromJsonAsync<GameResultsViewModel>($"api/games/{GameId}/results");
+		} catch (Exception ex) {
+			error = $"Could not load results: {ex.Message}";
+		}
+	}
+
+	private static string FormatDuration(TimeSpan ts) {
+		if (ts.TotalDays >= 1) return $"{(int)ts.TotalDays}d {ts.Hours}h";
+		if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+		return $"{ts.Minutes}m";
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -1,4 +1,5 @@
 @page "/messages"
+@page "/games/{GameId}/messages"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -69,6 +70,9 @@
 }
 
 @code {
+	[Parameter]
+	public string? GameId { get; set; }
+
 	private List<MessageViewModel>? inbox;
 	private SendMessageViewModel composeModel = new();
 	private string? sendResult;

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -1,4 +1,5 @@
 @page "/ranking"
+@page "/games/{GameId}/ranking"
 @using BrowserGameEngine.Shared
 @using System.Linq
 @inject HttpClient Http
@@ -42,6 +43,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private PublicPlayerViewModel[]? model;
     private string filter = "all";
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
@@ -1,4 +1,5 @@
 ﻿@page "/selectenemy/{UnitId}"
+@page "/games/{GameId}/selectenemy/{UnitId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
@@ -28,6 +29,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     [Parameter]
     public required string UnitId { get; set; }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -1,4 +1,5 @@
 ﻿@page "/units"
+@page "/games/{GameId}/units"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
@@ -63,6 +64,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private UnitsViewModel? model;
     private string? lastError;
     private Dictionary<Guid, bool> showSplit = new();

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -1,4 +1,5 @@
 @page "/upgrades"
+@page "/games/{GameId}/upgrades"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -64,6 +65,9 @@
 </div>
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private UpgradesViewModel? model;
     private string? lastError;
 

--- a/src/BrowserGameEngine.BlazorClient/Program.cs
+++ b/src/BrowserGameEngine.BlazorClient/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using BrowserGameEngine.BlazorClient;
 using BrowserGameEngine.BlazorClient.Auth;
+using BrowserGameEngine.BlazorClient.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("app");
@@ -17,6 +18,7 @@ builder.Services.AddHttpClient("ServerAPI", client => {
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ServerAPI"));
 builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.RefreshService>();
+builder.Services.AddScoped<ICurrentGameService, CurrentGameService>();
 
 await builder.Build().RunAsync();
 

--- a/src/BrowserGameEngine.BlazorClient/Services/CurrentGameService.cs
+++ b/src/BrowserGameEngine.BlazorClient/Services/CurrentGameService.cs
@@ -1,0 +1,71 @@
+using BrowserGameEngine.Shared;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.BlazorClient.Services {
+	public interface ICurrentGameService {
+		GameDetailViewModel? CurrentGame { get; }
+		string? CurrentGameId { get; }
+		event Action? OnChanged;
+		Task RefreshAsync();
+	}
+
+	public class CurrentGameService : ICurrentGameService, IDisposable {
+		private readonly HttpClient http;
+		private readonly NavigationManager nav;
+		private static readonly Regex GameIdPattern = new(@"^games/([^/]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+		public GameDetailViewModel? CurrentGame { get; private set; }
+		public string? CurrentGameId { get; private set; }
+		public event Action? OnChanged;
+
+		public CurrentGameService(HttpClient http, NavigationManager nav) {
+			this.http = http;
+			this.nav = nav;
+			this.nav.LocationChanged += OnLocationChanged;
+			_ = LoadFromUri(nav.Uri);
+		}
+
+		private async void OnLocationChanged(object? sender, LocationChangedEventArgs args) {
+			await LoadFromUri(args.Location);
+		}
+
+		private async Task LoadFromUri(string uri) {
+			var relative = nav.ToBaseRelativePath(uri);
+			var match = GameIdPattern.Match(relative);
+			var gameId = match.Success ? match.Groups[1].Value : null;
+
+			if (gameId == CurrentGameId) return;
+
+			CurrentGameId = gameId;
+			if (gameId != null) {
+				try {
+					CurrentGame = await http.GetFromJsonAsync<GameDetailViewModel>($"api/games/{gameId}");
+				} catch {
+					CurrentGame = null;
+				}
+			} else {
+				CurrentGame = null;
+			}
+
+			OnChanged?.Invoke();
+		}
+
+		public async Task RefreshAsync() {
+			if (CurrentGameId == null) return;
+			try {
+				CurrentGame = await http.GetFromJsonAsync<GameDetailViewModel>($"api/games/{CurrentGameId}");
+				OnChanged?.Invoke();
+			} catch { }
+		}
+
+		public void Dispose() {
+			nav.LocationChanged -= OnLocationChanged;
+		}
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject ICurrentGameService CurrentGameService
+@inject NavigationManager Nav
 @implements IDisposable
 
 <div class="sidebar">
@@ -33,12 +34,49 @@
 </div>
 
 @code {
+    private System.Threading.CancellationTokenSource? pollCts;
+
     protected override void OnInitialized() {
-        CurrentGameService.OnChanged += StateHasChanged;
+        CurrentGameService.OnChanged += OnGameChanged;
+        StartPolling();
+    }
+
+    private void OnGameChanged() {
+        StateHasChanged();
+        RedirectIfFinished();
+    }
+
+    private void StartPolling() {
+        pollCts?.Cancel();
+        pollCts = new System.Threading.CancellationTokenSource();
+        _ = PollGameStatusAsync(pollCts.Token);
+    }
+
+    private async Task PollGameStatusAsync(System.Threading.CancellationToken ct) {
+        while (!ct.IsCancellationRequested) {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct).ContinueWith(_ => { });
+            if (ct.IsCancellationRequested) break;
+            if (CurrentGameService.CurrentGameId != null) {
+                await CurrentGameService.RefreshAsync();
+            }
+        }
+    }
+
+    private void RedirectIfFinished() {
+        var game = CurrentGameService.CurrentGame;
+        if (game == null || game.Status != "Finished") return;
+        var relative = Nav.ToBaseRelativePath(Nav.Uri);
+        // Only redirect if we're on an in-game page, not already on the results page
+        if (relative.StartsWith($"games/{game.GameId}/", StringComparison.OrdinalIgnoreCase)
+            && !relative.Equals($"games/{game.GameId}/results", StringComparison.OrdinalIgnoreCase)) {
+            Nav.NavigateTo($"games/{game.GameId}/results");
+        }
     }
 
     public void Dispose() {
-        CurrentGameService.OnChanged -= StateHasChanged;
+        CurrentGameService.OnChanged -= OnGameChanged;
+        pollCts?.Cancel();
+        pollCts?.Dispose();
     }
 
     private static string GetStatusBadge(string status) => status switch {

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -1,4 +1,6 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+@inject ICurrentGameService CurrentGameService
+@implements IDisposable
 
 <div class="sidebar">
     <NavMenu />
@@ -10,7 +12,45 @@
         <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
     </div>
 
+    @if (CurrentGameService.CurrentGame != null) {
+        var game = CurrentGameService.CurrentGame;
+        var remaining = game.EndTime - DateTime.UtcNow;
+        <div class="game-context-banner px-4 py-1 d-flex align-items-center gap-3" style="background: #1a3a5c; color: white; font-size: 0.9rem;">
+            <strong>@game.Name</strong>
+            <span class="badge @GetStatusBadge(game.Status)">@game.Status</span>
+            @if (remaining > TimeSpan.Zero) {
+                <span>Ends in: @FormatRemaining(remaining)</span>
+            } else if (game.Status != "Finished") {
+                <span>Ending soon</span>
+            }
+            <a href="games" class="ms-auto text-white-50" style="font-size:0.8rem;">&#8592; All Games</a>
+        </div>
+    }
+
     <div class="content px-4">
         @Body
     </div>
 </div>
+
+@code {
+    protected override void OnInitialized() {
+        CurrentGameService.OnChanged += StateHasChanged;
+    }
+
+    public void Dispose() {
+        CurrentGameService.OnChanged -= StateHasChanged;
+    }
+
+    private static string GetStatusBadge(string status) => status switch {
+        "Active" => "bg-success",
+        "Upcoming" => "bg-warning text-dark",
+        "Finished" => "bg-secondary",
+        _ => "bg-light text-dark"
+    };
+
+    private static string FormatRemaining(TimeSpan ts) {
+        if (ts.TotalDays >= 1) return $"{(int)ts.TotalDays}d {ts.Hours}h";
+        if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+        return $"{ts.Minutes}m {ts.Seconds}s";
+    }
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -13,6 +13,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="games">
+                <span class="oi oi-grid-three-up" aria-hidden="true"></span> Games
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="base">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Basis
             </NavLink>

--- a/src/BrowserGameEngine.BlazorClient/_Imports.razor
+++ b/src/BrowserGameEngine.BlazorClient/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using BrowserGameEngine.BlazorClient
 @using BrowserGameEngine.BlazorClient.Shared
+@using BrowserGameEngine.BlazorClient.Services

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -100,6 +100,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
 		}
 
+		[Authorize]
 		[HttpGet("{gameId}/results")]
 		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
 			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -103,10 +103,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[Authorize]
 		[HttpGet("{gameId}/results")]
 		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
-			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);
+			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();
 
-			var standings = globalState.Achievements
+			var standings = globalState.GetAchievements()
 				.Where(a => a.GameId.Id == gameId)
 				.OrderBy(a => a.FinalRank)
 				.Select(a => new GameResultEntryViewModel(

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
@@ -97,6 +98,33 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			logger.LogInformation("Game {GameId} created: {Name}", gameId.Id, request.Name);
 
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
+		}
+
+		[HttpGet("{gameId}/results")]
+		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
+			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);
+			if (record == null) return NotFound();
+
+			var standings = globalState.Achievements
+				.Where(a => a.GameId.Id == gameId)
+				.OrderBy(a => a.FinalRank)
+				.Select(a => new GameResultEntryViewModel(
+					Rank: a.FinalRank,
+					PlayerName: a.PlayerName,
+					PlayerId: a.PlayerId.Id,
+					Score: a.FinalScore,
+					IsWinner: a.FinalRank == 1
+				))
+				.ToList();
+
+			return Ok(new GameResultsViewModel(
+				GameId: gameId,
+				Name: record.Name,
+				StartTime: record.StartTime,
+				ActualEndTime: record.ActualEndTime,
+				EndTime: record.EndTime,
+				Standings: standings
+			));
 		}
 
 		private GameSummaryViewModel ToSummary(GameRecordImmutable record) {

--- a/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
@@ -5,6 +5,7 @@ namespace BrowserGameEngine.GameModel {
 		string UserId,
 		GameId GameId,
 		PlayerId PlayerId,
+		string PlayerName,
 		int FinalRank,
 		decimal FinalScore,
 		string GameDefType,

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
 	public record GameSummaryViewModel(
@@ -29,5 +30,22 @@ namespace BrowserGameEngine.Shared {
 		DateTime StartTime,
 		DateTime EndTime,
 		string TickDuration
+	);
+
+	public record GameResultEntryViewModel(
+		int Rank,
+		string PlayerName,
+		string PlayerId,
+		decimal Score,
+		bool IsWinner
+	);
+
+	public record GameResultsViewModel(
+		string GameId,
+		string Name,
+		DateTime StartTime,
+		DateTime? ActualEndTime,
+		DateTime EndTime,
+		List<GameResultEntryViewModel> Standings
 	);
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -135,6 +135,29 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public async Task FinalizeGame_AchievementsPreservePlayerNameAndRankOrder() {
+			var ws = MakeTwoPlayerState("test-game").ToMutable();
+			var (registry, _) = MakeActiveEndedGame(ws);
+			var engine = MakeEngine(registry);
+
+			await engine.ProcessLifecycleAsync();
+
+			var achievements = registry.GlobalState.Achievements
+				.OrderBy(a => a.FinalRank)
+				.ToList();
+
+			// Rank 1 = highest score (p1 with res1=2000), Rank 2 = lower score (p2)
+			Assert.Equal(2, achievements.Count);
+			Assert.Equal("Player 1", achievements[0].PlayerName);
+			Assert.Equal(1, achievements[0].FinalRank);
+			Assert.Equal("Player 2", achievements[1].PlayerName);
+			Assert.Equal(2, achievements[1].FinalRank);
+			// Rank-1 player is the winner recorded on the game record
+			var finalRecord = registry.GlobalState.Games[0];
+			Assert.Equal(achievements[0].PlayerId.Id, finalRecord.WinnerId?.Id);
+		}
+
+		[Fact]
 		public async Task FinalizeGame_RemovesInstanceFromRegistry() {
 			var ws = MakeTwoPlayerState("test-game").ToMutable();
 			var (registry, _) = MakeActiveEndedGame(ws);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -142,7 +142,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			await engine.ProcessLifecycleAsync();
 
-			var achievements = registry.GlobalState.Achievements
+			var achievements = registry.GlobalState.GetAchievements()
 				.OrderBy(a => a.FinalRank)
 				.ToList();
 
@@ -153,7 +153,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Equal("Player 2", achievements[1].PlayerName);
 			Assert.Equal(2, achievements[1].FinalRank);
 			// Rank-1 player is the winner recorded on the game record
-			var finalRecord = registry.GlobalState.Games[0];
+			var finalRecord = registry.GlobalState.GetGames()[0];
 			Assert.Equal(achievements[0].PlayerId.Id, finalRecord.WinnerId?.Id);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -91,6 +91,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 						UserId: player.UserId,
 						GameId: record.GameId,
 						PlayerId: playerId,
+						PlayerName: player.Name,
 						FinalRank: i + 1,
 						FinalScore: score,
 						GameDefType: record.GameDefType,


### PR DESCRIPTION
## Summary

- **`CurrentGameService`** (`ICurrentGameService`) — scoped Blazor service that listens to navigation events, extracts `{gameId}` from `/games/{gameId}/...` URLs, and fetches game details from `GET /api/games/{gameId}`. Components subscribe to `OnChanged` to re-render when the active game changes.
- **Game-scoped routes** added to all gameplay pages: `base`, `units`, `upgrades`, `alliances`, `allianceranking`, `ranking`, `messages`, `selectenemy`, `enemybase` all accept both the legacy `/page` and the new `/games/{gameId}/page` routes.
- **In-game context banner** in `MainLayout.razor` — shows game name, status badge, and time remaining while inside a game route. Disappears on non-game pages.
- **`/games` lobby page** lists all games with Play/Results navigation links.
- **Nav menu** gains a "Games" link to the lobby.

> ⚠️ **Depends on BGE-156 (PR #49)** — this branch is based on `feat/bge-156-game-lifecycle`. Must be rebased onto master after BGE-156 merges.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (137 tests)
- [ ] Navigate to `/games` — lobby loads, lists games from API
- [ ] Navigate to `/games/{gameId}/base` — game context banner appears in header with name and status
- [ ] Navigate away from game route — banner disappears
- [ ] All existing routes (`/base`, `/units`, etc.) still work
- [ ] Auth redirect: unauthenticated 401 from API redirects to `/signin`

Closes BGE-162