### PR TITLE
feat: BGE-270 OpenAPI/Swagger documentation

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -7,6 +7,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>f4bd9b12-89a7-43ca-a935-647ac2ae6729</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -21,6 +23,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -74,7 +74,10 @@ public class AdminController : ControllerBase
 
 	// ── Existing cheat endpoints ──────────────────────────────────────────────
 
+	/// <summary>Dev-only: Sets a player's resource amount to the specified value. Requires Bge:DevAuth=true.</summary>
 	[HttpPost("set-resources")]
+	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public ActionResult SetResources([FromBody] SetResourcesRequest request)
 	{
 		if (!options.Value.DevAuth) return NotFound();
@@ -86,7 +89,11 @@ public class AdminController : ControllerBase
 		return Ok();
 	}
 
+	/// <summary>Dev-only: Grants a building to a player instantly. Requires Bge:DevAuth=true.</summary>
 	[HttpPost("grant-building")]
+	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public ActionResult GrantBuilding([FromBody] GrantBuildingRequest request)
 	{
 		if (!options.Value.DevAuth) return NotFound();
@@ -98,7 +105,11 @@ public class AdminController : ControllerBase
 		return Ok();
 	}
 
+	/// <summary>Dev-only: Grants units to a player instantly. Requires Bge:DevAuth=true.</summary>
 	[HttpPost("grant-units")]
+	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public ActionResult GrantUnits([FromBody] GrantUnitsRequest request)
 	{
 		if (!options.Value.DevAuth) return NotFound();
@@ -110,7 +121,10 @@ public class AdminController : ControllerBase
 		return Ok();
 	}
 
+	/// <summary>Dev-only: Resets a player's state to initial values. Requires Bge:DevAuth=true.</summary>
 	[HttpPost("reset-player")]
+	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public ActionResult ResetPlayer([FromBody] ResetPlayerRequest request)
 	{
 		if (!options.Value.DevAuth) return NotFound();
@@ -121,7 +135,12 @@ public class AdminController : ControllerBase
 		return Ok();
 	}
 
+	/// <summary>Dev-only: Forces N game ticks to run immediately. Requires Bge:DevAuth=true.</summary>
+	/// <param name="count">Number of ticks to run (1–1000).</param>
 	[HttpPost("force-tick")]
+	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public ActionResult ForceTick([FromQuery] int count = 1)
 	{
 		if (!options.Value.DevAuth) return NotFound();

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AllianceRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AllianceRankingController.cs
@@ -15,7 +15,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.allianceScoreRepository = allianceScoreRepository;
 		}
 
+		/// <summary>Returns the current game's alliance ranking ordered by score.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(System.Collections.Generic.IEnumerable<AllianceRankingViewModel>), StatusCodes.Status200OK)]
 		public IEnumerable<AllianceRankingViewModel> Get() {
 			return allianceScoreRepository.GetRanked().Select(s => new AllianceRankingViewModel(
 				s.AllianceId, s.Name, s.MemberCount, s.TotalLand, s.AvgLand, s.Score));

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -30,7 +30,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.playerRepository = playerRepository;
 		}
 
+		/// <summary>Returns all alliances in the current game.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(IEnumerable<AllianceViewModel>), StatusCodes.Status200OK)]
 		public ActionResult<IEnumerable<AllianceViewModel>> GetAll() {
 			return Ok(allianceRepository.GetAll().Select(a => new AllianceViewModel {
 				AllianceId = a.AllianceId.ToString(),
@@ -41,7 +43,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}));
 		}
 
+		/// <summary>Returns the current player's alliance membership status.</summary>
 		[HttpGet("my-status")]
+		[ProducesResponseType(typeof(MyAllianceStatusViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<MyAllianceStatusViewModel> MyStatus() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var alliance = allianceRepository.GetByPlayerId(currentUserContext.PlayerId);
@@ -58,7 +63,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			});
 		}
 
+		/// <summary>Returns detailed information about a specific alliance including member list.</summary>
+		/// <param name="id">The alliance ID.</param>
 		[HttpGet("{id}")]
+		[ProducesResponseType(typeof(AllianceDetailViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public ActionResult<AllianceDetailViewModel> GetById(string id) {
 			var allianceId = AllianceIdFactory.Create(id);
 			var alliance = allianceRepository.Get(allianceId);
@@ -85,7 +94,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			});
 		}
 
+		/// <summary>Creates a new alliance with the current player as leader.</summary>
 		[HttpPost]
+		[ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
 		public ActionResult<string> Create([FromBody] CreateAllianceRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
@@ -99,7 +113,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
+		/// <summary>Requests to join an alliance (requires leader approval if password-protected).</summary>
+		/// <param name="id">The alliance ID to join.</param>
+		/// <param name="request">Join request containing the optional password.</param>
 		[HttpPost("{id}/join")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public ActionResult Join(string id, [FromBody] JoinAllianceRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AssetsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AssetsController.cs
@@ -46,7 +46,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDef = gameDef;
 		}
 
+		/// <summary>Returns all buildings (assets) available to the current player, including build status and prerequisites.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(AssetsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult<AssetsViewModel>> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			return new AssetsViewModel {
@@ -54,7 +57,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Initiates construction of a building. The build is added to the queue and completes after the required ticks.</summary>
+		/// <param name="assetDefId">Building definition ID (e.g. "barracks").</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Build([FromQuery] string assetDefId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -52,7 +52,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
+		/// <summary>Lists players that the current player can attack.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(SelectEnemyViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<SelectEnemyViewModel> AttackablePlayers() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			return new SelectEnemyViewModel {
@@ -60,7 +63,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Sends a unit to attack an enemy player's base.</summary>
+		/// <param name="unitId">The unit ID to send.</param>
+		/// <param name="enemyPlayerId">The target enemy player ID.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult SendUnits([FromQuery] string unitId, [FromQuery] string enemyPlayerId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
@@ -77,7 +86,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
+		/// <summary>Returns information about an enemy player's base, including their defending units and your attacking units en route.</summary>
+		/// <param name="enemyPlayerId">The enemy player ID to scout.</param>
 		[HttpGet]
+		[ProducesResponseType(typeof(EnemyBaseViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<EnemyBaseViewModel> EnemyBase([FromQuery] string enemyPlayerId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
@@ -97,7 +111,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 
+		/// <summary>Executes a battle against an enemy player using units already sent to their base.</summary>
+		/// <param name="enemyPlayerId">The enemy player ID to attack.</param>
 		[HttpPost]
+		[ProducesResponseType(typeof(BattleResultViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<BattleResultViewModel> Attack([FromQuery] string enemyPlayerId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var result = unitRepositoryWrite.Attack(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId));

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
@@ -34,7 +34,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDef = gameDef;
 		}
 
+		/// <summary>Returns the current player's build queue entries.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(BuildQueueViewModel), StatusCodes.Status200OK)]
 		public BuildQueueViewModel Get() {
 			if (!currentUserContext.IsValid) return new BuildQueueViewModel();
 			var entries = buildQueueRepository.GetQueue(currentUserContext.PlayerId);
@@ -43,7 +45,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Adds a unit or building to the build queue.</summary>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Add([FromBody] AddToQueueRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			if (request.Type != "unit" && request.Type != "asset") {
@@ -59,14 +65,21 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return Ok();
 		}
 
+		/// <summary>Removes an entry from the build queue by its ID.</summary>
+		/// <param name="entryId">The queue entry ID to remove.</param>
 		[HttpDelete]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Remove([FromQuery] Guid entryId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			buildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(currentUserContext.PlayerId, entryId));
 			return Ok();
 		}
 
+		/// <summary>Changes the priority of a queue entry.</summary>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Reorder([FromBody] ReorderQueueRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			buildQueueRepositoryWrite.ReorderQueue(new ReorderQueueCommand(

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
@@ -27,7 +27,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.colonizeRepositoryWrite = colonizeRepositoryWrite;
 		}
 
+		/// <summary>Colonizes additional land by spending the required resources.</summary>
+		/// <param name="amount">Number of land tiles to colonize.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult Colonize([FromQuery] int amount) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
@@ -29,7 +29,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.timeProvider = timeProvider;
 		}
 
+		/// <summary>Returns server time, the next scheduled tick timestamp, and the current player's unread message count.</summary>
 		[HttpGet("tick-info")]
+		[ProducesResponseType(typeof(TickInfoViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<TickInfoViewModel> GetTickInfo() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			int unreadCount = messageRepository.GetUnreadCount(currentUserContext.PlayerId);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -42,15 +42,22 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.timeProvider = timeProvider;
 		}
 
+		/// <summary>Lists all games (upcoming, active, and finished).</summary>
+		/// <returns>Summary list of all games.</returns>
 		[AllowAnonymous]
 		[HttpGet]
+		[ProducesResponseType(typeof(GameListViewModel), StatusCodes.Status200OK)]
 		public ActionResult<GameListViewModel> GetAll() {
 			var summaries = globalState.GetGames().Select(ToSummary).ToList();
 			return Ok(new GameListViewModel(summaries));
 		}
 
+		/// <summary>Returns detailed information about a single game.</summary>
+		/// <param name="gameId">The game identifier.</param>
 		[AllowAnonymous]
 		[HttpGet("{gameId}")]
+		[ProducesResponseType(typeof(GameDetailViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public ActionResult<GameDetailViewModel> GetById(string gameId) {
 			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();
@@ -69,7 +76,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			));
 		}
 
+		/// <summary>Creates a new game. Requires authentication.</summary>
+		/// <param name="request">Game creation parameters.</param>
+		/// <returns>Summary of the newly created game.</returns>
 		[HttpPost]
+		[ProducesResponseType(typeof(GameSummaryViewModel), StatusCodes.Status201Created)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<GameSummaryViewModel> Create([FromBody] CreateGameRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			if (string.IsNullOrWhiteSpace(request.Name)) return BadRequest("Name is required");
@@ -104,7 +117,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
 		}
 
+		/// <summary>Joins an upcoming game with the current player. Requires authentication.</summary>
+		/// <param name="gameId">The game identifier.</param>
 		[HttpPost("{gameId}/join")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
 		public ActionResult Join(string gameId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
@@ -123,8 +143,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return Ok();
 		}
 
+		/// <summary>Returns the final standings and scores for a completed game.</summary>
+		/// <param name="gameId">The game identifier.</param>
 		[Authorize]
 		[HttpGet("{gameId}/results")]
+		[ProducesResponseType(typeof(GameResultsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public ActionResult<GameResultsViewModel> GetResults(string gameId) {
 			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();

--- a/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/HistoryController.cs
@@ -18,7 +18,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.currentUser = currentUser;
 		}
 
+		/// <summary>Returns the current user's complete game history: all games played with final rank, score, and win/loss result.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(PlayerHistoryViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public IActionResult GetMyHistory() {
 			if (!currentUser.IsValid) return Unauthorized();
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/LeaderboardController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/LeaderboardController.cs
@@ -15,8 +15,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.globalState = globalState;
 		}
 
+		/// <summary>Returns the all-time leaderboard ranked by total wins, then best rank, then aggregate score. Public — no authentication required.</summary>
 		[AllowAnonymous]
 		[HttpGet("alltime")]
+		[ProducesResponseType(typeof(System.Collections.Generic.IEnumerable<AllTimeStandingViewModel>), StatusCodes.Status200OK)]
 		public IActionResult GetAllTime() {
 			var achievements = globalState.GetAchievements();
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
@@ -32,7 +32,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.playerRepository = playerRepository;
 		}
 
+		/// <summary>Returns all messages in the current player's inbox.</summary>
 		[HttpGet("inbox")]
+		[ProducesResponseType(typeof(MessageInboxViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<MessageInboxViewModel> Inbox() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var messages = messageRepository.GetMessages(currentUserContext.PlayerId!)
@@ -41,7 +44,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new MessageInboxViewModel { Messages = messages };
 		}
 
+		/// <summary>Sends a message to another player.</summary>
 		[HttpPost("send")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult Send([FromBody] SendMessageViewModel model) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var recipientId = PlayerIdFactory.Create(model.RecipientId);
@@ -58,7 +65,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return Ok();
 		}
 
+		/// <summary>Marks a message as read.</summary>
+		/// <param name="id">The message ID.</param>
 		[HttpPost("{id}/read")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
 		public ActionResult MarkRead(string id) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var messageId = MessageIdFactory.Create(id);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -37,7 +37,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.userRepositoryWrite = userRepositoryWrite;
 		}
 
+		/// <summary>Returns all players belonging to the authenticated user.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(PlayerListViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<PlayerListViewModel> GetMyPlayers() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var players = userRepository.GetPlayersForUser(currentUserContext.UserId).ToList();
@@ -50,7 +53,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Creates a new player for the authenticated user.</summary>
+		/// <param name="model">Player creation parameters.</param>
+		/// <returns>The newly created player summary.</returns>
 		[HttpPost]
+		[ProducesResponseType(typeof(PlayerSummaryViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<PlayerSummaryViewModel> CreatePlayer(CreatePlayerForUserViewModel model) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			if (string.IsNullOrWhiteSpace(model.PlayerName)) return BadRequest("PlayerName is required");
@@ -66,7 +75,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Deletes a player owned by the authenticated user.</summary>
+		/// <param name="playerId">The player identifier.</param>
 		[HttpDelete("{playerId}")]
+		[ProducesResponseType(StatusCodes.Status204NoContent)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
 		public ActionResult DeletePlayer(string playerId) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var pid = PlayerIdFactory.Create(playerId);
@@ -77,7 +92,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return NoContent();
 		}
 
+		/// <summary>Generates a new bot API key for a player. Replaces any existing key.</summary>
+		/// <param name="playerId">The player identifier.</param>
+		/// <returns>The raw API key (shown once — store it securely).</returns>
 		[HttpPost("{playerId}/apikey")]
+		[ProducesResponseType(typeof(ApiKeyViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
 		public ActionResult<ApiKeyViewModel> GenerateApiKey(string playerId) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var pid = PlayerIdFactory.Create(playerId);
@@ -92,7 +113,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new ApiKeyViewModel { ApiKey = rawKey };
 		}
 
+		/// <summary>Revokes the bot API key for a player.</summary>
+		/// <param name="playerId">The player identifier.</param>
 		[HttpDelete("{playerId}/apikey")]
+		[ProducesResponseType(StatusCodes.Status204NoContent)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
 		public ActionResult RevokeApiKey(string playerId) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var pid = PlayerIdFactory.Create(playerId);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -42,7 +42,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
+		/// <summary>Returns the current player's profile including name, score, and protection status.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(PlayerProfileViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<PlayerProfileViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var player = playerRepository.Get(currentUserContext.PlayerId!);
@@ -56,8 +59,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Returns initial data for the player creation form, pre-filled from the authenticated user's display name.</summary>
 		[HttpGet]
 		[Route("init")]
+		[ProducesResponseType(typeof(CreatePlayerViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<CreatePlayerViewModel> Init() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			return new CreatePlayerViewModel {
@@ -65,24 +71,34 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Returns whether the authenticated user already has a player registered in the current game.</summary>
 		[HttpGet]
 		[Route("exists")]
+		[ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<bool> Exists() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var players = userRepository.GetPlayersForUser(currentUserContext.UserId);
 			return players.Any();
 		}
 
+		/// <summary>Changes the current player's display name.</summary>
 		[HttpPost]
 		[Route("changename")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult ChangePlayerName(PlayerProfileViewModel playerProfile) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(currentUserContext.PlayerId!, playerProfile.PlayerName!));
 			return Ok();
 		}
 
+		/// <summary>Creates a new player for the authenticated user in the current game.</summary>
 		[HttpPost]
 		[Route("create")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
 		public ActionResult Create(CreatePlayerViewModel model) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -32,7 +32,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.onlineStatusRepository = onlineStatusRepository;
 		}
 
+		/// <summary>Returns the current game's player ranking list with scores and online status.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(System.Collections.Generic.IEnumerable<PublicPlayerViewModel>), StatusCodes.Status200OK)]
 		public IEnumerable<PublicPlayerViewModel> Get() {
 			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository));
 		}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
@@ -34,7 +34,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
 		}
 
+		/// <summary>Returns the current player's resources: minerals, gas, land, and colonization cost.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(PlayerResourcesViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult<PlayerResourcesViewModel>> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var playerId = currentUserContext.PlayerId!;
@@ -46,7 +49,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Trades one resource type for another at the current exchange rate.</summary>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult Trade([FromBody] TradeResourceRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			if (request.FromResource == null || request.Amount <= 0)

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UnitDefinitionsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UnitDefinitionsController.cs
@@ -23,7 +23,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDefinition = gameDefinition;
 		}
 
+		/// <summary>Returns all unit type definitions for the current game, including stats, costs, and prerequisites.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(System.Collections.Generic.IEnumerable<UnitDefinitionViewModel>), StatusCodes.Status200OK)]
 		public IEnumerable<UnitDefinitionViewModel> Get() {
 			return gameDefinition.Units.Select(x => UnitDefinitionViewModel.Create(x, true /* TODO */)).ToArray();
 		}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
@@ -40,7 +40,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDef = gameDef;
 		}
 
+		/// <summary>Returns all units currently owned by the current player.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(UnitsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<UnitsViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			return new UnitsViewModel {
@@ -48,7 +51,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Trains a given number of units of the specified type.</summary>
+		/// <param name="unitDefId">Unit definition ID (e.g. "marine").</param>
+		/// <param name="count">Number of units to train.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Build([FromQuery] string unitDefId, [FromQuery] int count) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
@@ -61,7 +70,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
+		/// <summary>Merges multiple unit groups of the same type into one. If unitDefId is omitted, merges all unit types.</summary>
+		/// <param name="unitDefId">Optional unit definition ID to merge only that type.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Merge([FromQuery] string? unitDefId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
@@ -76,7 +90,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
+		/// <summary>Splits a unit group into two groups.</summary>
+		/// <param name="unitId">The unit group ID to split.</param>
+		/// <param name="splitCount">Number of units to move to the new group.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Split([FromQuery] Guid unitId, [FromQuery] int splitCount) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
@@ -27,7 +27,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.upgradeRepositoryWrite = upgradeRepositoryWrite;
 		}
 
+		/// <summary>Returns the current player's attack and defense upgrade levels, plus costs for the next upgrade tier.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(UpgradesViewModel), StatusCodes.Status200OK)]
 		public UpgradesViewModel Get() {
 			var playerId = currentUserContext.PlayerId;
 			int attackLevel = upgradeRepository.GetAttackUpgradeLevel(playerId);
@@ -42,7 +44,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Starts researching an upgrade. Only one upgrade can be researched at a time.</summary>
+		/// <param name="upgradeType">Upgrade type: "Attack" or "Defense".</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		public ActionResult Research([FromQuery] string upgradeType) {
 			if (!System.Enum.TryParse<UpgradeType>(upgradeType, ignoreCase: true, out var type) || type == UpgradeType.None) {
 				return BadRequest("Invalid upgradeType. Use 'Attack' or 'Defense'.");

--- a/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
@@ -9,7 +9,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private static readonly string CommitHash =
 			Environment.GetEnvironmentVariable("APP_VERSION") ?? "dev";
 
+		/// <summary>Returns the deployed version (git commit hash) of the server.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(VersionInfoViewModel), StatusCodes.Status200OK)]
 		public ActionResult<VersionInfoViewModel> GetVersion() {
 			return Ok(new VersionInfoViewModel(CommitHash));
 		}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
@@ -36,7 +36,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDef = gameDef;
 		}
 
+		/// <summary>Returns the current worker assignment: total workers and how many are assigned to minerals vs gas.</summary>
 		[HttpGet]
+		[ProducesResponseType(typeof(WorkerAssignmentViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<WorkerAssignmentViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var playerId = currentUserContext.PlayerId!;
@@ -49,7 +52,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
+		/// <summary>Reassigns workers between mineral and gas gathering. Total must not exceed available workers.</summary>
+		/// <param name="mineralWorkers">Workers to assign to mineral harvesting.</param>
+		/// <param name="gasWorkers">Workers to assign to gas harvesting.</param>
 		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Assign([FromQuery] int mineralWorkers, [FromQuery] int gasWorkers) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -134,6 +134,10 @@ if (app.Environment.IsDevelopment()) {
 }
 app.UseExceptionHandler("/Error");
 app.MapOpenApi();
+app.UseSwaggerUI(c => {
+    c.SwaggerEndpoint("/openapi/v1.json", "BGE API v1");
+    c.RoutePrefix = "swagger";
+});
 
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles(new StaticFileOptions {

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -134,10 +134,12 @@ if (app.Environment.IsDevelopment()) {
 }
 app.UseExceptionHandler("/Error");
 app.MapOpenApi();
-app.UseSwaggerUI(c => {
-    c.SwaggerEndpoint("/openapi/v1.json", "BGE API v1");
-    c.RoutePrefix = "swagger";
-});
+if (app.Configuration["Bge:EnableSwagger"] == "true") {
+    app.UseSwaggerUI(c => {
+        c.SwaggerEndpoint("/openapi/v1.json", "BGE API v1");
+        c.RoutePrefix = "swagger";
+    });
+}
 
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles(new StaticFileOptions {


### PR DESCRIPTION
## Summary

- Builds on BGE-265 (cherry-picked) for Swashbuckle.AspNetCore.SwaggerUI + XML doc generation
- Gates Swagger UI at `/swagger` behind `Bge:EnableSwagger=true` config flag (default off — prod safe)
- Adds `/// <summary>` XML doc comments and `[ProducesResponseType]` attributes to **all 21 controllers**
- Bearer auth remains usable via the existing API key flow through BearerTokenMiddleware

## Controllers annotated

All controllers now have XML summaries and ProducesResponseType:
`GamesController`, `PlayerManagementController` (BGE-265), plus:
`Assets`, `Battle`, `BuildQueue`, `Colonize`, `GameInfo`, `History`, `Leaderboard`, `Messages`, `PlayerProfile`, `PlayerRanking`, `Resources`, `UnitDefinitions`, `Units`, `Upgrades`, `Version`, `Workers`, `Alliances`, `AllianceRanking`, `Admin`

## Test plan

- [ ] Build passes: `dotnet build --configuration Release` ✅ (0 errors)
- [ ] Tests pass: 138/138 ✅
- [ ] Enable swagger locally: set `Bge:EnableSwagger=true` → verify `/swagger` serves Swagger UI
- [ ] Verify `/swagger` is **not** accessible when `Bge:EnableSwagger` is unset or false
- [ ] Confirm all game endpoints appear in the Swagger UI with summaries and response types