### PR TITLE
fix: BGE-315 show player names instead of raw IDs

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -11,8 +11,17 @@
 	<DataAnnotationsValidator />
 	<ValidationSummary />
 	<div>
-		<label>To (Player ID):</label>
-		<InputText @bind-Value="composeModel.RecipientId" placeholder="Player ID" />
+		<label>To:</label>
+		@if (players == null) {
+			<InputText @bind-Value="composeModel.RecipientId" placeholder="Player ID" />
+		} else {
+			<select class="form-select" @bind="composeModel.RecipientId">
+				<option value="">— Select a player —</option>
+				@foreach (var p in players) {
+					<option value="@p.PlayerId">@p.PlayerName</option>
+				}
+			</select>
+		}
 	</div>
 	<div>
 		<label>Subject:</label>
@@ -75,13 +84,14 @@
 	public string? GameId { get; set; }
 
 	private List<MessageViewModel>? inbox;
+	private List<PublicPlayerViewModel>? players;
 	private SendMessageViewModel composeModel = new();
 	private string? sendResult;
 	private string? expandedMessageId;
 	private CancellationTokenSource? _cts;
 
 	protected override async Task OnInitializedAsync() {
-		await LoadInbox();
+		await Task.WhenAll(LoadInbox(), LoadPlayers());
 		_cts = new CancellationTokenSource();
 		_ = RunRefreshLoop(_cts.Token);
 	}
@@ -97,6 +107,15 @@
 	private async Task LoadInbox() {
 		var result = await Http.GetFromJsonAsync<MessageInboxViewModel>("api/messages/inbox");
 		inbox = result?.Messages ?? new();
+	}
+
+	private async Task LoadPlayers() {
+		try {
+			var result = await Http.GetFromJsonAsync<List<PublicPlayerViewModel>>("api/playerranking");
+			players = result ?? new();
+		} catch {
+			players = new();
+		}
 	}
 
 	private async Task HandleSend() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -38,7 +38,9 @@
                         <td><_UnitProperties UnitDef="item.Definition" /></td>
                         <td>
                             @if (item.PositionPlayerId != null) {
-                                <NavLink class="nav-link" href="@($"enemybase/{Uri.EscapeDataString(item.PositionPlayerId)}")">@item.PositionPlayerId</NavLink>
+                                <NavLink class="nav-link" href="@($"enemybase/{Uri.EscapeDataString(item.PositionPlayerId)}")">
+                                    @(item.PositionPlayerName ?? item.PositionPlayerId)
+                                </NavLink>
                             }
                         </td>
                         <td>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UnitsController.cs
@@ -47,7 +47,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult<UnitsViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			return new UnitsViewModel {
-				Units = unitRepository.GetAll(currentUserContext.PlayerId!).Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
+				Units = unitRepository.GetAll(currentUserContext.PlayerId!).Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef, playerRepository)).ToList()
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -23,15 +23,21 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			};
 		}
 
-		public static UnitViewModel ToUnitViewModel(this UnitImmutable unit, UnitRepository unitRepository, CurrentUserContext currentUserContext, GameDef gameDef) {
+		public static UnitViewModel ToUnitViewModel(this UnitImmutable unit, UnitRepository unitRepository, CurrentUserContext currentUserContext, GameDef gameDef, PlayerRepository? playerRepository = null) {
 			var unitDef = gameDef.GetUnitDef(unit.UnitDefId);
 			if (unitDef == null) throw new InvalidGameDefException($"Unit '{unit.UnitDefId}' not found");
+
+			string? positionPlayerName = null;
+			if (unit.Position != null && playerRepository != null && playerRepository.Exists(unit.Position)) {
+				positionPlayerName = playerRepository.Get(unit.Position).Name;
+			}
 
 			return new UnitViewModel {
 				UnitId = unit.UnitId.Id,
 				Definition = UnitDefinitionViewModel.Create(unitDef, unitRepository.PrerequisitesMet(currentUserContext.PlayerId!, unitDef)),
 				Count = unit.Count,
-				PositionPlayerId = unit.Position?.Id
+				PositionPlayerId = unit.Position?.Id,
+				PositionPlayerName = positionPlayerName
 			};
 		}
 	}

--- a/src/BrowserGameEngine.Shared/UnitsViewModel.cs
+++ b/src/BrowserGameEngine.Shared/UnitsViewModel.cs
@@ -15,5 +15,6 @@ namespace BrowserGameEngine.Shared {
 		public required UnitDefinitionViewModel Definition { get; set; }
 		public int Count { get; set; }
 		public string? PositionPlayerId { get; set; }
+		public string? PositionPlayerName { get; set; }
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two UX audit items where raw player GUIDs were shown to users.

**M4 — Messages compose To field**
- Replaced the plain `Player ID` text input with a `<select>` dropdown
- Dropdown is populated from `api/playerranking` (players in the current game)
- Shows player names; binds to the player ID for the send API

**M5 — Units table position column**
- Added `PositionPlayerName` to `UnitViewModel`
- Resolved server-side in `ViewModelExtensions.ToUnitViewModel` using `PlayerRepository`
- UI shows the player name as link text; falls back to raw ID if name unavailable

## Test plan

- [ ] Go to Messages page — compose To field shows a dropdown of player names
- [ ] Send a message to a player selected by name — message is delivered correctly
- [ ] Go to Units page with units positioned at an enemy base — position column shows player name instead of GUID
- [ ] Verify link still navigates to the correct enemy base page