### PR TITLE
fix: BGE-179 increase new player protection from 32 to 480 ticks

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -110,7 +110,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 								Level = 1
 							},
 						},
-						ProtectionTicksRemaining = 32
+						ProtectionTicksRemaining = 480  // 4 hours at 30s/tick
 					}
 				};
 			}


### PR DESCRIPTION
## Summary
- Increases `ProtectionTicksRemaining` from `32` to `480` on new player creation
- 32 ticks × 30s = 16 minutes — far too short to be meaningful protection
- 480 ticks × 30s = 4 hours — matches the original design intent

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (131/131)
- [ ] Verify new players have 4h protection shown in the UI after deploy

Closes BGE-179