### PR TITLE
fix: BGE-335 s3:ListBucket IAM + key prefix separator

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -182,11 +182,18 @@ resource "aws_iam_policy" "ecs_task_s3" {
   name = "${var.app_name}-ecs-s3"
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["s3:GetObject", "s3:PutObject", "s3:HeadObject"]
-      Resource = "${aws_s3_bucket.game_state.arn}/*"
-    }]
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:HeadObject"]
+        Resource = "${aws_s3_bucket.game_state.arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.game_state.arn
+      }
+    ]
   })
 }
 

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -108,7 +108,8 @@ if (!string.IsNullOrWhiteSpace(githubClientId) && !string.IsNullOrWhiteSpace(git
 
 var s3BucketForDp = builder.Configuration["Bge:S3BucketName"];
 if (!string.IsNullOrEmpty(s3BucketForDp)) {
-    var s3KeyPrefixForDp = (builder.Configuration["Bge:S3KeyPrefix"] ?? "") + "data-protection-keys/";
+    var rawPrefix = builder.Configuration["Bge:S3KeyPrefix"] ?? "";
+    var s3KeyPrefixForDp = (string.IsNullOrEmpty(rawPrefix) ? "" : rawPrefix.TrimEnd('/') + "/") + "data-protection-keys/";
     var s3ClientForDp = new AmazonS3Client();
     builder.Services.AddDataProtection()
         .AddKeyManagementOptions(opts =>

--- a/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
+++ b/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
@@ -1,9 +1,9 @@
-using Amazon.S3;
-using Amazon.S3.Model;
-using Microsoft.AspNetCore.DataProtection.Repositories;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 
 namespace BrowserGameEngine.FrontendServer;
 


### PR DESCRIPTION
## Summary

Addresses two blocking issues identified in the PR #101 (BGE-319) review that were merged without being fixed:

- **IAM policy (`infra/main.tf`):** Added `s3:ListBucket` as a bucket-level action on the bucket ARN. `GetAllElements()` calls `ListObjectsV2Async` which requires this permission. Without it, every Data Protection key ring load throws `AccessDenied` in production, causing all authenticated requests to fail.
- **Key prefix separator (`Program.cs`):** Fixed missing `/` separator when `Bge:S3KeyPrefix` is non-empty. Old code produced `"stagingdata-protection-keys/"` — now uses `TrimEnd('/') + "/"` to normalise correctly.
- **Using directives (`S3DataProtectionKeyRepository.cs`):** Sorted with `System.*` first per `.editorconfig`.

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (173/173)
- [ ] Terraform plan shows IAM policy updated with `s3:ListBucket` statement
- [ ] Verify `s3KeyPrefixForDp` is `"staging/data-protection-keys/"` when `S3KeyPrefix=staging`

Closes BGE-335