### PR TITLE
feat: BGE-267 in-app player notification center

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -14,7 +14,39 @@
 <div class="main">
     <div class="top-row px-4 d-flex align-items-center justify-content-between">
         <_PlayerResources />
-        <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
+        <div class="d-flex align-items-center gap-3">
+            <div class="position-relative" style="cursor:pointer;" @onclick="ToggleNotifications">
+                <span style="font-size:1.4rem;" title="Notifications">&#128276;</span>
+                @if (_notifications.Count > 0) {
+                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size:0.65rem;">
+                        @(_notifications.Count > 9 ? "9+" : _notifications.Count.ToString())
+                    </span>
+                }
+            </div>
+            @if (_showNotifications) {
+                <div class="position-absolute bg-white border rounded shadow" style="top:3.5rem;right:1rem;width:340px;max-height:400px;overflow-y:auto;z-index:1050;">
+                    <div class="d-flex align-items-center justify-content-between px-3 py-2 border-bottom">
+                        <strong>Notifications</strong>
+                        @if (_notifications.Count > 0) {
+                            <button class="btn btn-sm btn-outline-secondary" @onclick="DismissAll">Clear all</button>
+                        }
+                    </div>
+                    @if (_notifications.Count == 0) {
+                        <div class="px-3 py-3 text-muted text-center">No notifications</div>
+                    } else {
+                        @foreach (var n in _notifications) {
+                            <div class="d-flex align-items-start px-3 py-2 border-bottom @GetNotificationClass(n.Kind)">
+                                <div class="flex-grow-1">
+                                    <div style="font-size:0.85rem;">@n.Message</div>
+                                    <div class="text-muted" style="font-size:0.75rem;">@FormatNotificationTime(n.CreatedAt)</div>
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+            }
+            <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
+        </div>
     </div>
 
     @if (CurrentGameService.CurrentGame != null) {
@@ -61,6 +93,9 @@
     private string? _lastGameStatus;
     private bool _endingSoonAlertShown;
 
+    private List<PlayerNotificationViewModel> _notifications = new();
+    private bool _showNotifications = false;
+
     protected override void OnInitialized() {
         CurrentGameService.OnChanged += OnGameChanged;
         StartPolling();
@@ -93,6 +128,9 @@
     }
 
     private async Task PollGameStatusAsync(System.Threading.CancellationToken ct) {
+        // Initial notification fetch
+        await FetchNotificationsAsync();
+
         while (!ct.IsCancellationRequested) {
             await Task.Delay(TimeSpan.FromSeconds(10), ct).ContinueWith(_ => { });
             if (ct.IsCancellationRequested) break;
@@ -100,7 +138,55 @@
                 await CurrentGameService.RefreshAsync();
             }
             await DetectAlertsAsync();
+
+            // Fetch notifications every 30s (every 3rd 10s poll)
+            if (++_notificationPollCounter >= 3) {
+                _notificationPollCounter = 0;
+                await FetchNotificationsAsync();
+            }
         }
+    }
+
+    private int _notificationPollCounter = 0;
+
+    private async Task FetchNotificationsAsync() {
+        try {
+            var result = await Http.GetFromJsonAsync<List<PlayerNotificationViewModel>>("api/notifications");
+            if (result != null) {
+                _notifications = result;
+                await InvokeAsync(StateHasChanged);
+            }
+        } catch {
+            // Ignore errors — user may not be authenticated yet
+        }
+    }
+
+    private async Task DismissAll() {
+        try {
+            await Http.DeleteAsync("api/notifications");
+            _notifications = new List<PlayerNotificationViewModel>();
+            _showNotifications = false;
+        } catch {
+            // Ignore
+        }
+    }
+
+    private void ToggleNotifications() {
+        _showNotifications = !_showNotifications;
+    }
+
+    private static string GetNotificationClass(NotificationKind kind) => kind switch {
+        NotificationKind.Warning => "bg-warning bg-opacity-10",
+        NotificationKind.GameEvent => "bg-info bg-opacity-10",
+        _ => ""
+    };
+
+    private static string FormatNotificationTime(DateTime createdAt) {
+        var age = DateTime.UtcNow - createdAt;
+        if (age.TotalMinutes < 1) return "just now";
+        if (age.TotalMinutes < 60) return $"{(int)age.TotalMinutes}m ago";
+        if (age.TotalHours < 24) return $"{(int)age.TotalHours}h ago";
+        return createdAt.ToString("MMM d");
     }
 
     private async Task DetectAlertsAsync() {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
@@ -1,0 +1,52 @@
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/notifications")]
+	public class NotificationsController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly IPlayerNotificationService playerNotificationService;
+
+		public NotificationsController(
+			CurrentUserContext currentUserContext,
+			IPlayerNotificationService playerNotificationService
+		) {
+			this.currentUserContext = currentUserContext;
+			this.playerNotificationService = playerNotificationService;
+		}
+
+		[HttpGet]
+		public ActionResult<List<BrowserGameEngine.Shared.PlayerNotificationViewModel>> GetNotifications() {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var notifications = playerNotificationService.GetRecent(currentUserContext.UserId);
+			return Ok(notifications.Select(n => new BrowserGameEngine.Shared.PlayerNotificationViewModel(
+				Id: n.Id,
+				Message: n.Message,
+				Kind: MapKind(n.Kind),
+				CreatedAt: n.CreatedAt,
+				IsRead: false
+			)).ToList());
+		}
+
+		[HttpDelete]
+		public ActionResult ClearNotifications() {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			playerNotificationService.ClearAll(currentUserContext.UserId);
+			return Ok();
+		}
+
+		private static BrowserGameEngine.Shared.NotificationKind MapKind(BrowserGameEngine.StatefulGameServer.Notifications.NotificationKind kind) {
+			return kind switch {
+				BrowserGameEngine.StatefulGameServer.Notifications.NotificationKind.Warning => BrowserGameEngine.Shared.NotificationKind.Warning,
+				BrowserGameEngine.StatefulGameServer.Notifications.NotificationKind.GameEvent => BrowserGameEngine.Shared.NotificationKind.GameEvent,
+				_ => BrowserGameEngine.Shared.NotificationKind.Info,
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/NotificationViewModels.cs
+++ b/src/BrowserGameEngine.Shared/NotificationViewModels.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public enum NotificationKind { Info, Warning, GameEvent }
+
+	public record PlayerNotificationViewModel(
+		string Id,
+		string Message,
+		NotificationKind Kind,
+		DateTime CreatedAt,
+		bool IsRead
+	);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -92,6 +92,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				persistenceService,
 				globalPersistenceService,
 				new GameRegistryNs.NullGameNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -54,6 +54,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				new PersistenceService(storage, serializer),
 				new GlobalPersistenceService(storage, globalSerializer),
 				new GameRegistryNs.NullGameNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,20 +10,27 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly PlayerRepository playerRepository;
 		private readonly MessageRepositoryWrite messageRepositoryWrite;
 		private readonly GameDef gameDef;
+		private readonly IPlayerNotificationService playerNotificationService;
 
 		public BattleReportGenerator(
 			PlayerRepository playerRepository,
 			MessageRepositoryWrite messageRepositoryWrite,
-			GameDef gameDef
+			GameDef gameDef,
+			IPlayerNotificationService playerNotificationService
 		) {
 			this.playerRepository = playerRepository;
 			this.messageRepositoryWrite = messageRepositoryWrite;
 			this.gameDef = gameDef;
+			this.playerNotificationService = playerNotificationService;
 		}
 
 		public void GenerateReports(BattleResult battleResult) {
 			var attacker = playerRepository.Get(battleResult.Attacker);
 			var defender = playerRepository.Get(battleResult.Defender);
+
+			if (defender.UserId != null) {
+				playerNotificationService.Push(defender.UserId, $"Your base was attacked by {attacker.Name}!", NotificationKind.Warning);
+			}
 			var attackerRace = GetRaceName(attacker.PlayerType);
 			var defenderRace = GetRaceName(defender.PlayerType);
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -1,6 +1,7 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
@@ -13,6 +14,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		private readonly PersistenceService persistenceService;
 		private readonly GlobalPersistenceService globalPersistenceService;
 		private readonly IGameNotificationService notificationService;
+		private readonly IPlayerNotificationService playerNotificationService;
 		private readonly ILogger<GameLifecycleEngine> logger;
 
 		public GameLifecycleEngine(
@@ -21,6 +23,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			PersistenceService persistenceService,
 			GlobalPersistenceService globalPersistenceService,
 			IGameNotificationService notificationService,
+			IPlayerNotificationService playerNotificationService,
 			ILogger<GameLifecycleEngine> logger
 		) {
 			this.gameRegistry = gameRegistry;
@@ -28,6 +31,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			this.persistenceService = persistenceService;
 			this.globalPersistenceService = globalPersistenceService;
 			this.notificationService = notificationService;
+			this.playerNotificationService = playerNotificationService;
 			this.logger = logger;
 		}
 
@@ -49,8 +53,17 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				var updated = record with { Status = GameStatus.Active };
 				globalState.UpdateGame(record, updated);
 				logger.LogInformation("Game {GameId} activated", record.GameId.Id);
-				var playerCount = gameRegistry.TryGetInstance(record.GameId)?.PlayerCount ?? 0;
+				var instance = gameRegistry.TryGetInstance(record.GameId);
+				var playerCount = instance?.PlayerCount ?? 0;
 				await notificationService.NotifyGameStartedAsync(updated, playerCount);
+
+				if (instance != null) {
+					foreach (var player in instance.WorldState.Players.Values) {
+						if (player.UserId != null) {
+							playerNotificationService.Push(player.UserId, $"Game \"{record.Name}\" has started!", NotificationKind.GameEvent);
+						}
+					}
+				}
 			}
 			return toActivate.Count > 0;
 		}
@@ -114,6 +127,13 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 
 			// Persist final world state before freeing memory
 			await persistenceService.StoreGameState(record.GameId, instance.WorldState.ToImmutable());
+
+			// Notify players that the game has ended
+			foreach (var player in instance.WorldState.Players.Values) {
+				if (player.UserId != null) {
+					playerNotificationService.Push(player.UserId, $"Game \"{record.Name}\" has ended. Check results!", NotificationKind.GameEvent);
+				}
+			}
 
 			// Remove instance from registry to free memory
 			gameRegistry.Remove(record.GameId);

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -72,6 +73,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton(globalPersistenceService);
 			services.AddSingleton<IWorldStateFactory>(worldStateFactory);
 			services.AddSingleton<IGameNotificationService, NullGameNotificationService>();
+			services.AddSingleton<IPlayerNotificationService, InMemoryPlayerNotificationService>();
 			services.AddSingleton<GameLifecycleEngine>();
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/IPlayerNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/IPlayerNotificationService.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	public interface IPlayerNotificationService {
+		void Push(string userId, string message, NotificationKind kind);
+		List<PlayerNotification> GetRecent(string userId, int limit = 20);
+		void ClearAll(string userId);
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/InMemoryPlayerNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/InMemoryPlayerNotificationService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	public class InMemoryPlayerNotificationService : IPlayerNotificationService {
+		private const int MaxPerUser = 20;
+
+		// Each user has a fixed-capacity ring of notifications; newest first
+		private readonly ConcurrentDictionary<string, LinkedList<PlayerNotification>> _store = new();
+
+		public void Push(string userId, string message, NotificationKind kind) {
+			var notification = new PlayerNotification(
+				Id: Guid.NewGuid().ToString(),
+				Message: message,
+				Kind: kind,
+				CreatedAt: DateTime.UtcNow
+			);
+
+			_store.AddOrUpdate(
+				userId,
+				_ => {
+					var list = new LinkedList<PlayerNotification>();
+					list.AddFirst(notification);
+					return list;
+				},
+				(_, existing) => {
+					lock (existing) {
+						existing.AddFirst(notification);
+						while (existing.Count > MaxPerUser) {
+							existing.RemoveLast();
+						}
+					}
+					return existing;
+				}
+			);
+		}
+
+		public List<PlayerNotification> GetRecent(string userId, int limit = 20) {
+			if (!_store.TryGetValue(userId, out var list)) return new List<PlayerNotification>();
+			lock (list) {
+				return list.Take(limit).ToList();
+			}
+		}
+
+		public void ClearAll(string userId) {
+			if (_store.TryGetValue(userId, out var list)) {
+				lock (list) {
+					list.Clear();
+				}
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/PlayerNotification.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/PlayerNotification.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	public enum NotificationKind { Info, Warning, GameEvent }
+
+	public record PlayerNotification(
+		string Id,
+		string Message,
+		NotificationKind Kind,
+		DateTime CreatedAt
+	);
+}


### PR DESCRIPTION
## Summary

- Adds `IPlayerNotificationService` / `InMemoryPlayerNotificationService` to `StatefulGameServer` — thread-safe ring buffer (max 20 per user, keyed by `UserId`)
- Pushes notifications at three trigger points: game activated (start), game finalized (end), and incoming attack (defender)
- Adds `GET /api/notifications` and `DELETE /api/notifications` endpoints in `NotificationsController`
- Adds a bell icon with unread count badge to the top navbar in `MainLayout.razor`; clicking toggles a dropdown list of notifications; polling every 30s; "Clear all" calls DELETE
- Adds `PlayerNotificationViewModel` + `NotificationKind` enum to `BrowserGameEngine.Shared`
- Fixes two test files (`GameLifecycleEngineTest`, `MultiGameLifecycleTest`) to pass the new constructor parameter
- All 147 existing tests pass

## Test plan

- [ ] Log in as a player; have another player attack you — bell shows count 1 with "Your base was attacked" message
- [ ] Start/end a game — players receive game-start and game-end notifications
- [ ] Click bell icon — dropdown shows notifications with timestamps
- [ ] Click "Clear all" — dropdown empties and badge disappears
- [ ] Verify notifications clear on server restart (in-memory, no persistence)
- [ ] `dotnet test` passes (147 tests)