### PR TITLE
feat: BGE-269 Season subscription + auto-join preferences

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -68,15 +68,37 @@
 	</div>
 }
 
+<h2>Game Preferences</h2>
+@if (preferences == null) {
+	<p><em>Loading preferences...</em></p>
+} else {
+	<div>
+		<label>
+			<input type="checkbox" checked="@preferences.WantsGameNotification"
+				@onchange="e => HandlePreferenceChange(nameof(preferences.WantsGameNotification), (bool)e.Value!)" />
+			Notify me when a new game starts
+		</label>
+	</div>
+	<div>
+		<label>
+			<input type="checkbox" checked="@preferences.AutoJoinNextGame"
+				@onchange="e => HandlePreferenceChange(nameof(preferences.AutoJoinNextGame), (bool)e.Value!)" />
+			Auto-join next game
+		</label>
+	</div>
+}
+
 @code {
 	private List<PlayerSummaryViewModel>? players;
 	private CreatePlayerForUserViewModel createModel = new();
 	private string? createError;
 	private string? newApiKey;
+	private UserPreferencesViewModel? preferences;
 	private CancellationTokenSource? _cts;
 
 	protected override async Task OnInitializedAsync() {
 		await LoadPlayers();
+		await LoadPreferences();
 		_cts = new CancellationTokenSource();
 		_ = RunRefreshLoop(_cts.Token);
 	}
@@ -92,6 +114,21 @@
 	private async Task LoadPlayers() {
 		var result = await Http.GetFromJsonAsync<PlayerListViewModel>("api/players");
 		players = result?.Players ?? new();
+	}
+
+	private async Task LoadPreferences() {
+		preferences = await Http.GetFromJsonAsync<UserPreferencesViewModel>("api/users/me/preferences");
+	}
+
+	private async Task HandlePreferenceChange(string field, bool value) {
+		if (preferences == null) return;
+		var request = field == nameof(UserPreferencesViewModel.WantsGameNotification)
+			? new UpdateUserPreferencesRequest(WantsGameNotification: value, AutoJoinNextGame: null)
+			: new UpdateUserPreferencesRequest(WantsGameNotification: null, AutoJoinNextGame: value);
+		var response = await Http.PatchAsJsonAsync("api/users/me/preferences", request);
+		if (response.IsSuccessStatusCode) {
+			await LoadPreferences();
+		}
 	}
 
 	private async Task HandleCreatePlayer() {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UserPreferencesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UserPreferencesController.cs
@@ -1,0 +1,47 @@
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/users/me/preferences")]
+	public class UserPreferencesController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly UserRepository userRepository;
+		private readonly UserRepositoryWrite userRepositoryWrite;
+
+		public UserPreferencesController(
+			CurrentUserContext currentUserContext,
+			UserRepository userRepository,
+			UserRepositoryWrite userRepositoryWrite
+		) {
+			this.currentUserContext = currentUserContext;
+			this.userRepository = userRepository;
+			this.userRepositoryWrite = userRepositoryWrite;
+		}
+
+		[HttpGet]
+		public ActionResult<UserPreferencesViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var user = userRepository.GetByGithubId(currentUserContext.GithubId);
+			if (user == null) return NotFound();
+			return Ok(new UserPreferencesViewModel(
+				WantsGameNotification: user.WantsGameNotification,
+				AutoJoinNextGame: user.AutoJoinNextGame
+			));
+		}
+
+		[HttpPatch]
+		public ActionResult Patch([FromBody] UpdateUserPreferencesRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var user = userRepository.GetByGithubId(currentUserContext.GithubId);
+			if (user == null) return NotFound();
+			var wantsNotification = request.WantsGameNotification ?? user.WantsGameNotification;
+			var autoJoin = request.AutoJoinNextGame ?? user.AutoJoinNextGame;
+			userRepositoryWrite.SetGamePreferences(currentUserContext.GithubId, wantsNotification, autoJoin);
+			return NoContent();
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/CurrentUserContext.cs
+++ b/src/BrowserGameEngine.FrontendServer/CurrentUserContext.cs
@@ -11,6 +11,8 @@ namespace BrowserGameEngine.FrontendServer {
 
 		public string? UserId { get; set; }
 
+		public string? GithubId { get; set; }
+
 		public bool IsValid { get; set; } = false;
 
 		public static CurrentUserContext Create(string playerId) {

--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentUserMiddleware.cs
@@ -48,6 +48,7 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 
 					// Select active player: first player belonging to this user
 					var players = userRepository.GetPlayersForUser(user.UserId).ToList();
+					currentUserContext.GithubId = githubId;
 					if (players.Count > 0) {
 						var selectedPlayerId = players[0].PlayerId;
 						// Support BGE.SelectedPlayer cookie for multi-player accounts

--- a/src/BrowserGameEngine.GameModel/UserImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/UserImmutable.cs
@@ -6,6 +6,8 @@ namespace BrowserGameEngine.GameModel {
 		string GithubId,
 		string GithubLogin,
 		string DisplayName,
-		DateTime Created
+		DateTime Created,
+		bool WantsGameNotification = false,
+		bool AutoJoinNextGame = false
 	);
 }

--- a/src/BrowserGameEngine.Shared/UserPreferencesViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UserPreferencesViewModel.cs
@@ -1,0 +1,11 @@
+namespace BrowserGameEngine.Shared;
+
+public record UserPreferencesViewModel(
+	bool WantsGameNotification,
+	bool AutoJoinNextGame
+);
+
+public record UpdateUserPreferencesRequest(
+	bool? WantsGameNotification,
+	bool? AutoJoinNextGame
+);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -86,6 +86,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, serializer);
 			var globalSerializer = new GlobalStateJsonSerializer();
 			var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
+			var defaultInstance = gameRegistry.GetDefaultInstance();
+			var userRepositoryWrite = new UserRepositoryWrite(gameRegistry.GlobalState, defaultInstance.WorldState, TimeProvider.System);
 			return new GameRegistryNs.GameLifecycleEngine(
 				gameRegistry,
 				gameRegistry.GlobalState,
@@ -93,6 +95,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				globalPersistenceService,
 				new GameRegistryNs.NullGameNotificationService(),
 				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				userRepositoryWrite,
+				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -48,6 +48,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var storage = new InMemoryBlobStorage();
 			var serializer = new GameStateJsonSerializer();
 			var globalSerializer = new GlobalStateJsonSerializer();
+			var defaultInstance = registry.GetDefaultInstance();
+			var userRepositoryWrite = new UserRepositoryWrite(registry.GlobalState, defaultInstance.WorldState, TimeProvider.System);
 			return new GameRegistryNs.GameLifecycleEngine(
 				registry,
 				registry.GlobalState,
@@ -55,6 +57,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				new GlobalPersistenceService(storage, globalSerializer),
 				new GameRegistryNs.NullGameNotificationService(),
 				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				userRepositoryWrite,
+				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/User.cs
@@ -8,6 +8,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public required string GithubLogin { get; set; }
 		public required string DisplayName { get; set; }
 		public DateTime Created { get; init; }
+		public bool WantsGameNotification { get; set; }
+		public bool AutoJoinNextGame { get; set; }
 	}
 
 	internal static class UserExtensions {
@@ -17,7 +19,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GithubId: user.GithubId,
 				GithubLogin: user.GithubLogin,
 				DisplayName: user.DisplayName,
-				Created: user.Created
+				Created: user.Created,
+				WantsGameNotification: user.WantsGameNotification,
+				AutoJoinNextGame: user.AutoJoinNextGame
 			);
 		}
 
@@ -27,7 +31,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GithubId = userImmutable.GithubId,
 				GithubLogin = userImmutable.GithubLogin,
 				DisplayName = userImmutable.DisplayName,
-				Created = userImmutable.Created
+				Created = userImmutable.Created,
+				WantsGameNotification = userImmutable.WantsGameNotification,
+				AutoJoinNextGame = userImmutable.AutoJoinNextGame
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -15,6 +15,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		private readonly GlobalPersistenceService globalPersistenceService;
 		private readonly IGameNotificationService notificationService;
 		private readonly IPlayerNotificationService playerNotificationService;
+		private readonly UserRepositoryWrite userRepositoryWrite;
+		private readonly TimeProvider timeProvider;
 		private readonly ILogger<GameLifecycleEngine> logger;
 
 		public GameLifecycleEngine(
@@ -24,6 +26,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			GlobalPersistenceService globalPersistenceService,
 			IGameNotificationService notificationService,
 			IPlayerNotificationService playerNotificationService,
+			UserRepositoryWrite userRepositoryWrite,
+			TimeProvider timeProvider,
 			ILogger<GameLifecycleEngine> logger
 		) {
 			this.gameRegistry = gameRegistry;
@@ -32,6 +36,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			this.globalPersistenceService = globalPersistenceService;
 			this.notificationService = notificationService;
 			this.playerNotificationService = playerNotificationService;
+			this.userRepositoryWrite = userRepositoryWrite;
+			this.timeProvider = timeProvider;
 			this.logger = logger;
 		}
 
@@ -57,7 +63,22 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				var playerCount = instance?.PlayerCount ?? 0;
 				await notificationService.NotifyGameStartedAsync(updated, playerCount);
 
+				// Auto-join users who opted in
 				if (instance != null) {
+					var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
+					var usersToAutoJoin = globalState.Users.Values
+						.Where(u => u.AutoJoinNextGame)
+						.ToList();
+					foreach (var user in usersToAutoJoin) {
+						var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString("N")[..12]);
+						if (!instance.HasPlayer(playerId)) {
+							playerRepoWrite.CreatePlayer(playerId, user.UserId);
+							logger.LogInformation("Auto-joined user {UserId} as player {PlayerId} in game {GameId}",
+								user.UserId, playerId.Id, record.GameId.Id);
+						}
+						userRepositoryWrite.SetGamePreferences(user.GithubId, user.WantsGameNotification, false);
+					}
+
 					foreach (var player in instance.WorldState.Players.Values) {
 						if (player.UserId != null) {
 							playerNotificationService.Push(player.UserId, $"Game \"{record.Name}\" has started!", NotificationKind.GameEvent);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
@@ -36,6 +36,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 			return player?.ToImmutable();
 		}
 
+		public UserImmutable? GetByUserId(string userId) {
+			var user = globalState.Users.Values.FirstOrDefault(u => u.UserId == userId);
+			return user?.ToImmutable();
+		}
+
 		public string? GetDisplayNameByUserId(string userId) {
 			var user = globalState.Users.Values.FirstOrDefault(u => u.UserId == userId);
 			return user?.DisplayName;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
@@ -1,6 +1,7 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
@@ -49,6 +50,15 @@ namespace BrowserGameEngine.StatefulGameServer {
 				};
 				globalState.Users[githubId] = user;
 				return user.ToImmutable();
+			}
+		}
+
+		public void SetGamePreferences(string githubId, bool wantsNotification, bool autoJoin) {
+			lock (_lock) {
+				if (!globalState.Users.TryGetValue(githubId, out var user))
+					throw new KeyNotFoundException($"User with githubId {githubId} not found");
+				user.WantsGameNotification = wantsNotification;
+				user.AutoJoinNextGame = autoJoin;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Add `WantsGameNotification` and `AutoJoinNextGame` boolean fields to the user model (`UserImmutable`, mutable `User`, serialization round-trip)
- New `GET /api/users/me/preferences` and `PATCH /api/users/me/preferences` endpoints via `UserPreferencesController`
- `GameLifecycleEngine` auto-joins opted-in users when a game transitions from Upcoming → Active, then clears their `AutoJoinNextGame` flag
- `Players.razor` gains a "Game Preferences" section with two checkboxes that save on change
- `GithubId` added to `CurrentUserContext` (set in `CurrentUserMiddleware`) so the preferences controller can look up and update the user

Closes BGE-269

## Test plan

- [ ] Build passes: `dotnet build`
- [ ] All 147 tests pass: `dotnet test`
- [ ] Log in, navigate to `/players` — "Game Preferences" section appears below the player list
- [ ] Toggle "Notify me when a new game starts" — checkbox state persists across page reload
- [ ] Toggle "Auto-join next game" — checkbox state persists across page reload
- [ ] Create an upcoming game; set `AutoJoinNextGame = true` for a user; advance time past `StartTime`; verify the user has a player in the game and the flag is cleared
- [ ] Users without `AutoJoinNextGame` set are not affected by game activation