### PR TITLE
fix: BGE-249 HistoryController — use GetAchievements()/GetGames() methods

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
@@ -22,15 +22,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public IActionResult GetMyHistory() {
 			if (!currentUser.IsValid) return Unauthorized();
 
-			var achievements = globalState.Achievements
+			var achievements = globalState.GetAchievements()
 				.Where(a => a.UserId == currentUser.UserId)
 				.OrderByDescending(a => a.FinishedAt)
 				.ToList();
 
-			var gameMap = globalState.Games
+			var gameMap = globalState.GetGames()
 				.ToDictionary(g => g.GameId.Id);
 
-			var playersPerGame = globalState.Achievements
+			var playersPerGame = globalState.GetAchievements()
 				.GroupBy(a => a.GameId.Id)
 				.ToDictionary(g => g.Key, g => g.Select(a => a.UserId).Distinct().Count());
 


### PR DESCRIPTION
## Summary

- Fixes master build break introduced when `GlobalState.Achievements` and `GlobalState.Games` were refactored to methods in the multi-game work
- `HistoryController.cs` lines 25, 30, 33: replace `.Achievements` / `.Games` property access with `.GetAchievements()` / `.GetGames()` method calls
- Build verified: 0 errors

## Related

Closes BGE-249

## Test plan

- [ ] CI passes (no CS1061 errors)
- [ ] `GET /api/history` returns player history correctly