### PR TITLE
feat: BGE-165 — Game Results Screen & auto-redirect

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
@@ -41,7 +41,7 @@
 						} else if (game.Status == "Upcoming") {
 							<span class="text-muted">Upcoming</span>
 						} else {
-							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/ranking">Results</a>
+							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/results">Results</a>
 						}
 					</td>
 				</tr>

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
@@ -1,0 +1,87 @@
+@page "/games/{GameId}/results"
+@namespace BrowserGameEngine.BlazorClient.Pages.GameResults
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+@if (error != null) {
+	<div class="alert alert-danger">@error</div>
+}
+
+@if (model == null && error == null) {
+	<p><em>Loading...</em></p>
+} else if (model != null) {
+	<h1>@model.Name — Results</h1>
+
+	<p class="text-muted">
+		@{
+			var end = model.ActualEndTime ?? model.EndTime;
+			var duration = end - model.StartTime;
+		}
+		@model.StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @end.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
+		&nbsp;·&nbsp; Duration: @FormatDuration(duration)
+	</p>
+
+	@if (model.Standings.Count == 0) {
+		<p class="text-muted">No standings recorded for this game.</p>
+	} else {
+		<table class="table table-hover">
+			<thead>
+				<tr>
+					<th>Rank</th>
+					<th>Player</th>
+					<th>Score</th>
+				</tr>
+			</thead>
+			<tbody>
+				@foreach (var entry in model.Standings) {
+					<tr class="@(entry.IsWinner ? "table-warning" : "")">
+						<td>
+							@if (entry.IsWinner) {
+								<span>🏆 #@entry.Rank</span>
+							} else {
+								<span>#@entry.Rank</span>
+							}
+						</td>
+						<td>
+							@entry.PlayerName
+							@if (entry.IsWinner) {
+								<span class="badge bg-warning text-dark ms-2">Winner</span>
+							}
+						</td>
+						<td>@entry.Score.ToString("N0")</td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+
+	<div class="mt-4 d-flex gap-2">
+		<a class="btn btn-secondary" href="games">Browse Games</a>
+		<a class="btn btn-outline-secondary" href="leaderboard/alltime">View All-Time Leaderboard</a>
+	</div>
+}
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private GameResultsViewModel? model;
+	private string? error;
+
+	protected override async Task OnParametersSetAsync() {
+		model = null;
+		error = null;
+		try {
+			model = await Http.GetFromJsonAsync<GameResultsViewModel>($"api/games/{GameId}/results");
+		} catch (Exception ex) {
+			error = $"Could not load results: {ex.Message}";
+		}
+	}
+
+	private static string FormatDuration(TimeSpan ts) {
+		if (ts.TotalDays >= 1) return $"{(int)ts.TotalDays}d {ts.Hours}h";
+		if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+		return $"{ts.Minutes}m";
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject ICurrentGameService CurrentGameService
+@inject NavigationManager Nav
 @implements IDisposable
 
 <div class="sidebar">
@@ -33,12 +34,49 @@
 </div>
 
 @code {
+    private System.Threading.CancellationTokenSource? pollCts;
+
     protected override void OnInitialized() {
-        CurrentGameService.OnChanged += StateHasChanged;
+        CurrentGameService.OnChanged += OnGameChanged;
+        StartPolling();
+    }
+
+    private void OnGameChanged() {
+        StateHasChanged();
+        RedirectIfFinished();
+    }
+
+    private void StartPolling() {
+        pollCts?.Cancel();
+        pollCts = new System.Threading.CancellationTokenSource();
+        _ = PollGameStatusAsync(pollCts.Token);
+    }
+
+    private async Task PollGameStatusAsync(System.Threading.CancellationToken ct) {
+        while (!ct.IsCancellationRequested) {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct).ContinueWith(_ => { });
+            if (ct.IsCancellationRequested) break;
+            if (CurrentGameService.CurrentGameId != null) {
+                await CurrentGameService.RefreshAsync();
+            }
+        }
+    }
+
+    private void RedirectIfFinished() {
+        var game = CurrentGameService.CurrentGame;
+        if (game == null || game.Status != "Finished") return;
+        var relative = Nav.ToBaseRelativePath(Nav.Uri);
+        // Only redirect if we're on an in-game page, not already on the results page
+        if (relative.StartsWith($"games/{game.GameId}/", StringComparison.OrdinalIgnoreCase)
+            && !relative.Equals($"games/{game.GameId}/results", StringComparison.OrdinalIgnoreCase)) {
+            Nav.NavigateTo($"games/{game.GameId}/results");
+        }
     }
 
     public void Dispose() {
-        CurrentGameService.OnChanged -= StateHasChanged;
+        CurrentGameService.OnChanged -= OnGameChanged;
+        pollCts?.Cancel();
+        pollCts?.Dispose();
     }
 
     private static string GetStatusBadge(string status) => status switch {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -100,6 +100,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
 		}
 
+		[Authorize]
 		[HttpGet("{gameId}/results")]
 		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
 			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -103,10 +103,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[Authorize]
 		[HttpGet("{gameId}/results")]
 		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
-			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);
+			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();
 
-			var standings = globalState.Achievements
+			var standings = globalState.GetAchievements()
 				.Where(a => a.GameId.Id == gameId)
 				.OrderBy(a => a.FinalRank)
 				.Select(a => new GameResultEntryViewModel(

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
@@ -97,6 +98,33 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			logger.LogInformation("Game {GameId} created: {Name}", gameId.Id, request.Name);
 
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
+		}
+
+		[HttpGet("{gameId}/results")]
+		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
+			var record = globalState.Games.FirstOrDefault(g => g.GameId.Id == gameId);
+			if (record == null) return NotFound();
+
+			var standings = globalState.Achievements
+				.Where(a => a.GameId.Id == gameId)
+				.OrderBy(a => a.FinalRank)
+				.Select(a => new GameResultEntryViewModel(
+					Rank: a.FinalRank,
+					PlayerName: a.PlayerName,
+					PlayerId: a.PlayerId.Id,
+					Score: a.FinalScore,
+					IsWinner: a.FinalRank == 1
+				))
+				.ToList();
+
+			return Ok(new GameResultsViewModel(
+				GameId: gameId,
+				Name: record.Name,
+				StartTime: record.StartTime,
+				ActualEndTime: record.ActualEndTime,
+				EndTime: record.EndTime,
+				Standings: standings
+			));
 		}
 
 		private GameSummaryViewModel ToSummary(GameRecordImmutable record) {

--- a/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerAchievementImmutable.cs
@@ -5,6 +5,7 @@ namespace BrowserGameEngine.GameModel {
 		string UserId,
 		GameId GameId,
 		PlayerId PlayerId,
+		string PlayerName,
 		int FinalRank,
 		decimal FinalScore,
 		string GameDefType,

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
 	public record GameSummaryViewModel(
@@ -29,5 +30,22 @@ namespace BrowserGameEngine.Shared {
 		DateTime StartTime,
 		DateTime EndTime,
 		string TickDuration
+	);
+
+	public record GameResultEntryViewModel(
+		int Rank,
+		string PlayerName,
+		string PlayerId,
+		decimal Score,
+		bool IsWinner
+	);
+
+	public record GameResultsViewModel(
+		string GameId,
+		string Name,
+		DateTime StartTime,
+		DateTime? ActualEndTime,
+		DateTime EndTime,
+		List<GameResultEntryViewModel> Standings
 	);
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -135,6 +135,29 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public async Task FinalizeGame_AchievementsPreservePlayerNameAndRankOrder() {
+			var ws = MakeTwoPlayerState("test-game").ToMutable();
+			var (registry, _) = MakeActiveEndedGame(ws);
+			var engine = MakeEngine(registry);
+
+			await engine.ProcessLifecycleAsync();
+
+			var achievements = registry.GlobalState.Achievements
+				.OrderBy(a => a.FinalRank)
+				.ToList();
+
+			// Rank 1 = highest score (p1 with res1=2000), Rank 2 = lower score (p2)
+			Assert.Equal(2, achievements.Count);
+			Assert.Equal("Player 1", achievements[0].PlayerName);
+			Assert.Equal(1, achievements[0].FinalRank);
+			Assert.Equal("Player 2", achievements[1].PlayerName);
+			Assert.Equal(2, achievements[1].FinalRank);
+			// Rank-1 player is the winner recorded on the game record
+			var finalRecord = registry.GlobalState.Games[0];
+			Assert.Equal(achievements[0].PlayerId.Id, finalRecord.WinnerId?.Id);
+		}
+
+		[Fact]
 		public async Task FinalizeGame_RemovesInstanceFromRegistry() {
 			var ws = MakeTwoPlayerState("test-game").ToMutable();
 			var (registry, _) = MakeActiveEndedGame(ws);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -142,7 +142,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			await engine.ProcessLifecycleAsync();
 
-			var achievements = registry.GlobalState.Achievements
+			var achievements = registry.GlobalState.GetAchievements()
 				.OrderBy(a => a.FinalRank)
 				.ToList();
 
@@ -153,7 +153,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Equal("Player 2", achievements[1].PlayerName);
 			Assert.Equal(2, achievements[1].FinalRank);
 			// Rank-1 player is the winner recorded on the game record
-			var finalRecord = registry.GlobalState.Games[0];
+			var finalRecord = registry.GlobalState.GetGames()[0];
 			Assert.Equal(achievements[0].PlayerId.Id, finalRecord.WinnerId?.Id);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -91,6 +91,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 						UserId: player.UserId,
 						GameId: record.GameId,
 						PlayerId: playerId,
+						PlayerName: player.Name,
 						FinalRank: i + 1,
 						FinalScore: score,
 						GameDefType: record.GameDefType,


### PR DESCRIPTION
## Summary

- Adds `GET /api/games/{gameId}/results` endpoint that returns final standings from stored `PlayerAchievement` records
- Creates `Pages/Games/Results.razor` at `/games/{gameId}/results` showing game name, duration, final leaderboard (rank, player, score, winner badge), and nav buttons
- Adds `PlayerName` to `PlayerAchievementImmutable` so names are preserved after game instance is freed
- Adds 30s polling in `MainLayout.razor` via `ICurrentGameService.RefreshAsync()`; when an active game transitions to `Finished`, players on any in-game page are automatically redirected to the results page

## Depends on

- `feat/bge-162-game-routing` (BGE-162) — `ICurrentGameService`, `GameDetailViewModel`, game routing infrastructure. This PR targets that branch.
- BGE-156 — `GlobalState.Achievements`, `GameLifecycleEngine` (included in the base branch)

## Test plan

- [ ] Build passes (`dotnet build --configuration Release`)
- [ ] All 137 tests pass (`dotnet test`)
- [ ] Create a game, let it finish; visit `/games/{gameId}/results` — standings show correctly
- [ ] While on an in-game page (`/games/{gameId}/base`), simulate game finishing; confirm auto-redirect fires within ~30s
- [ ] Games lobby (`/games`) "Results" button links to results page for finished games
- [ ] "Browse Games" button on results page → `/games`
- [ ] "View All-Time Leaderboard" button → `/leaderboard/alltime`