### PR TITLE
fix: BGE-319 persist Data Protection keys to S3

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -1,5 +1,6 @@
 using Amazon.S3;
 using BrowserGameEngine.FrontendServer;
+using Microsoft.AspNetCore.DataProtection;
 using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.FrontendServer.Services;
 using BrowserGameEngine.GameDefinition;
@@ -105,6 +106,17 @@ if (!string.IsNullOrWhiteSpace(githubClientId) && !string.IsNullOrWhiteSpace(git
     Log.Warning("GitHub OAuth is disabled because GitHub:ClientId or GitHub:ClientSecret is not configured.");
 }
 
+var s3BucketForDp = builder.Configuration["Bge:S3BucketName"];
+if (!string.IsNullOrEmpty(s3BucketForDp)) {
+    var s3KeyPrefixForDp = (builder.Configuration["Bge:S3KeyPrefix"] ?? "") + "data-protection-keys/";
+    var s3ClientForDp = new AmazonS3Client();
+    builder.Services.AddDataProtection()
+        .AddKeyManagementOptions(opts =>
+            opts.XmlRepository = new S3DataProtectionKeyRepository(s3ClientForDp, s3BucketForDp, s3KeyPrefixForDp));
+    Log.Information("Data Protection keys will be persisted to S3 at {Bucket}/{Prefix}", s3BucketForDp, s3KeyPrefixForDp);
+} else {
+    Log.Warning("Data Protection keys are ephemeral (no S3 bucket configured). This is fine for local dev.");
+}
 
 await ConfigureGameServices(builder.Services);
 

--- a/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
+++ b/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
@@ -1,0 +1,57 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+namespace BrowserGameEngine.FrontendServer;
+
+/// <summary>
+/// Persists ASP.NET Core Data Protection XML keys to S3 so all container
+/// instances share a single key ring and OAuth state cookies survive
+/// rolling deployments.
+/// </summary>
+internal sealed class S3DataProtectionKeyRepository : IXmlRepository
+{
+	private readonly IAmazonS3 _s3;
+	private readonly string _bucketName;
+	private readonly string _keyPrefix;
+
+	public S3DataProtectionKeyRepository(IAmazonS3 s3, string bucketName, string keyPrefix)
+	{
+		_s3 = s3;
+		_bucketName = bucketName;
+		_keyPrefix = keyPrefix.TrimEnd('/') + '/';
+	}
+
+	public IReadOnlyCollection<XElement> GetAllElements()
+	{
+		var list = _s3.ListObjectsV2Async(new ListObjectsV2Request {
+			BucketName = _bucketName,
+			Prefix = _keyPrefix
+		}).GetAwaiter().GetResult();
+
+		var elements = new List<XElement>();
+		foreach (var obj in list.S3Objects) {
+			var response = _s3.GetObjectAsync(_bucketName, obj.Key).GetAwaiter().GetResult();
+			using var stream = response.ResponseStream;
+			elements.Add(XElement.Load(stream));
+		}
+		return elements;
+	}
+
+	public void StoreElement(XElement element, string friendlyName)
+	{
+		var key = $"{_keyPrefix}{friendlyName}.xml";
+		using var ms = new MemoryStream();
+		element.Save(ms);
+		ms.Position = 0;
+		_s3.PutObjectAsync(new PutObjectRequest {
+			BucketName = _bucketName,
+			Key = key,
+			InputStream = ms,
+			ContentType = "application/xml"
+		}).GetAwaiter().GetResult();
+	}
+}


### PR DESCRIPTION
## Summary
- OAuth logins were failing during rolling deployments because ASP.NET Core Data Protection keys were ephemeral (container-local). Two containers running simultaneously had different key rings, so correlation cookies set by one container could not be decrypted by the other → `AuthenticationFailureException: The oauth state was missing or invalid`.
- Added `S3DataProtectionKeyRepository` — a custom `IXmlRepository` that persists key XML blobs to the existing `bge-game-state` S3 bucket under `<key-prefix>data-protection-keys/`.
- When `Bge:S3BucketName` is configured (prod/staging), keys are shared across all container instances. Local dev (no bucket) is unaffected; a startup warning is logged.
- No new IAM permissions required — the ECS task role already has S3 read/write access.
- No new NuGet packages — uses the `AWSSDK.S3` dependency already present transitively.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (164 passed)
- [ ] Deploy to staging and verify `Storing keys in a directory ... may not be persisted` warning is gone from CloudWatch logs
- [ ] Trigger a rolling deployment and confirm OAuth login succeeds without errors

Closes BGE-319