### PR TITLE
feat: BGE-240 game discovery landing page

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Index.razor
@@ -1,14 +1,92 @@
 @page "/"
+@using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
 
-<h3>Hello</h3>
+<h2>Games</h2>
+
+@if (games == null) {
+	<p>Loading...</p>
+} else {
+	var upcoming = games.Games.Where(g => g.Status == "Upcoming").ToList();
+	var active = games.Games.Where(g => g.Status == "Active").ToList();
+	var finished = games.Games.Where(g => g.Status == "Finished").ToList();
+
+	@if (upcoming.Any()) {
+		<h3>Upcoming</h3>
+		<table class="table">
+			<thead><tr><th>Name</th><th>Players</th><th>Starts</th><th></th></tr></thead>
+			<tbody>
+				@foreach (var g in upcoming) {
+					<tr>
+						<td>@g.Name</td>
+						<td>@g.PlayerCount</td>
+						<td>@(g.StartTime.HasValue ? g.StartTime.Value.ToLocalTime().ToString("g") : "-")</td>
+						<td>
+							@if (g.CanJoin) {
+								<a href="/signin" class="btn btn-sm btn-primary">Join</a>
+							}
+						</td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+
+	@if (active.Any()) {
+		<h3>Active</h3>
+		<table class="table">
+			<thead><tr><th>Name</th><th>Players</th><th>Ends</th><th></th></tr></thead>
+			<tbody>
+				@foreach (var g in active) {
+					<tr>
+						<td>@g.Name</td>
+						<td>@g.PlayerCount</td>
+						<td>@(g.EndTime.HasValue ? g.EndTime.Value.ToLocalTime().ToString("g") : "-")</td>
+						<td>
+							@if (myRegistrations != null && myRegistrations.GameIds.Contains(g.GameId)) {
+								<a href="/base" class="btn btn-sm btn-success">Play Now</a>
+							} else {
+								<span class="text-muted">Game in progress</span>
+							}
+						</td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+
+	@if (finished.Any()) {
+		<h3>Finished</h3>
+		<table class="table">
+			<thead><tr><th>Name</th><th>Players</th><th></th></tr></thead>
+			<tbody>
+				@foreach (var g in finished) {
+					<tr>
+						<td>@g.Name</td>
+						<td>@g.PlayerCount</td>
+						<td><a href="/games/@g.GameId/results">View Results</a></td>
+					</tr>
+				}
+			</tbody>
+		</table>
+	}
+
+	@if (!upcoming.Any() && !active.Any() && !finished.Any()) {
+		<p>No games available yet.</p>
+	}
+}
 
 @code {
-    protected override async Task OnInitializedAsync() {
-        var exists = await Http.GetFromJsonAsync<bool>("api/playerprofile/exists");
-        if (!exists) {
-            Nav.NavigateTo("/createplayer");
-        }
-    }
+	private GameListViewModel? games;
+	private MyRegistrationsViewModel? myRegistrations;
+
+	protected override async Task OnInitializedAsync() {
+		games = await Http.GetFromJsonAsync<GameListViewModel>("api/games");
+		try {
+			myRegistrations = await Http.GetFromJsonAsync<MyRegistrationsViewModel>("api/games/my-registrations");
+		} catch {
+			// Anonymous visitors get 401 — swallow and continue
+		}
+	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -49,6 +49,29 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return Ok(new GameListViewModel(summaries));
 		}
 
+		[HttpGet("my-registrations")]
+		public ActionResult<MyRegistrationsViewModel> GetMyRegistrations() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var gameIds = new HashSet<string>();
+
+			// Active/upcoming games: check live world state
+			foreach (var instance in gameRegistry.GetAllInstances()) {
+				if (instance.HasUserPlayer(currentUserContext.UserId)) {
+					gameIds.Add(instance.Record.GameId.Id);
+				}
+			}
+
+			// Finished games: check achievements
+			foreach (var achievement in globalState.GetAchievements()) {
+				if (achievement.UserId == currentUserContext.UserId) {
+					gameIds.Add(achievement.GameId.Id);
+				}
+			}
+
+			return Ok(new MyRegistrationsViewModel(gameIds.ToList()));
+		}
+
 		[AllowAnonymous]
 		[HttpGet("{gameId}")]
 		public ActionResult<GameDetailViewModel> GetById(string gameId) {

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -15,6 +15,7 @@ namespace BrowserGameEngine.GameModel {
 		TimeSpan TickDuration,
 		PlayerId? WinnerId = null,
 		DateTime? ActualEndTime = null,
-		string? CreatedByUserId = null
+		string? CreatedByUserId = null,
+		string? DiscordWebhookUrl = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -17,4 +17,6 @@ namespace BrowserGameEngine.Shared {
 	public record GameListViewModel(List<GameSummaryViewModel> Games);
 
 	public record JoinGameRequest(string GameId);
+
+	public record MyRegistrationsViewModel(List<string> GameIds);
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -21,6 +22,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		public int PlayerCount => WorldState.Players.Count;
 
 		public bool HasPlayer(PlayerId playerId) => WorldState.PlayerExists(playerId);
+
+		public bool HasUserPlayer(string? userId) => userId != null && WorldState.Players.Values.Any(p => p.UserId == userId);
 
 		public void SetTickEngine(GameTickEngine tickEngine) { TickEngine = tickEngine; }
 	}


### PR DESCRIPTION
## Summary
- Adds `DiscordWebhookUrl` optional field to `GameRecordImmutable` (prerequisite for BGE-241)
- Adds `MyRegistrationsViewModel` to `GameLobbyViewModels`
- Adds `HasUserPlayer(userId)` to `GameInstance` for cross-assembly user lookups
- New `GET /api/games/my-registrations` endpoint returning game IDs the user has joined (active/upcoming from live state, finished from achievements)
- Redesigns `Index.razor` with three sections: Upcoming (join), Active (Play Now or "in progress"), Finished (view results)

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (138 tests)
- [ ] Anonymous visitor sees game list
- [ ] Registered player in active game sees "Play Now" link
- [ ] Non-registered user sees "Game in progress"
- [ ] `GET /api/games/my-registrations` returns correct game IDs

Closes BGE-240