### PR TITLE
feat: BGE-290 resource trading market

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Market.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Market.razor
@@ -1,0 +1,158 @@
+@page "/market"
+@page "/games/{GameId}/market"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@implements IDisposable
+
+<h1>Market</h1>
+
+<div class="container">
+
+    <_PlayerResources />
+
+    @if (model == null) {
+        <p><em>Loading...</em></p>
+    } else {
+        @if (!string.IsNullOrEmpty(lastError)) {
+            <span class="error">@lastError</span>
+        }
+
+        <div class="row mt-3">
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Post Trade Offer</h5>
+                        <div class="mb-2">
+                            <label class="form-label">Offer resource</label>
+                            <input class="form-control" @bind="offerResourceId" placeholder="e.g. minerals" />
+                        </div>
+                        <div class="mb-2">
+                            <label class="form-label">Amount to offer</label>
+                            <input type="number" class="form-control" @bind="offerAmount" min="1" />
+                        </div>
+                        <div class="mb-2">
+                            <label class="form-label">Want resource</label>
+                            <input class="form-control" @bind="wantResourceId" placeholder="e.g. gas" />
+                        </div>
+                        <div class="mb-2">
+                            <label class="form-label">Amount wanted</label>
+                            <input type="number" class="form-control" @bind="wantAmount" min="1" />
+                        </div>
+                        <button class="btn btn-primary mt-2" @onclick="PostOffer">Post Offer</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col-12">
+                <h5>Open Orders</h5>
+                @if (!model.OpenOrders.Any()) {
+                    <p>No open orders. Be the first to post one!</p>
+                } else {
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Seller</th>
+                                <th>Offering</th>
+                                <th>Wants</th>
+                                <th>Posted</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var order in model.OpenOrders) {
+                                <tr>
+                                    <td>@order.SellerPlayerName</td>
+                                    <td>@order.OfferedAmount @order.OfferedResourceName</td>
+                                    <td>@order.WantedAmount @order.WantedResourceName</td>
+                                    <td>@order.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
+                                    <td>
+                                        <button class="btn btn-sm btn-success" @onclick="() => Accept(order.OrderId)">Accept</button>
+                                        <button class="btn btn-sm btn-danger ms-1" @onclick="() => Cancel(order.OrderId)">Cancel</button>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public string? GameId { get; set; }
+
+    private MarketViewModel? model;
+    private string? lastError;
+    private string offerResourceId = "";
+    private decimal offerAmount = 100;
+    private string wantResourceId = "";
+    private decimal wantAmount = 100;
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnInitializedAsync() {
+        await Update();
+        _cts = new CancellationTokenSource();
+        _ = RunRefreshLoop(_cts.Token);
+    }
+
+    private async Task RunRefreshLoop(CancellationToken ct) {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+            await InvokeAsync(Update);
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task Update() {
+        model = await Http.GetFromJsonAsync<MarketViewModel>("api/market");
+    }
+
+    private async Task PostOffer() {
+        lastError = null;
+        var request = new CreateMarketOrderRequest {
+            OfferedResourceId = offerResourceId,
+            OfferedAmount = offerAmount,
+            WantedResourceId = wantResourceId,
+            WantedAmount = wantAmount
+        };
+        var response = await Http.PostAsJsonAsync("api/market", request);
+        if (response.IsSuccessStatusCode) {
+            offerResourceId = "";
+            offerAmount = 100;
+            wantResourceId = "";
+            wantAmount = 100;
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task Accept(Guid orderId) {
+        lastError = null;
+        var response = await Http.PostAsJsonAsync($"api/market/accept?orderId={orderId}", "");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task Cancel(Guid orderId) {
+        lastError = null;
+        var response = await Http.DeleteAsync($"api/market/cancel?orderId={orderId}");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    public void Dispose() {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -49,6 +49,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="market">
+                <span class="oi oi-cart" aria-hidden="true"></span> Market
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="ranking">
                 <span class="oi oi-bar-chart" aria-hidden="true"></span> Ranking
             </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
@@ -1,0 +1,134 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}/{id?}")]
+	public class MarketController : ControllerBase {
+		private readonly ILogger<MarketController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly MarketRepository marketRepository;
+		private readonly MarketRepositoryWrite marketRepositoryWrite;
+		private readonly PlayerRepository playerRepository;
+		private readonly GameDef gameDef;
+
+		public MarketController(
+			ILogger<MarketController> logger,
+			CurrentUserContext currentUserContext,
+			MarketRepository marketRepository,
+			MarketRepositoryWrite marketRepositoryWrite,
+			PlayerRepository playerRepository,
+			GameDef gameDef
+		) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.marketRepository = marketRepository;
+			this.marketRepositoryWrite = marketRepositoryWrite;
+			this.playerRepository = playerRepository;
+			this.gameDef = gameDef;
+		}
+
+		[HttpGet]
+		public ActionResult<MarketViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var orders = marketRepository.GetOpenOrders();
+			var viewModel = new MarketViewModel {
+				OpenOrders = orders.Select(o => ToViewModel(o)).ToList()
+			};
+			return viewModel;
+		}
+
+		[HttpPost]
+		public ActionResult Post([FromBody] CreateMarketOrderRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			if (request.OfferedAmount <= 0 || request.WantedAmount <= 0)
+				return BadRequest("Amounts must be positive.");
+			if (string.IsNullOrEmpty(request.OfferedResourceId) || string.IsNullOrEmpty(request.WantedResourceId))
+				return BadRequest("Resource IDs are required.");
+
+			try {
+				marketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+					PlayerId: currentUserContext.PlayerId!,
+					OfferedResourceId: Id.ResDef(request.OfferedResourceId),
+					OfferedAmount: request.OfferedAmount,
+					WantedResourceId: Id.ResDef(request.WantedResourceId),
+					WantedAmount: request.WantedAmount
+				));
+				return Ok();
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			} catch (InvalidOperationException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		[HttpPost]
+		public ActionResult Accept([FromQuery] Guid orderId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			try {
+				marketRepositoryWrite.AcceptOrder(new AcceptMarketOrderCommand(
+					BuyerPlayerId: currentUserContext.PlayerId!,
+					OrderId: MarketOrderIdFactory.Create(orderId)
+				));
+				return Ok();
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			} catch (InvalidOperationException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		[HttpDelete]
+		public ActionResult Cancel([FromQuery] Guid orderId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			try {
+				marketRepositoryWrite.CancelOrder(new CancelMarketOrderCommand(
+					PlayerId: currentUserContext.PlayerId!,
+					OrderId: MarketOrderIdFactory.Create(orderId)
+				));
+				return Ok();
+			} catch (InvalidOperationException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		private MarketOrderViewModel ToViewModel(MarketOrderImmutable order) {
+			var sellerName = TryGetPlayerName(order.SellerPlayerId);
+			var offeredRes = gameDef.Resources.FirstOrDefault(r => r.Id == order.OfferedResourceId);
+			var wantedRes = gameDef.Resources.FirstOrDefault(r => r.Id == order.WantedResourceId);
+			return new MarketOrderViewModel {
+				OrderId = order.OrderId.Id,
+				SellerPlayerId = order.SellerPlayerId.Id,
+				SellerPlayerName = sellerName,
+				OfferedResourceId = order.OfferedResourceId.Id,
+				OfferedResourceName = offeredRes?.Name ?? order.OfferedResourceId.Id,
+				OfferedAmount = order.OfferedAmount,
+				WantedResourceId = order.WantedResourceId.Id,
+				WantedResourceName = wantedRes?.Name ?? order.WantedResourceId.Id,
+				WantedAmount = order.WantedAmount,
+				CreatedAt = order.CreatedAt
+			};
+		}
+
+		private string TryGetPlayerName(PlayerId playerId) {
+			try {
+				return playerRepository.Get(playerId).Name;
+			} catch {
+				return playerId.Id;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameModel/MarketOrderId.cs
+++ b/src/BrowserGameEngine.GameModel/MarketOrderId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record MarketOrderId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class MarketOrderIdFactory {
+		public static MarketOrderId Create(Guid id) => new MarketOrderId(id);
+		public static MarketOrderId Create(string id) => new MarketOrderId(Guid.Parse(id));
+		public static MarketOrderId NewMarketOrderId() => new MarketOrderId(Guid.NewGuid());
+	}
+}

--- a/src/BrowserGameEngine.GameModel/MarketOrderImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/MarketOrderImmutable.cs
@@ -1,0 +1,21 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public enum MarketOrderStatus {
+		Open,
+		Filled,
+		Cancelled
+	}
+
+	public record MarketOrderImmutable(
+		MarketOrderId OrderId,
+		PlayerId SellerPlayerId,
+		ResourceDefId OfferedResourceId,
+		decimal OfferedAmount,
+		ResourceDefId WantedResourceId,
+		decimal WantedAmount,
+		DateTime CreatedAt,
+		MarketOrderStatus Status
+	);
+}

--- a/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
@@ -6,6 +6,7 @@ namespace BrowserGameEngine.GameModel {
 		GameTickStateImmutable GameTickState,
 		IList<GameActionImmutable> GameActionQueue,
 		IDictionary<AllianceId, AllianceImmutable>? Alliances = null,
-		GameId? GameId = null  // null = legacy JSON; treated as "default" in ToMutable()
+		GameId? GameId = null,  // null = legacy JSON; treated as "default" in ToMutable()
+		IList<MarketOrderImmutable>? MarketOrders = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/MarketViewModels.cs
+++ b/src/BrowserGameEngine.Shared/MarketViewModels.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public record MarketOrderViewModel {
+		public Guid OrderId { get; set; }
+		public string SellerPlayerId { get; set; } = "";
+		public string SellerPlayerName { get; set; } = "";
+		public string OfferedResourceId { get; set; } = "";
+		public string OfferedResourceName { get; set; } = "";
+		public decimal OfferedAmount { get; set; }
+		public string WantedResourceId { get; set; } = "";
+		public string WantedResourceName { get; set; } = "";
+		public decimal WantedAmount { get; set; }
+		public DateTime CreatedAt { get; set; }
+	}
+
+	public record MarketViewModel {
+		public List<MarketOrderViewModel> OpenOrders { get; set; } = new();
+	}
+
+	public record CreateMarketOrderRequest {
+		public string OfferedResourceId { get; set; } = "";
+		public decimal OfferedAmount { get; set; }
+		public string WantedResourceId { get; set; } = "";
+		public decimal WantedAmount { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MarketTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MarketTest.cs
@@ -1,0 +1,175 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class MarketTest {
+		[Fact]
+		public void CreateOrder_DeductsOfferedResourcesFromSeller() {
+			var game = new TestGame(playerCount: 2);
+			var seller = game.WorldStateFactory.Player1;
+			var initialRes1 = game.ResourceRepository.GetAmount(seller, Id.ResDef("res1"));
+
+			game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 200
+			));
+
+			var afterRes1 = game.ResourceRepository.GetAmount(seller, Id.ResDef("res1"));
+			Assert.Equal(initialRes1 - 100, afterRes1);
+		}
+
+		[Fact]
+		public void CreateOrder_AppearsinOpenOrders() {
+			var game = new TestGame(playerCount: 1);
+			var seller = game.WorldStateFactory.Player1;
+
+			game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 200
+			));
+
+			var orders = game.MarketRepository.GetOpenOrders();
+			Assert.Single(orders);
+			Assert.Equal(seller, orders[0].SellerPlayerId);
+			Assert.Equal(Id.ResDef("res1"), orders[0].OfferedResourceId);
+			Assert.Equal(100, orders[0].OfferedAmount);
+		}
+
+		[Fact]
+		public void AcceptOrder_TransfersResourcesBothWays() {
+			var game = new TestGame(playerCount: 2);
+			var seller = PlayerIdFactory.Create("player0");
+			var buyer = PlayerIdFactory.Create("player1");
+
+			var sellerRes1Before = game.ResourceRepository.GetAmount(seller, Id.ResDef("res1"));
+			var sellerRes2Before = game.ResourceRepository.GetAmount(seller, Id.ResDef("res2"));
+			var buyerRes1Before = game.ResourceRepository.GetAmount(buyer, Id.ResDef("res1"));
+			var buyerRes2Before = game.ResourceRepository.GetAmount(buyer, Id.ResDef("res2"));
+
+			var orderId = game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 200
+			));
+
+			game.MarketRepositoryWrite.AcceptOrder(new AcceptMarketOrderCommand(
+				BuyerPlayerId: buyer,
+				OrderId: orderId
+			));
+
+			// Seller: lost res1 (offered), gained res2 (wanted)
+			Assert.Equal(sellerRes1Before - 100, game.ResourceRepository.GetAmount(seller, Id.ResDef("res1")));
+			Assert.Equal(sellerRes2Before + 200, game.ResourceRepository.GetAmount(seller, Id.ResDef("res2")));
+
+			// Buyer: gained res1 (offered by seller), lost res2 (wanted by seller)
+			Assert.Equal(buyerRes1Before + 100, game.ResourceRepository.GetAmount(buyer, Id.ResDef("res1")));
+			Assert.Equal(buyerRes2Before - 200, game.ResourceRepository.GetAmount(buyer, Id.ResDef("res2")));
+
+			// Order is no longer open
+			var orders = game.MarketRepository.GetOpenOrders();
+			Assert.Empty(orders);
+		}
+
+		[Fact]
+		public void CancelOrder_RefundsOfferedResourcesToSeller() {
+			var game = new TestGame(playerCount: 1);
+			var seller = game.WorldStateFactory.Player1;
+			var initialRes1 = game.ResourceRepository.GetAmount(seller, Id.ResDef("res1"));
+
+			var orderId = game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 200
+			));
+
+			game.MarketRepositoryWrite.CancelOrder(new CancelMarketOrderCommand(
+				PlayerId: seller,
+				OrderId: orderId
+			));
+
+			// Resources fully refunded
+			Assert.Equal(initialRes1, game.ResourceRepository.GetAmount(seller, Id.ResDef("res1")));
+
+			// Order is no longer open
+			var orders = game.MarketRepository.GetOpenOrders();
+			Assert.Empty(orders);
+		}
+
+		[Fact]
+		public void AcceptOrder_CannotAcceptOwnOrder() {
+			var game = new TestGame(playerCount: 1);
+			var seller = game.WorldStateFactory.Player1;
+
+			var orderId = game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 200
+			));
+
+			Assert.Throws<InvalidOperationException>(() =>
+				game.MarketRepositoryWrite.AcceptOrder(new AcceptMarketOrderCommand(
+					BuyerPlayerId: seller,
+					OrderId: orderId
+				))
+			);
+		}
+
+		[Fact]
+		public void CreateOrder_InsufficientResources_Throws() {
+			var game = new TestGame(playerCount: 1);
+			var seller = game.WorldStateFactory.Player1;
+
+			Assert.Throws<CannotAffordException>(() =>
+				game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+					PlayerId: seller,
+					OfferedResourceId: Id.ResDef("res1"),
+					OfferedAmount: 999999,  // more than player has
+					WantedResourceId: Id.ResDef("res2"),
+					WantedAmount: 100
+				))
+			);
+		}
+
+		[Fact]
+		public void MarketOrders_RoundTripThroughImmutable() {
+			var game = new TestGame(playerCount: 1);
+			var seller = game.WorldStateFactory.Player1;
+
+			game.MarketRepositoryWrite.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: seller,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 50,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 100
+			));
+
+			// Serialize to immutable
+			var snapshot = game.World.ToImmutable();
+			Assert.NotNull(snapshot.MarketOrders);
+			Assert.Single(snapshot.MarketOrders!);
+			Assert.Equal(50, snapshot.MarketOrders![0].OfferedAmount);
+			Assert.Equal(MarketOrderStatus.Open, snapshot.MarketOrders![0].Status);
+
+			// Restore from immutable and verify via repository
+			var restoredGame = new TestGame(snapshot);
+			var restoredOrders = restoredGame.MarketRepository.GetOpenOrders();
+			Assert.Single(restoredOrders);
+			Assert.Equal(50, restoredOrders[0].OfferedAmount);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -35,6 +35,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public MessageRepositoryWrite MessageRepositoryWrite { get; }
 		public BuildQueueRepository BuildQueueRepository { get; }
 		public BuildQueueRepositoryWrite BuildQueueRepositoryWrite { get; }
+		public MarketRepository MarketRepository { get; }
+		public MarketRepositoryWrite MarketRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -68,6 +70,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			MessageRepositoryWrite = new MessageRepositoryWrite(Accessor, TimeProvider.System);
 			BuildQueueRepository = new BuildQueueRepository(Accessor);
 			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), Accessor, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
+			MarketRepository = new MarketRepository(Accessor);
+			MarketRepositoryWrite = new MarketRepositoryWrite(Accessor, MarketRepository, ResourceRepository, ResourceRepositoryWrite);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -33,4 +33,8 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record RemoveFromQueueCommand(PlayerId PlayerId, Guid EntryId) : ICommand;
 	public record ReorderQueueCommand(PlayerId PlayerId, Guid EntryId, int NewPriority) : ICommand;
 	public record TradeResourceCommand(PlayerId PlayerId, ResourceDefId FromResource, int Amount) : ICommand;
+
+	public record CreateMarketOrderCommand(PlayerId PlayerId, ResourceDefId OfferedResourceId, decimal OfferedAmount, ResourceDefId WantedResourceId, decimal WantedAmount) : ICommand;
+	public record AcceptMarketOrderCommand(PlayerId BuyerPlayerId, MarketOrderId OrderId) : ICommand;
+	public record CancelMarketOrderCommand(PlayerId PlayerId, MarketOrderId OrderId) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/MarketOrder.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/MarketOrder.cs
@@ -1,0 +1,54 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class MarketOrder {
+		internal required MarketOrderId OrderId { get; init; }
+		internal required PlayerId SellerPlayerId { get; init; }
+		internal required ResourceDefId OfferedResourceId { get; init; }
+		internal required decimal OfferedAmount { get; init; }
+		internal required ResourceDefId WantedResourceId { get; init; }
+		internal required decimal WantedAmount { get; init; }
+		internal required DateTime CreatedAt { get; init; }
+		internal MarketOrderStatus Status { get; set; } = MarketOrderStatus.Open;
+	}
+
+	internal static class MarketOrderExtensions {
+		internal static MarketOrderImmutable ToImmutable(this MarketOrder order) {
+			return new MarketOrderImmutable(
+				OrderId: order.OrderId,
+				SellerPlayerId: order.SellerPlayerId,
+				OfferedResourceId: order.OfferedResourceId,
+				OfferedAmount: order.OfferedAmount,
+				WantedResourceId: order.WantedResourceId,
+				WantedAmount: order.WantedAmount,
+				CreatedAt: order.CreatedAt,
+				Status: order.Status
+			);
+		}
+
+		internal static MarketOrder ToMutable(this MarketOrderImmutable order) {
+			return new MarketOrder {
+				OrderId = order.OrderId,
+				SellerPlayerId = order.SellerPlayerId,
+				OfferedResourceId = order.OfferedResourceId,
+				OfferedAmount = order.OfferedAmount,
+				WantedResourceId = order.WantedResourceId,
+				WantedAmount = order.WantedAmount,
+				CreatedAt = order.CreatedAt,
+				Status = order.Status
+			};
+		}
+
+		internal static IList<MarketOrderImmutable> ToImmutable(this IList<MarketOrder> orders) {
+			return orders.Select(o => o.ToImmutable()).ToList();
+		}
+
+		internal static IList<MarketOrder> ToMutable(this IList<MarketOrderImmutable> orders) {
+			return orders.Select(o => o.ToMutable()).ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -18,6 +18,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 		internal IList<GameAction> GameActionQueue { get; set; } = new List<GameAction>();
 
+		internal IList<MarketOrder> MarketOrders { get; set; } = new List<MarketOrder>();
+
 		// throws if player not found
 		internal Player GetPlayer(PlayerId playerId) {
 			if (Players.TryGetValue(playerId, out Player? player)) return player;
@@ -63,6 +65,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			worldState.Alliances = mutable.Alliances;
 			worldState.GameTickState = mutable.GameTickState;
 			worldState.GameActionQueue = mutable.GameActionQueue;
+			worldState.MarketOrders = mutable.MarketOrders;
 		}
 
 
@@ -72,7 +75,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GameTickState: worldState.GameTickState.ToImmutable(),
 				GameActionQueue: worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList(),
 				Alliances: worldState.Alliances.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
-				GameId: worldState.GameId
+				GameId: worldState.GameId,
+				MarketOrders: worldState.MarketOrders.ToImmutable()
 			);
 		}
 
@@ -82,7 +86,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Players = new ConcurrentDictionary<PlayerId, Player>(worldStateImmutable.Players.ToDictionary(x => x.Key, y => y.Value.ToMutable())),
 				Alliances = new ConcurrentDictionary<AllianceId, Alliance>(worldStateImmutable.Alliances?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<AllianceId, Alliance>()),
 				GameTickState = worldStateImmutable.GameTickState.ToMutable(),
-				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList()
+				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList(),
+				MarketOrders = worldStateImmutable.MarketOrders?.ToMutable() ?? new List<MarketOrder>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -47,6 +47,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<UpgradeRepositoryWrite>();
 			services.AddSingleton<BuildQueueRepository>();
 			services.AddSingleton<BuildQueueRepositoryWrite>();
+			services.AddSingleton<MarketRepository>();
+			services.AddSingleton<MarketRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepository.cs
@@ -1,0 +1,26 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class MarketRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public MarketRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IList<MarketOrderImmutable> GetOpenOrders() {
+			return world.MarketOrders
+				.Where(o => o.Status == MarketOrderStatus.Open)
+				.Select(o => o.ToImmutable())
+				.ToList();
+		}
+
+		internal MarketOrder? GetOrderMutable(MarketOrderId orderId) {
+			return world.MarketOrders.SingleOrDefault(o => o.OrderId == orderId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepositoryWrite.cs
@@ -1,0 +1,97 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class MarketRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly MarketRepository marketRepository;
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+
+		public MarketRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			MarketRepository marketRepository,
+			ResourceRepository resourceRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite
+		) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.marketRepository = marketRepository;
+			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+		}
+
+		public MarketOrderId CreateOrder(CreateMarketOrderCommand cmd) {
+			lock (_lock) {
+				world.ValidatePlayer(cmd.PlayerId);
+
+				if (cmd.OfferedAmount <= 0) throw new InvalidOperationException("Offered amount must be positive.");
+				if (cmd.WantedAmount <= 0) throw new InvalidOperationException("Wanted amount must be positive.");
+				if (cmd.OfferedResourceId == cmd.WantedResourceId) throw new InvalidOperationException("Cannot trade a resource for itself.");
+
+				// Deduct offered resources immediately (lock them in the order)
+				resourceRepositoryWrite.DeductCost(cmd.PlayerId, cmd.OfferedResourceId, cmd.OfferedAmount);
+
+				var order = new MarketOrder {
+					OrderId = MarketOrderIdFactory.NewMarketOrderId(),
+					SellerPlayerId = cmd.PlayerId,
+					OfferedResourceId = cmd.OfferedResourceId,
+					OfferedAmount = cmd.OfferedAmount,
+					WantedResourceId = cmd.WantedResourceId,
+					WantedAmount = cmd.WantedAmount,
+					CreatedAt = DateTime.UtcNow,
+					Status = MarketOrderStatus.Open
+				};
+
+				world.MarketOrders.Add(order);
+				return order.OrderId;
+			}
+		}
+
+		public void AcceptOrder(AcceptMarketOrderCommand cmd) {
+			lock (_lock) {
+				world.ValidatePlayer(cmd.BuyerPlayerId);
+
+				var order = marketRepository.GetOrderMutable(cmd.OrderId)
+					?? throw new InvalidOperationException("Order not found.");
+
+				if (order.Status != MarketOrderStatus.Open)
+					throw new InvalidOperationException("Order is no longer open.");
+
+				if (order.SellerPlayerId == cmd.BuyerPlayerId)
+					throw new InvalidOperationException("Cannot accept your own order.");
+
+				// Buyer pays the wanted amount
+				resourceRepositoryWrite.DeductCost(cmd.BuyerPlayerId, order.WantedResourceId, order.WantedAmount);
+
+				// Transfer: seller gets wanted resources, buyer gets offered resources
+				resourceRepositoryWrite.AddResources(order.SellerPlayerId, order.WantedResourceId, order.WantedAmount);
+				resourceRepositoryWrite.AddResources(cmd.BuyerPlayerId, order.OfferedResourceId, order.OfferedAmount);
+
+				order.Status = MarketOrderStatus.Filled;
+			}
+		}
+
+		public void CancelOrder(CancelMarketOrderCommand cmd) {
+			lock (_lock) {
+				var order = marketRepository.GetOrderMutable(cmd.OrderId)
+					?? throw new InvalidOperationException("Order not found.");
+
+				if (order.Status != MarketOrderStatus.Open)
+					throw new InvalidOperationException("Order is no longer open.");
+
+				if (order.SellerPlayerId != cmd.PlayerId)
+					throw new InvalidOperationException("Cannot cancel another player's order.");
+
+				// Refund offered resources to seller
+				resourceRepositoryWrite.AddResources(cmd.PlayerId, order.OfferedResourceId, order.OfferedAmount);
+
+				order.Status = MarketOrderStatus.Cancelled;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `MarketOrderImmutable` model and `MarketOrderId` in GameModel; extend `WorldStateImmutable` with optional `MarketOrders` list (backward-compatible with existing saved state)
- Add mutable `MarketOrder` in GameModelInternal; update `WorldState` + ToImmutable/ToMutable conversions
- Add `CreateMarketOrderCommand`, `AcceptMarketOrderCommand`, `CancelMarketOrderCommand`
- Add `MarketRepository` (read) and `MarketRepositoryWrite` (write) with proper lock-based thread safety
- Offered resources are deducted immediately on order creation, refunded on cancel, transferred atomically on accept
- Add `MarketController` with GET (list open orders), POST (create), POST /accept, DELETE /cancel endpoints
- Add `Market.razor` Blazor page at `/market` with order table + post-offer form + 10s auto-refresh
- Add "Market" nav entry in NavMenu
- 7 new xUnit tests covering all key operations including serialization round-trip

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (154 tests, 7 new)
- [ ] Navigate to /market as a logged-in player — page loads with empty orders
- [ ] Post a trade offer — resource is deducted, order appears in table
- [ ] Accept another player's order — resources transfer correctly to both players
- [ ] Cancel own order — resource is refunded
- [ ] Cannot accept own order — error shown

Closes BGE-290