### PR TITLE
feat: BGE-292 player achievements page

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Achievements.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Achievements.razor
@@ -1,0 +1,114 @@
+@page "/achievements"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+
+<h1>Achievements</h1>
+<p class="text-muted">Your earned badges across all games.</p>
+
+<style>
+	.achievement-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+		gap: 1rem;
+	}
+
+	.achievement-card {
+		background: #1e2a3a;
+		border: 1px solid #2c3e50;
+		border-radius: 0.5rem;
+		padding: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		transition: border-color 0.2s;
+	}
+
+	.achievement-card:hover {
+		border-color: #4a6fa5;
+	}
+
+	.achievement-card.winner {
+		border-color: #ffd700;
+		background: linear-gradient(135deg, #1e2a3a 0%, #2a2208 100%);
+	}
+
+	.achievement-card.runner-up {
+		border-color: #c0c0c0;
+	}
+
+	.achievement-card.top3 {
+		border-color: #cd7f32;
+	}
+
+	.achievement-icon {
+		font-size: 2rem;
+		line-height: 1;
+	}
+
+	.achievement-label {
+		font-weight: bold;
+		font-size: 1rem;
+		color: #e0e0e0;
+	}
+
+	.achievement-game {
+		font-size: 0.85rem;
+		color: #90a8c8;
+	}
+
+	.achievement-meta {
+		font-size: 0.78rem;
+		color: #607080;
+		margin-top: auto;
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: 3rem 1rem;
+		color: #607080;
+	}
+
+	.empty-state .empty-icon {
+		font-size: 4rem;
+		margin-bottom: 1rem;
+	}
+</style>
+
+@if (model == null) {
+	<div class="d-flex align-items-center gap-2">
+		<div class="spinner-border spinner-border-sm" role="status"></div>
+		<span>Loading achievements...</span>
+	</div>
+} else if (model.Achievements.Count == 0) {
+	<div class="empty-state">
+		<div class="empty-icon">🎯</div>
+		<h4>No achievements yet</h4>
+		<p>Complete your first game to earn your first badge!</p>
+		<a class="btn btn-primary" href="games">Browse Games</a>
+	</div>
+} else {
+	<p class="mb-3"><strong>@model.Achievements.Count</strong> achievement@(model.Achievements.Count == 1 ? "" : "s") earned</p>
+	<div class="achievement-grid">
+		@foreach (var a in model.Achievements) {
+			<div class="achievement-card @a.AchievementType">
+				<div class="achievement-icon">@a.AchievementIcon</div>
+				<div class="achievement-label">@a.AchievementLabel</div>
+				<div class="achievement-game">@a.GameName</div>
+				<div class="achievement-meta">
+					<span>Rank #@a.FinalRank &nbsp;·&nbsp; Score: @a.Score.ToString("N0")</span>
+					<span>@a.EarnedAt.ToString("yyyy-MM-dd")</span>
+				</div>
+			</div>
+		}
+	</div>
+}
+
+@code {
+	private PlayerAchievementsViewModel? model;
+
+	protected override async Task OnInitializedAsync() {
+		model = await Http.GetFromJsonAsync<PlayerAchievementsViewModel>("api/players/me/achievements");
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Achievements.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Achievements.razor
@@ -1,5 +1,7 @@
 @page "/achievements"
 @using BrowserGameEngine.Shared
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @inject HttpClient Http
 
 <h1>Achievements</h1>

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
@@ -23,6 +23,9 @@
             <button type="submit">Submit</button>
         </EditForm>
     </div>
+    <div class="mt-3">
+        <a class="btn btn-outline-secondary btn-sm" href="achievements">View Achievements</a>
+    </div>
 }
 
 @code {

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -86,6 +86,11 @@
                 <span class="oi oi-account-login" aria-hidden="true"></span> Profile
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="achievements">
+                <span class="oi oi-star" aria-hidden="true"></span> Achievements
+            </NavLink>
+        </li>
         <AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="history">

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -86,12 +86,12 @@
                 <span class="oi oi-account-login" aria-hidden="true"></span> Profile
             </NavLink>
         </li>
+        <AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="achievements">
                 <span class="oi oi-star" aria-hidden="true"></span> Achievements
             </NavLink>
         </li>
-        <AuthorizeView>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="history">
                 <span class="oi oi-clock" aria-hidden="true"></span> History

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AchievementMapper.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AchievementMapper.cs
@@ -1,0 +1,28 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+
+namespace BrowserGameEngine.FrontendServer.Controllers;
+
+internal static class AchievementMapper
+{
+	internal static AchievementViewModel ToViewModel(PlayerAchievementImmutable a, string gameName)
+	{
+		var (type, label, icon) = a.FinalRank switch {
+			1 => ("winner", "Commander Victory", "🏆"),
+			2 => ("runner-up", "Runner-Up", "🥈"),
+			3 => ("top3", "Top 3 Finish", "🥉"),
+			_ => ("competitor", "Game Completed", "⚔️")
+		};
+		return new AchievementViewModel(
+			AchievementType: type,
+			AchievementLabel: label,
+			AchievementIcon: icon,
+			GameId: a.GameId.Id,
+			GameName: gameName,
+			GameDefType: a.GameDefType,
+			FinalRank: a.FinalRank,
+			Score: a.FinalScore,
+			EarnedAt: a.FinishedAt
+		);
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AchievementMapper.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AchievementMapper.cs
@@ -1,28 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
-namespace BrowserGameEngine.FrontendServer.Controllers;
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	internal static class AchievementMapper {
+		internal static List<AchievementViewModel> GetForUser(GlobalState globalState, string userId) {
+			var gameMap = globalState.GetGames().ToDictionary(g => g.GameId.Id);
+			return globalState.GetAchievements()
+				.Where(a => a.UserId == userId)
+				.OrderByDescending(a => a.FinishedAt)
+				.Select(a => {
+					gameMap.TryGetValue(a.GameId.Id, out var rec);
+					return ToViewModel(a, rec?.Name ?? a.GameId.Id);
+				})
+				.ToList();
+		}
 
-internal static class AchievementMapper
-{
-	internal static AchievementViewModel ToViewModel(PlayerAchievementImmutable a, string gameName)
-	{
-		var (type, label, icon) = a.FinalRank switch {
-			1 => ("winner", "Commander Victory", "🏆"),
-			2 => ("runner-up", "Runner-Up", "🥈"),
-			3 => ("top3", "Top 3 Finish", "🥉"),
-			_ => ("competitor", "Game Completed", "⚔️")
-		};
-		return new AchievementViewModel(
-			AchievementType: type,
-			AchievementLabel: label,
-			AchievementIcon: icon,
-			GameId: a.GameId.Id,
-			GameName: gameName,
-			GameDefType: a.GameDefType,
-			FinalRank: a.FinalRank,
-			Score: a.FinalScore,
-			EarnedAt: a.FinishedAt
-		);
+		internal static AchievementViewModel ToViewModel(PlayerAchievementImmutable a, string gameName) {
+			var (type, label, icon) = a.FinalRank switch {
+				1 => ("winner", "Commander Victory", "🏆"),
+				2 => ("runner-up", "Runner-Up", "🥈"),
+				3 => ("top3", "Top 3 Finish", "🥉"),
+				_ => ("competitor", "Game Completed", "⚔️")
+			};
+			return new AchievementViewModel(
+				AchievementType: type,
+				AchievementLabel: label,
+				AchievementIcon: icon,
+				GameId: a.GameId.Id,
+				GameName: gameName,
+				GameDefType: a.GameDefType,
+				FinalRank: a.FinalRank,
+				Score: a.FinalScore,
+				EarnedAt: a.FinishedAt
+			);
+		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -140,16 +140,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult<PlayerAchievementsViewModel> GetMyAchievements() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 
-			var gameMap = globalState.GetGames().ToDictionary(g => g.GameId.Id);
-			var achievements = globalState.GetAchievements()
-				.Where(a => a.UserId == currentUserContext.UserId)
-				.OrderByDescending(a => a.FinishedAt)
-				.Select(a => {
-					gameMap.TryGetValue(a.GameId.Id, out var rec);
-					return AchievementMapper.ToViewModel(a, rec?.Name ?? a.GameId.Id);
-				})
-				.ToList();
-
+			var achievements = AchievementMapper.GetForUser(globalState, currentUserContext.UserId);
 			return Ok(new PlayerAchievementsViewModel(achievements));
 		}
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -146,31 +146,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				.OrderByDescending(a => a.FinishedAt)
 				.Select(a => {
 					gameMap.TryGetValue(a.GameId.Id, out var rec);
-					return ToAchievementViewModel(a, rec?.Name ?? a.GameId.Id);
+					return AchievementMapper.ToViewModel(a, rec?.Name ?? a.GameId.Id);
 				})
 				.ToList();
 
 			return Ok(new PlayerAchievementsViewModel(achievements));
-		}
-
-		private static AchievementViewModel ToAchievementViewModel(BrowserGameEngine.GameModel.PlayerAchievementImmutable a, string gameName) {
-			var (type, label, icon) = a.FinalRank switch {
-				1 => ("winner", "Commander Victory", "🏆"),
-				2 => ("runner-up", "Runner-Up", "🥈"),
-				3 => ("top3", "Top 3 Finish", "🥉"),
-				_ => ("competitor", "Game Completed", "⚔️")
-			};
-			return new AchievementViewModel(
-				AchievementType: type,
-				AchievementLabel: label,
-				AchievementIcon: icon,
-				GameId: a.GameId.Id,
-				GameName: gameName,
-				GameDefType: a.GameDefType,
-				FinalRank: a.FinalRank,
-				Score: a.FinalScore,
-				EarnedAt: a.FinishedAt
-			);
 		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -6,6 +6,7 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -21,6 +22,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly PlayerRepository playerRepository;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly UserRepositoryWrite userRepositoryWrite;
+		private readonly GlobalState globalState;
 
 		public PlayerManagementController(
 			ILogger<PlayerManagementController> logger,
@@ -28,13 +30,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			UserRepository userRepository,
 			PlayerRepository playerRepository,
 			PlayerRepositoryWrite playerRepositoryWrite,
-			UserRepositoryWrite userRepositoryWrite) {
+			UserRepositoryWrite userRepositoryWrite,
+			GlobalState globalState) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.userRepository = userRepository;
 			this.playerRepository = playerRepository;
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.userRepositoryWrite = userRepositoryWrite;
+			this.globalState = globalState;
 		}
 
 		/// <summary>Returns all players belonging to the authenticated user.</summary>
@@ -127,6 +131,46 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			userRepositoryWrite.SetApiKeyHash(pid, null);
 			return NoContent();
+		}
+
+		/// <summary>Returns all earned achievements for the authenticated user across all games.</summary>
+		[HttpGet("me/achievements")]
+		[ProducesResponseType(typeof(PlayerAchievementsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<PlayerAchievementsViewModel> GetMyAchievements() {
+			if (currentUserContext.UserId == null) return Unauthorized();
+
+			var gameMap = globalState.GetGames().ToDictionary(g => g.GameId.Id);
+			var achievements = globalState.GetAchievements()
+				.Where(a => a.UserId == currentUserContext.UserId)
+				.OrderByDescending(a => a.FinishedAt)
+				.Select(a => {
+					gameMap.TryGetValue(a.GameId.Id, out var rec);
+					return ToAchievementViewModel(a, rec?.Name ?? a.GameId.Id);
+				})
+				.ToList();
+
+			return Ok(new PlayerAchievementsViewModel(achievements));
+		}
+
+		private static AchievementViewModel ToAchievementViewModel(BrowserGameEngine.GameModel.PlayerAchievementImmutable a, string gameName) {
+			var (type, label, icon) = a.FinalRank switch {
+				1 => ("winner", "Commander Victory", "🏆"),
+				2 => ("runner-up", "Runner-Up", "🥈"),
+				3 => ("top3", "Top 3 Finish", "🥉"),
+				_ => ("competitor", "Game Completed", "⚔️")
+			};
+			return new AchievementViewModel(
+				AchievementType: type,
+				AchievementLabel: label,
+				AchievementIcon: icon,
+				GameId: a.GameId.Id,
+				GameName: gameName,
+				GameDefType: a.GameDefType,
+				FinalRank: a.FinalRank,
+				Score: a.FinalScore,
+				EarnedAt: a.FinishedAt
+			);
 		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -16,6 +16,25 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		/// <summary>
+		/// Public achievements for any user, identified by their OAuth user ID.
+		/// Returns empty list when the user has no achievements.
+		/// </summary>
+		[AllowAnonymous]
+		[HttpGet("{userId}/achievements")]
+		public ActionResult<PlayerAchievementsViewModel> GetAchievements(string userId) {
+			var gameMap = globalState.GetGames().ToDictionary(g => g.GameId.Id);
+			var achievements = globalState.GetAchievements()
+				.Where(a => a.UserId == userId)
+				.OrderByDescending(a => a.FinishedAt)
+				.Select(a => {
+					gameMap.TryGetValue(a.GameId.Id, out var rec);
+					return ToAchievementViewModel(a, rec?.Name ?? a.GameId.Id);
+				})
+				.ToList();
+			return Ok(new PlayerAchievementsViewModel(achievements));
+		}
+
+		/// <summary>
 		/// Public cross-game stats for any user, identified by their OAuth user ID (e.g. GitHub login).
 		/// Returns NotFound when the user has no game history.
 		/// </summary>
@@ -53,6 +72,26 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				TotalScore: entries.Sum(e => e.FinalScore),
 				Games: entries
 			));
+		}
+
+		private static AchievementViewModel ToAchievementViewModel(BrowserGameEngine.GameModel.PlayerAchievementImmutable a, string gameName) {
+			var (type, label, icon) = a.FinalRank switch {
+				1 => ("winner", "Commander Victory", "🏆"),
+				2 => ("runner-up", "Runner-Up", "🥈"),
+				3 => ("top3", "Top 3 Finish", "🥉"),
+				_ => ("competitor", "Game Completed", "⚔️")
+			};
+			return new AchievementViewModel(
+				AchievementType: type,
+				AchievementLabel: label,
+				AchievementIcon: icon,
+				GameId: a.GameId.Id,
+				GameName: gameName,
+				GameDefType: a.GameDefType,
+				FinalRank: a.FinalRank,
+				Score: a.FinalScore,
+				EarnedAt: a.FinishedAt
+			);
 		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -28,7 +28,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				.OrderByDescending(a => a.FinishedAt)
 				.Select(a => {
 					gameMap.TryGetValue(a.GameId.Id, out var rec);
-					return ToAchievementViewModel(a, rec?.Name ?? a.GameId.Id);
+					return AchievementMapper.ToViewModel(a, rec?.Name ?? a.GameId.Id);
 				})
 				.ToList();
 			return Ok(new PlayerAchievementsViewModel(achievements));
@@ -74,24 +74,5 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			));
 		}
 
-		private static AchievementViewModel ToAchievementViewModel(BrowserGameEngine.GameModel.PlayerAchievementImmutable a, string gameName) {
-			var (type, label, icon) = a.FinalRank switch {
-				1 => ("winner", "Commander Victory", "🏆"),
-				2 => ("runner-up", "Runner-Up", "🥈"),
-				3 => ("top3", "Top 3 Finish", "🥉"),
-				_ => ("competitor", "Game Completed", "⚔️")
-			};
-			return new AchievementViewModel(
-				AchievementType: type,
-				AchievementLabel: label,
-				AchievementIcon: icon,
-				GameId: a.GameId.Id,
-				GameName: gameName,
-				GameDefType: a.GameDefType,
-				FinalRank: a.FinalRank,
-				Score: a.FinalScore,
-				EarnedAt: a.FinishedAt
-			);
-		}
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -22,15 +22,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[AllowAnonymous]
 		[HttpGet("{userId}/achievements")]
 		public ActionResult<PlayerAchievementsViewModel> GetAchievements(string userId) {
-			var gameMap = globalState.GetGames().ToDictionary(g => g.GameId.Id);
-			var achievements = globalState.GetAchievements()
-				.Where(a => a.UserId == userId)
-				.OrderByDescending(a => a.FinishedAt)
-				.Select(a => {
-					gameMap.TryGetValue(a.GameId.Id, out var rec);
-					return AchievementMapper.ToViewModel(a, rec?.Name ?? a.GameId.Id);
-				})
-				.ToList();
+			var achievements = AchievementMapper.GetForUser(globalState, userId);
 			return Ok(new PlayerAchievementsViewModel(achievements));
 		}
 

--- a/src/BrowserGameEngine.Shared/AchievementViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AchievementViewModels.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public record AchievementViewModel(
+		string AchievementType,
+		string AchievementLabel,
+		string AchievementIcon,
+		string GameId,
+		string GameName,
+		string GameDefType,
+		int FinalRank,
+		decimal Score,
+		DateTime EarnedAt
+	);
+
+	public record PlayerAchievementsViewModel(
+		List<AchievementViewModel> Achievements
+	);
+}


### PR DESCRIPTION
## Summary
- Adds `AchievementViewModel` / `PlayerAchievementsViewModel` to Shared
- `GET /api/players/me/achievements` (authenticated) returns all earned achievements for current user
- `GET /api/players/{userId}/achievements` (public) for profile views
- Achievement type derived from FinalRank: winner 🏆 / runner-up 🥈 / top3 🥉 / competitor ⚔️
- `Achievements.razor` page at `/achievements` with a dark-themed badge grid
- Empty state with motivational message and CTA
- Added Achievements link to NavMenu (after Profile)
- Added "View Achievements" link in PlayerProfile.razor

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (164 passed, 0 failed)
- [ ] Navigate to `/achievements` as a player with no game history — see empty state
- [ ] Navigate to `/achievements` as a player who finished games — see badge grid
- [ ] Verify winner card has gold border, runner-up silver, top3 bronze
- [ ] Check `/api/players/{userId}/achievements` returns public data

Closes BGE-292