### PR TITLE
feat: BGE-306 player profile page with game stats

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
@@ -1,43 +1,205 @@
-﻿@page "/profile"
+@page "/profile"
 @using BrowserGameEngine.Shared
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @inject HttpClient Http
 
 <h1>Profile</h1>
 
-@if (model == null) {
-    <p><em>Loading...</em></p>
-} else {
-    <div class="mb-3">
-        <span>@(model.IsOnline ? "🟢 Online" : "⚫ Offline")</span>
-        @if (model.LastOnline.HasValue) {
-            <span class="text-muted ms-2">Last seen: @model.LastOnline.Value.ToLocalTime().ToString("g")</span>
-        }
-    </div>
-    <div>
-        <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
-            <DataAnnotationsValidator />
-            <ValidationSummary />
+<style>
+	.profile-card {
+		background: #1e2a3a;
+		border: 1px solid #2c3e50;
+		border-radius: 0.5rem;
+		padding: 1.5rem;
+		max-width: 680px;
+	}
 
-            <InputText id="PlayerName" @bind-Value="model.PlayerName" />
+	.profile-avatar {
+		width: 72px;
+		height: 72px;
+		border-radius: 50%;
+		object-fit: cover;
+		border: 2px solid #4a6fa5;
+	}
 
-            <button type="submit">Submit</button>
-        </EditForm>
-    </div>
-    <div class="mt-3">
-        <a class="btn btn-outline-secondary btn-sm" href="achievements">View Achievements</a>
-    </div>
+	.profile-avatar-placeholder {
+		width: 72px;
+		height: 72px;
+		border-radius: 50%;
+		background: #2c3e50;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 2rem;
+		color: #90a8c8;
+		border: 2px solid #4a6fa5;
+	}
+
+	.stat-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.stat-item {
+		background: #162030;
+		border: 1px solid #2c3e50;
+		border-radius: 0.4rem;
+		padding: 0.75rem 1rem;
+	}
+
+	.stat-label {
+		font-size: 0.75rem;
+		color: #90a8c8;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.stat-value {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: #e0e0e0;
+		margin-top: 0.1rem;
+	}
+
+	.stat-value.rank {
+		color: #ffd700;
+	}
+
+	.section-title {
+		font-size: 0.85rem;
+		color: #607080;
+		text-transform: uppercase;
+		letter-spacing: 0.07em;
+		margin-bottom: 0.5rem;
+		margin-top: 1.5rem;
+	}
+</style>
+
+@if (model == null && !loadError) {
+	<div class="d-flex align-items-center gap-2">
+		<div class="spinner-border spinner-border-sm" role="status"></div>
+		<span>Loading profile...</span>
+	</div>
+} else if (loadError) {
+	<div class="alert alert-danger">Failed to load profile.</div>
+} else if (model != null) {
+	<div class="profile-card">
+		<div class="d-flex align-items-center gap-3 mb-3">
+			@if (model.AvatarUrl != null) {
+				<img class="profile-avatar" src="@model.AvatarUrl" alt="Avatar" />
+			} else {
+				<div class="profile-avatar-placeholder">&#128100;</div>
+			}
+			<div>
+				<div style="font-size:1.3rem; font-weight:600; color:#e0e0e0;">@(model.DisplayName ?? model.PlayerName)</div>
+				@if (model.DisplayName != null && model.DisplayName != model.PlayerName) {
+					<div style="font-size:0.9rem; color:#90a8c8;">Player: @model.PlayerName</div>
+				}
+			</div>
+		</div>
+
+		@if (model.CurrentGameId != null) {
+			<a class="btn btn-sm btn-outline-primary mb-3" href="games/@model.CurrentGameId">Go to Current Game</a>
+		}
+
+		<div class="section-title">Current Game Stats</div>
+		<div class="stat-grid">
+			<div class="stat-item">
+				<div class="stat-label">Rank</div>
+				<div class="stat-value rank">#@model.Rank <span style="font-size:0.85rem; color:#607080;">/ @model.TotalPlayers</span></div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-label">Land</div>
+				<div class="stat-value">@model.Land.ToString("N0")</div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-label">Minerals</div>
+				<div class="stat-value">@model.Minerals.ToString("N0")</div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-label">Gas</div>
+				<div class="stat-value">@model.Gas.ToString("N0")</div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-label">Army Size</div>
+				<div class="stat-value">@model.ArmySize.ToString("N0")</div>
+			</div>
+		</div>
+
+		<div class="section-title">History</div>
+		<div class="stat-grid">
+			<div class="stat-item">
+				<div class="stat-label">Games Played</div>
+				<div class="stat-value">@model.GamesPlayed</div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-label">Wins</div>
+				<div class="stat-value">@model.Wins</div>
+			</div>
+		</div>
+		<p style="font-size:0.8rem; color:#607080; margin-top:0.4rem;">Full history available once achievements are implemented.</p>
+
+		<div class="section-title">Settings</div>
+		<div class="mt-1">
+			<EditForm Model="@renameModel" OnValidSubmit="HandleRename">
+				<DataAnnotationsValidator />
+				<div class="d-flex gap-2 align-items-center">
+					<InputText id="PlayerName" class="form-control form-control-sm" style="max-width:220px;" @bind-Value="renameModel.PlayerName" />
+					<button type="submit" class="btn btn-sm btn-outline-secondary">Rename</button>
+				</div>
+				<ValidationSummary />
+			</EditForm>
+			@if (renameSuccess) {
+				<div class="text-success mt-1" style="font-size:0.85rem;">Name updated.</div>
+			}
+			@if (renameError) {
+				<div class="text-danger mt-1" style="font-size:0.85rem;">Failed to update name.</div>
+			}
+		</div>
+
+		<div class="mt-3 d-flex gap-2">
+			<a class="btn btn-outline-secondary btn-sm" href="achievements">Achievements</a>
+			<a class="btn btn-outline-secondary btn-sm" href="history">History</a>
+		</div>
+	</div>
 }
 
 @code {
-    private PlayerProfileViewModel? model;
+	private ProfileViewModel? model;
+	private PlayerProfileViewModel renameModel = new();
+	private bool loadError;
+	private bool renameSuccess;
+	private bool renameError;
 
-    protected override async Task OnInitializedAsync() {
-        model = await Http.GetFromJsonAsync<PlayerProfileViewModel>("api/playerprofile");
-    }
+	protected override async Task OnInitializedAsync() {
+		try {
+			model = await Http.GetFromJsonAsync<ProfileViewModel>("api/profile");
+			if (model != null) {
+				renameModel = new PlayerProfileViewModel { PlayerName = model.PlayerName };
+			}
+		} catch {
+			loadError = true;
+		}
+	}
 
-    private async Task HandleValidSubmit() {
-        if (model == null) return;
-        await Http.PostAsJsonAsync("api/playerprofile/changename", model);
-    }
-
+	private async Task HandleRename() {
+		renameSuccess = false;
+		renameError = false;
+		try {
+			var resp = await Http.PostAsJsonAsync("api/playerprofile/changename", renameModel);
+			if (resp.IsSuccessStatusCode) {
+				renameSuccess = true;
+				if (model != null) {
+					model = model with { PlayerName = renameModel.PlayerName };
+				}
+			} else {
+				renameError = true;
+			}
+		} catch {
+			renameError = true;
+		}
+	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
@@ -1,0 +1,96 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/profile")]
+	public class ProfileController : ControllerBase {
+		private readonly ILogger<ProfileController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly PlayerRepository playerRepository;
+		private readonly UserRepository userRepository;
+		private readonly ScoreRepository scoreRepository;
+		private readonly ResourceRepository resourceRepository;
+		private readonly UnitRepository unitRepository;
+		private readonly GameRegistry gameRegistry;
+
+		public ProfileController(
+			ILogger<ProfileController> logger,
+			CurrentUserContext currentUserContext,
+			PlayerRepository playerRepository,
+			UserRepository userRepository,
+			ScoreRepository scoreRepository,
+			ResourceRepository resourceRepository,
+			UnitRepository unitRepository,
+			GameRegistry gameRegistry
+		) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.playerRepository = playerRepository;
+			this.userRepository = userRepository;
+			this.scoreRepository = scoreRepository;
+			this.resourceRepository = resourceRepository;
+			this.unitRepository = unitRepository;
+			this.gameRegistry = gameRegistry;
+		}
+
+		/// <summary>Returns the authenticated user's full profile: display name, avatar, current game stats, and game history stubs.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(ProfileViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<ProfileViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var playerId = currentUserContext.PlayerId!;
+			var player = playerRepository.Get(playerId);
+
+			var user = currentUserContext.UserId != null
+				? userRepository.GetByUserId(currentUserContext.UserId)
+				: null;
+
+			var avatarUrl = user?.GithubLogin != null
+				? $"https://github.com/{user.GithubLogin}.png"
+				: null;
+
+			var land = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
+			var minerals = resourceRepository.GetAmount(playerId, Id.ResDef("minerals"));
+			var gas = resourceRepository.GetAmount(playerId, Id.ResDef("gas"));
+
+			var armySize = unitRepository.GetAll(playerId).Sum(u => u.Count);
+
+			var allPlayers = playerRepository.GetAll().ToList();
+			var ranked = allPlayers
+				.OrderByDescending(p => scoreRepository.GetScore(p.PlayerId))
+				.ToList();
+			var rank = ranked.FindIndex(p => p.PlayerId == playerId) + 1;
+
+			var currentInstance = gameRegistry.GetAllInstances()
+				.FirstOrDefault(i => i.HasPlayer(playerId));
+			var currentGameId = currentInstance?.Record.GameId.Id;
+
+			return new ProfileViewModel {
+				PlayerName = player.Name,
+				DisplayName = user?.DisplayName,
+				AvatarUrl = avatarUrl,
+				Score = scoreRepository.GetScore(playerId),
+				Land = land,
+				Minerals = minerals,
+				Gas = gas,
+				ArmySize = armySize,
+				Rank = rank,
+				TotalPlayers = allPlayers.Count,
+				GamesPlayed = 0,
+				Wins = 0,
+				CurrentGameId = currentGameId
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/ProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/ProfileViewModel.cs
@@ -1,0 +1,17 @@
+namespace BrowserGameEngine.Shared {
+	public record ProfileViewModel {
+		public string? PlayerName { get; init; }
+		public string? DisplayName { get; init; }
+		public string? AvatarUrl { get; init; }
+		public decimal Score { get; init; }
+		public decimal Land { get; init; }
+		public decimal Minerals { get; init; }
+		public decimal Gas { get; init; }
+		public int ArmySize { get; init; }
+		public int Rank { get; init; }
+		public int TotalPlayers { get; init; }
+		public int GamesPlayed { get; init; }
+		public int Wins { get; init; }
+		public string? CurrentGameId { get; init; }
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/profile` endpoint returning display name, GitHub avatar, current game stats (land, minerals, gas, army size, rank), and stub history counts
- Update `/profile` page with a stats card layout: avatar, rank badge, resource stats grid, history stubs, and a rename form
- Link to the current game (if in one) from the profile page

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (173/173)
- [ ] Log in and navigate to `/profile` — verify avatar, display name, and stats are shown
- [ ] Verify "Go to Current Game" link appears when player is in an active game
- [ ] Verify rename form still works

Closes BGE-306