### PR TITLE
fix: BGE-218 replace async void timer callbacks with PeriodicTimer

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -90,6 +90,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -78,19 +78,19 @@
     private string newMessage = "";
     private string newPassword = "";
     private string? lastError;
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await Update();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await Update();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+        }
     }
 
     private async Task Update() {
@@ -136,6 +136,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -1,6 +1,7 @@
 @page "/alliances/{AllianceId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Alliance: @(detail?.Name ?? "...")</h1>
 
@@ -77,9 +78,19 @@
     private string newMessage = "";
     private string newPassword = "";
     private string? lastError;
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
         await Update();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await Update();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task Update() {
@@ -122,5 +133,9 @@
         var r = await Http.PatchAsJsonAsync($"api/alliances/{AllianceId}/password", new SetAlliancePasswordRequest { NewPassword = newPassword });
         if (r.IsSuccessStatusCode) { newPassword = ""; await Update(); }
         else lastError = await r.Content.ReadAsStringAsync();
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
@@ -43,19 +43,19 @@
     public string? GameId { get; set; }
 
     private AllianceRankingViewModel[]? model;
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await LoadData();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await LoadData();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(LoadData);
+        }
     }
 
     private async Task LoadData() {
@@ -63,6 +63,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
@@ -55,6 +55,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(LoadData);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceRanking.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/allianceranking"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Alliance Ranking</h1>
 
@@ -42,8 +43,26 @@
     public string? GameId { get; set; }
 
     private AllianceRankingViewModel[]? model;
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
+        await LoadData();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await LoadData();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
+    }
+
+    private async Task LoadData() {
         model = await Http.GetFromJsonAsync<AllianceRankingViewModel[]>("api/allianceranking");
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/alliances"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Alliances</h1>
 
@@ -86,9 +87,19 @@
     private string joinPassword = "";
     private AllianceViewModel? joiningAlliance;
     private string? lastError;
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
         await Update();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await Update();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task Update() {
@@ -133,5 +144,9 @@
         } else {
             lastError = await response.Content.ReadAsStringAsync();
         }
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -87,19 +87,19 @@
     private string joinPassword = "";
     private AllianceViewModel? joiningAlliance;
     private string? lastError;
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await Update();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await Update();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+        }
     }
 
     private async Task Update() {
@@ -147,6 +147,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -99,6 +99,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -116,6 +116,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/base"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Basis</h1>
 
@@ -103,9 +104,19 @@
     private int tradeAmount = 1;
     private string? tradeError;
     private _BuildQueue? buildQueue;
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
         await Update();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await Update();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task BuildAsset(AssetViewModel asset) {
@@ -156,6 +167,10 @@
     private async Task Update() {
         model = await Http.GetFromJsonAsync<AssetsViewModel>("api/assets");
         resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -104,19 +104,19 @@
     private int tradeAmount = 1;
     private string? tradeError;
     private _BuildQueue? buildQueue;
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await Update();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await Update();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+        }
     }
 
     private async Task BuildAsset(AssetViewModel asset) {
@@ -170,7 +170,8 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -85,19 +85,19 @@
     [Parameter]
     public required string EnemeyPlayerId { get; set; }
 
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await LoadData();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await LoadData();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(LoadData);
+        }
     }
 
     private async Task LoadData() {
@@ -115,6 +115,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -97,6 +97,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(LoadData);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/enemybase/{EnemeyPlayerId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Angriff</h1>
 
@@ -84,7 +85,22 @@
     [Parameter]
     public required string EnemeyPlayerId { get; set; }
 
+    private System.Threading.Timer? _refreshTimer;
+
     protected override async Task OnInitializedAsync() {
+        await LoadData();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await LoadData();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
+    }
+
+    private async Task LoadData() {
         model = await Http.GetFromJsonAsync<EnemyBaseViewModel>($"api/battle/enemybase?enemyPlayerId={Uri.EscapeDataString(EnemeyPlayerId)}");
     }
 
@@ -96,5 +112,9 @@
             var error = await response.Content.ReadAsStringAsync();
             lastError = error;
         }
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/messages"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Messages</h1>
 
@@ -77,9 +78,19 @@
 	private SendMessageViewModel composeModel = new();
 	private string? sendResult;
 	private string? expandedMessageId;
+	private System.Threading.Timer? _refreshTimer;
 
 	protected override async Task OnInitializedAsync() {
 		await LoadInbox();
+		_refreshTimer = new System.Threading.Timer(
+			async _ => {
+				await LoadInbox();
+				await InvokeAsync(StateHasChanged);
+			},
+			null,
+			TimeSpan.FromSeconds(10),
+			TimeSpan.FromSeconds(10)
+		);
 	}
 
 	private async Task LoadInbox() {
@@ -108,5 +119,9 @@
 
 	private void ToggleMessage(MessageViewModel msg) {
 		expandedMessageId = expandedMessageId == msg.MessageId ? null : msg.MessageId;
+	}
+
+	public void Dispose() {
+		_refreshTimer?.Dispose();
 	}
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -90,6 +90,7 @@
 		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
 		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
 			await InvokeAsync(LoadInbox);
+			await InvokeAsync(StateHasChanged);
 		}
 	}
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -78,19 +78,19 @@
 	private SendMessageViewModel composeModel = new();
 	private string? sendResult;
 	private string? expandedMessageId;
-	private System.Threading.Timer? _refreshTimer;
+	private CancellationTokenSource? _cts;
 
 	protected override async Task OnInitializedAsync() {
 		await LoadInbox();
-		_refreshTimer = new System.Threading.Timer(
-			async _ => {
-				await LoadInbox();
-				await InvokeAsync(StateHasChanged);
-			},
-			null,
-			TimeSpan.FromSeconds(10),
-			TimeSpan.FromSeconds(10)
-		);
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(LoadInbox);
+		}
 	}
 
 	private async Task LoadInbox() {
@@ -122,6 +122,7 @@
 	}
 
 	public void Dispose() {
-		_refreshTimer?.Dispose();
+		_cts?.Cancel();
+		_cts?.Dispose();
 	}
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -91,19 +91,19 @@
     private AllTimeStandingViewModel[]? allTimeModel;
     private string filter = "all";
     private string activeTab = "current";
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await LoadData();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await LoadData();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(LoadData);
+        }
     }
 
     private async Task SwitchTab(string tab) {
@@ -136,6 +136,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -3,6 +3,7 @@
 @using BrowserGameEngine.Shared
 @using System.Linq
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Ranking</h1>
 
@@ -90,9 +91,19 @@
     private AllTimeStandingViewModel[]? allTimeModel;
     private string filter = "all";
     private string activeTab = "current";
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
-        await LoadCurrentGame();
+        await LoadData();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await LoadData();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task SwitchTab(string tab) {
@@ -102,7 +113,7 @@
         }
     }
 
-    private async Task LoadCurrentGame() {
+    private async Task LoadData() {
         model = await Http.GetFromJsonAsync<PublicPlayerViewModel[]>("api/playerranking");
     }
 
@@ -122,5 +133,9 @@
             .OrderByDescending(x => x.Score)
             .GroupBy(p => p.UserId)
             .Select(g => (g.Key, g.First().UserDisplayName, (IEnumerable<PublicPlayerViewModel>)g));
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -103,6 +103,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(LoadData);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -85,6 +85,7 @@
 		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
 		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
 			await InvokeAsync(LoadPlayers);
+			await InvokeAsync(StateHasChanged);
 		}
 	}
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -73,19 +73,19 @@
 	private CreatePlayerForUserViewModel createModel = new();
 	private string? createError;
 	private string? newApiKey;
-	private System.Threading.Timer? _refreshTimer;
+	private CancellationTokenSource? _cts;
 
 	protected override async Task OnInitializedAsync() {
 		await LoadPlayers();
-		_refreshTimer = new System.Threading.Timer(
-			async _ => {
-				await LoadPlayers();
-				await InvokeAsync(StateHasChanged);
-			},
-			null,
-			TimeSpan.FromSeconds(10),
-			TimeSpan.FromSeconds(10)
-		);
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(LoadPlayers);
+		}
 	}
 
 	private async Task LoadPlayers() {
@@ -132,6 +132,7 @@
 	}
 
 	public void Dispose() {
-		_refreshTimer?.Dispose();
+		_cts?.Cancel();
+		_cts?.Dispose();
 	}
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -3,6 +3,7 @@
 @inject HttpClient Http
 @inject NavigationManager Nav
 @inject IJSRuntime JS
+@implements IDisposable
 
 <h1>My Players</h1>
 
@@ -72,9 +73,19 @@
 	private CreatePlayerForUserViewModel createModel = new();
 	private string? createError;
 	private string? newApiKey;
+	private System.Threading.Timer? _refreshTimer;
 
 	protected override async Task OnInitializedAsync() {
 		await LoadPlayers();
+		_refreshTimer = new System.Threading.Timer(
+			async _ => {
+				await LoadPlayers();
+				await InvokeAsync(StateHasChanged);
+			},
+			null,
+			TimeSpan.FromSeconds(10),
+			TimeSpan.FromSeconds(10)
+		);
 	}
 
 	private async Task LoadPlayers() {
@@ -118,5 +129,9 @@
 
 	private async Task CopyToClipboard(string text) {
 		await JS.InvokeVoidAsync("navigator.clipboard.writeText", text);
+	}
+
+	public void Dispose() {
+		_refreshTimer?.Dispose();
 	}
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -3,6 +3,7 @@
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
+@implements IDisposable
 
 <h1>Einheiten</h1>
 
@@ -70,9 +71,19 @@
     private UnitsViewModel? model;
     private string? lastError;
     private Dictionary<Guid, bool> showSplit = new();
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
         await Update();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await Update();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task Update() {
@@ -109,5 +120,9 @@
 
     private void ToggleShowSplit(Guid unitId) {
         showSplit[unitId] = !IsShowSplit(unitId);
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -83,6 +83,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -71,19 +71,19 @@
     private UnitsViewModel? model;
     private string? lastError;
     private Dictionary<Guid, bool> showSplit = new();
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await Update();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await Update();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+        }
     }
 
     private async Task Update() {
@@ -123,6 +123,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -2,6 +2,7 @@
 @page "/games/{GameId}/upgrades"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
+@implements IDisposable
 
 <h1>Forschung</h1>
 
@@ -70,9 +71,19 @@
 
     private UpgradesViewModel? model;
     private string? lastError;
+    private System.Threading.Timer? _refreshTimer;
 
     protected override async Task OnInitializedAsync() {
         await Update();
+        _refreshTimer = new System.Threading.Timer(
+            async _ => {
+                await Update();
+                await InvokeAsync(StateHasChanged);
+            },
+            null,
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(10)
+        );
     }
 
     private async Task ResearchAttack() => await Research("Attack");
@@ -90,5 +101,9 @@
 
     private async Task Update() {
         model = await Http.GetFromJsonAsync<UpgradesViewModel>("api/upgrades");
+    }
+
+    public void Dispose() {
+        _refreshTimer?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -83,6 +83,7 @@
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
         while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -71,19 +71,19 @@
 
     private UpgradesViewModel? model;
     private string? lastError;
-    private System.Threading.Timer? _refreshTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         await Update();
-        _refreshTimer = new System.Threading.Timer(
-            async _ => {
-                await Update();
-                await InvokeAsync(StateHasChanged);
-            },
-            null,
-            TimeSpan.FromSeconds(10),
-            TimeSpan.FromSeconds(10)
-        );
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+        }
     }
 
     private async Task ResearchAttack() => await Research("Attack");
@@ -104,6 +104,7 @@
     }
 
     public void Dispose() {
-        _refreshTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -22,14 +22,20 @@
 @code {
     private PlayerResourcesViewModel? resources;
     private TickInfoViewModel? tickInfo;
-    private System.Threading.Timer? countdownTimer;
+    private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync() {
         RefreshService.RefreshRequested += OnRefresh;
         await Update();
-        countdownTimer = new System.Threading.Timer(async _ => {
+        _cts = new CancellationTokenSource();
+        _ = RunCountdownLoop(_cts.Token);
+    }
+
+    private async Task RunCountdownLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
             await InvokeAsync(StateHasChanged);
-        }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
     }
 
     private async void OnRefresh() {
@@ -50,6 +56,7 @@
 
     public void Dispose() {
         RefreshService.RefreshRequested -= OnRefresh;
-        countdownTimer?.Dispose();
+        _cts?.Cancel();
+        _cts?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Fixes QA-requested changes from PR #58 (BGE-189 auto-refresh)
- All 11 Blazor pages used `System.Threading.Timer` with `async void` callbacks — fire-and-forget delegates where exceptions are unobserved and timing is non-deterministic
- Replaced with `PeriodicTimer` + `CancellationTokenSource` pattern in every affected page
- `RunRefreshLoop`/`RunCountdownLoop` awaits `WaitForNextTickAsync(ct)` and exits cleanly when the component is disposed via `_cts.Cancel()`
- `InvokeAsync(LoadData)` ensures data fetch runs on the Blazor synchronization context

## Affected pages
Base, Players, Messages, Upgrades, AllianceDetail, Units, Alliances, AllianceRanking, EnemyBase, PlayerRanking, _PlayerResources

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (131 tests)
- [ ] Navigate to each affected page and verify auto-refresh still works after ~10s
- [ ] Dispose/navigate away from page — no unhandled exceptions in console

Closes BGE-218