### PR TITLE
feat: BGE-289 alliance chat / bulletin board

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -68,6 +68,35 @@
             </div>
         </div>
     }
+
+    @if (myStatus.IsMember && !myStatus.IsPending) {
+        <h3>Chat</h3>
+        <div class="card mb-3">
+            <div class="card-body">
+                <div class="input-group mb-2">
+                    <input class="form-control" @bind="newChatBody" placeholder="Write a message..." />
+                    <button class="btn btn-primary" @onclick="PostChat">Send</button>
+                </div>
+            </div>
+        </div>
+        @if (chatPosts == null) {
+            <p><em>Loading chat...</em></p>
+        } else if (chatPosts.Count == 0) {
+            <p class="text-muted">No messages yet. Be the first to post!</p>
+        } else {
+            <div class="list-group">
+                @foreach (var post in chatPosts) {
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between">
+                            <strong>@post.AuthorName</strong>
+                            <small class="text-muted">@post.CreatedAt.ToString("yyyy-MM-dd HH:mm")</small>
+                        </div>
+                        <p class="mb-0">@post.Body</p>
+                    </div>
+                }
+            </div>
+        }
+    }
 }
 
 @code {
@@ -75,8 +104,10 @@
 
     private AllianceDetailViewModel? detail;
     private MyAllianceStatusViewModel? myStatus;
+    private List<AllianceChatPostViewModel>? chatPosts;
     private string newMessage = "";
     private string newPassword = "";
+    private string newChatBody = "";
     private string? lastError;
     private CancellationTokenSource? _cts;
 
@@ -97,6 +128,9 @@
     private async Task Update() {
         detail = await Http.GetFromJsonAsync<AllianceDetailViewModel>($"api/alliances/{AllianceId}");
         myStatus = await Http.GetFromJsonAsync<MyAllianceStatusViewModel>("api/alliances/my-status");
+        if (myStatus?.IsMember == true && myStatus.IsPending == false) {
+            chatPosts = await Http.GetFromJsonAsync<List<AllianceChatPostViewModel>>($"api/alliances/{AllianceId}/posts");
+        }
         lastError = null;
     }
 
@@ -133,6 +167,13 @@
     private async Task SetPassword() {
         var r = await Http.PatchAsJsonAsync($"api/alliances/{AllianceId}/password", new SetAlliancePasswordRequest { NewPassword = newPassword });
         if (r.IsSuccessStatusCode) { newPassword = ""; await Update(); }
+        else lastError = await r.Content.ReadAsStringAsync();
+    }
+
+    private async Task PostChat() {
+        if (string.IsNullOrWhiteSpace(newChatBody)) return;
+        var r = await Http.PostAsJsonAsync($"api/alliances/{AllianceId}/posts", new PostAllianceChatRequest { Body = newChatBody });
+        if (r.IsSuccessStatusCode) { newChatBody = ""; await Update(); }
         else lastError = await r.Content.ReadAsStringAsync();
     }
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -16,17 +16,23 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly AllianceRepository allianceRepository;
 		private readonly AllianceRepositoryWrite allianceRepositoryWrite;
+		private readonly AllianceChatRepository allianceChatRepository;
+		private readonly AllianceChatRepositoryWrite allianceChatRepositoryWrite;
 		private readonly PlayerRepository playerRepository;
 
 		public AlliancesController(
 			CurrentUserContext currentUserContext,
 			AllianceRepository allianceRepository,
 			AllianceRepositoryWrite allianceRepositoryWrite,
+			AllianceChatRepository allianceChatRepository,
+			AllianceChatRepositoryWrite allianceChatRepositoryWrite,
 			PlayerRepository playerRepository
 		) {
 			this.currentUserContext = currentUserContext;
 			this.allianceRepository = allianceRepository;
 			this.allianceRepositoryWrite = allianceRepositoryWrite;
+			this.allianceChatRepository = allianceChatRepository;
+			this.allianceChatRepositoryWrite = allianceChatRepositoryWrite;
 			this.playerRepository = playerRepository;
 		}
 
@@ -205,6 +211,42 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				return StatusCode(403, e.Message);
 			} catch (NotAllianceMemberException e) {
 				return BadRequest(e.Message);
+			}
+		}
+
+		[HttpGet("{id}/posts")]
+		public ActionResult<IEnumerable<AllianceChatPostViewModel>> GetPosts(string id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var allianceId = AllianceIdFactory.Create(id);
+			if (!allianceRepository.IsMember(currentUserContext.PlayerId, allianceId)) {
+				return StatusCode(403, "You are not a member of this alliance.");
+			}
+			var posts = allianceChatRepository.GetPosts(allianceId);
+			return Ok(posts.Select(p => {
+				string authorName;
+				try { authorName = playerRepository.Get(p.AuthorPlayerId).Name; }
+				catch { authorName = p.AuthorPlayerId.Id; }
+				return new AllianceChatPostViewModel {
+					PostId = p.PostId.ToString(),
+					AuthorPlayerId = p.AuthorPlayerId.Id,
+					AuthorName = authorName,
+					Body = p.Body,
+					CreatedAt = p.CreatedAt
+				};
+			}));
+		}
+
+		[HttpPost("{id}/posts")]
+		public ActionResult<string> PostChat(string id, [FromBody] PostAllianceChatRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				var postId = allianceChatRepositoryWrite.Post(
+					new PostAllianceChatCommand(currentUserContext.PlayerId, AllianceIdFactory.Create(id), request.Body));
+				return Ok(postId.ToString());
+			} catch (AllianceNotFoundException) {
+				return NotFound();
+			} catch (NotAllianceMemberException e) {
+				return StatusCode(403, e.Message);
 			}
 		}
 	}

--- a/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
@@ -16,6 +16,7 @@ namespace BrowserGameEngine.GameModel {
 		PlayerId LeaderId,
 		DateTime Created,
 		IList<AllianceMemberImmutable> Members,
-		string? Message = null
+		string? Message = null,
+		IList<AlliancePostImmutable>? Posts = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/AlliancePostImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AlliancePostImmutable.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record AlliancePostId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class AlliancePostIdFactory {
+		public static AlliancePostId Create(Guid id) => new AlliancePostId(id);
+		public static AlliancePostId Create(string id) => new AlliancePostId(Guid.Parse(id));
+		public static AlliancePostId NewPostId() => new AlliancePostId(Guid.NewGuid());
+	}
+
+	public record AlliancePostImmutable(
+		AlliancePostId PostId,
+		AllianceId AllianceId,
+		PlayerId AuthorPlayerId,
+		string Body,
+		DateTime CreatedAt
+	);
+}

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -56,4 +56,16 @@ namespace BrowserGameEngine.Shared {
 	public class SetAllianceMessageRequest {
 		public string Message { get; set; }
 	}
+
+	public class AllianceChatPostViewModel {
+		public string PostId { get; set; }
+		public string AuthorPlayerId { get; set; }
+		public string AuthorName { get; set; }
+		public string Body { get; set; }
+		public DateTime CreatedAt { get; set; }
+	}
+
+	public class PostAllianceChatRequest {
+		public string Body { get; set; }
+	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -14,6 +14,7 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record VoteLeaderCommand(PlayerId PlayerId, PlayerId VoteePlayerId) : ICommand;
 	public record SetAlliancePasswordCommand(PlayerId PlayerId, string NewPassword) : ICommand;
 	public record SetAllianceMessageCommand(PlayerId PlayerId, string Message) : ICommand;
+	public record PostAllianceChatCommand(PlayerId PlayerId, AllianceId AllianceId, string Body) : ICommand;
 
 	public record BuildAssetCommand(PlayerId PlayerId, AssetDefId AssetDefId) : ICommand;
 	public record BuildUnitCommand(PlayerId PlayerId, UnitDefId UnitDefId, int Count) : ICommand;

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
@@ -11,6 +11,14 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int VoteCount { get; set; }
 	}
 
+	internal class AlliancePost {
+		public AlliancePostId PostId { get; set; } = default!;
+		public AllianceId AllianceId { get; set; } = default!;
+		public PlayerId AuthorPlayerId { get; set; } = default!;
+		public string Body { get; set; } = string.Empty;
+		public DateTime CreatedAt { get; set; }
+	}
+
 	internal class Alliance {
 		public AllianceId AllianceId { get; init; }
 		public string Name { get; set; }
@@ -19,6 +27,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public DateTime Created { get; init; }
 		public List<AllianceMember> Members { get; set; } = new List<AllianceMember>();
 		public string? Message { get; set; }
+		public List<AlliancePost> Posts { get; set; } = new List<AlliancePost>();
 	}
 
 	internal static class AllianceExtensions {
@@ -40,6 +49,26 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			};
 		}
 
+		internal static AlliancePostImmutable ToImmutable(this AlliancePost post) {
+			return new AlliancePostImmutable(
+				PostId: post.PostId,
+				AllianceId: post.AllianceId,
+				AuthorPlayerId: post.AuthorPlayerId,
+				Body: post.Body,
+				CreatedAt: post.CreatedAt
+			);
+		}
+
+		internal static AlliancePost ToMutable(this AlliancePostImmutable post) {
+			return new AlliancePost {
+				PostId = post.PostId,
+				AllianceId = post.AllianceId,
+				AuthorPlayerId = post.AuthorPlayerId,
+				Body = post.Body,
+				CreatedAt = post.CreatedAt
+			};
+		}
+
 		internal static AllianceImmutable ToImmutable(this Alliance alliance) {
 			return new AllianceImmutable(
 				AllianceId: alliance.AllianceId,
@@ -48,7 +77,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				LeaderId: alliance.LeaderId,
 				Created: alliance.Created,
 				Members: alliance.Members.Select(m => m.ToImmutable()).ToList(),
-				Message: alliance.Message
+				Message: alliance.Message,
+				Posts: alliance.Posts.Select(p => p.ToImmutable()).ToList()
 			);
 		}
 
@@ -60,7 +90,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				LeaderId = alliance.LeaderId,
 				Created = alliance.Created,
 				Members = alliance.Members.Select(m => m.ToMutable()).ToList(),
-				Message = alliance.Message
+				Message = alliance.Message,
+				Posts = alliance.Posts?.Select(p => p.ToMutable()).ToList() ?? new List<AlliancePost>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -33,6 +33,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<ScoreRepository>();
 			services.AddSingleton<AllianceRepository>();
 			services.AddSingleton<AllianceRepositoryWrite>();
+			services.AddSingleton<AllianceChatRepository>();
+			services.AddSingleton<AllianceChatRepositoryWrite>();
 			services.AddSingleton<AllianceScoreRepository>();
 			services.AddSingleton<AssetRepository>();
 			services.AddSingleton<AssetRepositoryWrite>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepository.cs
@@ -1,0 +1,24 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceChatRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public AllianceChatRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IList<AlliancePostImmutable> GetPosts(AllianceId allianceId, int count = 50) {
+			if (!world.Alliances.TryGetValue(allianceId, out var alliance)) return new List<AlliancePostImmutable>();
+			return alliance.Posts
+				.Select(p => p.ToImmutable())
+				.OrderByDescending(p => p.CreatedAt)
+				.Take(count)
+				.ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
@@ -1,0 +1,37 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceChatRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly TimeProvider timeProvider;
+
+		public AllianceChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.timeProvider = timeProvider;
+		}
+
+		public AlliancePostId Post(PostAllianceChatCommand command) {
+			var postId = AlliancePostIdFactory.NewPostId();
+			lock (_lock) {
+				var alliance = world.GetAlliance(command.AllianceId);
+				if (!alliance.Members.Exists(m => m.PlayerId == command.PlayerId && !m.IsPending)) {
+					throw new NotAllianceMemberException();
+				}
+				alliance.Posts.Add(new AlliancePost {
+					PostId = postId,
+					AllianceId = command.AllianceId,
+					AuthorPlayerId = command.PlayerId,
+					Body = command.Body,
+					CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+				});
+			}
+			return postId;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add alliance-scoped message board so alliance members can coordinate strategy
- Alliance members can post and read messages in their alliance chat; non-members receive 403
- Posts persist across server restarts via WorldState serialization

## Changes
- `AlliancePostImmutable` record + `AlliancePostId` in `GameModel`
- `AlliancePost` mutable class in `GameModelInternal`; `Alliance` extended with `Posts` list
- `PostAllianceChatCommand` added to `Commands`
- `AllianceChatRepository` (read) and `AllianceChatRepositoryWrite` (write) with lock-based thread safety
- `GET /api/alliances/{id}/posts` and `POST /api/alliances/{id}/posts` in `AlliancesController`
- `AllianceChatPostViewModel` and `PostAllianceChatRequest` in `Shared`
- Chat section with compose box and 10s auto-refresh added to `AllianceDetail.razor`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (147 tests)
- [ ] Alliance member can post a message and see it appear in the chat section
- [ ] Non-member attempting POST /api/alliances/{id}/posts receives 403
- [ ] Chat auto-refreshes every 10 seconds without full page reload
- [ ] Posts persist after server restart

Closes BGE-289