### PR TITLE
feat: BGE-233 enhanced health check endpoint and startup logging

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/BlobStorageHealthCheck.cs
+++ b/src/BrowserGameEngine.FrontendServer/BlobStorageHealthCheck.cs
@@ -1,0 +1,36 @@
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace BrowserGameEngine.FrontendServer;
+
+public class BlobStorageHealthCheck : IHealthCheck
+{
+	private readonly IBlobStorage _storage;
+	private readonly GameRegistry _gameRegistry;
+
+	public BlobStorageHealthCheck(IBlobStorage storage, GameRegistry gameRegistry)
+	{
+		_storage = storage;
+		_gameRegistry = gameRegistry;
+	}
+
+	public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+	{
+		var activeGameCount = _gameRegistry.GetAllInstances().Count;
+		var data = new Dictionary<string, object>
+		{
+			["activeGames"] = activeGameCount,
+			["timestamp"] = DateTime.UtcNow
+		};
+
+		try {
+			_storage.List("global").FirstOrDefault();
+			data["blobStorage"] = "reachable";
+			return Task.FromResult(HealthCheckResult.Healthy("OK", data));
+		} catch (Exception ex) {
+			data["blobStorage"] = "unreachable";
+			return Task.FromResult(HealthCheckResult.Unhealthy("Blob storage unreachable", ex, data));
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -46,7 +46,8 @@ builder.Services.Configure<BgeOptions>(builder.Configuration.GetSection(BgeOptio
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddLogging();
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddCheck<BlobStorageHealthCheck>("blob-storage");
 builder.Services.AddOpenApi();
 
 builder.Services.AddOpenTelemetry()
@@ -161,7 +162,21 @@ app.UseRateLimiter();
 app.UseMiddleware<CurrentUserMiddleware>();
 app.UseAuthorization();
 
-app.MapHealthChecks("/health");
+app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions {
+    ResponseWriter = async (ctx, report) => {
+        ctx.Response.ContentType = "application/json";
+        var result = System.Text.Json.JsonSerializer.Serialize(new {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(e => new {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                data = e.Value.Data
+            }),
+            totalDuration = report.TotalDuration.TotalMilliseconds
+        });
+        await ctx.Response.WriteAsync(result);
+    }
+});
 app.MapDefaultControllerRoute();
 app.MapRazorPages();
 app.MapControllers();
@@ -230,6 +245,12 @@ async Task ConfigureGameServices(IServiceCollection services) {
     }
 
     services.AddGameServer(storage, gameRegistry, stateFactory);
+
+    var bucketDisplay = string.IsNullOrEmpty(s3BucketName) ? "(local FileStorage)" : s3BucketName;
+    Log.Information("Startup: games loaded={GameCount}, users={UserCount}, storage={Storage}",
+        gameRegistry.GetAllInstances().Count,
+        globalState.ToImmutable().Users.Count,
+        bucketDisplay);
 
     services.AddScoped(_ => CurrentUserContext.Inactive());
 


### PR DESCRIPTION
## Summary

- **Enhanced `/health` endpoint**: Now returns JSON with status, blob storage reachability, active game count, and response time. Previously returned plain `Healthy` string.
- **Startup logging**: Logs game count, user count, and storage bucket at startup — aids in diagnosing deploy issues.
- **ALB health check**: Already configured at `/health` with 30s interval in Terraform — no change needed.
- **CloudWatch alarm**: `bge-no-healthy-hosts` alarm already exists in Terraform (HealthyHostCount < 1 for 2 periods) — no Terraform change needed.

## Changed files

- `BlobStorageHealthCheck.cs` (new): `IHealthCheck` that pings blob storage and reports active game count
- `Program.cs`: registers the health check, maps `/health` with JSON writer, adds startup log

## Test plan

- [ ] Build passes (`dotnet build --configuration Release`)
- [ ] All 138 tests pass (`dotnet test`)
- [ ] After deploy: `curl https://ageofagents.net/health` returns JSON with `status`, `checks[].data.activeGames`, and `checks[].data.blobStorage`
- [ ] CloudWatch Logs show startup line: `Startup: games loaded=N, users=M, storage=bge-game-state`