### PR TITLE
feat: BGE-372 UX round 2 — medium-priority audit items

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games.razor
@@ -59,7 +59,9 @@
 							@if (game.CanJoin) {
 								<button class="btn btn-sm btn-success" @onclick="() => JoinGame(game)">Join</button>
 							}
-							<a class="btn btn-sm btn-primary" href="games/@game.GameId/base">Play Now</a>
+							@if (game.IsPlayerEnrolled) {
+								<a class="btn btn-sm btn-primary" href="games/@game.GameId/base">Play Now</a>
+							}
 							<a class="btn btn-sm btn-outline-secondary" href="games/@game.GameId/ranking">Spectate</a>
 						</div>
 					</div>
@@ -104,32 +106,43 @@
 	}
 
 	@if (finished.Count > 0) {
-		<h2>Finished</h2>
-		<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
-			@foreach (var game in finished) {
-				<div class="col">
-					<div class="card h-100">
-						<div class="card-body">
-							<div class="d-flex justify-content-between align-items-start mb-2">
-								<h5 class="card-title mb-0">@game.Name</h5>
-								<span class="badge bg-secondary">FINISHED</span>
-							</div>
-							@if (!string.IsNullOrEmpty(game.WinnerName)) {
-								<p class="card-text mb-0">
-									<small class="text-muted">Winner: <strong>@game.WinnerName</strong></small>
-								</p>
-							}
-							<p class="card-text">
-								<small class="text-muted">Ended: @(game.EndTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "TBD")</small>
-							</p>
-						</div>
-						<div class="card-footer">
-							<a class="btn btn-sm btn-outline-secondary" href="games/@game.GameId/results">View Results</a>
-						</div>
-					</div>
-				</div>
+		<div class="d-flex align-items-center gap-2 mb-2">
+			<h2 class="mb-0">Finished</h2>
+			@if (finished.Count > 5) {
+				<button class="btn btn-sm btn-link p-0" @onclick="ToggleFinished">
+					@(showFinished ? "▲ Collapse" : $"▼ Show all ({finished.Count})")
+				</button>
 			}
 		</div>
+		@if (showFinished || finished.Count <= 5) {
+			<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
+				@foreach (var game in finished) {
+					<div class="col">
+						<div class="card h-100">
+							<div class="card-body">
+								<div class="d-flex justify-content-between align-items-start mb-2">
+									<h5 class="card-title mb-0">@game.Name</h5>
+									<span class="badge bg-secondary">FINISHED</span>
+								</div>
+								@if (!string.IsNullOrEmpty(game.WinnerName)) {
+									<p class="card-text mb-0">
+										<small class="text-muted">Winner: <strong>@game.WinnerName</strong></small>
+									</p>
+								}
+								<p class="card-text">
+									<small class="text-muted">Ended: @(game.EndTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "TBD")</small>
+								</p>
+							</div>
+							<div class="card-footer">
+								<a class="btn btn-sm btn-outline-secondary" href="games/@game.GameId/results">View Results</a>
+							</div>
+						</div>
+					</div>
+				}
+			</div>
+		} else {
+			<p class="text-muted mb-4">@finished.Count finished games — click "Show all" to expand.</p>
+		}
 	}
 }
 
@@ -138,6 +151,7 @@
 	private string? lastError;
 	private string? successMessage;
 	private bool isNewPlayer;
+	private bool showFinished = false;
 
 	protected override async Task OnInitializedAsync() {
 		isNewPlayer = Nav.Uri.Contains("welcome=1", StringComparison.Ordinal);
@@ -153,6 +167,8 @@
 			games = new List<GameSummaryViewModel>();
 		}
 	}
+
+	private void ToggleFinished() => showFinished = !showFinished;
 
 	private async Task JoinGame(GameSummaryViewModel game) {
 		lastError = null;

--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
@@ -25,34 +25,39 @@
 
 	@if (model.Standings.Count == 0) {
 		<p class="text-muted">No standings recorded for this game.</p>
-	} else {
-		@if (model.Standings.Count >= 3) {
-			<div role="region" aria-label="Top 3 finishers" class="d-flex gap-3 mb-4 align-items-end justify-content-center">
-				@{ var top3 = model.Standings.Take(3).ToList(); }
+	}
+	@if (model.Standings.Count >= 1) {
+		var first = model.Standings[0];
+		var second = model.Standings.Count >= 2 ? model.Standings[1] : null;
+		var third = model.Standings.Count >= 3 ? model.Standings[2] : null;
+		<div role="region" aria-label="Top finishers" class="d-flex gap-3 mb-4 align-items-end justify-content-center">
+			@if (second != null) {
 				<div class="card border-secondary text-center" style="width:160px">
 					<div class="card-body py-2">
 						<div class="fs-4">🥈</div>
-						<div class="fw-bold">@top3[1].PlayerName</div>
-						<div class="text-muted small">@top3[1].Score.ToString("N0")</div>
+						<div class="fw-bold">@second.PlayerName</div>
+						<div class="text-muted small">@second.Score.ToString("N0")</div>
 					</div>
 				</div>
-				<div class="card border-warning text-center" style="width:180px">
-					<div class="card-body py-3">
-						<div class="fs-2">🏆</div>
-						<div class="fw-bold fs-5">@top3[0].PlayerName</div>
-						<div class="text-muted">@top3[0].Score.ToString("N0")</div>
-						<span class="badge bg-warning text-dark mt-1">Winner</span>
-					</div>
+			}
+			<div class="card border-warning text-center" style="width:180px">
+				<div class="card-body py-3">
+					<div class="fs-2">🏆</div>
+					<div class="fw-bold fs-5">@first.PlayerName</div>
+					<div class="text-muted">@first.Score.ToString("N0")</div>
+					<span class="badge bg-warning text-dark mt-1">Winner</span>
 				</div>
+			</div>
+			@if (third != null) {
 				<div class="card border-secondary text-center" style="width:160px">
 					<div class="card-body py-2">
 						<div class="fs-4">🥉</div>
-						<div class="fw-bold">@top3[2].PlayerName</div>
-						<div class="text-muted small">@top3[2].Score.ToString("N0")</div>
+						<div class="fw-bold">@third.PlayerName</div>
+						<div class="text-muted small">@third.Score.ToString("N0")</div>
 					</div>
 				</div>
-			</div>
-		}
+			}
+		</div>
 
 		<table class="table table-hover">
 			<thead>
@@ -64,7 +69,9 @@
 			</thead>
 			<tbody>
 				@foreach (var entry in model.Standings) {
-					<tr class="@(entry.IsWinner ? "table-warning" : "")">
+					var isMe = entry.PlayerId == model.CurrentPlayerId;
+					var rowClass = isMe ? "table-primary fw-semibold" : (entry.IsWinner ? "table-warning" : "");
+					<tr class="@rowClass">
 						<td>
 							@if (entry.IsWinner) {
 								<span>🏆 #@entry.Rank</span>
@@ -74,7 +81,9 @@
 						</td>
 						<td>
 							@entry.PlayerName
-							@if (entry.IsWinner) {
+							@if (isMe) {
+								<span class="badge bg-primary ms-2">You</span>
+							} else if (entry.IsWinner) {
 								<span class="badge bg-warning text-dark ms-2">Winner</span>
 							}
 						</td>

--- a/src/BrowserGameEngine.BlazorClient/Pages/Market.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Market.razor
@@ -13,15 +13,14 @@
     @if (model == null) {
         <p><em>Loading...</em></p>
     } else {
-        @if (!string.IsNullOrEmpty(lastError)) {
-            <span class="error">@lastError</span>
-        }
-
         <div class="row mt-3">
             <div class="col-md-6">
                 <div class="card mb-3">
                     <div class="card-body">
                         <h5 class="card-title">Post Trade Offer</h5>
+                        @if (!string.IsNullOrEmpty(postError)) {
+                            <div class="alert alert-danger py-1 px-2 mb-2">@postError</div>
+                        }
                         <div class="mb-2">
                             <label class="form-label">Offer resource</label>
                             <input class="form-control" @bind="offerResourceId" placeholder="e.g. minerals" />
@@ -44,11 +43,46 @@
             </div>
         </div>
 
+        @if (model.OpenOrders.Any(o => o.SellerPlayerId == model.CurrentPlayerId)) {
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h5>My Orders</h5>
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Offering</th>
+                                <th>Wants</th>
+                                <th>Rate</th>
+                                <th>Posted</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var order in model.OpenOrders.Where(o => o.SellerPlayerId == model.CurrentPlayerId)) {
+                                <tr class="table-info">
+                                    <td>@order.OfferedAmount @order.OfferedResourceName</td>
+                                    <td>@order.WantedAmount @order.WantedResourceName</td>
+                                    <td><span class="text-muted small">@ExchangeRate(order)</span></td>
+                                    <td>@order.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
+                                    <td>
+                                        <button class="btn btn-sm btn-danger" @onclick="() => Cancel(order.OrderId)">Cancel</button>
+                                        @if (orderErrors.TryGetValue(order.OrderId, out var myErr)) {
+                                            <span class="text-danger ms-2 small">@myErr</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        }
+
         <div class="row mt-3">
             <div class="col-12">
                 <h5>Open Orders</h5>
-                @if (!model.OpenOrders.Any()) {
-                    <p>No open orders. Be the first to post one!</p>
+                @if (!model.OpenOrders.Any(o => o.SellerPlayerId != model.CurrentPlayerId)) {
+                    <p class="text-muted">No open orders from other players.</p>
                 } else {
                     <table class="table table-striped">
                         <thead>
@@ -56,20 +90,24 @@
                                 <th>Seller</th>
                                 <th>Offering</th>
                                 <th>Wants</th>
+                                <th>Rate</th>
                                 <th>Posted</th>
                                 <th></th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var order in model.OpenOrders) {
+                            @foreach (var order in model.OpenOrders.Where(o => o.SellerPlayerId != model.CurrentPlayerId)) {
                                 <tr>
                                     <td>@order.SellerPlayerName</td>
                                     <td>@order.OfferedAmount @order.OfferedResourceName</td>
                                     <td>@order.WantedAmount @order.WantedResourceName</td>
+                                    <td><span class="text-muted small">@ExchangeRate(order)</span></td>
                                     <td>@order.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
                                     <td>
                                         <button class="btn btn-sm btn-success" @onclick="() => Accept(order.OrderId)">Accept</button>
-                                        <button class="btn btn-sm btn-danger ms-1" @onclick="() => Cancel(order.OrderId)">Cancel</button>
+                                        @if (orderErrors.TryGetValue(order.OrderId, out var otherErr)) {
+                                            <span class="text-danger ms-2 small">@otherErr</span>
+                                        }
                                     </td>
                                 </tr>
                             }
@@ -86,7 +124,8 @@
     public string? GameId { get; set; }
 
     private MarketViewModel? model;
-    private string? lastError;
+    private string? postError;
+    private Dictionary<Guid, string> orderErrors = new();
     private string offerResourceId = "";
     private decimal offerAmount = 100;
     private string wantResourceId = "";
@@ -112,7 +151,7 @@
     }
 
     private async Task PostOffer() {
-        lastError = null;
+        postError = null;
         var request = new CreateMarketOrderRequest {
             OfferedResourceId = offerResourceId,
             OfferedAmount = offerAmount,
@@ -127,28 +166,34 @@
             wantAmount = 100;
             await Update();
         } else {
-            lastError = await response.Content.ReadAsStringAsync();
+            postError = await response.Content.ReadAsStringAsync();
         }
     }
 
     private async Task Accept(Guid orderId) {
-        lastError = null;
+        orderErrors.Remove(orderId);
         var response = await Http.PostAsJsonAsync($"api/market/accept?orderId={orderId}", "");
         if (response.IsSuccessStatusCode) {
             await Update();
         } else {
-            lastError = await response.Content.ReadAsStringAsync();
+            orderErrors[orderId] = await response.Content.ReadAsStringAsync();
         }
     }
 
     private async Task Cancel(Guid orderId) {
-        lastError = null;
+        orderErrors.Remove(orderId);
         var response = await Http.DeleteAsync($"api/market/cancel?orderId={orderId}");
         if (response.IsSuccessStatusCode) {
             await Update();
         } else {
-            lastError = await response.Content.ReadAsStringAsync();
+            orderErrors[orderId] = await response.Content.ReadAsStringAsync();
         }
+    }
+
+    private static string ExchangeRate(MarketOrderViewModel order) {
+        if (order.WantedAmount == 0) return "—";
+        var ratio = order.OfferedAmount / order.WantedAmount;
+        return $"{ratio:G4} {order.OfferedResourceName}/{order.WantedResourceName}";
     }
 
     public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerProfile.razor
@@ -139,8 +139,14 @@
 				<div class="stat-label">Wins</div>
 				<div class="stat-value">@model.Wins</div>
 			</div>
+			<div class="stat-item">
+				<div class="stat-label">Best Rank</div>
+				<div class="stat-value rank">@(model.BestRank > 0 ? $"#{model.BestRank}" : "—")</div>
+			</div>
 		</div>
-		<p style="font-size:0.8rem; color:#607080; margin-top:0.4rem;">Full history available once achievements are implemented.</p>
+		<div style="margin-top:0.5rem;">
+			<a href="history" style="font-size:0.85rem; color:#4a8fd4;">View full history →</a>
+		</div>
 
 		<div class="section-title">Settings</div>
 		<div class="mt-1">

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -277,9 +277,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
 			if (record == null) return NotFound();
 
-			var standings = globalState.GetAchievements()
+			var achievements = globalState.GetAchievements()
 				.Where(a => a.GameId.Id == gameId)
 				.OrderBy(a => a.FinalRank)
+				.ToList();
+
+			var standings = achievements
 				.Select(a => new GameResultEntryViewModel(
 					Rank: a.FinalRank,
 					PlayerName: a.PlayerName,
@@ -289,13 +292,21 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				))
 				.ToList();
 
+			string? currentPlayerId = null;
+			if (currentUserContext.IsValid) {
+				currentPlayerId = achievements
+					.FirstOrDefault(a => a.UserId == currentUserContext.UserId)
+					?.PlayerId.Id;
+			}
+
 			return Ok(new GameResultsViewModel(
 				GameId: gameId,
 				Name: record.Name,
 				StartTime: record.StartTime,
 				ActualEndTime: record.ActualEndTime,
 				EndTime: record.EndTime,
-				Standings: standings
+				Standings: standings,
+				CurrentPlayerId: currentPlayerId
 			));
 		}
 
@@ -305,6 +316,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				winnerName = globalState.GetAchievements()
 					.FirstOrDefault(a => a.GameId == record.GameId && a.PlayerId == record.WinnerId)
 					?.PlayerName;
+			}
+			bool isPlayerEnrolled = false;
+			if (currentUserContext.IsValid && currentUserContext.UserId != null) {
+				var instance = gameRegistry.TryGetInstance(record.GameId);
+				isPlayerEnrolled = instance?.HasUserPlayer(currentUserContext.UserId) ?? false;
 			}
 			return new GameSummaryViewModel(
 				GameId: record.GameId.Id,
@@ -318,7 +334,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				CanJoin: record.Status == GameStatus.Upcoming || record.Status == GameStatus.Active,
 				WinnerId: record.WinnerId?.Id,
 				WinnerName: winnerName,
-				DiscordWebhookUrl: record.DiscordWebhookUrl
+				DiscordWebhookUrl: record.DiscordWebhookUrl,
+				IsPlayerEnrolled: isPlayerEnrolled
 			);
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
@@ -40,7 +40,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			var orders = marketRepository.GetOpenOrders();
 			var viewModel = new MarketViewModel {
-				OpenOrders = orders.Select(o => ToViewModel(o)).ToList()
+				OpenOrders = orders.Select(o => ToViewModel(o)).ToList(),
+				CurrentPlayerId = currentUserContext.PlayerId!.Id
 			};
 			return viewModel;
 		}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +22,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ResourceRepository resourceRepository;
 		private readonly UnitRepository unitRepository;
 		private readonly GameRegistry gameRegistry;
+		private readonly GlobalState globalState;
 
 		public ProfileController(
 			ILogger<ProfileController> logger,
@@ -30,7 +32,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			ScoreRepository scoreRepository,
 			ResourceRepository resourceRepository,
 			UnitRepository unitRepository,
-			GameRegistry gameRegistry
+			GameRegistry gameRegistry,
+			GlobalState globalState
 		) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
@@ -40,6 +43,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.resourceRepository = resourceRepository;
 			this.unitRepository = unitRepository;
 			this.gameRegistry = gameRegistry;
+			this.globalState = globalState;
 		}
 
 		/// <summary>Returns the authenticated user's full profile: display name, avatar, current game stats, and game history stubs.</summary>
@@ -76,6 +80,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				.FirstOrDefault(i => i.HasPlayer(playerId));
 			var currentGameId = currentInstance?.Record.GameId.Id;
 
+			var userAchievements = currentUserContext.UserId != null
+				? globalState.GetAchievements().Where(a => a.UserId == currentUserContext.UserId).ToList()
+				: new System.Collections.Generic.List<PlayerAchievementImmutable>();
+			var gamesPlayed = userAchievements.Count;
+			var wins = userAchievements.Count(a => a.FinalRank == 1);
+			var bestRank = gamesPlayed > 0 ? userAchievements.Min(a => a.FinalRank) : 0;
+
 			return new ProfileViewModel {
 				PlayerName = player.Name,
 				DisplayName = user?.DisplayName,
@@ -87,8 +98,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				ArmySize = armySize,
 				Rank = rank,
 				TotalPlayers = allPlayers.Count,
-				GamesPlayed = 0,
-				Wins = 0,
+				GamesPlayed = gamesPlayed,
+				Wins = wins,
+				BestRank = bestRank,
 				CurrentGameId = currentGameId
 			};
 		}

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -14,7 +14,8 @@ namespace BrowserGameEngine.Shared {
 		bool CanJoin,
 		string? WinnerId = null,
 		string? WinnerName = null,
-		string? DiscordWebhookUrl = null
+		string? DiscordWebhookUrl = null,
+		bool IsPlayerEnrolled = false
 	);
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -44,7 +44,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime StartTime,
 		DateTime? ActualEndTime,
 		DateTime EndTime,
-		List<GameResultEntryViewModel> Standings
+		List<GameResultEntryViewModel> Standings,
+		string? CurrentPlayerId = null
 	);
 
 	/// <summary>A game the current user is actively playing in, with their player info.</summary>

--- a/src/BrowserGameEngine.Shared/MarketViewModels.cs
+++ b/src/BrowserGameEngine.Shared/MarketViewModels.cs
@@ -17,6 +17,7 @@ namespace BrowserGameEngine.Shared {
 
 	public record MarketViewModel {
 		public List<MarketOrderViewModel> OpenOrders { get; set; } = new();
+		public string CurrentPlayerId { get; set; } = "";
 	}
 
 	public record CreateMarketOrderRequest {

--- a/src/BrowserGameEngine.Shared/ProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/ProfileViewModel.cs
@@ -12,6 +12,7 @@ namespace BrowserGameEngine.Shared {
 		public int TotalPlayers { get; init; }
 		public int GamesPlayed { get; init; }
 		public int Wins { get; init; }
+		public int BestRank { get; init; }
 		public string? CurrentGameId { get; init; }
 	}
 }


### PR DESCRIPTION
## Summary

Implements all medium-priority items from the UX audit ([BGE-354](/BGE/issues/BGE-354)).

**Market (`/market`)**
- My Orders section: current player's orders appear in their own highlighted table above the main orders list
- Inline errors: failed accept/cancel shows the error message next to the button that was clicked, not at the top of the page
- Exchange-rate column: shows the ratio (e.g. `2 minerals/gas`) for every order row

**Season Schedule (`/games`)**
- Play Now button only shown when the authenticated user is enrolled in that game (`IsPlayerEnrolled` added to `GameSummaryViewModel`)
- Finished games section is collapsible; collapsed by default when there are more than 5 entries

**Results page (`/games/{id}/results`)**
- Current player's row is highlighted in blue with a "You" badge
- Podium shown for any game with ≥ 1 player (previously required 3); handles 1-player and 2-player games gracefully

**Player Profile (`/profile`)**
- Stats strip now includes Games Played, Wins, and Best Rank (populated from achievements in `ProfileController`)
- "View full history →" link replaces the old placeholder text

## Test plan
- [ ] Build passes: `dotnet build`
- [ ] 173 unit tests pass: `dotnet test`
- [ ] Market page: post an order; verify it appears in "My Orders" with rate column and Cancel-only button; confirm no "You" row in others' table
- [ ] Games page: join an active game and verify Play Now appears only for that game; create 6+ finished games and verify collapse behaviour
- [ ] Results page: view results for a game you played; confirm your row is highlighted and podium appears even for 1- or 2-player games
- [ ] Profile page: verify Games Played / Wins / Best Rank are non-zero after playing a game