### PR TITLE
feat: BGE-280 layout, navigation & German→English translation

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -4,7 +4,7 @@
 @inject HttpClient Http
 @implements IDisposable
 
-<h1>Basis</h1>
+<h1>Base</h1>
 
 <div class="container">
 
@@ -13,15 +13,15 @@
     <_WorkerAssignment />
 
     <div class="bge-trade mt-3">
-        <h3>Handel</h3>
+        <h3>Trade</h3>
         <div>
             <select @bind="tradeFromResource" class="form-select d-inline-block" style="width:150px">
-                <option value="minerals">Mineralien → Gas</option>
-                <option value="gas">Gas → Mineralien</option>
+                <option value="minerals">Minerals → Gas</option>
+                <option value="gas">Gas → Minerals</option>
             </select>
             <input type="number" min="1" @bind="tradeAmount" class="form-control d-inline-block ms-2" style="width:100px" />
-            <span class="ms-2">Kosten: @(tradeAmount * 2) → erhalten: @tradeAmount</span>
-            <button class="btn btn-warning ms-2" @onclick="Trade">Handeln</button>
+            <span class="ms-2">Cost: @(tradeAmount * 2) → receive: @tradeAmount</span>
+            <button class="btn btn-warning ms-2" @onclick="Trade">Trade</button>
         </div>
         @if (!string.IsNullOrEmpty(tradeError)) {
             <span class="text-danger">@tradeError</span>
@@ -29,13 +29,13 @@
     </div>
 
     <div class="bge-colonize mt-3">
-        <h3>Kolonisieren</h3>
+        <h3>Colonize</h3>
         @if (resources != null) {
-            <div>Kosten: @resources.ColonizationCostPerLand Mineralien pro Land</div>
+            <div>Cost: @resources.ColonizationCostPerLand minerals per land</div>
             <div>
                 <input type="number" min="1" max="24" @bind="colonizeAmount" class="form-control d-inline-block" style="width:100px" />
-                <span class="ms-2">= @(colonizeAmount * resources.ColonizationCostPerLand) Mineralien</span>
-                <button class="btn btn-success ms-2" @onclick="Colonize">Kolonisieren</button>
+                <span class="ms-2">= @(colonizeAmount * resources.ColonizationCostPerLand) minerals</span>
+                <button class="btn btn-success ms-2" @onclick="Colonize">Colonize</button>
             </div>
             @if (!string.IsNullOrEmpty(colonizeError)) {
                 <span class="error">@colonizeError</span>
@@ -44,7 +44,7 @@
     </div>
 
     @if (model == null) {
-        <p><em>Lade...</em></p>
+        <p><em>Loading...</em></p>
     } else {
         if (!string.IsNullOrEmpty(lastError)) {
             <span class="error">@lastError</span>
@@ -57,26 +57,26 @@
                         <h2>@item.Definition?.Name</h2>
 
                         @if (item.Built) {
-                            <span>Bereits gebaut!</span>
+                            <span>Already built!</span>
 
                             <div class="bge-recruiting">
                                 <_BuildUnitsForm AvailableUnits="item.AvailableUnits" BuildQueue="buildQueue" OnQueueChanged="OnQueueChanged" />
                             </div>
 
                         } else if (item.AlreadyQueued) {
-                            <span>Wird in @item.TicksLeftForBuild Runden fertig sein.</span>
+                            <span>Will be ready in @item.TicksLeftForBuild rounds.</span>
                         } else {
-                            <div>Kosten: <_Cost Cost="@item.Cost" /></div>
-                            <div>Benötigt: @item.Prerequisites </div>
+                            <div>Requires: <_Cost Cost="@item.Cost" /></div>
+                            <div>Requires: @item.Prerequisites </div>
                             @if (item.PrerequisitesMet) {
                                 <div>
                                     @if (item.CanAfford) {
                                         <button class="btn btn-primary" @onclick="(e) => BuildAsset(item)">
-                                            Bauen
+                                            Build
                                         </button>
                                     }
                                     <button class="btn btn-secondary" @onclick="(e) => QueueAsset(item)">
-                                        In Warteschlange
+                                        Queue
                                     </button>
                                 </div>
                             }

--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -1,10 +1,10 @@
-﻿@page "/enemybase/{EnemeyPlayerId}"
+@page "/enemybase/{EnemeyPlayerId}"
 @page "/games/{GameId}/enemybase/{EnemeyPlayerId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @implements IDisposable
 
-<h1>Angriff</h1>
+<h1>Attack</h1>
 
 @if (!string.IsNullOrEmpty(lastError)) {
     <span class="error">@lastError</span>
@@ -14,24 +14,24 @@
     <p><em>Loading...</em></p>
 } else {
 
-    <NavLink class="nav-link" href="units">Nachschub anfordern</NavLink>
+    <NavLink class="nav-link" href="units">Request Reinforcements</NavLink>
 
     <button class="btn btn-primary" @onclick="Attack">
-        Angreifen
+        Attack
     </button>
 
     @if (battleResult != null) {
-        <h2>Schlachtergebnis</h2>
+        <h2>Battle Result</h2>
 
     } else {
-        <h2>Eigene Truppen</h2>
+        <h2>Your Troops</h2>
 
         <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>
-                    <th>Anzahl</th>
-                    <th>Eigenschaften</th>
+                    <th>Count</th>
+                    <th>Properties</th>
                     <th>Position</th>
                 </tr>
             </thead>
@@ -42,19 +42,19 @@
                         <td>@item.Count</td>
                         <td><_UnitProperties UnitDef="item.Definition" /></td>
                         <td>@item.PositionPlayerId</td>
-                        <td>Rückzug</td>
+                        <td>Retreat</td>
                     </tr>
                 }
             </tbody>
         </table>
 
-        <h2>Feindliche Truppen</h2>
+        <h2>Enemy Troops</h2>
         <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>
-                    <th>Anzahl</th>
-                    <th>Eigenschaften</th>
+                    <th>Count</th>
+                    <th>Properties</th>
                     <th>Position</th>
                 </tr>
             </thead>

--- a/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
@@ -1,10 +1,10 @@
-﻿@page "/selectenemy/{UnitId}"
+@page "/selectenemy/{UnitId}"
 @page "/games/{GameId}/selectenemy/{UnitId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
 
-<h1>Gegner auswählen</h1>
+<h1>Select Enemy</h1>
 
 @if (!string.IsNullOrEmpty(lastError)) {
     <span class="error">@lastError</span>
@@ -22,10 +22,10 @@
                 <option value="@x.PlayerId">@x.PlayerName (@x.Score)</option>
                 }
         </InputSelect>
-        <button type="submit">Truppen senden</button>
+        <button type="submit">Send Troops</button>
     </EditForm>
 
-    <NavLink class="nav-link" href="units">Angriff abbrechen</NavLink>
+    <NavLink class="nav-link" href="units">Cancel Attack</NavLink>
 }
 
 @code {

--- a/src/BrowserGameEngine.BlazorClient/Pages/UnitDefinition.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/UnitDefinition.razor
@@ -1,8 +1,8 @@
-﻿@page "/unitdefinitions"
+@page "/unitdefinitions"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
-<h1>Einheiten Definitionen</h1>
+<h1>Unit Definitions</h1>
 
 @if (model == null) {
     <p><em>Loading...</em></p>
@@ -12,9 +12,9 @@
             <tr>
                 <th>Id</th>
                 <th>Name</th>
-                <th>Angriff</th>
-                <th>Verteidigung</th>
-                <th>Kosten</th>
+                <th>Attack</th>
+                <th>Defense</th>
+                <th>Cost</th>
             </tr>
         </thead>
         <tbody>

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -1,11 +1,11 @@
-﻿@page "/units"
+@page "/units"
 @page "/games/{GameId}/units"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @inject NavigationManager Nav
 @implements IDisposable
 
-<h1>Einheiten</h1>
+<h1>Units</h1>
 
 @if (!string.IsNullOrEmpty(lastError)) {
     <span class="error">@lastError</span>
@@ -17,15 +17,15 @@
     <p><em>Loading...</em></p>
 } else {
     <button class="btn btn-primary" @onclick="MergeAll">
-        Truppen zusammenführen
+        Merge All Troops
     </button>
 
     <table class="table">
         <thead>
             <tr>
                 <th>Name</th>
-                <th>Anzahl</th>
-                <th>Eigenschaften</th>
+                <th>Count</th>
+                <th>Properties</th>
                 <th>Position</th>
             </tr>
         </thead>
@@ -43,19 +43,19 @@
                         </td>
                         <td>
                             <button class="btn btn-primary" @onclick="async () => await Merge(item.Definition!.Id!)">
-                                Truppen dieses Typs zusammenführen
+                                Merge units of this type
                             </button>
 
                             @if (item.Count > 1) {
                                 @if (!IsShowSplit(item.UnitId)) {
                                     <button class="btn btn-primary" @onclick="() => ToggleShowSplit(item.UnitId)">
-                                        Truppen aufteilen
+                                        Split troops
                                     </button>
                                 } else {
                                     <_SplitUnitForm UnitId="item.UnitId" SplitDoneEvent="Update" InitCount="item.Count / 2" />
                                 }
                             }
-                            <NavLink class="nav-link" href="@($"selectenemy/{item.UnitId}")">Angriff</NavLink>
+                            <NavLink class="nav-link" href="@($"selectenemy/{item.UnitId}")">Attack</NavLink>
                         </td>
                     </tr>
                 }

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -4,14 +4,14 @@
 @inject HttpClient Http
 @implements IDisposable
 
-<h1>Forschung</h1>
+<h1>Research</h1>
 
 <div class="container">
 
     <_PlayerResources />
 
     @if (model == null) {
-        <p><em>Lade...</em></p>
+        <p><em>Loading...</em></p>
     } else {
         if (!string.IsNullOrEmpty(lastError)) {
             <span class="error">@lastError</span>
@@ -21,19 +21,19 @@
             <div class="col-md-6">
                 <div class="card mb-3">
                     <div class="card-body">
-                        <h5 class="card-title">Angriffs-Upgrades</h5>
+                        <h5 class="card-title">Attack Upgrades</h5>
                         <p>Level: @model.AttackUpgradeLevel / @model.MaxUpgradeLevel</p>
 
                         @if (model.UpgradeBeingResearched == "Attack") {
-                            <p>Wird erforscht... (@model.UpgradeResearchTimer Runden verbleibend)</p>
+                            <p>Researching... (@model.UpgradeResearchTimer rounds remaining)</p>
                         } else if (model.AttackUpgradeLevel >= model.MaxUpgradeLevel) {
-                            <p>Maximales Level erreicht!</p>
+                            <p>Maximum level reached!</p>
                         } else if (model.UpgradeBeingResearched != "None") {
-                            <p>Eine andere Forschung läuft gerade.</p>
+                            <p>Another research is in progress.</p>
                         } else {
-                            <div>Kosten: <_Cost Cost="@model.NextAttackUpgradeCost" /></div>
+                            <div>Cost: <_Cost Cost="@model.NextAttackUpgradeCost" /></div>
                             <button class="btn btn-danger mt-2" @onclick="ResearchAttack">
-                                Angriffs-Upgrade erforschen (Level @(model.AttackUpgradeLevel + 1))
+                                Research Attack Upgrade (Level @(model.AttackUpgradeLevel + 1))
                             </button>
                         }
                     </div>
@@ -43,19 +43,19 @@
             <div class="col-md-6">
                 <div class="card mb-3">
                     <div class="card-body">
-                        <h5 class="card-title">Verteidigungs-Upgrades</h5>
+                        <h5 class="card-title">Defense Upgrades</h5>
                         <p>Level: @model.DefenseUpgradeLevel / @model.MaxUpgradeLevel</p>
 
                         @if (model.UpgradeBeingResearched == "Defense") {
-                            <p>Wird erforscht... (@model.UpgradeResearchTimer Runden verbleibend)</p>
+                            <p>Researching... (@model.UpgradeResearchTimer rounds remaining)</p>
                         } else if (model.DefenseUpgradeLevel >= model.MaxUpgradeLevel) {
-                            <p>Maximales Level erreicht!</p>
+                            <p>Maximum level reached!</p>
                         } else if (model.UpgradeBeingResearched != "None") {
-                            <p>Eine andere Forschung läuft gerade.</p>
+                            <p>Another research is in progress.</p>
                         } else {
-                            <div>Kosten: <_Cost Cost="@model.NextDefenseUpgradeCost" /></div>
+                            <div>Cost: <_Cost Cost="@model.NextDefenseUpgradeCost" /></div>
                             <button class="btn btn-primary mt-2" @onclick="ResearchDefense">
-                                Verteidigungs-Upgrade erforschen (Level @(model.DefenseUpgradeLevel + 1))
+                                Research Defense Upgrade (Level @(model.DefenseUpgradeLevel + 1))
                             </button>
                         }
                     </div>

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
@@ -1,24 +1,24 @@
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
-<h3>Bauaufträge</h3>
+<h3>Build Queue</h3>
 
 @if (!string.IsNullOrEmpty(lastError)) {
     <span class="error">@lastError</span>
 }
 
 @if (model == null) {
-    <p><em>Lade...</em></p>
+    <p><em>Loading...</em></p>
 } else if (!model.Entries.Any()) {
-    <p>Keine Bauaufträge in der Warteschlange.</p>
+    <p>No items in the build queue.</p>
 } else {
     <table class="table table-sm">
         <thead>
             <tr>
-                <th>Priorität</th>
-                <th>Typ</th>
+                <th>Priority</th>
+                <th>Type</th>
                 <th>Name</th>
-                <th>Anzahl</th>
+                <th>Count</th>
                 <th></th>
             </tr>
         </thead>
@@ -26,11 +26,11 @@
             @foreach (var entry in model.Entries.OrderBy(x => x.Priority)) {
                 <tr>
                     <td>@entry.Priority</td>
-                    <td>@(entry.Type == "asset" ? "Gebäude" : "Einheit")</td>
+                    <td>@(entry.Type == "asset" ? "Building" : "Unit")</td>
                     <td>@entry.Name</td>
                     <td>@entry.Count</td>
                     <td>
-                        <button class="btn btn-sm btn-danger" @onclick="() => RemoveEntry(entry.Id)">Entfernen</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => RemoveEntry(entry.Id)">Remove</button>
                     </td>
                 </tr>
             }

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildUnitsForm.razor
@@ -16,8 +16,8 @@
             <option value="@x.Id">@x.Name</option>
         }
     </InputSelect>
-    <button type="submit">Bauen</button>
-    <button type="button" @onclick="QueueUnit">In Warteschlange</button>
+    <button type="submit">Build</button>
+    <button type="button" @onclick="QueueUnit">Queue</button>
 </EditForm>
 
 @code {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -4,14 +4,14 @@
 @implements IDisposable
 
 @if (resources != null) {
-    <div class="d-flex flex-wrap gap-3 align-items-center small text-muted">
-        <span><strong>@resources.PrimaryResource.Cost.Single().Key</strong>: @resources.PrimaryResource.Cost.Single().Value</span>
+    <div class="d-flex flex-wrap gap-3 align-items-center small">
+        <span><strong>@resources.PrimaryResource.Cost.Single().Key</strong>: <span class="text-resource">@resources.PrimaryResource.Cost.Single().Value</span></span>
         @foreach (var res in resources.SecondaryResources.Cost) {
-            <span><strong>@res.Key</strong>: @res.Value</span>
+            <span><strong>@res.Key</strong>: <span class="text-resource">@res.Value</span></span>
         }
         @if (tickInfo != null) {
             <span><strong>Server:</strong> @tickInfo.ServerTime.ToString("HH:mm:ss") UTC</span>
-            <span><strong>Next tick:</strong> @FormatCountdown(tickInfo.NextTickAt)</span>
+            <span><strong>Next tick:</strong> <span class="@CountdownClass(tickInfo.NextTickAt)">@FormatCountdown(tickInfo.NextTickAt)</span></span>
             @if (tickInfo.UnreadMessageCount > 0) {
                 <span class="badge bg-danger">@tickInfo.UnreadMessageCount unread</span>
             }
@@ -52,6 +52,11 @@
         var remaining = nextTickAt - DateTime.UtcNow;
         if (remaining <= TimeSpan.Zero) return "now";
         return $"{(int)remaining.TotalSeconds}s";
+    }
+
+    private string CountdownClass(DateTime nextTickAt) {
+        var remaining = nextTickAt - DateTime.UtcNow;
+        return remaining.TotalSeconds < 60 ? "countdown-urgent" : "";
     }
 
     public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_UnitProperties.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_UnitProperties.razor
@@ -1,7 +1,7 @@
-﻿<div>
+<div>
     <div>Hitpoints: @UnitDef.Hitpoints</div>
-    <div>Angriff: @UnitDef.Attack</div>
-    <div>Verteidigung: @UnitDef.Defense</div>
+    <div>Attack: @UnitDef.Attack</div>
+    <div>Defense: @UnitDef.Defense</div>
 
 </div>
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
@@ -6,16 +6,16 @@
 }
 @if (model != null) {
 	<div>
-		<h3>Arbeiter</h3>
-		<div>Gesamt: @model.TotalWorkers</div>
-		<div>Untätig: @(model.TotalWorkers - mineralWorkers - gasWorkers)</div>
+		<h3>Workers</h3>
+		<div>Total: @model.TotalWorkers</div>
+		<div>Idle: @(model.TotalWorkers - mineralWorkers - gasWorkers)</div>
 		<div>
-			<label>Mineralien: <InputNumber @bind-Value="mineralWorkers" /></label>
+			<label>Minerals: <InputNumber @bind-Value="mineralWorkers" /></label>
 		</div>
 		<div>
 			<label>Gas: <InputNumber @bind-Value="gasWorkers" /></label>
 		</div>
-		<button @onclick="Assign">Zuweisen</button>
+		<button @onclick="Assign">Assign</button>
 	</div>
 }
 

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 
 <div class="top-row pl-4 navbar navbar-dark">
-    <a class="navbar-brand" href="">BrowserGameEngine</a>
+    <a class="navbar-brand" href="">Age of Agents</a>
     <button class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>
@@ -30,27 +30,27 @@
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="base">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Basis
+                <span class="oi oi-layers" aria-hidden="true"></span> Base
             </NavLink>
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="units">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Einheiten
+                <span class="oi oi-shield" aria-hidden="true"></span> Units
             </NavLink>
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="unitdefinitions">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Einheitentypen
+                <span class="oi oi-spreadsheet" aria-hidden="true"></span> Unit Types
             </NavLink>
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="upgrades">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Forschung
+                <span class="oi oi-beaker" aria-hidden="true"></span> Research
             </NavLink>
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="ranking">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Ranking
+                <span class="oi oi-bar-chart" aria-hidden="true"></span> Ranking
             </NavLink>
         </li>
         <li class="nav-item px-3">
@@ -60,12 +60,12 @@
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="allianceranking">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Alliance Ranking
+                <span class="oi oi-graph" aria-hidden="true"></span> Alliance Ranking
             </NavLink>
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="players">
-                <span class="oi oi-people" aria-hidden="true"></span> My Players
+                <span class="oi oi-person" aria-hidden="true"></span> Players
             </NavLink>
         </li>
         <li class="nav-item px-3">
@@ -78,13 +78,13 @@
         </li>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="profile">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Profile
+                <span class="oi oi-account-login" aria-hidden="true"></span> Profile
             </NavLink>
         </li>
         <AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="history">
-                <span class="oi oi-clock" aria-hidden="true"></span> My History
+                <span class="oi oi-clock" aria-hidden="true"></span> History
             </NavLink>
         </li>
         <li class="nav-item px-3">
@@ -95,7 +95,7 @@
         </AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="signout">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Logout
+                <span class="oi oi-account-logout" aria-hidden="true"></span> Sign Out
             </NavLink>
         </li>
     </ul>


### PR DESCRIPTION
## Summary
- Renames brand in NavMenu from `BrowserGameEngine` to `Age of Agents`
- Translates all German UI strings to English across 12 Blazor razor files (Base, Units, Upgrades, BuildQueue, WorkerAssignment, BuildUnitsForm, UnitDefinition, SelectEnemy, EnemyBase, UnitProperties, NavMenu, PlayerResources)
- Assigns distinct OpenIconic icons to each nav item (oi-layers, oi-shield, oi-spreadsheet, oi-beaker, oi-bar-chart, oi-graph, oi-person, oi-account-login, oi-account-logout, etc.)
- Wraps resource values in `.text-resource` span for CSS theming (BGE-279)
- Adds `countdown-urgent` CSS class to the next-tick countdown when <60s remaining
- Removes `text-muted` from the resource bar wrapper div

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (147/147)
- [ ] Visually verify nav shows English labels and distinct icons
- [ ] Verify no German text visible anywhere in the UI

Closes BGE-280