### PR TITLE
fix: BGE-276 register AddAuthorizationCore in Blazor WASM client

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Program.cs
+++ b/src/BrowserGameEngine.BlazorClient/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().Cre
 builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.RefreshService>();
 builder.Services.AddSingleton<BrowserGameEngine.BlazorClient.Code.AlertService>();
 builder.Services.AddScoped<ICurrentGameService, CurrentGameService>();
+builder.Services.AddAuthorizationCore();
 
 await builder.Build().RunAsync();
 


### PR DESCRIPTION
## Summary
- `AuthorizeView` (used in `NavMenu.razor`) requires `IAuthorizationPolicyProvider` to be registered in DI
- `AddAuthorizationCore()` was missing from `BlazorClient/Program.cs`, causing the production login page to crash with `InvalidOperationException`
- Fix: add `builder.Services.AddAuthorizationCore()` before `Build()`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (147/147)
- [ ] Deploy to production and verify login at ageofagents.net works without browser console errors

Closes BGE-276