### PR TITLE
feat: BGE-192 player game history & stats page

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerHistory.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerHistory.razor
@@ -1,0 +1,114 @@
+@page "/history"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h1>My History</h1>
+
+@if (model == null) {
+	<p><em>Loading...</em></p>
+} else if (model.TotalGames == 0) {
+	<div class="text-center mt-5">
+		<span class="oi oi-clock" style="font-size:3rem; opacity:0.3" aria-hidden="true"></span>
+		<p class="mt-3 text-muted">You haven't finished any games yet.</p>
+		<p class="text-muted">Complete a game round to see your history and stats here.</p>
+	</div>
+} else {
+	<div class="row row-cols-2 row-cols-md-4 g-3 mb-4">
+		<div class="col">
+			<div class="card text-center bg-dark border-secondary">
+				<div class="card-body py-2">
+					<div class="fs-3 fw-bold">@model.TotalGames</div>
+					<div class="text-muted small">Games Played</div>
+				</div>
+			</div>
+		</div>
+		<div class="col">
+			<div class="card text-center bg-dark border-secondary">
+				<div class="card-body py-2">
+					<div class="fs-3 fw-bold text-warning">@model.TotalWins</div>
+					<div class="text-muted small">Wins</div>
+				</div>
+			</div>
+		</div>
+		<div class="col">
+			<div class="card text-center bg-dark border-secondary">
+				<div class="card-body py-2">
+					<div class="fs-3 fw-bold">#@model.BestRank</div>
+					<div class="text-muted small">Best Rank</div>
+				</div>
+			</div>
+		</div>
+		<div class="col">
+			<div class="card text-center bg-dark border-secondary">
+				<div class="card-body py-2">
+					<div class="fs-3 fw-bold">@model.TotalScore.ToString("N0")</div>
+					<div class="text-muted small">Total Score</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<table class="table table-sm table-dark table-striped table-hover">
+		<thead>
+			<tr>
+				<th></th>
+				<th>Game</th>
+				<th>Ended</th>
+				<th>Duration</th>
+				<th>Rank</th>
+				<th>Score</th>
+				<th>Players</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var entry in model.Games) {
+				<tr>
+					<td>
+						@if (entry.IsWin) {
+							<span title="Win">🏆</span>
+						}
+					</td>
+					<td>
+						<span class="fw-semibold">@entry.GameName</span>
+						<span class="text-muted small ms-1">@entry.GameDefType</span>
+					</td>
+					<td>
+						<span title="@entry.EndTime.ToLocalTime().ToString("g")">
+							@entry.EndTime.ToLocalTime().ToString("d MMM yyyy")
+						</span>
+					</td>
+					<td class="text-muted">@FormatDuration(entry.EndTime - entry.StartTime)</td>
+					<td>
+						<span class="@RankBadgeClass(entry.FinalRank, entry.PlayersInGame)">
+							#@entry.FinalRank
+						</span>
+					</td>
+					<td>@entry.FinalScore.ToString("N0")</td>
+					<td class="text-muted">@entry.PlayersInGame</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+@code {
+	private PlayerHistoryViewModel? model;
+
+	protected override async Task OnInitializedAsync() {
+		model = await Http.GetFromJsonAsync<PlayerHistoryViewModel>("api/history");
+	}
+
+	private static string FormatDuration(TimeSpan span) {
+		if (span.TotalDays >= 1) return $"{(int)span.TotalDays}d {span.Hours}h";
+		if (span.TotalHours >= 1) return $"{(int)span.TotalHours}h {span.Minutes}m";
+		return $"{(int)span.TotalMinutes}m";
+	}
+
+	private static string RankBadgeClass(int rank, int players) => rank switch {
+		1 => "badge bg-warning text-dark",
+		2 => "badge bg-secondary",
+		3 => "badge bg-danger bg-opacity-75",
+		_ when rank > players / 2 => "badge bg-dark border border-secondary text-muted",
+		_ => "badge bg-dark border border-secondary"
+	};
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -63,6 +63,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="history">
+                <span class="oi oi-clock" aria-hidden="true"></span> My History
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="signout">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Logout
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
@@ -1,0 +1,64 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/history")]
+	public class HistoryController : ControllerBase {
+		private readonly GlobalState globalState;
+		private readonly CurrentUserContext currentUser;
+
+		public HistoryController(GlobalState globalState, CurrentUserContext currentUser) {
+			this.globalState = globalState;
+			this.currentUser = currentUser;
+		}
+
+		[HttpGet]
+		public IActionResult GetMyHistory() {
+			if (!currentUser.IsValid) return Unauthorized();
+
+			var achievements = globalState.Achievements
+				.Where(a => a.UserId == currentUser.UserId)
+				.OrderByDescending(a => a.FinishedAt)
+				.ToList();
+
+			var gameMap = globalState.Games
+				.ToDictionary(g => g.GameId.Id);
+
+			var playersPerGame = globalState.Achievements
+				.GroupBy(a => a.GameId.Id)
+				.ToDictionary(g => g.Key, g => g.Select(a => a.UserId).Distinct().Count());
+
+			var entries = achievements.Select(a => {
+				gameMap.TryGetValue(a.GameId.Id, out var rec);
+				return new PlayerGameHistoryEntryViewModel(
+					GameId: a.GameId.Id,
+					GameName: rec?.Name ?? a.GameId.Id,
+					GameDefType: a.GameDefType,
+					StartTime: rec?.StartTime ?? System.DateTime.MinValue,
+					EndTime: rec?.ActualEndTime ?? rec?.EndTime ?? System.DateTime.MinValue,
+					FinishedAt: a.FinishedAt,
+					FinalRank: a.FinalRank,
+					FinalScore: a.FinalScore,
+					PlayersInGame: playersPerGame.GetValueOrDefault(a.GameId.Id, 1),
+					IsWin: a.FinalRank == 1
+				);
+			}).ToArray();
+
+			var vm = new PlayerHistoryViewModel(
+				TotalGames: entries.Length,
+				TotalWins: entries.Count(e => e.IsWin),
+				BestRank: entries.Length > 0 ? entries.Min(e => e.FinalRank) : 0,
+				TotalScore: entries.Sum(e => e.FinalScore),
+				Games: entries
+			);
+
+			return Ok(vm);
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/PlayerHistoryViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerHistoryViewModel.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public record PlayerGameHistoryEntryViewModel(
+		string GameId,
+		string GameName,
+		string GameDefType,
+		DateTime StartTime,
+		DateTime EndTime,
+		DateTime FinishedAt,
+		int FinalRank,
+		decimal FinalScore,
+		int PlayersInGame,
+		bool IsWin
+	);
+
+	public record PlayerHistoryViewModel(
+		int TotalGames,
+		int TotalWins,
+		int BestRank,
+		decimal TotalScore,
+		PlayerGameHistoryEntryViewModel[] Games
+	);
+}


### PR DESCRIPTION
## Summary
- Add `PlayerHistoryViewModel` and `PlayerGameHistoryEntryViewModel` to `BrowserGameEngine.Shared`
- Add `HistoryController` at `GET /api/history` (requires auth) — returns per-user game history and summary stats from `GlobalState.Achievements`
- Add `PlayerHistory.razor` at `/history` — stats strip (games played, wins, best rank, total score) + history table with rank badges, duration, and win indicator
- Add "My History" nav link (clock icon) after Profile

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (131 tests)
- [ ] Log in, navigate to `/history` — empty state shown when no completed games
- [ ] Complete a game — entry appears with correct rank, score, duration, and win badge

Closes BGE-192