### PR TITLE
feat: BGE-291 spy/scout mission

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -1,14 +1,11 @@
 @page "/enemybase/{EnemeyPlayerId}"
 @page "/games/{GameId}/enemybase/{EnemeyPlayerId}"
 @using BrowserGameEngine.Shared
+@using System.Linq
 @inject HttpClient Http
 @implements IDisposable
 
 <h1>Attack</h1>
-
-@if (!string.IsNullOrEmpty(lastError)) {
-    <span class="error">@lastError</span>
-}
 
 @if (model == null) {
     <p><em>Loading...</em></p>
@@ -19,6 +16,35 @@
     <button class="btn btn-primary" @onclick="Attack">
         Attack
     </button>
+    <button class="btn btn-secondary ms-2" @onclick="SendSpy" disabled="@spyLoading">
+        @(spyLoading ? "Spying..." : "Send Spy (50 minerals)")
+    </button>
+
+    @if (!string.IsNullOrEmpty(lastError)) {
+        <span class="error">@lastError</span>
+    }
+
+    @if (spyReport != null) {
+        <details open class="mt-3">
+            <summary><strong>Spy Report — @spyReport.TargetPlayerName</strong> <small class="text-muted">(@spyReport.ReportTime.ToLocalTime().ToString("HH:mm:ss"))</small></summary>
+            <div class="mt-2">
+                <p><strong>Approximate Resources:</strong> ~@((int)spyReport.ApproximateMinerals) minerals, ~@((int)spyReport.ApproximateGas) gas</p>
+                @if (spyReport.UnitEstimates.Any()) {
+                    <table class="table table-sm">
+                        <thead><tr><th>Unit</th><th>~Count</th></tr></thead>
+                        <tbody>
+                            @foreach (var u in spyReport.UnitEstimates.OrderByDescending(x => x.ApproximateCount)) {
+                                <tr><td>@u.UnitTypeName</td><td>~@u.ApproximateCount</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                } else {
+                    <p class="text-muted">No units detected at base.</p>
+                }
+                <p class="text-muted"><small>Next spy available: @spyReport.CooldownExpiresAt.ToLocalTime()</small></p>
+            </div>
+        </details>
+    }
 
     @if (battleResult != null) {
         <h2>Battle Result</h2>
@@ -147,6 +173,10 @@
 
     private BattleResultViewModel? battleResult;
 
+    private SpyReportViewModel? spyReport;
+
+    private bool spyLoading;
+
     private string? lastError;
 
     [Parameter]
@@ -179,6 +209,20 @@
         var response = await Http.PostAsync($"api/battle/attack?enemyPlayerId={Uri.EscapeDataString(EnemeyPlayerId)}", null);
         if (response.IsSuccessStatusCode) {
             battleResult = await response.Content.ReadFromJsonAsync<BattleResultViewModel>();
+        } else {
+            var error = await response.Content.ReadAsStringAsync();
+            lastError = error;
+        }
+    }
+
+    private async Task SendSpy() {
+        spyLoading = true;
+        lastError = null;
+        spyReport = null;
+        var response = await Http.PostAsync($"api/spy/execute?targetPlayerId={Uri.EscapeDataString(EnemeyPlayerId)}", null);
+        spyLoading = false;
+        if (response.IsSuccessStatusCode) {
+            spyReport = await response.Content.ReadFromJsonAsync<SpyReportViewModel>();
         } else {
             var error = await response.Content.ReadAsStringAsync();
             lastError = error;

--- a/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
@@ -25,7 +25,32 @@
                 }
         </InputSelect>
         <button type="submit">Send Troops</button>
+        <button type="button" class="btn btn-secondary ms-2" @onclick="SendSpy" disabled="@(string.IsNullOrEmpty(SelectedPlayerId) || spyLoading)">
+            @(spyLoading ? "Spying..." : "Send Spy (50 minerals)")
+        </button>
     </EditForm>
+
+    @if (spyReport != null) {
+        <details open class="mt-3">
+            <summary><strong>Spy Report — @spyReport.TargetPlayerName</strong> <small class="text-muted">(@spyReport.ReportTime.ToLocalTime():HH:mm:ss)</small></summary>
+            <div class="mt-2">
+                <p><strong>Approximate Resources:</strong> ~@((int)spyReport.ApproximateMinerals) minerals, ~@((int)spyReport.ApproximateGas) gas</p>
+                @if (spyReport.UnitEstimates.Any()) {
+                    <table class="table table-sm">
+                        <thead><tr><th>Unit</th><th>~Count</th></tr></thead>
+                        <tbody>
+                            @foreach (var u in spyReport.UnitEstimates.OrderByDescending(x => x.ApproximateCount)) {
+                                <tr><td>@u.UnitTypeName</td><td>~@u.ApproximateCount</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                } else {
+                    <p class="text-muted">No units detected at base.</p>
+                }
+                <p class="text-muted"><small>Next spy available: @spyReport.CooldownExpiresAt.ToLocalTime()</small></p>
+            </div>
+        </details>
+    }
 
     <NavLink class="nav-link" href="units">Cancel Attack</NavLink>
 }
@@ -43,6 +68,10 @@
 
     private string? lastError;
 
+    private SpyReportViewModel? spyReport;
+
+    private bool spyLoading;
+
     protected override async Task OnInitializedAsync() {
         model = await Http.GetFromJsonAsync<SelectEnemyViewModel>("api/battle/attackableplayers");
         if (model != null && model.AttackablePlayers.Any()) SelectedPlayerId = model.AttackablePlayers.First().PlayerId;
@@ -57,6 +86,21 @@
         if (response.IsSuccessStatusCode) {
             await Tutorial.MarkStepAsync(3);
             Nav.NavigateTo($"/enemybase/{Uri.EscapeDataString(SelectedPlayerId)}");
+        } else {
+            var error = await response.Content.ReadAsStringAsync();
+            lastError = error;
+        }
+    }
+
+    private async Task SendSpy() {
+        if (string.IsNullOrEmpty(SelectedPlayerId)) return;
+        spyLoading = true;
+        lastError = null;
+        spyReport = null;
+        var response = await Http.PostAsync($"api/spy/execute?targetPlayerId={Uri.EscapeDataString(SelectedPlayerId)}", null);
+        spyLoading = false;
+        if (response.IsSuccessStatusCode) {
+            spyReport = await response.Content.ReadFromJsonAsync<SpyReportViewModel>();
         } else {
             var error = await response.Content.ReadAsStringAsync();
             lastError = error;

--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -1,0 +1,92 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}")]
+	public class SpyController : ControllerBase {
+		private readonly ILogger<SpyController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly SpyRepositoryWrite spyRepositoryWrite;
+		private readonly PlayerRepository playerRepository;
+		private readonly UserRepository userRepository;
+		private readonly GameDef gameDef;
+
+		public SpyController(
+			ILogger<SpyController> logger,
+			CurrentUserContext currentUserContext,
+			SpyRepositoryWrite spyRepositoryWrite,
+			PlayerRepository playerRepository,
+			UserRepository userRepository,
+			GameDef gameDef
+		) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.spyRepositoryWrite = spyRepositoryWrite;
+			this.playerRepository = playerRepository;
+			this.userRepository = userRepository;
+			this.gameDef = gameDef;
+		}
+
+		/// <summary>Executes a spy mission against a target player, returning fuzzy intel at a mineral cost. Subject to a 30-minute per-target cooldown.</summary>
+		/// <param name="targetPlayerId">The player ID to spy on.</param>
+		[HttpPost]
+		[ProducesResponseType(typeof(SpyReportViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+		public ActionResult<SpyReportViewModel> Execute([FromQuery] string targetPlayerId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				var result = spyRepositoryWrite.ExecuteSpy(new SpyCommand(
+					currentUserContext.PlayerId!,
+					PlayerIdFactory.Create(targetPlayerId)
+				));
+
+				var targetPlayer = playerRepository.Get(result.TargetPlayerId);
+				var targetName = targetPlayer.UserId != null
+					? userRepository.GetDisplayNameByUserId(targetPlayer.UserId) ?? targetPlayer.Name
+					: targetPlayer.Name;
+
+				var mineralDefId = Id.ResDef("minerals");
+				var gasDefId = Id.ResDef("gas");
+
+				result.ApproximateResources.TryGetValue(mineralDefId, out var approxMinerals);
+				result.ApproximateResources.TryGetValue(gasDefId, out var approxGas);
+
+				var unitEstimates = result.UnitEstimates
+					.Select(u => new UnitEstimateViewModel {
+						UnitDefId = u.UnitDefId.Id,
+						UnitTypeName = gameDef.GetUnitDef(u.UnitDefId)?.Name ?? u.UnitDefId.Id,
+						ApproximateCount = u.ApproximateCount
+					})
+					.ToList();
+
+				return new SpyReportViewModel {
+					TargetPlayerId = result.TargetPlayerId.ToString(),
+					TargetPlayerName = targetName,
+					ApproximateMinerals = Math.Round(approxMinerals, 0),
+					ApproximateGas = Math.Round(approxGas, 0),
+					UnitEstimates = unitEstimates,
+					ReportTime = result.ReportTime,
+					CooldownExpiresAt = result.CooldownExpiresAt
+				};
+			} catch (SpyCooldownException e) {
+				Response.Headers.Append("Retry-After", ((int)(e.CooldownExpiresAt - DateTime.UtcNow).TotalSeconds).ToString());
+				return StatusCode(StatusCodes.Status429TooManyRequests, e.Message);
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -18,6 +18,7 @@ namespace BrowserGameEngine.GameModel {
 		int DefenseUpgradeLevel = 0,
 		int UpgradeResearchTimer = 0,
 		UpgradeType UpgradeBeingResearched = UpgradeType.None,
-		IList<BuildQueueEntryImmutable>? BuildQueue = null
+		IList<BuildQueueEntryImmutable>? BuildQueue = null,
+		IDictionary<string, DateTime>? SpyCooldowns = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/SpyResult.cs
+++ b/src/BrowserGameEngine.GameModel/SpyResult.cs
@@ -1,0 +1,15 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameModel {
+	public record SpyUnitEstimate(UnitDefId UnitDefId, int ApproximateCount);
+
+	public record SpyResult(
+		PlayerId TargetPlayerId,
+		IDictionary<ResourceDefId, decimal> ApproximateResources,
+		IList<SpyUnitEstimate> UnitEstimates,
+		DateTime ReportTime,
+		DateTime CooldownExpiresAt
+	);
+}

--- a/src/BrowserGameEngine.Shared/SpyReportViewModel.cs
+++ b/src/BrowserGameEngine.Shared/SpyReportViewModel.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class SpyReportViewModel {
+		public string TargetPlayerId { get; set; } = "";
+		public string TargetPlayerName { get; set; } = "";
+		public decimal ApproximateMinerals { get; set; }
+		public decimal ApproximateGas { get; set; }
+		public List<UnitEstimateViewModel> UnitEstimates { get; set; } = new();
+		public DateTime ReportTime { get; set; }
+		public DateTime CooldownExpiresAt { get; set; }
+	}
+
+	public class UnitEstimateViewModel {
+		public string UnitDefId { get; set; } = "";
+		public string UnitTypeName { get; set; } = "";
+		public int ApproximateCount { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SpyRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SpyRepositoryTest.cs
@@ -1,0 +1,112 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class SpyRepositoryTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void ExecuteSpy_ValidTarget_ReturnsSpyReport() {
+			var game = new TestGame(playerCount: 2); // Player1 starts with 5000 minerals, enough for spy cost
+
+			var result = game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			Assert.Equal(Player2, result.TargetPlayerId);
+			Assert.NotNull(result.ApproximateResources);
+			Assert.NotNull(result.UnitEstimates);
+			Assert.True(result.ReportTime > DateTime.MinValue);
+		}
+
+		[Fact]
+		public void ExecuteSpy_DeductsGrowthResourceCost() {
+			// TestGame uses "res1" as the growth resource (defined in TestGameDefFactory)
+			var growthResourceId = Id.ResDef("res1");
+			var game = new TestGame(playerCount: 2);
+			var resourceBefore = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			var resourceAfter = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+			Assert.Equal(resourceBefore - 50m, resourceAfter);
+		}
+
+		[Fact]
+		public void ExecuteSpy_InsufficientResources_ThrowsCannotAfford() {
+			var game = new TestGame(playerCount: 2);
+			// Drain all of res1 (the growth/spy-cost resource in the test game def) from Player1
+			var amount = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res1"));
+			game.ResourceRepositoryWrite.DeductCost(Player1, Id.ResDef("res1"), amount);
+
+			Assert.Throws<CannotAffordException>(() =>
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2)));
+		}
+
+		[Fact]
+		public void ExecuteSpy_OnCooldown_ThrowsSpyCooldownException() {
+			var game = new TestGame(playerCount: 2); // Player1 starts with 5000 minerals
+
+			// First spy succeeds
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			// Second spy should throw cooldown exception
+			Assert.Throws<SpyCooldownException>(() =>
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2)));
+		}
+
+		[Fact]
+		public void ExecuteSpy_DifferentTargets_NotOnCooldown() {
+			var game = new TestGame(playerCount: 3); // Player1 starts with 5000 minerals
+
+			var player3 = PlayerIdFactory.Create("player2");
+
+			// Spy on player2 first
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			// Spy on player3 should not be on cooldown
+			var result = game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, player3));
+			Assert.Equal(player3, result.TargetPlayerId);
+		}
+
+		[Fact]
+		public void SpyRepository_IsOnCooldown_FalseBeforeSpy() {
+			var game = new TestGame(playerCount: 2);
+
+			Assert.False(game.SpyRepository.IsOnCooldown(Player1, Player2));
+		}
+
+		[Fact]
+		public void SpyRepository_IsOnCooldown_TrueAfterSpy() {
+			var game = new TestGame(playerCount: 2); // Player1 starts with 5000 minerals
+
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			Assert.True(game.SpyRepository.IsOnCooldown(Player1, Player2));
+		}
+
+		[Fact]
+		public void ExecuteSpy_FuzzyResources_WithinExpectedRange() {
+			// TestGame uses "res1" as the primary resource
+			var res1Id = Id.ResDef("res1");
+
+			// Run several times (each fresh game) to confirm fuzzy values land within ±30% of exact value
+			for (int i = 0; i < 10; i++) {
+				var freshGame = new TestGame(playerCount: 2);
+				// Set Player2 to a known res1 value
+				var existing = freshGame.ResourceRepository.GetAmount(Player2, res1Id);
+				freshGame.ResourceRepositoryWrite.DeductCost(Player2, res1Id, existing);
+				freshGame.ResourceRepositoryWrite.AddResources(Player2, res1Id, 1000m);
+
+				var result = freshGame.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+				var approxRes1 = result.ApproximateResources[res1Id];
+				Assert.True(approxRes1 >= 700m && approxRes1 <= 1300m,
+					$"Expected fuzzy res1 in [700, 1300] but got {approxRes1}");
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -36,6 +36,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public BuildQueueRepository BuildQueueRepository { get; }
 		public BuildQueueRepositoryWrite BuildQueueRepositoryWrite { get; }
 		public MarketRepository MarketRepository { get; }
+		public SpyRepository SpyRepository { get; }
+		public SpyRepositoryWrite SpyRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -70,6 +72,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			BuildQueueRepository = new BuildQueueRepository(Accessor);
 			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), Accessor, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
 			MarketRepository = new MarketRepository(Accessor, ResourceRepository, ResourceRepositoryWrite);
+			SpyRepository = new SpyRepository(Accessor, TimeProvider.System);
+			SpyRepositoryWrite = new SpyRepositoryWrite(Accessor, SpyRepository, ResourceRepositoryWrite, GameDef, TimeProvider.System);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -40,4 +40,6 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record CancelMarketOrderCommand(PlayerId PlayerId, MarketOrderId OrderId) : ICommand;
 
 	public record PostChatMessageCommand(PlayerId AuthorPlayerId, string Body) : ICommand;
+
+	public record SpyCommand(PlayerId SpyingPlayerId, PlayerId TargetPlayerId) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/SpyCooldownException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/SpyCooldownException.cs
@@ -1,0 +1,13 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SpyCooldownException : Exception {
+		public DateTime CooldownExpiresAt { get; }
+
+		public SpyCooldownException(PlayerId targetPlayerId, DateTime cooldownExpiresAt)
+			: base($"Spy mission against player '{targetPlayerId}' is on cooldown until {cooldownExpiresAt:u}") {
+			CooldownExpiresAt = cooldownExpiresAt;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -20,6 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int UpgradeResearchTimer { get; set; }
 		public UpgradeType UpgradeBeingResearched { get; set; }
 		public List<BuildQueueEntry> BuildQueue { get; set; } = new List<BuildQueueEntry>();
+		public Dictionary<string, DateTime> SpyCooldowns { get; set; } = new Dictionary<string, DateTime>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -38,7 +39,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
 				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
 				UpgradeBeingResearched: playerState.UpgradeBeingResearched,
-				BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList()
+				BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList(),
+				SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns)
 			);
 		}
 
@@ -58,7 +60,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UpgradeResearchTimer = playerStateImmutable.UpgradeResearchTimer,
 				UpgradeBeingResearched = playerStateImmutable.UpgradeBeingResearched,
 				BuildQueue = (playerStateImmutable.BuildQueue ?? new List<BuildQueueEntryImmutable>())
-					.Select(x => x.ToMutable()).ToList()
+					.Select(x => x.ToMutable()).ToList(),
+				SpyCooldowns = playerStateImmutable.SpyCooldowns != null
+					? new Dictionary<string, DateTime>(playerStateImmutable.SpyCooldowns)
+					: new Dictionary<string, DateTime>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -53,6 +53,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<BuildQueueRepository>();
 			services.AddSingleton<BuildQueueRepositoryWrite>();
 			services.AddSingleton<MarketRepository>();
+			services.AddSingleton<SpyRepository>();
+			services.AddSingleton<SpyRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
@@ -1,0 +1,31 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SpyRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly TimeProvider timeProvider;
+
+		private static readonly TimeSpan CooldownDuration = TimeSpan.FromMinutes(30);
+
+		public SpyRepository(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.timeProvider = timeProvider;
+		}
+
+		public bool IsOnCooldown(PlayerId spyingPlayerId, PlayerId targetPlayerId) {
+			return GetCooldownExpiry(spyingPlayerId, targetPlayerId) != null;
+		}
+
+		public DateTime? GetCooldownExpiry(PlayerId spyingPlayerId, PlayerId targetPlayerId) {
+			var cooldowns = world.GetPlayer(spyingPlayerId).State.SpyCooldowns;
+			var key = targetPlayerId.ToString();
+			if (!cooldowns.TryGetValue(key, out var lastSpyTime)) return null;
+			var expiry = lastSpyTime + CooldownDuration;
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			return expiry > now ? expiry : null;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -1,0 +1,90 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SpyRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly SpyRepository spyRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+		private readonly TimeProvider timeProvider;
+		private readonly Cost spyCost;
+
+		private const decimal SpyCostAmount = 50m;
+		private static readonly TimeSpan CooldownDuration = TimeSpan.FromMinutes(30);
+
+		public SpyRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			SpyRepository spyRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite,
+			GameDef gameDef,
+			TimeProvider timeProvider
+		) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.spyRepository = spyRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+			this.timeProvider = timeProvider;
+			spyCost = Cost.FromSingle(GetGrowthResource(gameDef), SpyCostAmount);
+		}
+
+		private static ResourceDefId GetGrowthResource(GameDef gameDef) {
+			foreach (var module in gameDef.GameTickModules) {
+				if (module.Properties.TryGetValue("growth-resource", out var resourceId)) {
+					return new ResourceDefId(resourceId);
+				}
+			}
+			return gameDef.ScoreResource;
+		}
+
+		public SpyResult ExecuteSpy(SpyCommand command) {
+			lock (_lock) {
+				world.ValidatePlayer(command.SpyingPlayerId);
+				world.ValidatePlayer(command.TargetPlayerId);
+
+				var cooldownExpiry = spyRepository.GetCooldownExpiry(command.SpyingPlayerId, command.TargetPlayerId);
+				if (cooldownExpiry != null) {
+					throw new SpyCooldownException(command.TargetPlayerId, cooldownExpiry.Value);
+				}
+
+				resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, spyCost);
+
+				var now = timeProvider.GetUtcNow().UtcDateTime;
+				world.GetPlayer(command.SpyingPlayerId).State.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
+
+				var targetState = world.GetPlayer(command.TargetPlayerId).State;
+				var rng = new Random();
+
+				var approxResources = new Dictionary<ResourceDefId, decimal>();
+				foreach (var kv in targetState.Resources) {
+					var noise = 1.0 + (rng.NextDouble() * 0.6 - 0.3); // ±30%
+					approxResources[kv.Key] = Math.Max(0, (decimal)((double)kv.Value * noise));
+				}
+
+				var unitGroups = targetState.Units
+					.Where(u => u.Position == null) // only home units
+					.GroupBy(u => u.UnitDefId)
+					.Select(g => {
+						var exactCount = g.Sum(u => u.Count);
+						var noise = 1.0 + (rng.NextDouble() * 0.4 - 0.2); // ±20%
+						return new SpyUnitEstimate(g.Key, Math.Max(0, (int)(exactCount * noise)));
+					})
+					.ToList();
+
+				return new SpyResult(
+					TargetPlayerId: command.TargetPlayerId,
+					ApproximateResources: approxResources,
+					UnitEstimates: unitGroups,
+					ReportTime: now,
+					CooldownExpiresAt: now + CooldownDuration
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the spy/scout mission feature (BGE-291): players can send a spy against any enemy player for 50 minerals (the game's growth resource)
- Returns fuzzy intel immediately: unit counts with ±20% noise, resource levels with ±30% noise
- 30-minute per-target cooldown enforced server-side; returns HTTP 429 + `Retry-After` header when on cooldown
- SpyCooldowns persisted in `PlayerState` via the existing mutable/immutable serialization round-trip
- Spy cost resource read dynamically from GameDef tick-module settings (`growth-resource` key), making it work correctly for both the production SCO game and test game fixtures
- "Send Spy" button added to `SelectEnemy.razor` and `EnemyBase.razor`; report shown inline as a collapsible `<details>` block after mission completes

## Test plan

- [x] `dotnet build` passes (0 warnings)
- [x] `dotnet test` passes (181/181)
- [x] `SpyRepositoryTest`: 7 tests covering happy-path, cooldown enforcement, insufficient resources, multi-target (different cooldown per target), and fuzzy-range bounds
- [ ] Manual: open the game, send a spy from SelectEnemy or EnemyBase, verify report appears inline with approximate values
- [ ] Manual: retry spy within 30 minutes, verify 429 error with message shown

Closes BGE-291