### PR TITLE
fix: BGE-318 correct auto-join duplicate player guard

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -194,6 +194,62 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public async Task ActivateGame_AutoJoin_DoesNotDuplicatePlayerAlreadyInGame() {
+			// A user with AutoJoinNextGame=true who already has a player in the game
+			// must NOT receive a second duplicate player record when the game activates.
+			var globalState = new GlobalState();
+			var record = new GameRecordImmutable(
+				new GameId("upcoming-autojoin"), "Upcoming", "sco", GameStatus.Upcoming,
+				DateTime.UtcNow.AddMinutes(-1),
+				DateTime.UtcNow.AddDays(1),
+				TimeSpan.FromSeconds(10));
+			globalState.AddGame(record);
+
+			var ws = MakeTwoPlayerState("upcoming-autojoin").ToMutable();
+			var registry = new GameRegistryNs.GameRegistry(globalState);
+			var instance = new GameRegistryNs.GameInstance(record, ws, TestGameDef);
+			registry.Register(instance);
+
+			// Set up user with AutoJoinNextGame=true via the write repository
+			var userRepoWrite = new UserRepositoryWrite(globalState, ws, TimeProvider.System);
+			var userImm = userRepoWrite.GetOrCreateUser("gh-autojoin", "autojoin", "AutoJoin User");
+			userRepoWrite.SetGamePreferences("gh-autojoin", false, true);
+
+			// Pre-create the player record for that user in the game (simulates manual join)
+			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, TimeProvider.System);
+			var existingPlayerId = PlayerIdFactory.Create("existing123");
+			playerRepoWrite.CreatePlayer(existingPlayerId, userImm.UserId);
+
+			int playerCountBefore = instance.PlayerCount;
+
+			var storage = new InMemoryBlobStorage();
+			var serializer = new GameStateJsonSerializer();
+			var persistenceService = new PersistenceService(storage, serializer);
+			var globalSerializer = new GlobalStateJsonSerializer();
+			var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
+			var engine = new GameRegistryNs.GameLifecycleEngine(
+				registry,
+				globalState,
+				persistenceService,
+				globalPersistenceService,
+				new GameRegistryNs.NullGameNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				userRepoWrite,
+				TimeProvider.System,
+				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
+			);
+
+			await engine.ProcessLifecycleAsync();
+
+			var activatedInstance = registry.TryGetInstance(new GameId("upcoming-autojoin"));
+			Assert.NotNull(activatedInstance);
+			// Player count must not increase from the pre-activation count
+			Assert.Equal(playerCountBefore, activatedInstance.PlayerCount);
+			// The user must still have exactly one player
+			Assert.True(activatedInstance.HasUserPlayer(userImm.UserId));
+		}
+
+		[Fact]
 		public async Task UpcomingGame_NotStartedYet_RemainsUpcoming() {
 			var globalState = new GlobalState();
 			var record = new GameRecordImmutable(

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -70,8 +70,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 						.Where(u => u.AutoJoinNextGame)
 						.ToList();
 					foreach (var user in usersToAutoJoin) {
-						var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString("N")[..12]);
-						if (!instance.HasPlayer(playerId)) {
+						bool alreadyJoined = instance.WorldState.Players.Values.Any(p => p.UserId == user.UserId);
+						if (!alreadyJoined) {
+							var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString("N")[..12]);
 							playerRepoWrite.CreatePlayer(playerId, user.UserId);
 							logger.LogInformation("Auto-joined user {UserId} as player {PlayerId} in game {GameId}",
 								user.UserId, playerId.Id, record.GameId.Id);


### PR DESCRIPTION
## Summary
- Fixed a broken no-op guard in `GameLifecycleEngine.cs` that was checking whether a *freshly-generated random* `playerId` existed in the game — it never could, so the check was always `true` and every auto-join user received a duplicate player even if they had already manually joined.
- Fix: check `UserId` membership on `WorldState.Players.Values` before generating the new `playerId`.
- Added test: `ActivateGame_AutoJoin_DoesNotDuplicatePlayerAlreadyInGame`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (165 total, 1 new test)
- [x] New test specifically covers the duplicate-guard scenario: user with `AutoJoinNextGame=true` who already has a player in the game is NOT given a second player on activation

Closes BGE-318