### PR TITLE
feat: BGE-212 end-of-game countdown banner

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -26,6 +26,21 @@
             }
             <a href="games" class="ms-auto text-white-50" style="font-size:0.8rem;">&#8592; All Games</a>
         </div>
+
+        @if (game.Status == "Finished") {
+            <div class="alert alert-secondary mx-4 mt-2 mb-0 d-flex align-items-center justify-content-between" role="alert">
+                <span><strong>This game has ended.</strong></span>
+                <a href="games/@game.GameId/results" class="btn btn-sm btn-outline-secondary">View Results</a>
+            </div>
+        } else if (remaining > TimeSpan.Zero && remaining <= TimeSpan.FromHours(1)) {
+            <div class="alert alert-danger mx-4 mt-2 mb-0" role="alert">
+                &#9888; <strong>Game ending soon!</strong> This game ends in <strong>@FormatRemaining(remaining)</strong>. Make your final moves.
+            </div>
+        } else if (remaining > TimeSpan.Zero && remaining <= TimeSpan.FromHours(24)) {
+            <div class="alert alert-warning mx-4 mt-2 mb-0" role="alert">
+                <strong>Game ending in @FormatRemaining(remaining).</strong> Plan your final moves.
+            </div>
+        }
     }
 
     <div class="content px-4">
@@ -35,15 +50,31 @@
 
 @code {
     private System.Threading.CancellationTokenSource? pollCts;
+    private System.Threading.Timer? displayTimer;
 
     protected override void OnInitialized() {
         CurrentGameService.OnChanged += OnGameChanged;
         StartPolling();
+        UpdateDisplayTimer();
     }
 
     private void OnGameChanged() {
         StateHasChanged();
         RedirectIfFinished();
+        UpdateDisplayTimer();
+    }
+
+    private void UpdateDisplayTimer() {
+        displayTimer?.Dispose();
+        displayTimer = null;
+        var game = CurrentGameService.CurrentGame;
+        if (game == null || game.Status == "Finished") return;
+        var remaining = game.EndTime - DateTime.UtcNow;
+        if (remaining <= TimeSpan.Zero || remaining > TimeSpan.FromHours(24)) return;
+        var interval = remaining <= TimeSpan.FromHours(1)
+            ? TimeSpan.FromSeconds(1)
+            : TimeSpan.FromMinutes(1);
+        displayTimer = new System.Threading.Timer(_ => InvokeAsync(StateHasChanged), null, interval, interval);
     }
 
     private void StartPolling() {
@@ -77,6 +108,7 @@
         CurrentGameService.OnChanged -= OnGameChanged;
         pollCts?.Cancel();
         pollCts?.Dispose();
+        displayTimer?.Dispose();
     }
 
     private static string GetStatusBadge(string status) => status switch {


### PR DESCRIPTION
## Summary

- Adds urgency-tiered warning banners to `MainLayout.razor` based on time remaining until `EndTime`
- Yellow (warning) alert when EndTime is within 24 hours: "Game ending in Xh Ym. Plan your final moves."
- Red (danger) alert when EndTime is within 1 hour: "⚠ Game ending soon! ...Xm Ys... Make your final moves."
- Grey (secondary) alert when `Status == Finished`: "This game has ended." with a View Results button
- Client-side `System.Threading.Timer` fires `StateHasChanged` every second (< 1h) or every minute (1–24h) so the countdown updates live between API polls
- No visual change for active games with EndTime > 24h away (no regression)

Closes BGE-212

## Test plan

- [ ] Load a game page with EndTime > 24h away — no new banner visible
- [ ] Simulate EndTime within 24h — yellow warning banner appears with live countdown updating each minute
- [ ] Simulate EndTime within 1h — red danger banner appears with live countdown updating each second
- [ ] Simulate `Status == Finished` — grey "This game has ended" banner with View Results link; redirect triggers for in-game pages
- [ ] Verify existing game-context-banner (name/status/countdown in dark bar) still renders correctly