### PR TITLE
fix: BGE-333 remove About link to blazor.net

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -45,7 +45,6 @@
                     }
                 </div>
             }
-            <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

- Remove the boilerplate "About" link pointing to `http://blazor.net` from `MainLayout.razor`. It was a default template link with no relevance to this application.

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (173/173)
- [ ] Visually verify the top-right header no longer shows the "About" link

Closes BGE-333