### PR TITLE
fix: BGE-225 remove unused Race selector from JoinGame UI

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
@@ -35,11 +35,18 @@
 					<td>@game.PlayerCount</td>
 					<td>@(game.StartTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "TBD")</td>
 					<td>@(game.EndTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "TBD")</td>
-					<td>
+					<td class="d-flex gap-1 flex-wrap">
 						@if (game.Status == "Active") {
 							<a class="btn btn-sm btn-primary" href="games/@game.GameId/base">Play</a>
+							@if (game.CanJoin) {
+								<a class="btn btn-sm btn-outline-primary" href="games/@game.GameId/join">Join</a>
+							}
 						} else if (game.Status == "Upcoming") {
-							<span class="text-muted">Upcoming</span>
+							@if (game.CanJoin) {
+								<a class="btn btn-sm btn-success" href="games/@game.GameId/join">Join</a>
+							} else {
+								<span class="text-muted">Upcoming</span>
+							}
 						} else {
 							<a class="btn btn-sm btn-secondary" href="games/@game.GameId/results">Results</a>
 						}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/JoinGame.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/JoinGame.razor
@@ -34,21 +34,6 @@
 					<input class="form-control" type="text" @bind="playerName" placeholder="Enter your name" maxlength="32" />
 				</div>
 
-				<div class="mb-4">
-					<label class="form-label">Race</label>
-					<div class="d-flex gap-3 flex-wrap">
-						@foreach (var race in races) {
-							<div class="form-check">
-								<input class="form-check-input" type="radio" name="race"
-									   id="race_@race.Id" value="@race.Id"
-									   checked="@(selectedRace == race.Id)"
-									   @onchange="() => selectedRace = race.Id" />
-								<label class="form-check-label" for="race_@race.Id">@race.Name</label>
-							</div>
-						}
-					</div>
-				</div>
-
 				<button class="btn btn-primary w-100" @onclick="Join" disabled="@joining">
 					@if (joining) {
 						<span class="spinner-border spinner-border-sm me-1" role="status"></span>
@@ -70,15 +55,8 @@
 	private string? error;
 	private string? joinError;
 	private string playerName = "";
-	private string selectedRace = "terran";
 	private bool joining = false;
 	private bool alreadyJoined = false;
-
-	private static readonly (string Id, string Name)[] races = new[] {
-		("terran", "Terraner"),
-		("protoss", "Protoss"),
-		("zerg", "Zerg"),
-	};
 
 	protected override async Task OnParametersSetAsync() {
 		game = null;
@@ -98,7 +76,7 @@
 		}
 		joining = true;
 		joinError = null;
-		var request = new JoinGameRequest(PlayerName: playerName.Trim(), Race: selectedRace);
+		var request = new JoinGameRequest(PlayerName: playerName.Trim());
 		var response = await Http.PostAsJsonAsync($"api/games/{GameId}/join", request);
 		if (response.IsSuccessStatusCode) {
 			Nav.NavigateTo($"games/{GameId}/base");

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/JoinGame.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/JoinGame.razor
@@ -1,0 +1,119 @@
+@page "/games/{GameId}/join"
+@namespace BrowserGameEngine.BlazorClient.Pages.GameJoin
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+<h1>Join Game</h1>
+
+@if (game == null && error == null) {
+	<p><em>Loading...</em></p>
+} else if (error != null) {
+	<div class="alert alert-danger">@error</div>
+	<a class="btn btn-secondary" href="games">Back to Games</a>
+} else if (game != null) {
+	<div class="mb-3">
+		<strong>@game.Name</strong>
+		<span class="badge @GetStatusBadge(game.Status) ms-2">@game.Status</span>
+	</div>
+
+	@if (alreadyJoined) {
+		<div class="alert alert-info">You have already joined this game.</div>
+		<a class="btn btn-primary" href="games/@GameId/base">Play</a>
+	} else {
+		<div class="card" style="max-width: 400px;">
+			<div class="card-body">
+				<h5 class="card-title mb-3">Choose your commander</h5>
+
+				@if (!string.IsNullOrEmpty(joinError)) {
+					<div class="alert alert-danger py-2">@joinError</div>
+				}
+
+				<div class="mb-3">
+					<label class="form-label">Commander Name</label>
+					<input class="form-control" type="text" @bind="playerName" placeholder="Enter your name" maxlength="32" />
+				</div>
+
+				<div class="mb-4">
+					<label class="form-label">Race</label>
+					<div class="d-flex gap-3 flex-wrap">
+						@foreach (var race in races) {
+							<div class="form-check">
+								<input class="form-check-input" type="radio" name="race"
+									   id="race_@race.Id" value="@race.Id"
+									   checked="@(selectedRace == race.Id)"
+									   @onchange="() => selectedRace = race.Id" />
+								<label class="form-check-label" for="race_@race.Id">@race.Name</label>
+							</div>
+						}
+					</div>
+				</div>
+
+				<button class="btn btn-primary w-100" @onclick="Join" disabled="@joining">
+					@if (joining) {
+						<span class="spinner-border spinner-border-sm me-1" role="status"></span>
+						<span>Joining...</span>
+					} else {
+						<span>Join Game</span>
+					}
+				</button>
+			</div>
+		</div>
+	}
+}
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private GameDetailViewModel? game;
+	private string? error;
+	private string? joinError;
+	private string playerName = "";
+	private string selectedRace = "terran";
+	private bool joining = false;
+	private bool alreadyJoined = false;
+
+	private static readonly (string Id, string Name)[] races = new[] {
+		("terran", "Terraner"),
+		("protoss", "Protoss"),
+		("zerg", "Zerg"),
+	};
+
+	protected override async Task OnParametersSetAsync() {
+		game = null;
+		error = null;
+		alreadyJoined = false;
+		try {
+			game = await Http.GetFromJsonAsync<GameDetailViewModel>($"api/games/{GameId}");
+		} catch {
+			error = "Game not found.";
+		}
+	}
+
+	private async Task Join() {
+		if (string.IsNullOrWhiteSpace(playerName)) {
+			joinError = "Please enter a commander name.";
+			return;
+		}
+		joining = true;
+		joinError = null;
+		var request = new JoinGameRequest(PlayerName: playerName.Trim(), Race: selectedRace);
+		var response = await Http.PostAsJsonAsync($"api/games/{GameId}/join", request);
+		if (response.IsSuccessStatusCode) {
+			Nav.NavigateTo($"games/{GameId}/base");
+		} else if (response.StatusCode == System.Net.HttpStatusCode.Conflict) {
+			alreadyJoined = true;
+		} else {
+			joinError = await response.Content.ReadAsStringAsync();
+		}
+		joining = false;
+	}
+
+	private static string GetStatusBadge(string status) => status switch {
+		"Active" => "bg-success",
+		"Upcoming" => "bg-warning text-dark",
+		"Finished" => "bg-secondary",
+		_ => "bg-light text-dark"
+	};
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
@@ -2,13 +2,8 @@
 @inject HttpClient Http
 @inject NavigationManager Nav
 
-<h3>Hello</h3>
-
 @code {
-    protected override async Task OnInitializedAsync() {
-        var exists = await Http.GetFromJsonAsync<bool>("api/playerprofile/exists");
-        if (!exists) {
-            Nav.NavigateTo("/createplayer");
-        }
+    protected override void OnInitialized() {
+        Nav.NavigateTo("games");
     }
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using Microsoft.AspNetCore.Authorization;
@@ -105,22 +106,27 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpPost("{gameId}/join")]
-		public ActionResult Join(string gameId) {
-			if (!currentUserContext.IsValid) return Unauthorized();
+		public ActionResult Join(string gameId, [FromBody] JoinGameRequest request) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			if (string.IsNullOrWhiteSpace(request.PlayerName)) return BadRequest("Player name is required");
+
 			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();
-			if (record.Status != GameStatus.Upcoming) return BadRequest("This game is not open for joining.");
+			if (record.Status == GameStatus.Finished) return BadRequest("This game has ended.");
 
 			var instance = gameRegistry.TryGetInstance(record.GameId);
 			if (instance == null) return NotFound();
 
-			if (instance.HasPlayer(currentUserContext.PlayerId!)) {
-				return Conflict("You have already joined this game.");
-			}
+			// Check if user already has a player in this game (by UserId)
+			if (instance.HasUserPlayer(currentUserContext.UserId)) return Conflict("You have already joined this game.");
+
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
-			playerRepoWrite.CreatePlayer(currentUserContext.PlayerId!, currentUserContext.UserId);
-			logger.LogInformation("Player {PlayerId} joined game {GameId}", currentUserContext.PlayerId!.Id, gameId);
-			return Ok();
+			playerRepoWrite.CreatePlayer(playerId, currentUserContext.UserId);
+			playerRepoWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, request.PlayerName));
+
+			logger.LogInformation("Player {PlayerId} joined game {GameId} as {PlayerName}", playerId.Id, gameId, request.PlayerName);
+			return Ok(new { PlayerId = playerId.Id });
 		}
 
 		[Authorize]

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -16,5 +16,5 @@ namespace BrowserGameEngine.Shared {
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);
 
-	public record JoinGameRequest(string PlayerName, string Race = "terran");
+	public record JoinGameRequest(string PlayerName);
 }

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -16,5 +16,5 @@ namespace BrowserGameEngine.Shared {
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);
 
-	public record JoinGameRequest(string GameId);
+	public record JoinGameRequest(string PlayerName, string Race = "terran");
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
+using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 	public class GameInstance {
@@ -21,6 +22,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		public int PlayerCount => WorldState.Players.Count;
 
 		public bool HasPlayer(PlayerId playerId) => WorldState.PlayerExists(playerId);
+
+		public bool HasUserPlayer(string userId) =>
+			WorldState.Players.Values.Any(p => p.UserId == userId);
 
 		public void SetTickEngine(GameTickEngine tickEngine) { TickEngine = tickEngine; }
 	}


### PR DESCRIPTION
## Summary

- Removes the Race/faction radio selector from `JoinGame.razor` — it was collected in the UI and sent in `JoinGameRequest` but never used server-side
- Removes the `Race` field from `JoinGameRequest` record in `GameLobbyViewModels.cs`
- Fixes the blocking issue found during QA review of [BGE-158](https://github.com/discostu105/bge/pull/60) Phase 4

Closes BGE-225. Resolves the blocker on BGE-158.

## Test plan

- [ ] Navigate to `/games/{id}/join` — no Race selector should appear
- [ ] Join a game with only a Commander Name — should succeed and redirect to base
- [ ] Build passes (`dotnet build`)