### PR TITLE
feat: BGE-266 edit game settings post-creation

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
@@ -156,7 +156,7 @@
 		editModel = new EditGameFormModel {
 			Name = game.Name,
 			EndTime = game.EndTime?.ToLocalTime() ?? DateTime.Now.AddDays(7),
-			DiscordWebhookUrl = string.Empty
+			DiscordWebhookUrl = game.DiscordWebhookUrl
 		};
 		editError = null;
 		editSuccess = null;

--- a/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Admin/Games.razor
@@ -64,8 +64,43 @@
 					<td>@game.PlayerCount</td>
 					<td>@game.StartTime?.ToLocalTime().ToString("g")</td>
 					<td>@game.EndTime?.ToLocalTime().ToString("g")</td>
-					<td><a href="/games/@game.GameId">View</a></td>
+					<td>
+						<a href="/games/@game.GameId">View</a>
+						@if (editingGameId != game.GameId) {
+							<button @onclick="() => StartEdit(game)" style="margin-left:8px">Edit</button>
+						}
+					</td>
 				</tr>
+				@if (editingGameId == game.GameId) {
+					<tr>
+						<td colspan="6" style="background:#f8f9fa; padding:12px">
+							<div style="display:grid; gap:8px; max-width:480px">
+								<div>
+									<label><strong>Name</strong></label><br />
+									<input type="text" @bind="editModel.Name" style="width:100%" />
+								</div>
+								<div>
+									<label><strong>Discord Webhook URL</strong></label><br />
+									<input type="text" @bind="editModel.DiscordWebhookUrl" placeholder="(optional)" style="width:100%" />
+								</div>
+								<div>
+									<label><strong>End Time</strong></label><br />
+									<input type="datetime-local" value="@editModel.EndTime.ToString("yyyy-MM-ddTHH:mm")" @onchange="e => editModel.EndTime = ParseDateTime(e.Value?.ToString())" />
+								</div>
+								<div>
+									<button @onclick="HandleSaveEdit">Save</button>
+									<button @onclick="CancelEdit" style="margin-left:8px">Cancel</button>
+									@if (!string.IsNullOrEmpty(editError)) {
+										<span style="color:red; margin-left:8px">@editError</span>
+									}
+									@if (!string.IsNullOrEmpty(editSuccess)) {
+										<span style="color:green; margin-left:8px">@editSuccess</span>
+									}
+								</div>
+							</div>
+						</td>
+					</tr>
+				}
 			}
 		</tbody>
 	</table>
@@ -77,12 +112,18 @@
 	private string? createError;
 	private string? createSuccess;
 
+	private string? editingGameId;
+	private EditGameFormModel editModel = new();
+	private string? editError;
+	private string? editSuccess;
+
 	protected override async Task OnInitializedAsync() {
 		await LoadGames();
 	}
 
 	private async Task LoadGames() {
-		games = await Http.GetFromJsonAsync<List<GameSummaryViewModel>>("api/games") ?? new();
+		var list = await Http.GetFromJsonAsync<GameListViewModel>("api/games");
+		games = list?.Games ?? new();
 	}
 
 	private async Task HandleCreate() {
@@ -110,6 +151,50 @@
 		}
 	}
 
+	private void StartEdit(GameSummaryViewModel game) {
+		editingGameId = game.GameId;
+		editModel = new EditGameFormModel {
+			Name = game.Name,
+			EndTime = game.EndTime?.ToLocalTime() ?? DateTime.Now.AddDays(7),
+			DiscordWebhookUrl = string.Empty
+		};
+		editError = null;
+		editSuccess = null;
+	}
+
+	private void CancelEdit() {
+		editingGameId = null;
+		editError = null;
+		editSuccess = null;
+	}
+
+	private async Task HandleSaveEdit() {
+		editError = null;
+		editSuccess = null;
+
+		if (editingGameId == null) return;
+
+		var request = new UpdateGameRequest(
+			Name: editModel.Name,
+			EndTime: editModel.EndTime.ToUniversalTime(),
+			DiscordWebhookUrl: string.IsNullOrWhiteSpace(editModel.DiscordWebhookUrl) ? null : editModel.DiscordWebhookUrl
+		);
+
+		var response = await Http.PatchAsJsonAsync($"api/games/{editingGameId}", request);
+		if (response.IsSuccessStatusCode) {
+			editSuccess = "Game updated.";
+			editingGameId = null;
+			await LoadGames();
+		} else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) {
+			editError = "Unauthorized.";
+		} else if (response.StatusCode == System.Net.HttpStatusCode.Forbidden) {
+			editError = "Only the game creator can edit this game.";
+		} else {
+			var body = await response.Content.ReadAsStringAsync();
+			editError = $"Failed to update game: {body}";
+		}
+	}
+
 	private static DateTime ParseDateTime(string? value) {
 		if (DateTime.TryParse(value, out var dt)) return dt;
 		return DateTime.Now;
@@ -120,5 +205,11 @@
 		public string TickDuration { get; set; } = "00:01:00";
 		public DateTime StartTime { get; set; } = DateTime.Now.AddHours(1);
 		public DateTime EndTime { get; set; } = DateTime.Now.AddDays(7);
+	}
+
+	private class EditGameFormModel {
+		public string Name { get; set; } = string.Empty;
+		public DateTime EndTime { get; set; } = DateTime.Now.AddDays(7);
+		public string? DiscordWebhookUrl { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -239,7 +239,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				EndTime: record.EndTime,
 				CanJoin: record.Status == GameStatus.Upcoming,
 				WinnerId: record.WinnerId?.Id,
-				WinnerName: winnerName
+				WinnerName: winnerName,
+				DiscordWebhookUrl: record.DiscordWebhookUrl
 			);
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -102,7 +102,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				StartTime: request.StartTime.ToUniversalTime(),
 				EndTime: request.EndTime.ToUniversalTime(),
 				TickDuration: tickDuration,
-				DiscordWebhookUrl: request.DiscordWebhookUrl
+				DiscordWebhookUrl: request.DiscordWebhookUrl,
+				CreatedByUserId: currentUserContext.UserId
 			);
 
 			// Create a fresh world state for the new game
@@ -117,6 +118,48 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			logger.LogInformation("Game {GameId} created: {Name}", gameId.Id, request.Name);
 
 			return CreatedAtAction(nameof(GetById), new { gameId = gameId.Id }, ToSummary(record));
+		}
+
+		/// <summary>Updates game settings (name, end time, Discord webhook). Only the game creator may update.</summary>
+		/// <param name="gameId">The game identifier.</param>
+		[HttpPatch("{gameId}")]
+		public ActionResult<GameDetailViewModel> Update(string gameId, [FromBody] UpdateGameRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
+			if (record == null) return NotFound();
+
+			if (record.CreatedByUserId != null && record.CreatedByUserId != currentUserContext.UserId)
+				return StatusCode(403, "Only the game creator can edit this game.");
+
+			if (string.IsNullOrWhiteSpace(request.Name)) return BadRequest("Name is required.");
+
+			var newEndTime = request.EndTime.ToUniversalTime();
+			if (newEndTime <= record.StartTime) return BadRequest("EndTime must be after StartTime.");
+			if (record.Status != GameStatus.Upcoming && newEndTime < record.EndTime)
+				return BadRequest("Cannot shorten EndTime of an active or finished game.");
+
+			var updated = record with {
+				Name = request.Name,
+				EndTime = newEndTime,
+				DiscordWebhookUrl = request.DiscordWebhookUrl
+			};
+
+			globalState.UpdateGame(record, updated);
+			logger.LogInformation("Game {GameId} updated by {UserId}", gameId, currentUserContext.UserId);
+
+			return Ok(new GameDetailViewModel(
+				GameId: updated.GameId.Id,
+				Name: updated.Name,
+				GameDefType: updated.GameDefType,
+				Status: updated.Status.ToString(),
+				StartTime: updated.StartTime,
+				EndTime: updated.EndTime,
+				PlayerCount: GetPlayerCount(updated),
+				WinnerId: updated.WinnerId?.Id,
+				ActualEndTime: updated.ActualEndTime,
+				DiscordWebhookUrl: updated.DiscordWebhookUrl
+			));
 		}
 
 		/// <summary>Joins an upcoming game with the current player. Requires authentication.</summary>

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -13,7 +13,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime? EndTime,
 		bool CanJoin,
 		string? WinnerId = null,
-		string? WinnerName = null
+		string? WinnerName = null,
+		string? DiscordWebhookUrl = null
 	);
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -24,6 +24,12 @@ namespace BrowserGameEngine.Shared {
 		string? DiscordWebhookUrl = null
 	);
 
+	public record UpdateGameRequest(
+		string Name,
+		DateTime EndTime,
+		string? DiscordWebhookUrl = null
+	);
+
 	public record GameResultEntryViewModel(
 		int Rank,
 		string PlayerName,

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BrowserGameEngine.StatefulGameServer.Test.csproj
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BrowserGameEngine.StatefulGameServer.Test.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
@@ -27,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BrowserGameEngine.GameDefinition.SCO\BrowserGameEngine.GameDefinition.SCO.csproj" />
     <ProjectReference Include="..\BrowserGameEngine.StatefulGameServer\BrowserGameEngine.StatefulGameServer.csproj" />
+    <ProjectReference Include="..\BrowserGameEngine.FrontendServer\BrowserGameEngine.FrontendServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -1,0 +1,164 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Controllers;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	/// <summary>
+	/// Unit tests for GamesController.Update (PATCH /api/games/{gameId}).
+	/// Covers BGE-266: ownership enforcement, EndTime validation, and successful mutation.
+	/// </summary>
+	public class GamesControllerTest {
+		private static GameRecordImmutable MakeRecord(
+			string gameId,
+			string? createdByUserId,
+			GameStatus status = GameStatus.Upcoming,
+			string? webhookUrl = null
+		) {
+			var start = DateTime.UtcNow.AddHours(-1);
+			var end = status == GameStatus.Finished
+				? DateTime.UtcNow.AddMinutes(-10)
+				: DateTime.UtcNow.AddDays(1);
+			return new GameRecordImmutable(
+				new GameId(gameId),
+				"Test Game",
+				"sco",
+				status,
+				start,
+				end,
+				TimeSpan.FromSeconds(10),
+				DiscordWebhookUrl: webhookUrl,
+				CreatedByUserId: createdByUserId
+			);
+		}
+
+		private static GamesController MakeController(
+			GlobalState globalState,
+			string? userId
+		) {
+			var game = new TestGame();
+			var gameRegistry = new GameRegistry.GameRegistry(globalState);
+			var userCtx = new CurrentUserContext();
+			if (userId != null) {
+				userCtx.UserId = userId;
+				userCtx.Activate(PlayerIdFactory.Create(userId));
+			}
+
+			return new GamesController(
+				NullLogger<GamesController>.Instance,
+				gameRegistry,
+				globalState,
+				game.WorldStateFactory,
+				game.GameDef,
+				userCtx,
+				TimeProvider.System
+			);
+		}
+
+		[Fact]
+		public void Update_AsNonCreator_Returns403() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1", createdByUserId: "alice");
+			globalState.AddGame(record);
+
+			var controller = MakeController(globalState, userId: "bob");
+			var request = new UpdateGameRequest(
+				Name: "New Name",
+				EndTime: DateTime.UtcNow.AddDays(2)
+			);
+
+			var result = controller.Update("game1", request);
+
+			var objectResult = Assert.IsType<ObjectResult>(result.Result);
+			Assert.Equal(403, objectResult.StatusCode);
+		}
+
+		[Fact]
+		public void Update_EndTimeBeforeStartTime_Returns400() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game2", createdByUserId: "alice");
+			globalState.AddGame(record);
+
+			var controller = MakeController(globalState, userId: "alice");
+			var request = new UpdateGameRequest(
+				Name: "New Name",
+				EndTime: record.StartTime.AddMinutes(-1)
+			);
+
+			var result = controller.Update("game2", request);
+
+			var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+			Assert.NotNull(badRequest);
+		}
+
+		[Fact]
+		public void Update_ShortenEndTimeOnActiveGame_Returns400() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game3", createdByUserId: "alice", status: GameStatus.Active);
+			globalState.AddGame(record);
+
+			var controller = MakeController(globalState, userId: "alice");
+			var request = new UpdateGameRequest(
+				Name: "New Name",
+				EndTime: record.EndTime.AddHours(-1)
+			);
+
+			var result = controller.Update("game3", request);
+
+			var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+			Assert.NotNull(badRequest);
+		}
+
+		[Fact]
+		public void Update_AsCreator_MutatesGame() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game4", createdByUserId: "alice", webhookUrl: "https://old.hook");
+			globalState.AddGame(record);
+
+			var controller = MakeController(globalState, userId: "alice");
+			var newEnd = record.EndTime.AddDays(1);
+			var request = new UpdateGameRequest(
+				Name: "Updated Name",
+				EndTime: newEnd,
+				DiscordWebhookUrl: "https://new.hook"
+			);
+
+			var result = controller.Update("game4", request);
+
+			var okResult = Assert.IsType<OkObjectResult>(result.Result);
+			var detail = Assert.IsType<GameDetailViewModel>(okResult.Value);
+			Assert.Equal("Updated Name", detail.Name);
+			Assert.Equal("https://new.hook", detail.DiscordWebhookUrl);
+			Assert.Equal(newEnd.ToUniversalTime(), detail.EndTime);
+
+			// Verify GlobalState was mutated
+			var updated = globalState.GetGames()[0];
+			Assert.Equal("Updated Name", updated.Name);
+			Assert.Equal("https://new.hook", updated.DiscordWebhookUrl);
+		}
+
+		[Fact]
+		public void Update_NullCreatorUserId_AllowsAnyAuthenticatedUser() {
+			// Legacy games created before CreatedByUserId was tracked have null — any authenticated user can edit
+			var globalState = new GlobalState();
+			var record = MakeRecord("game5", createdByUserId: null);
+			globalState.AddGame(record);
+
+			var controller = MakeController(globalState, userId: "anyone");
+			var request = new UpdateGameRequest(
+				Name: "Edited by Anyone",
+				EndTime: record.EndTime.AddDays(1)
+			);
+
+			var result = controller.Update("game5", request);
+
+			Assert.IsType<OkObjectResult>(result.Result);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `PATCH /api/games/{gameId}` endpoint to update game Name, DiscordWebhookUrl, and EndTime
- Store `CreatedByUserId` when creating a game (ownership check for PATCH)
- Add inline edit form to the admin Games page with pre-populated fields

## Details
- Non-admin callers (not the creator) receive 403
- EndTime validation: must remain after StartTime; cannot be shortened for active/finished games
- Changing webhook URL takes effect on next game start/end notification (reads from GlobalState)
- UI shows current values pre-populated; Edit button per game row expands inline form

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (147 tests)
- [ ] Create a game, click Edit, change name/webhook/end time, verify updated in list
- [ ] Verify non-creator user gets 403 from PATCH endpoint
- [ ] Verify EndTime before StartTime returns 400

Closes BGE-266