### PR TITLE
feat: BGE-135 improve login UX — copy updates and persistent session

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -32,19 +32,24 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[HttpGet("~/signin")]
-		public async Task<IActionResult> SignIn() => View("SignIn", await HttpContext.GetExternalProvidersAsync());
+		public async Task<IActionResult> SignIn(string? returnUrl = null) {
+			ViewBag.ReturnUrl = returnUrl;
+			return View("SignIn", await HttpContext.GetExternalProvidersAsync());
+		}
 
 		[HttpPost("~/signin")]
-		public async Task<IActionResult> SignIn([FromForm] string provider) {
+		public async Task<IActionResult> SignIn([FromForm] string provider, [FromForm] string? returnUrl = null, [FromForm] bool rememberMe = false) {
 			// Note: the "provider" parameter corresponds to the external
 			// authentication provider choosen by the user agent.
 			if (string.IsNullOrWhiteSpace(provider)) return BadRequest();
 			if (!await HttpContext.IsProviderSupportedAsync(provider)) return BadRequest();
 
+			var redirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/";
+
 			// Instruct the middleware corresponding to the requested external identity
 			// provider to redirect the user agent to its own authorization endpoint.
 			// Note: the authenticationScheme parameter must match the value configured in Startup.cs
-			return Challenge(new AuthenticationProperties { RedirectUri = "/" }, provider);
+			return Challenge(new AuthenticationProperties { RedirectUri = redirectUri, IsPersistent = rememberMe }, provider);
 		}
 
 		[HttpGet("~/signout")]

--- a/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
@@ -22,15 +22,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public IActionResult GetMyHistory() {
 			if (!currentUser.IsValid) return Unauthorized();
 
-			var achievements = globalState.Achievements
+			var achievements = globalState.GetAchievements()
 				.Where(a => a.UserId == currentUser.UserId)
 				.OrderByDescending(a => a.FinishedAt)
 				.ToList();
 
-			var gameMap = globalState.Games
+			var gameMap = globalState.GetGames()
 				.ToDictionary(g => g.GameId.Id);
 
-			var playersPerGame = globalState.Achievements
+			var playersPerGame = globalState.GetAchievements()
 				.GroupBy(a => a.GameId.Id)
 				.ToDictionary(g => g.Key, g => g.Select(a => a.UserId).Distinct().Count());
 

--- a/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
+++ b/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
@@ -10,7 +10,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Sign In — Browser Game Engine</title>
+	<title>Log In — Browser Game Engine</title>
 	<link href="~/css/bootstrap/bootstrap.min.css" rel="stylesheet" />
 	<style>
 		* { box-sizing: border-box; }
@@ -219,23 +219,27 @@
 		</div>
 
 		<div class="signin-card">
-			<h2>Sign in to your account</h2>
+			<h2>Log in to BGE</h2>
 
 			@foreach (var scheme in Model.OrderBy(p => p.DisplayName)) {
 				<form action="/signin" method="post">
 					<input type="hidden" name="Provider" value="@scheme.Name" />
 					<input type="hidden" name="ReturnUrl" value="@ViewBag.ReturnUrl" />
+					<div style="display:flex;align-items:center;gap:8px;margin-bottom:0.75rem;">
+						<input type="checkbox" name="RememberMe" value="true" id="rememberMe-@scheme.Name" checked style="width:16px;height:16px;cursor:pointer;" />
+						<label for="rememberMe-@scheme.Name" style="font-size:0.85rem;color:#8b949e;cursor:pointer;margin:0;">Keep me logged in</label>
+					</div>
 					<button class="btn-github" type="submit">
 						<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 							<path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>
 						</svg>
-						Sign in with @scheme.DisplayName
+						Continue with @scheme.DisplayName
 					</button>
 				</form>
 			}
 
 			<div class="signin-footer">
-				By signing in you agree to play fair and have fun.
+				By logging in you agree to play fair and have fun. New player? GitHub will ask you to authorize once.
 			</div>
 		</div>
 


### PR DESCRIPTION
## Summary
- Updates page title, card heading, and button text: "Log in to BGE" / "Continue with GitHub" (modern OAuth convention)
- Adds "Keep me logged in" checkbox above the GitHub button, checked by default
- When checked, passes `IsPersistent = true` to `Challenge()` so the auth cookie survives browser restarts (30-day sliding expiry via ASP.NET Core default cookie settings)
- Accepts `returnUrl` in `SignIn` GET/POST with open-redirect guard (`Url.IsLocalUrl`)
- Updates footer copy to mention first-time GitHub authorization
- Fixes pre-existing `HistoryController` build error (`globalState.Achievements` → `globalState.GetAchievements()`, etc.)

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (138/138)
- [ ] Navigate to `/signin` — verify heading reads "Log in to BGE", button reads "Continue with GitHub"
- [ ] Checkbox is checked by default; unchecking and logging in should give a session-only cookie
- [ ] Checking and logging in should give a persistent cookie (verify via browser DevTools → Application → Cookies → `Expires` should show a future date, not "Session")
- [ ] Footer text updated and visible

Closes BGE-135