### PR TITLE
feat: BGE-183 show deployment version in UI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f BrowserGameEngine.FrontendServer/Dockerfile .
+          docker build --build-arg COMMIT_SHA=$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f BrowserGameEngine.FrontendServer/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -1,4 +1,7 @@
-﻿<div class="top-row pl-4 navbar navbar-dark">
+@inject HttpClient Http
+@using BrowserGameEngine.Shared
+
+<div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">BrowserGameEngine</a>
     <button class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
@@ -68,15 +71,26 @@
             </NavLink>
         </li>
     </ul>
+    @if (version != null) {
+        <div class="px-3 py-2" style="font-size: 0.75rem; color: rgba(255,255,255,0.4);">
+            v@version.CommitHash
+        </div>
+    }
 </div>
 
 @code {
     private bool collapseNavMenu = true;
+    private VersionInfoViewModel? version;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
     private void ToggleNavMenu()
     {
         collapseNavMenu = !collapseNavMenu;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        version = await Http.GetFromJsonAsync<VersionInfoViewModel>("api/version");
     }
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
@@ -1,0 +1,17 @@
+using BrowserGameEngine.Shared;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Route("api/version")]
+	public class VersionController : ControllerBase {
+		private static readonly string CommitHash =
+			Environment.GetEnvironmentVariable("APP_VERSION") ?? "dev";
+
+		[HttpGet]
+		public ActionResult<VersionInfoViewModel> GetVersion() {
+			return Ok(new VersionInfoViewModel(CommitHash));
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Dockerfile
+++ b/src/BrowserGameEngine.FrontendServer/Dockerfile
@@ -24,6 +24,8 @@ FROM build AS publish
 RUN dotnet publish "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ARG COMMIT_SHA=dev
+ENV APP_VERSION=$COMMIT_SHA
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "BrowserGameEngine.FrontendServer.dll"]

--- a/src/BrowserGameEngine.Shared/VersionInfoViewModel.cs
+++ b/src/BrowserGameEngine.Shared/VersionInfoViewModel.cs
@@ -1,0 +1,3 @@
+namespace BrowserGameEngine.Shared {
+	public record VersionInfoViewModel(string CommitHash);
+}


### PR DESCRIPTION
## Summary
- Adds a `GET /api/version` endpoint (no auth required) that returns the current commit hash via `APP_VERSION` env var
- Displays the version at the bottom of the nav sidebar as `v<hash>`
- Dockerfile now accepts `COMMIT_SHA` build arg and sets it as `APP_VERSION` env var in the final image
- CI pipeline passes `--build-arg COMMIT_SHA=${{ github.sha }}` so every deployment bakes in its commit hash

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (131/131)
- [ ] Deploy and verify `v<sha>` appears in the nav sidebar
- [ ] Confirm `GET /api/version` returns `{"commitHash":"dev"}` in local dev

Closes BGE-183