### PR TITLE
fix: BGE-226 ending-soon alert fires only once per game window

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Code/AlertService.cs
+++ b/src/BrowserGameEngine.BlazorClient/Code/AlertService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.BlazorClient.Code {
+	public enum AlertType { Info, Warning, Danger }
+
+	public class Alert {
+		public Guid Id { get; } = Guid.NewGuid();
+		public string Message { get; }
+		public AlertType Type { get; }
+		public DateTime CreatedAt { get; } = DateTime.UtcNow;
+		public bool Seen { get; set; }
+
+		public Alert(string message, AlertType type = AlertType.Info) {
+			Message = message;
+			Type = type;
+		}
+	}
+
+	public class AlertService {
+		private readonly List<Alert> _alerts = new();
+		public event Action? AlertsChanged;
+
+		public IReadOnlyList<Alert> Alerts {
+			get { lock (_alerts) return _alerts.ToList(); }
+		}
+
+		public int UnseenCount {
+			get { lock (_alerts) return _alerts.Count(a => !a.Seen); }
+		}
+
+		public void AddAlert(string message, AlertType type = AlertType.Info) {
+			lock (_alerts) {
+				_alerts.Add(new Alert(message, type));
+			}
+			AlertsChanged?.Invoke();
+		}
+
+		public void Dismiss(Guid id) {
+			lock (_alerts) {
+				var alert = _alerts.FirstOrDefault(a => a.Id == id);
+				if (alert != null) _alerts.Remove(alert);
+			}
+			AlertsChanged?.Invoke();
+		}
+
+		public void MarkAllSeen() {
+			lock (_alerts) {
+				foreach (var a in _alerts) a.Seen = true;
+			}
+			AlertsChanged?.Invoke();
+		}
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Program.cs
+++ b/src/BrowserGameEngine.BlazorClient/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddHttpClient("ServerAPI", client => {
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ServerAPI"));
 builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.RefreshService>();
+builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.AlertService>();
 builder.Services.AddScoped<ICurrentGameService, CurrentGameService>();
 
 await builder.Build().RunAsync();

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -1,6 +1,10 @@
 @inherits LayoutComponentBase
 @inject ICurrentGameService CurrentGameService
 @inject NavigationManager Nav
+@inject AlertService AlertService
+@inject HttpClient Http
+@using BrowserGameEngine.BlazorClient.Code
+@using BrowserGameEngine.Shared
 @implements IDisposable
 
 <div class="sidebar">
@@ -48,9 +52,13 @@
     </div>
 </div>
 
+<_ToastAlerts />
+
 @code {
     private System.Threading.CancellationTokenSource? pollCts;
     private System.Threading.Timer? displayTimer;
+    private int _lastUnreadCount = -1;
+    private string? _lastGameStatus;
 
     protected override void OnInitialized() {
         CurrentGameService.OnChanged += OnGameChanged;
@@ -85,11 +93,54 @@
 
     private async Task PollGameStatusAsync(System.Threading.CancellationToken ct) {
         while (!ct.IsCancellationRequested) {
-            await Task.Delay(TimeSpan.FromSeconds(30), ct).ContinueWith(_ => { });
+            await Task.Delay(TimeSpan.FromSeconds(10), ct).ContinueWith(_ => { });
             if (ct.IsCancellationRequested) break;
             if (CurrentGameService.CurrentGameId != null) {
                 await CurrentGameService.RefreshAsync();
             }
+            await DetectAlertsAsync();
+        }
+    }
+
+    private async Task DetectAlertsAsync() {
+        try {
+            var tickInfo = await Http.GetFromJsonAsync<BrowserGameEngine.Shared.TickInfoViewModel>("api/game/tick-info");
+            if (tickInfo == null) return;
+
+            // New messages
+            if (_lastUnreadCount >= 0 && tickInfo.UnreadMessageCount > _lastUnreadCount) {
+                var diff = tickInfo.UnreadMessageCount - _lastUnreadCount;
+                AlertService.AddAlert(
+                    diff == 1 ? "You have 1 new message." : $"You have {diff} new messages.",
+                    AlertType.Info
+                );
+            }
+            _lastUnreadCount = tickInfo.UnreadMessageCount;
+        } catch {
+            // Ignore errors — user may not be logged in
+        }
+
+        // Game phase events from CurrentGameService
+        var game = CurrentGameService.CurrentGame;
+        if (game != null) {
+            if (_lastGameStatus != null && _lastGameStatus != game.Status) {
+                if (game.Status == "Active") {
+                    AlertService.AddAlert($"Game \"{game.Name}\" has started!", AlertType.Info);
+                } else if (game.Status == "Finished") {
+                    AlertService.AddAlert($"Game \"{game.Name}\" has ended.", AlertType.Warning);
+                }
+            }
+
+            // Ending soon: within 1 minute
+            if (game.Status == "Active") {
+                var remaining = game.EndTime - DateTime.UtcNow;
+                if (remaining > TimeSpan.Zero && remaining <= TimeSpan.FromMinutes(1)
+                    && _lastGameStatus == "Active") {
+                    AlertService.AddAlert($"Game \"{game.Name}\" ends in less than a minute!", AlertType.Danger);
+                }
+            }
+
+            _lastGameStatus = game.Status;
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -59,6 +59,7 @@
     private System.Threading.Timer? displayTimer;
     private int _lastUnreadCount = -1;
     private string? _lastGameStatus;
+    private bool _endingSoonAlertShown;
 
     protected override void OnInitialized() {
         CurrentGameService.OnChanged += OnGameChanged;
@@ -124,6 +125,7 @@
         var game = CurrentGameService.CurrentGame;
         if (game != null) {
             if (_lastGameStatus != null && _lastGameStatus != game.Status) {
+                _endingSoonAlertShown = false;
                 if (game.Status == "Active") {
                     AlertService.AddAlert($"Game \"{game.Name}\" has started!", AlertType.Info);
                 } else if (game.Status == "Finished") {
@@ -131,12 +133,13 @@
                 }
             }
 
-            // Ending soon: within 1 minute
-            if (game.Status == "Active") {
+            // Ending soon: within 1 minute — fire once only
+            if (game.Status == "Active" && !_endingSoonAlertShown) {
                 var remaining = game.EndTime - DateTime.UtcNow;
                 if (remaining > TimeSpan.Zero && remaining <= TimeSpan.FromMinutes(1)
                     && _lastGameStatus == "Active") {
                     AlertService.AddAlert($"Game \"{game.Name}\" ends in less than a minute!", AlertType.Danger);
+                    _endingSoonAlertShown = true;
                 }
             }
 

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -1,5 +1,8 @@
 @inject HttpClient Http
+@inject AlertService AlertService
 @using BrowserGameEngine.Shared
+@using BrowserGameEngine.BlazorClient.Code
+@implements IDisposable
 
 <div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">BrowserGameEngine</a>
@@ -68,6 +71,9 @@
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="messages">
                 <span class="oi oi-envelope-closed" aria-hidden="true"></span> Messages
+                @if (AlertService.UnseenCount > 0) {
+                    <span class="badge bg-danger ms-1">@AlertService.UnseenCount</span>
+                }
             </NavLink>
         </li>
         <li class="nav-item px-3">
@@ -106,6 +112,14 @@
 
     protected override async Task OnInitializedAsync()
     {
+        AlertService.AlertsChanged += OnAlertsChanged;
         version = await Http.GetFromJsonAsync<VersionInfoViewModel>("api/version");
+    }
+
+    private void OnAlertsChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        AlertService.AlertsChanged -= OnAlertsChanged;
     }
 }

--- a/src/BrowserGameEngine.BlazorClient/Shared/_ToastAlerts.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/_ToastAlerts.razor
@@ -1,0 +1,32 @@
+@using BrowserGameEngine.BlazorClient.Code
+@inject AlertService AlertService
+@implements IDisposable
+
+<div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index:9999">
+	@foreach (var alert in AlertService.Alerts.TakeLast(5).Reverse().ToList()) {
+		<div class="toast show align-items-center @GetToastClass(alert.Type) mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+			<div class="d-flex">
+				<div class="toast-body">@alert.Message</div>
+				<button type="button" class="btn-close btn-close-white me-2 m-auto" @onclick="() => AlertService.Dismiss(alert.Id)" aria-label="Close"></button>
+			</div>
+		</div>
+	}
+</div>
+
+@code {
+	protected override void OnInitialized() {
+		AlertService.AlertsChanged += OnAlertsChanged;
+	}
+
+	private void OnAlertsChanged() => InvokeAsync(StateHasChanged);
+
+	private static string GetToastClass(AlertType type) => type switch {
+		AlertType.Warning => "bg-warning text-dark",
+		AlertType.Danger => "bg-danger text-white",
+		_ => "bg-primary text-white"
+	};
+
+	public void Dispose() {
+		AlertService.AlertsChanged -= OnAlertsChanged;
+	}
+}


### PR DESCRIPTION
## Summary
- Add `_endingSoonAlertShown` boolean flag to `MainLayout.razor`
- The \"ends in less than a minute\" toast now fires **once** when the game enters its final minute, not on every 10-second poll cycle
- Flag resets on any game status change, so it fires correctly for subsequent games

**Root cause:** The existing guard `_lastGameStatus == "Active"` only verified the previous status was Active, but didn't prevent repeated firing during the same \"ending soon\" window.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (138/138)
- [ ] Manually: start a game, wait until < 1 minute remains → alert fires once
- [ ] Alert does NOT re-appear on next poll cycle (10s later)
- [ ] Alert fires again for the next game's final minute

Closes BGE-226