### PR TITLE
fix: BGE-357 S3DataProtectionKeyRepository NullReferenceException on first boot

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
+++ b/src/BrowserGameEngine.FrontendServer/S3DataProtectionKeyRepository.cs
@@ -33,7 +33,7 @@ internal sealed class S3DataProtectionKeyRepository : IXmlRepository
 		}).GetAwaiter().GetResult();
 
 		var elements = new List<XElement>();
-		foreach (var obj in list.S3Objects) {
+		foreach (var obj in list.S3Objects ?? []) {
 			var response = _s3.GetObjectAsync(_bucketName, obj.Key).GetAwaiter().GetResult();
 			using var stream = response.ResponseStream;
 			elements.Add(XElement.Load(stream));


### PR DESCRIPTION
## Summary
- Guard `list.S3Objects` against `null` with `?? []` in `GetAllElements()`
- AWS SDK returns `null` (not an empty list) when no objects exist under the given S3 prefix — this is normal on first container boot before any data-protection key has been written
- Without the fix, every startup throws `NullReferenceException` → `CryptographicException`, breaking GitHub OAuth login for all users

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (173 tests)
- [ ] Deploy to prod and confirm GitHub OAuth login succeeds on fresh container startup

Closes BGE-357