### PR TITLE
feat: BGE-211 game auto-finalization engine

### DIFF
--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -38,7 +38,8 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 
 					new GameTickModuleDef("protection:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
-					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary())
+					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
+					new GameTickModuleDef("gamefinalization:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
 
 				Assets = new List<AssetDef> {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameFinalizationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameFinalizationTest.cs
@@ -1,0 +1,118 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class GameFinalizationTest {
+		private const string TestGameId = "default";
+
+		private static (TestGame game, GameRegistryNs.GameRegistry registry, GameFinalizationModule module) Setup(
+			DateTime endTime, int playerCount = 1) {
+			var game = new TestGame(playerCount);
+			var record = new GameRecordImmutable(
+				new GameId(TestGameId), "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddHours(-2), endTime, TimeSpan.FromSeconds(30));
+			game.GlobalState.AddGame(record);
+
+			var registry = new GameRegistryNs.GameRegistry(game.GlobalState);
+			var instance = new GameRegistryNs.GameInstance(record, game.World, game.GameDef);
+			registry.Register(instance);
+
+			var module = new GameFinalizationModule(game.Accessor, game.GlobalState, registry, game.GameDef);
+			return (game, registry, module);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_SetsGameToFinished() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1));
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
+			Assert.Equal(GameStatus.Finished, gameRecord.Status);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_SetsActualEndTime() {
+			var before = DateTime.UtcNow;
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1));
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
+			Assert.NotNull(gameRecord.ActualEndTime);
+			Assert.True(gameRecord.ActualEndTime >= before);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_SetsWinnerId() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1));
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
+			Assert.NotNull(gameRecord.WinnerId);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_CreatesAchievementsForAllPlayers() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1), playerCount: 2);
+			var player2 = new BrowserGameEngine.GameModel.PlayerId("player1");
+
+			module.CalculateTick(game.Player1);
+
+			var achievements = game.GlobalState.GetAchievements();
+			Assert.Equal(2, achievements.Count);
+			Assert.All(achievements, a => Assert.Equal(TestGameId, a.GameId.Id));
+			Assert.All(achievements, a => Assert.Equal("sco", a.GameDefType));
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_AchievementsHaveCorrectRanks() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1), playerCount: 2);
+
+			module.CalculateTick(game.Player1);
+
+			var achievements = game.GlobalState.GetAchievements().OrderBy(a => a.FinalRank).ToList();
+			Assert.Equal(1, achievements[0].FinalRank);
+			Assert.Equal(2, achievements[1].FinalRank);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_RemovesGameFromRegistry() {
+			var (game, registry, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1));
+
+			module.CalculateTick(game.Player1);
+
+			Assert.Null(registry.TryGetInstance(new GameId(TestGameId)));
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeNotReached_DoesNotFinalizeGame() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(1));
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
+			Assert.Equal(GameStatus.Active, gameRecord.Status);
+			Assert.Empty(game.GlobalState.GetAchievements());
+		}
+
+		[Fact]
+		public void CalculateTick_CalledMultipleTimes_OnlyFinalizesOnce() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1), playerCount: 2);
+			var player2 = new BrowserGameEngine.GameModel.PlayerId("player1");
+
+			// Simulate multiple players calling CalculateTick in the same tick
+			module.CalculateTick(game.Player1);
+			module.CalculateTick(player2);
+
+			var achievements = game.GlobalState.GetAchievements();
+			Assert.Equal(2, achievements.Count); // Only 2 achievements, not 4
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -55,6 +55,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, NewPlayerProtectionModule>();
 			services.AddSingleton<IGameTickModule, UpgradeTimer>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
+			services.AddSingleton<IGameTickModule, GameFinalizationModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/GameFinalizationModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/GameFinalizationModule.cs
@@ -1,0 +1,90 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class GameFinalizationModule : IGameTickModule {
+		public string Name => "gamefinalization:1";
+
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private readonly GlobalState globalState;
+		private readonly GameRegistry.GameRegistry gameRegistry;
+		private readonly GameDef gameDef;
+		private readonly object _finalizeLock = new();
+
+		public GameFinalizationModule(
+			IWorldStateAccessor worldStateAccessor,
+			GlobalState globalState,
+			GameRegistry.GameRegistry gameRegistry,
+			GameDef gameDef) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.globalState = globalState;
+			this.gameRegistry = gameRegistry;
+			this.gameDef = gameDef;
+		}
+
+		public void SetProperty(string name, string value) { }
+
+		public void CalculateTick(PlayerId playerId) {
+			var gameId = worldStateAccessor.WorldState.GameId;
+			var gameRecord = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);
+			if (gameRecord == null || gameRecord.Status != GameStatus.Active) return;
+			if (gameRecord.EndTime >= DateTime.UtcNow) return;
+
+			lock (_finalizeLock) {
+				// Re-check inside lock to avoid double-finalization
+				gameRecord = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);
+				if (gameRecord == null || gameRecord.Status != GameStatus.Active) return;
+
+				FinalizeGame(gameId, gameRecord);
+			}
+		}
+
+		private void FinalizeGame(GameId gameId, GameRecordImmutable gameRecord) {
+			var finishedAt = DateTime.UtcNow;
+			var players = worldStateAccessor.WorldState.Players;
+
+			var rankedPlayers = players
+				.Select(kv => (PlayerId: kv.Key, Player: kv.Value, Score: GetScore(kv.Key)))
+				.OrderByDescending(x => x.Score)
+				.ToList();
+
+			PlayerId? winnerId = rankedPlayers.Count > 0 ? rankedPlayers[0].PlayerId : null;
+
+			for (int i = 0; i < rankedPlayers.Count; i++) {
+				var (pid, player, score) = rankedPlayers[i];
+				var achievement = new PlayerAchievementImmutable(
+					UserId: player.UserId ?? string.Empty,
+					GameId: gameId,
+					PlayerId: pid,
+					PlayerName: player.Name,
+					FinalRank: i + 1,
+					FinalScore: score,
+					GameDefType: gameRecord.GameDefType,
+					FinishedAt: finishedAt
+				);
+				globalState.AddAchievement(achievement);
+			}
+
+			var updatedRecord = gameRecord with {
+				Status = GameStatus.Finished,
+				WinnerId = winnerId,
+				ActualEndTime = finishedAt
+			};
+			globalState.UpdateGame(gameRecord, updatedRecord);
+			gameRegistry.Remove(gameId);
+		}
+
+		private decimal GetScore(PlayerId playerId) {
+			if (worldStateAccessor.WorldState.Players.TryGetValue(playerId, out var player)) {
+				if (player.State.Resources.TryGetValue(gameDef.ScoreResource, out var score)) {
+					return score;
+				}
+			}
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GameFinalizationModule` implementing `IGameTickModule` that automatically finishes a game when its `EndTime` is reached
- On each tick for an `Active` game, checks if `EndTime < DateTime.UtcNow`; if so, ranks players by `ScoreResource` (land), creates `PlayerAchievementImmutable` for each in `GlobalState`, updates `GameRecord` to `Finished` with `WinnerId` and `ActualEndTime`, and removes the game from `GameRegistry`
- Double-checked lock prevents double-finalization when multiple players' ticks fire in the same tick cycle
- Registered in `GameServerExtensions` and added `"gamefinalization:1"` to the SCO `GameDef`
- 8 unit tests covering: status transition, ActualEndTime, WinnerId, achievement creation, rank ordering, registry removal, early-exit when EndTime not reached, and idempotency across multiple ticks

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (146 tests, 8 new)
- [ ] Start a game, set `EndTime` to a past time via admin tools or test seed, verify game transitions to `Finished` within one tick
- [ ] Verify `PlayerAchievements` appear in global state (leaderboard/results page)

Closes BGE-211