### PR TITLE
feat: BGE-241 Discord webhook notifications for game start/end

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -65,7 +65,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				EndTime: record.EndTime,
 				PlayerCount: playerCount,
 				WinnerId: record.WinnerId?.Id,
-				ActualEndTime: record.ActualEndTime
+				ActualEndTime: record.ActualEndTime,
+				DiscordWebhookUrl: record.DiscordWebhookUrl
 			));
 		}
 
@@ -87,7 +88,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				Status: GameStatus.Upcoming,
 				StartTime: request.StartTime.ToUniversalTime(),
 				EndTime: request.EndTime.ToUniversalTime(),
-				TickDuration: tickDuration
+				TickDuration: tickDuration,
+				DiscordWebhookUrl: request.DiscordWebhookUrl
 			);
 
 			// Create a fresh world state for the new game

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -43,6 +43,8 @@ builder.Services.AddHostedService<GlobalPersistenceHostedService>();
 builder.Services.AddHostedService<GameLifecycleService>();
 
 builder.Services.Configure<BgeOptions>(builder.Configuration.GetSection(BgeOptions.Position));
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<BrowserGameEngine.StatefulGameServer.GameRegistry.IGameNotificationService, BrowserGameEngine.FrontendServer.Services.DiscordWebhookNotificationService>();
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddLogging();

--- a/src/BrowserGameEngine.FrontendServer/Services/DiscordWebhookNotificationService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/DiscordWebhookNotificationService.cs
@@ -1,0 +1,53 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer.Services {
+	public class DiscordWebhookNotificationService : IGameNotificationService {
+		private readonly IHttpClientFactory httpClientFactory;
+		private readonly ILogger<DiscordWebhookNotificationService> logger;
+
+		public DiscordWebhookNotificationService(IHttpClientFactory httpClientFactory, ILogger<DiscordWebhookNotificationService> logger) {
+			this.httpClientFactory = httpClientFactory;
+			this.logger = logger;
+		}
+
+		public async Task NotifyGameStartedAsync(GameRecordImmutable record, int playerCount) {
+			if (string.IsNullOrEmpty(record.DiscordWebhookUrl)) return;
+			await PostEmbedAsync(record.DiscordWebhookUrl,
+				title: $"Game Started: {record.Name}",
+				description: $"{playerCount} player(s) have joined. Good luck!\n\nhttps://ageofagents.net",
+				color: 0x57F287);
+		}
+
+		public async Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount) {
+			if (string.IsNullOrEmpty(record.DiscordWebhookUrl)) return;
+			var winner = winnerName != null ? $"Winner: **{winnerName}**" : "No winner";
+			await PostEmbedAsync(record.DiscordWebhookUrl,
+				title: $"Game Over: {record.Name}",
+				description: $"{winner}\n\nhttps://ageofagents.net/games/{record.GameId.Id}/results",
+				color: 0xED4245);
+		}
+
+		private async Task PostEmbedAsync(string webhookUrl, string title, string description, int color) {
+			try {
+				var client = httpClientFactory.CreateClient();
+				var payload = new {
+					embeds = new[] {
+						new { title, description, color }
+					}
+				};
+				var response = await client.PostAsJsonAsync(webhookUrl, payload);
+				if (!response.IsSuccessStatusCode) {
+					logger.LogWarning("Discord webhook returned {StatusCode} for {Url}", response.StatusCode, webhookUrl);
+				}
+			} catch (Exception ex) {
+				logger.LogWarning(ex, "Failed to send Discord webhook notification");
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -15,6 +15,7 @@ namespace BrowserGameEngine.GameModel {
 		TimeSpan TickDuration,
 		PlayerId? WinnerId = null,
 		DateTime? ActualEndTime = null,
-		string? CreatedByUserId = null
+		string? CreatedByUserId = null,
+		string? DiscordWebhookUrl = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -11,7 +11,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime EndTime,
 		int PlayerCount,
 		string? WinnerId,
-		DateTime? ActualEndTime
+		DateTime? ActualEndTime,
+		string? DiscordWebhookUrl = null
 	);
 
 	public record CreateGameRequest(
@@ -19,7 +20,8 @@ namespace BrowserGameEngine.Shared {
 		string GameDefType,
 		DateTime StartTime,
 		DateTime EndTime,
-		string TickDuration
+		string TickDuration,
+		string? DiscordWebhookUrl = null
 	);
 
 	public record GameResultEntryViewModel(

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -91,6 +91,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				gameRegistry.GlobalState,
 				persistenceService,
 				globalPersistenceService,
+				new GameRegistryNs.NullGameNotificationService(),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -53,6 +53,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				registry.GlobalState,
 				new PersistenceService(storage, serializer),
 				new GlobalPersistenceService(storage, globalSerializer),
+				new GameRegistryNs.NullGameNotificationService(),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -12,6 +12,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		private readonly GlobalState globalState;
 		private readonly PersistenceService persistenceService;
 		private readonly GlobalPersistenceService globalPersistenceService;
+		private readonly IGameNotificationService notificationService;
 		private readonly ILogger<GameLifecycleEngine> logger;
 
 		public GameLifecycleEngine(
@@ -19,25 +20,27 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			GlobalState globalState,
 			PersistenceService persistenceService,
 			GlobalPersistenceService globalPersistenceService,
+			IGameNotificationService notificationService,
 			ILogger<GameLifecycleEngine> logger
 		) {
 			this.gameRegistry = gameRegistry;
 			this.globalState = globalState;
 			this.persistenceService = persistenceService;
 			this.globalPersistenceService = globalPersistenceService;
+			this.notificationService = notificationService;
 			this.logger = logger;
 		}
 
 		public async Task ProcessLifecycleAsync() {
 			var utcNow = DateTime.UtcNow;
-			bool changed = ActivateUpcomingGames(utcNow);
+			bool changed = await ActivateUpcomingGamesAsync(utcNow);
 			changed |= await FinalizeEndedGamesAsync(utcNow);
 			if (changed) {
 				await globalPersistenceService.StoreGlobalState(globalState.ToImmutable());
 			}
 		}
 
-		private bool ActivateUpcomingGames(DateTime utcNow) {
+		private async Task<bool> ActivateUpcomingGamesAsync(DateTime utcNow) {
 			var toActivate = globalState.GetGames()
 				.Where(g => g.Status == GameStatus.Upcoming && g.StartTime <= utcNow)
 				.ToList();
@@ -46,6 +49,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				var updated = record with { Status = GameStatus.Active };
 				globalState.UpdateGame(record, updated);
 				logger.LogInformation("Game {GameId} activated", record.GameId.Id);
+				var playerCount = gameRegistry.TryGetInstance(record.GameId)?.PlayerCount ?? 0;
+				await notificationService.NotifyGameStartedAsync(updated, playerCount);
 			}
 			return toActivate.Count > 0;
 		}
@@ -81,8 +86,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				.ToList();
 
 			var winnerId = rankings.Count > 0 ? rankings[0].PlayerId : null;
-
-			// Write PlayerAchievement records for players that have a linked user
+			var winnerName = winnerId != null && instance.WorldState.Players.TryGetValue(winnerId, out var winner) ? winner.Name : null;
 			for (int i = 0; i < rankings.Count; i++) {
 				var (playerId, score) = rankings[i];
 				var player = instance.WorldState.Players[playerId];
@@ -116,6 +120,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 
 			logger.LogInformation("Game {GameId} finalized. Winner: {WinnerId}, Players: {PlayerCount}",
 				record.GameId.Id, winnerId?.Id ?? "(none)", rankings.Count);
+
+			await notificationService.NotifyGameFinishedAsync(updated, winnerId, winnerName, rankings.Count);
 		}
 
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/IGameNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/IGameNotificationService.cs
@@ -1,0 +1,9 @@
+using BrowserGameEngine.GameModel;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
+	public interface IGameNotificationService {
+		Task NotifyGameStartedAsync(GameRecordImmutable record, int playerCount);
+		Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount);
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/NullGameNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/NullGameNotificationService.cs
@@ -1,0 +1,9 @@
+using BrowserGameEngine.GameModel;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
+	public class NullGameNotificationService : IGameNotificationService {
+		public Task NotifyGameStartedAsync(GameRecordImmutable record, int playerCount) => Task.CompletedTask;
+		public Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount) => Task.CompletedTask;
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -71,6 +71,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton(globalSerializer);
 			services.AddSingleton(globalPersistenceService);
 			services.AddSingleton<IWorldStateFactory>(worldStateFactory);
+			services.AddSingleton<IGameNotificationService, NullGameNotificationService>();
 			services.AddSingleton<GameLifecycleEngine>();
 		}
 	}


### PR DESCRIPTION
## Summary
- `IGameNotificationService` interface with `NotifyGameStartedAsync` / `NotifyGameFinishedAsync`
- `NullGameNotificationService` no-op default registered in `GameServerExtensions`
- `GameLifecycleEngine` now injects and calls the service on game activation and finalization
- `DiscordWebhookNotificationService` in FrontendServer posts Discord embeds (green on start, red on end); swallows HTTP errors — lifecycle is never aborted
- `CreateGameRequest` and `GameDetailViewModel` gain optional `DiscordWebhookUrl` field
- `GamesController.Create` persists the webhook URL; `GetById` exposes it
- `AddHttpClient()` registered in `Program.cs`
- Test updated to pass `NullGameNotificationService` to `GameLifecycleEngine`

**Depends on BGE-240** for `DiscordWebhookUrl` on `GameRecordImmutable`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (138 tests)
- [ ] Create game with Discord webhook URL — on start Discord message received
- [ ] Game finalization triggers Discord end message with winner
- [ ] Null/empty webhook → no HTTP call made
- [ ] 4xx/5xx webhook response → logged as warning, game lifecycle continues

Closes BGE-241