### PR TITLE
fix: BGE-344 eliminate all compiler warnings and enforce TreatWarningsAsErrors

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/BrowserGameEngine.BlazorClient.csproj
+++ b/src/BrowserGameEngine.BlazorClient/BrowserGameEngine.BlazorClient.csproj
@@ -6,6 +6,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -100,7 +100,7 @@
 }
 
 @code {
-    [Parameter] public string AllianceId { get; set; }
+    [Parameter] public required string AllianceId { get; set; }
 
     private AllianceDetailViewModel? detail;
     private MyAllianceStatusViewModel? myStatus;

--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -9,6 +9,7 @@
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);1591</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -55,7 +55,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<MyAllianceStatusViewModel> MyStatus() {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			var alliance = allianceRepository.GetByPlayerId(currentUserContext.PlayerId);
+			var alliance = allianceRepository.GetByPlayerId(currentUserContext.PlayerId!);
 			if (alliance == null) {
 				return Ok(new MyAllianceStatusViewModel { IsMember = false });
 			}
@@ -110,7 +110,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				var allianceId = allianceRepositoryWrite.CreateAlliance(
-					new CreateAllianceCommand(currentUserContext.PlayerId, request.AllianceName, request.Password));
+					new CreateAllianceCommand(currentUserContext.PlayerId!, request.AllianceName, request.Password));
 				return Ok(allianceId.ToString());
 			} catch (AllianceNameTakenException e) {
 				return Conflict(e.Message);
@@ -131,7 +131,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.JoinAlliance(
-					new JoinAllianceCommand(currentUserContext.PlayerId, AllianceIdFactory.Create(id), request.Password));
+					new JoinAllianceCommand(currentUserContext.PlayerId!, AllianceIdFactory.Create(id), request.Password));
 				return Ok();
 			} catch (AllianceNotFoundException) {
 				return NotFound();
@@ -147,7 +147,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.AcceptMember(
-					new AcceptMemberCommand(currentUserContext.PlayerId, PlayerIdFactory.Create(pid)));
+					new AcceptMemberCommand(currentUserContext.PlayerId!, PlayerIdFactory.Create(pid)));
 				return Ok();
 			} catch (NotAllianceLeaderException e) {
 				return StatusCode(403, e.Message);
@@ -161,7 +161,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.RejectMember(
-					new RejectMemberCommand(currentUserContext.PlayerId, PlayerIdFactory.Create(pid)));
+					new RejectMemberCommand(currentUserContext.PlayerId!, PlayerIdFactory.Create(pid)));
 				return Ok();
 			} catch (NotAllianceLeaderException e) {
 				return StatusCode(403, e.Message);
@@ -174,7 +174,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult Leave() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
-				allianceRepositoryWrite.LeaveAlliance(new LeaveAllianceCommand(currentUserContext.PlayerId));
+				allianceRepositoryWrite.LeaveAlliance(new LeaveAllianceCommand(currentUserContext.PlayerId!));
 				return Ok();
 			} catch (NotAllianceMemberException e) {
 				return BadRequest(e.Message);
@@ -186,7 +186,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.KickMember(
-					new KickMemberCommand(currentUserContext.PlayerId, PlayerIdFactory.Create(pid)));
+					new KickMemberCommand(currentUserContext.PlayerId!, PlayerIdFactory.Create(pid)));
 				return Ok();
 			} catch (NotAllianceLeaderException e) {
 				return StatusCode(403, e.Message);
@@ -200,7 +200,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.VoteLeader(
-					new VoteLeaderCommand(currentUserContext.PlayerId, PlayerIdFactory.Create(request.VoteePlayerId)));
+					new VoteLeaderCommand(currentUserContext.PlayerId!, PlayerIdFactory.Create(request.VoteePlayerId)));
 				return Ok();
 			} catch (NotAllianceMemberException e) {
 				return BadRequest(e.Message);
@@ -212,7 +212,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.SetAlliancePassword(
-					new SetAlliancePasswordCommand(currentUserContext.PlayerId, request.NewPassword));
+					new SetAlliancePasswordCommand(currentUserContext.PlayerId!, request.NewPassword));
 				return Ok();
 			} catch (NotAllianceLeaderException e) {
 				return StatusCode(403, e.Message);
@@ -226,7 +226,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				allianceRepositoryWrite.SetAllianceMessage(
-					new SetAllianceMessageCommand(currentUserContext.PlayerId, request.Message));
+					new SetAllianceMessageCommand(currentUserContext.PlayerId!, request.Message));
 				return Ok();
 			} catch (NotAllianceLeaderException e) {
 				return StatusCode(403, e.Message);
@@ -239,7 +239,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult<IEnumerable<AllianceChatPostViewModel>> GetPosts(string id) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var allianceId = AllianceIdFactory.Create(id);
-			if (!allianceRepository.IsMember(currentUserContext.PlayerId, allianceId)) {
+			if (!allianceRepository.IsMember(currentUserContext.PlayerId!, allianceId)) {
 				return StatusCode(403, "You are not a member of this alliance.");
 			}
 			var posts = allianceChatRepository.GetPosts(allianceId);
@@ -262,7 +262,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
 				var postId = allianceChatRepositoryWrite.Post(
-					new PostAllianceChatCommand(currentUserContext.PlayerId, AllianceIdFactory.Create(id), request.Body));
+					new PostAllianceChatCommand(currentUserContext.PlayerId!, AllianceIdFactory.Create(id), request.Body));
 				return Ok(postId.ToString());
 			} catch (AllianceNotFoundException) {
 				return NotFound();

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
@@ -39,7 +39,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(typeof(BuildQueueViewModel), StatusCodes.Status200OK)]
 		public BuildQueueViewModel Get() {
 			if (!currentUserContext.IsValid) return new BuildQueueViewModel();
-			var entries = buildQueueRepository.GetQueue(currentUserContext.PlayerId);
+			var entries = buildQueueRepository.GetQueue(currentUserContext.PlayerId!);
 			return new BuildQueueViewModel {
 				Entries = entries.Select(x => ToViewModel(x)).ToList()
 			};
@@ -57,7 +57,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 			if (request.Count <= 0) return BadRequest("Count must be greater than 0.");
 			buildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(
-				currentUserContext.PlayerId,
+				currentUserContext.PlayerId!,
 				request.Type,
 				request.DefId,
 				request.Count
@@ -72,7 +72,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public async Task<ActionResult> Remove([FromQuery] Guid entryId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			buildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(currentUserContext.PlayerId, entryId));
+			buildQueueRepositoryWrite.RemoveFromQueue(new RemoveFromQueueCommand(currentUserContext.PlayerId!, entryId));
 			return Ok();
 		}
 
@@ -83,7 +83,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public async Task<ActionResult> Reorder([FromBody] ReorderQueueRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			buildQueueRepositoryWrite.ReorderQueue(new ReorderQueueCommand(
-				currentUserContext.PlayerId,
+				currentUserContext.PlayerId!,
 				request.EntryId,
 				request.NewPriority
 			));

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GameInfoController.cs
@@ -35,7 +35,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<TickInfoViewModel> GetTickInfo() {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			int unreadCount = messageRepository.GetUnreadCount(currentUserContext.PlayerId);
+			int unreadCount = messageRepository.GetUnreadCount(currentUserContext.PlayerId!);
 			return Ok(new TickInfoViewModel {
 				ServerTime = timeProvider.GetUtcNow().UtcDateTime,
 				NextTickAt = gameTickEngine.NextTickAt,

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -147,6 +147,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		/// <summary>Updates game settings (name, end time, Discord webhook). Only the game creator may update.</summary>
 		/// <param name="gameId">The game identifier.</param>
+		/// <param name="request">Game update parameters.</param>
 		[HttpPatch("{gameId}")]
 		public ActionResult<GameDetailViewModel> Update(string gameId, [FromBody] UpdateGameRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
@@ -189,6 +190,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 		/// <summary>Joins an upcoming game with the current player. Requires authentication.</summary>
 		/// <param name="gameId">The game identifier.</param>
+		/// <param name="request">Join request containing the player name.</param>
 		[HttpPost("{gameId}/join")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -207,7 +209,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (instance == null) return NotFound();
 
 			// Check if user already has a player in this game (by UserId)
-			if (instance.HasUserPlayer(currentUserContext.UserId)) return Conflict("You have already joined this game.");
+			if (instance.HasUserPlayer(currentUserContext.UserId!)) return Conflict("You have already joined this game.");
 
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UpgradesController.cs
@@ -34,7 +34,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		[ProducesResponseType(typeof(UpgradesViewModel), StatusCodes.Status200OK)]
 		public UpgradesViewModel Get() {
-			var playerId = currentUserContext.PlayerId;
+			var playerId = currentUserContext.PlayerId!;
 			int attackLevel = upgradeRepository.GetAttackUpgradeLevel(playerId);
 			int defenseLevel = upgradeRepository.GetDefenseUpgradeLevel(playerId);
 			return new UpgradesViewModel {
@@ -58,7 +58,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				return BadRequest("Invalid upgradeType. Use 'Attack' or 'Defense'.");
 			}
 			try {
-				upgradeRepositoryWrite.ResearchUpgrade(new ResearchUpgradeCommand(currentUserContext.PlayerId, type));
+				upgradeRepositoryWrite.ResearchUpgrade(new ResearchUpgradeCommand(currentUserContext.PlayerId!, type));
 				return Ok();
 			} catch (UpgradeAlreadyMaxLevelException e) {
 				return BadRequest(e.Message);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/UserPreferencesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/UserPreferencesController.cs
@@ -25,7 +25,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet]
 		public ActionResult<UserPreferencesViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			var user = userRepository.GetByGithubId(currentUserContext.GithubId);
+			var user = userRepository.GetByGithubId(currentUserContext.GithubId!);
 			if (user == null) return NotFound();
 			return Ok(new UserPreferencesViewModel(
 				WantsGameNotification: user.WantsGameNotification,
@@ -36,11 +36,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpPatch]
 		public ActionResult Patch([FromBody] UpdateUserPreferencesRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
-			var user = userRepository.GetByGithubId(currentUserContext.GithubId);
+			var user = userRepository.GetByGithubId(currentUserContext.GithubId!);
 			if (user == null) return NotFound();
 			var wantsNotification = request.WantsGameNotification ?? user.WantsGameNotification;
 			var autoJoin = request.AutoJoinNextGame ?? user.AutoJoinNextGame;
-			userRepositoryWrite.SetGamePreferences(currentUserContext.GithubId, wantsNotification, autoJoin);
+			userRepositoryWrite.SetGamePreferences(currentUserContext.GithubId!, wantsNotification, autoJoin);
 			return NoContent();
 		}
 	}

--- a/src/BrowserGameEngine.GameDefinition.SCO/BrowserGameEngine.GameDefinition.SCO.csproj
+++ b/src/BrowserGameEngine.GameDefinition.SCO/BrowserGameEngine.GameDefinition.SCO.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.GameDefinition/BrowserGameEngine.GameDefinition.csproj
+++ b/src/BrowserGameEngine.GameDefinition/BrowserGameEngine.GameDefinition.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/BrowserGameEngine.GameModel/BrowserGameEngine.GameModel.csproj
+++ b/src/BrowserGameEngine.GameModel/BrowserGameEngine.GameModel.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.GameModel/BuildQueueEntryImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/BuildQueueEntryImmutable.cs
@@ -4,8 +4,8 @@ using System;
 namespace BrowserGameEngine.GameModel {
 	public record BuildQueueEntryImmutable {
 		public Guid Id { get; init; }
-		public string Type { get; init; } // "unit" or "asset"
-		public string DefId { get; init; }
+		public required string Type { get; init; } // "unit" or "asset"
+		public required string DefId { get; init; }
 		public int Count { get; init; }
 		public int Priority { get; init; }
 	}

--- a/src/BrowserGameEngine.Persistence.S3/BrowserGameEngine.Persistence.S3.csproj
+++ b/src/BrowserGameEngine.Persistence.S3/BrowserGameEngine.Persistence.S3.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.Persistence/BrowserGameEngine.Persistence.csproj
+++ b/src/BrowserGameEngine.Persistence/BrowserGameEngine.Persistence.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
 	public class AllianceMemberViewModel {
-		public string PlayerId { get; set; }
-		public string PlayerName { get; set; }
+		public required string PlayerId { get; set; }
+		public required string PlayerName { get; set; }
 		public bool IsPending { get; set; }
 		public DateTime JoinedAt { get; set; }
 		public int VoteCount { get; set; }
@@ -12,19 +12,19 @@ namespace BrowserGameEngine.Shared {
 	}
 
 	public class AllianceViewModel {
-		public string AllianceId { get; set; }
-		public string Name { get; set; }
+		public required string AllianceId { get; set; }
+		public required string Name { get; set; }
 		public string? Message { get; set; }
 		public int MemberCount { get; set; }
 		public DateTime Created { get; set; }
 	}
 
 	public class AllianceDetailViewModel {
-		public string AllianceId { get; set; }
-		public string Name { get; set; }
+		public required string AllianceId { get; set; }
+		public required string Name { get; set; }
 		public string? Message { get; set; }
 		public DateTime Created { get; set; }
-		public string LeaderId { get; set; }
+		public required string LeaderId { get; set; }
 		public List<AllianceMemberViewModel> Members { get; set; } = new();
 	}
 
@@ -37,35 +37,35 @@ namespace BrowserGameEngine.Shared {
 	}
 
 	public class CreateAllianceRequest {
-		public string AllianceName { get; set; }
-		public string Password { get; set; }
+		public required string AllianceName { get; set; }
+		public required string Password { get; set; }
 	}
 
 	public class JoinAllianceRequest {
-		public string Password { get; set; }
+		public required string Password { get; set; }
 	}
 
 	public class VoteLeaderRequest {
-		public string VoteePlayerId { get; set; }
+		public required string VoteePlayerId { get; set; }
 	}
 
 	public class SetAlliancePasswordRequest {
-		public string NewPassword { get; set; }
+		public required string NewPassword { get; set; }
 	}
 
 	public class SetAllianceMessageRequest {
-		public string Message { get; set; }
+		public required string Message { get; set; }
 	}
 
 	public class AllianceChatPostViewModel {
-		public string PostId { get; set; }
-		public string AuthorPlayerId { get; set; }
-		public string AuthorName { get; set; }
-		public string Body { get; set; }
+		public required string PostId { get; set; }
+		public required string AuthorPlayerId { get; set; }
+		public required string AuthorName { get; set; }
+		public required string Body { get; set; }
 		public DateTime CreatedAt { get; set; }
 	}
 
 	public class PostAllianceChatRequest {
-		public string Body { get; set; }
+		public required string Body { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.Shared/BrowserGameEngine.ViewModels.csproj
+++ b/src/BrowserGameEngine.Shared/BrowserGameEngine.ViewModels.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.Shared/BuildQueueViewModel.cs
+++ b/src/BrowserGameEngine.Shared/BuildQueueViewModel.cs
@@ -8,16 +8,16 @@ namespace BrowserGameEngine.Shared {
 
 	public record BuildQueueEntryViewModel {
 		public Guid Id { get; set; }
-		public string Type { get; set; } // "unit" or "asset"
-		public string DefId { get; set; }
-		public string Name { get; set; }
+		public required string Type { get; set; } // "unit" or "asset"
+		public required string DefId { get; set; }
+		public required string Name { get; set; }
 		public int Count { get; set; }
 		public int Priority { get; set; }
 	}
 
 	public record AddToQueueRequest {
-		public string Type { get; set; } // "unit" or "asset"
-		public string DefId { get; set; }
+		public required string Type { get; set; } // "unit" or "asset"
+		public required string DefId { get; set; }
 		public int Count { get; set; }
 	}
 

--- a/src/BrowserGameEngine.StatefulGameServer.Benchmarks/BrowserGameEngine.StatefulGameServer.Benchmarks.csproj
+++ b/src/BrowserGameEngine.StatefulGameServer.Benchmarks/BrowserGameEngine.StatefulGameServer.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <GenerateProgramFile>false</GenerateProgramFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
@@ -47,7 +47,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
 			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
 
-			var alliance = game.AllianceRepository.Get(allianceId);
+			var alliance = game.AllianceRepository.Get(allianceId)!;
 			var member = alliance.Members.Single(m => m.PlayerId == Player2);
 			Assert.True(member.IsPending);
 			var player = game.PlayerRepository.Get(Player2);
@@ -61,7 +61,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
 			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
 
-			var alliance = game.AllianceRepository.Get(allianceId);
+			var alliance = game.AllianceRepository.Get(allianceId)!;
 			var member = alliance.Members.Single(m => m.PlayerId == Player2);
 			Assert.False(member.IsPending);
 		}
@@ -73,7 +73,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
 			game.AllianceRepositoryWrite.RejectMember(new RejectMemberCommand(Player1, Player2));
 
-			var alliance = game.AllianceRepository.Get(allianceId);
+			var alliance = game.AllianceRepository.Get(allianceId)!;
 			Assert.DoesNotContain(alliance.Members, m => m.PlayerId == Player2);
 			var player = game.PlayerRepository.Get(Player2);
 			Assert.Null(player.AllianceId);
@@ -112,7 +112,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
 			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
 
-			var alliance = game.AllianceRepository.Get(allianceId);
+			var alliance = game.AllianceRepository.Get(allianceId)!;
 			Assert.Equal(Player2, alliance.LeaderId);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BrowserGameEngine.StatefulGameServer.Test.csproj
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BrowserGameEngine.StatefulGameServer.Test.csproj
@@ -5,6 +5,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -123,7 +123,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.NotNull(registry.TryGetInstance(new GameId("game2")));
 
 			// No achievements for game 2 (it hasn't ended)
-			Assert.Empty(globalState.GetAchievements().Where(a => a.GameId.Id == "game2"));
+			Assert.DoesNotContain(globalState.GetAchievements(), a => a.GameId.Id == "game2");
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/BrowserGameEngine.StatefulGameServer.csproj
+++ b/src/BrowserGameEngine.StatefulGameServer/BrowserGameEngine.StatefulGameServer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AllianceNameTakenException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AllianceNameTakenException.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class AllianceNameTakenException : Exception {
 		public AllianceNameTakenException(string name) : base($"Alliance name '{name}' is already taken.") {
-		}
-
-		protected AllianceNameTakenException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AllianceNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AllianceNotFoundException.cs
@@ -1,14 +1,9 @@
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class AllianceNotFoundException : Exception {
 		public AllianceNotFoundException(AllianceId allianceId) : base($"Alliance '{allianceId}' does not exist.") {
-		}
-
-		protected AllianceNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AlreadyInAllianceException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AlreadyInAllianceException.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class AlreadyInAllianceException : Exception {
 		public AlreadyInAllianceException() : base("Player is already in an alliance.") {
-		}
-
-		protected AlreadyInAllianceException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/InvalidAlliancePasswordException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/InvalidAlliancePasswordException.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class InvalidAlliancePasswordException : Exception {
 		public InvalidAlliancePasswordException() : base("Invalid alliance password.") {
-		}
-
-		protected InvalidAlliancePasswordException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAllianceLeaderException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAllianceLeaderException.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class NotAllianceLeaderException : Exception {
 		public NotAllianceLeaderException() : base("Only the alliance leader can perform this action.") {
-		}
-
-		protected NotAllianceLeaderException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAllianceMemberException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAllianceMemberException.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class NotAllianceMemberException : Exception {
 		public NotAllianceMemberException() : base("Player is not a member of this alliance.") {
-		}
-
-		protected NotAllianceMemberException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeAlreadyMaxLevelException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeAlreadyMaxLevelException.cs
@@ -1,14 +1,9 @@
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UpgradeAlreadyMaxLevelException : Exception {
 		public UpgradeAlreadyMaxLevelException(UpgradeType upgradeType) : base($"Upgrade '{upgradeType}' is already at max level.") {
-		}
-
-		protected UpgradeAlreadyMaxLevelException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeResearchInProgressException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/UpgradeResearchInProgressException.cs
@@ -1,14 +1,9 @@
 using BrowserGameEngine.GameModel;
 using System;
-using System.Runtime.Serialization;
 
 namespace BrowserGameEngine.StatefulGameServer {
-	[Serializable]
 	public class UpgradeResearchInProgressException : Exception {
 		public UpgradeResearchInProgressException(UpgradeType upgradeBeingResearched) : base($"Research already in progress: '{upgradeBeingResearched}'.") {
-		}
-
-		protected UpgradeResearchInProgressException(SerializationInfo info, StreamingContext context) : base(info, context) {
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class AllianceMember {
-		public PlayerId PlayerId { get; set; }
+		public required PlayerId PlayerId { get; set; }
 		public bool IsPending { get; set; }
 		public DateTime JoinedAt { get; set; }
 		public int VoteCount { get; set; }
@@ -20,10 +20,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	}
 
 	internal class Alliance {
-		public AllianceId AllianceId { get; init; }
-		public string Name { get; set; }
-		public string PasswordHash { get; set; }
-		public PlayerId LeaderId { get; set; }
+		public required AllianceId AllianceId { get; init; }
+		public required string Name { get; set; }
+		public required string PasswordHash { get; set; }
+		public required PlayerId LeaderId { get; set; }
 		public DateTime Created { get; init; }
 		public List<AllianceMember> Members { get; set; } = new List<AllianceMember>();
 		public string? Message { get; set; }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BuildQueueEntry.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BuildQueueEntry.cs
@@ -6,8 +6,8 @@ using System.Linq;
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class BuildQueueEntry {
 		public Guid Id { get; init; }
-		public string Type { get; init; } // "unit" or "asset"
-		public string DefId { get; init; }
+		public required string Type { get; init; } // "unit" or "asset"
+		public required string DefId { get; init; }
 		public int Count { get; init; }
 		public int Priority { get; set; }
 	}


### PR DESCRIPTION
## Summary
- Fixed all 140 compiler warnings across the solution (0 warnings remain)
- Added `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to all 11 `.csproj` files to block future regressions

## Changes by warning type
- **CS8618 (66):** Added `required` modifier to uninitialized non-nullable properties in `GameModel`, `Shared`, `StatefulGameServer/GameModelInternal`, and `BlazorClient`
- **CS8604 (44):** Added null-forgiving operators (`!`) after `IsValid` guard checks in controllers (AlliancesController, BuildQueueController, GameInfoController, GamesController, UpgradesController, UserPreferencesController)
- **SYSLIB0051 (16):** Removed obsolete `[Serializable]`/`protected SerializationInfo` constructors from all 8 exception classes in `StatefulGameServer/Exceptions/`
- **CS8602 (8):** Added null-forgiving operators in `AllianceRepositoryTest.cs`
- **CS1573 (4):** Added missing `<param>` XML doc tags in `GamesController`
- **xUnit2029 (2):** Replaced `Assert.Empty+Where` with `Assert.DoesNotContain` in tests

## Test plan
- [x] `dotnet build` passes with 0 warnings, 0 errors
- [x] `dotnet test` passes — 173/173 tests pass
- [x] `TreatWarningsAsErrors` enforced in all 11 projects

Closes BGE-344