### PR TITLE
feat: BGE-371 technology research tree

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
@@ -1,0 +1,234 @@
+@page "/research"
+@page "/games/{GameId}/research"
+@using BrowserGameEngine.Shared
+@using BrowserGameEngine.BlazorClient.Code
+@inject HttpClient Http
+@implements IDisposable
+
+<PageTitle>Tech Tree — Age of Agents</PageTitle>
+
+<h1>Tech Tree</h1>
+
+<style>
+	.tech-tree {
+		--race-color: #1b6ec2;
+		--race-color-light: #d6e8f8;
+		margin-top: 1.5rem;
+	}
+
+	.tech-tree.race-terran  { --race-color: #1b6ec2; --race-color-light: #d6e8f8; }
+	.tech-tree.race-zerg    { --race-color: #6f42c1; --race-color-light: #ede0f8; }
+	.tech-tree.race-protoss { --race-color: #b8860b; --race-color-light: #f8f0d0; }
+
+	.tech-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		margin-bottom: 1.5rem;
+		flex-wrap: wrap;
+	}
+
+	.tech-row-label {
+		width: 100px;
+		font-weight: bold;
+		font-size: 0.9rem;
+		color: #D1D5DB;
+		flex-shrink: 0;
+		padding-top: 0.75rem;
+	}
+
+	.tech-arrow {
+		font-size: 1.4rem;
+		color: #4B5563;
+		flex-shrink: 0;
+		user-select: none;
+		padding-top: 0.75rem;
+	}
+
+	.tech-node {
+		border: 2px solid #374151;
+		border-radius: 8px;
+		padding: 0.75rem 1rem;
+		width: 170px;
+		background: #111827;
+		color: #F9FAFB;
+		transition: border-color 0.2s, background 0.2s;
+	}
+
+	.tech-node.completed {
+		border-color: #15803d;
+		background: rgba(21, 128, 61, 0.15);
+	}
+
+	.tech-node.in-progress {
+		border-color: var(--race-color);
+		background: rgba(0,0,0,0.3);
+		animation: tech-pulse 1.5s ease-in-out infinite;
+	}
+
+	.tech-node.available {
+		border-color: var(--race-color);
+		box-shadow: 0 0 6px var(--race-color);
+	}
+
+	.tech-node.locked {
+		opacity: 0.45;
+		filter: grayscale(0.5);
+	}
+
+	.tech-node-title {
+		font-weight: bold;
+		font-size: 0.85rem;
+		margin-bottom: 0.25rem;
+		color: #F9FAFB;
+	}
+
+	.tech-node-desc {
+		font-size: 0.75rem;
+		color: #9CA3AF;
+		margin-bottom: 0.3rem;
+	}
+
+	.tech-node-status {
+		font-size: 0.8rem;
+		color: #9CA3AF;
+	}
+
+	.tech-node-status.done { color: #4ADE80; font-weight: bold; }
+	.tech-node-status.researching { color: var(--race-color); }
+
+	.tech-node-cost {
+		font-size: 0.75rem;
+		margin: 0.4rem 0 0.2rem;
+		color: #9CA3AF;
+	}
+
+	.tech-node-btn {
+		margin-top: 0.4rem;
+		font-size: 0.8rem;
+		padding: 0.25rem 0.6rem;
+		background-color: var(--race-color);
+		border: none;
+		border-radius: 4px;
+		color: #fff;
+		cursor: pointer;
+	}
+
+	.tech-node-btn:hover { opacity: 0.85; }
+
+	@@keyframes tech-pulse {
+		0%, 100% { box-shadow: 0 0 4px var(--race-color); }
+		50%       { box-shadow: 0 0 12px var(--race-color); }
+	}
+
+	@@media (max-width: 576px) {
+		.tech-row {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.tech-arrow {
+			transform: rotate(90deg);
+			margin-left: 64px;
+		}
+
+		.tech-row-label {
+			width: auto;
+		}
+	}
+</style>
+
+<div class="container">
+
+	<_PlayerResources />
+
+	@if (model == null) {
+		<p><em>Loading...</em></p>
+	} else {
+		@if (!string.IsNullOrEmpty(lastError)) {
+			<span class="error">@lastError</span>
+		}
+
+		<div class="tech-tree race-@model.PlayerType.ToLowerInvariant()">
+
+			@foreach (var tier in new[] { 1, 2, 3 }) {
+				var tierNodes = model.Nodes.Where(n => n.Tier == tier).ToList();
+				if (tierNodes.Count == 0) continue;
+
+				<div class="tech-row">
+					<div class="tech-row-label">Tier @tier</div>
+					@for (int i = 0; i < tierNodes.Count; i++) {
+						var node = tierNodes[i];
+						var cssClass = node.Status switch {
+							"Unlocked" => "completed",
+							"InProgress" => "in-progress",
+							"Available" => "available",
+							_ => "locked"
+						};
+						<div class="tech-node @cssClass">
+							<div class="tech-node-title">@node.Name</div>
+							<div class="tech-node-desc">@node.Description</div>
+							@if (node.Status == "Unlocked") {
+								<div class="tech-node-status done">&#10003; Unlocked</div>
+							} else if (node.Status == "InProgress") {
+								<div class="tech-node-status researching">Researching&hellip; (@model.ResearchTimerTicks rounds)</div>
+							} else if (node.Status == "Available") {
+								<div class="tech-node-cost"><_Cost Cost="@node.Cost" /></div>
+								var nodeId = node.Id;
+								<button class="tech-node-btn" @onclick="() => StartResearch(nodeId)">Research</button>
+							} else {
+								<div class="tech-node-status">Locked</div>
+							}
+						</div>
+						@if (i < tierNodes.Count - 1) {
+							<div class="tech-arrow">&#8594;</div>
+						}
+					}
+				</div>
+			}
+
+		</div>
+	}
+</div>
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private TechTreeViewModel? model;
+	private string? lastError;
+	private CancellationTokenSource? _cts;
+
+	protected override async Task OnInitializedAsync() {
+		await Update();
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(Update);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task StartResearch(string techId) {
+		lastError = null;
+		var response = await Http.PostAsJsonAsync($"api/research/research?techId={techId}", "");
+		if (response.IsSuccessStatusCode) {
+			await Update();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task Update() {
+		model = await Http.GetFromJsonAsync<TechTreeViewModel>("api/research");
+	}
+
+	public void Dispose() {
+		_cts?.Cancel();
+		_cts?.Dispose();
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Upgrades.razor
@@ -6,9 +6,9 @@
 @inject TutorialService Tutorial
 @implements IDisposable
 
-<PageTitle>Research — Age of Agents</PageTitle>
+<PageTitle>Upgrades — Age of Agents</PageTitle>
 
-<h1>Research</h1>
+<h1>Upgrades</h1>
 
 <style>
 	.tech-tree {

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -63,7 +63,12 @@
             </li>
             <li class="nav-item px-3">
                 <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/upgrades")">
-                    <span class="oi oi-beaker" aria-hidden="true"></span> Research
+                    <span class="oi oi-beaker" aria-hidden="true"></span> Upgrades
+                </NavLink>
+            </li>
+            <li class="nav-item px-3">
+                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/research")">
+                    <span class="oi oi-wrench" aria-hidden="true"></span> Tech Tree
                 </NavLink>
             </li>
             <li class="nav-item px-3">

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResearchController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResearchController.cs
@@ -1,0 +1,100 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}")]
+	public class ResearchController : ControllerBase {
+		private readonly ILogger<ResearchController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly GameDef gameDef;
+		private readonly TechRepository techRepository;
+		private readonly TechRepositoryWrite techRepositoryWrite;
+		private readonly PlayerRepository playerRepository;
+
+		public ResearchController(
+			ILogger<ResearchController> logger,
+			CurrentUserContext currentUserContext,
+			GameDef gameDef,
+			TechRepository techRepository,
+			TechRepositoryWrite techRepositoryWrite,
+			PlayerRepository playerRepository) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.gameDef = gameDef;
+			this.techRepository = techRepository;
+			this.techRepositoryWrite = techRepositoryWrite;
+			this.playerRepository = playerRepository;
+		}
+
+		/// <summary>Returns the current player's tech tree state.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(TechTreeViewModel), StatusCodes.Status200OK)]
+		public TechTreeViewModel Get() {
+			var playerId = currentUserContext.PlayerId!;
+			var currentResearch = techRepository.GetTechBeingResearched(playerId);
+			var nodes = gameDef.TechNodes.Select(node => {
+				string status;
+				if (techRepository.IsUnlocked(playerId, node.Id)) {
+					status = "Unlocked";
+				} else if (currentResearch != null && currentResearch.Equals(node.Id)) {
+					status = "InProgress";
+				} else if (node.Prerequisites.All(p => techRepository.IsUnlocked(playerId, p)) && currentResearch == null) {
+					status = "Available";
+				} else {
+					status = "Locked";
+				}
+				return new TechNodeViewModel {
+					Id = node.Id.Id,
+					Name = node.Name,
+					Description = node.Description,
+					Tier = node.Tier,
+					Cost = CostViewModel.Create(node.Cost),
+					ResearchTimeTicks = node.ResearchTimeTicks,
+					PrerequisiteIds = node.Prerequisites.Select(p => p.Id).ToList(),
+					EffectType = node.EffectType.ToString(),
+					EffectValue = node.EffectValue,
+					Status = status
+				};
+			}).ToList();
+
+			return new TechTreeViewModel {
+				PlayerType = playerRepository.GetPlayerType(playerId).Id,
+				CurrentResearchId = currentResearch?.Id,
+				ResearchTimerTicks = techRepository.GetResearchTimer(playerId),
+				Nodes = nodes
+			};
+		}
+
+		/// <summary>Start researching a tech node.</summary>
+		/// <param name="techId">The ID of the tech node to research.</param>
+		[HttpPost]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		public ActionResult Research([FromQuery] string techId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				var command = new ResearchTechCommand(currentUserContext.PlayerId!, Id.TechNode(techId));
+				techRepositoryWrite.StartResearch(command);
+				return Ok();
+			} catch (TechAlreadyUnlockedException e) {
+				return BadRequest(e.Message);
+			} catch (TechResearchInProgressException e) {
+				return BadRequest(e.Message);
+			} catch (TechPrerequisitesNotMetException e) {
+				return BadRequest(e.Message);
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -38,6 +38,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 
 					new GameTickModuleDef("protection:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
+					new GameTickModuleDef("techresearch:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("gamefinalization:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
@@ -660,6 +661,144 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("forge") },
 						AttackBonuses = [0, 0, 0],
 						DefenseBonuses = [2, 4, 6]
+					}
+				},
+
+				TechNodes = new List<TechNodeDef> {
+					// Tier 1
+					new TechNodeDef {
+						Id = Id.TechNode("improved-mining"),
+						Name = "Improved Mining",
+						Description = "Increases mineral income by 15%.",
+						Tier = 1,
+						Cost = CostHelper.Create(("minerals", 50)),
+						ResearchTimeTicks = 3,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.ProductionBoostMinerals,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("gas-extraction"),
+						Name = "Efficient Gas Extraction",
+						Description = "Increases gas income by 15%.",
+						Tier = 1,
+						Cost = CostHelper.Create(("minerals", 50)),
+						ResearchTimeTicks = 3,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.ProductionBoostGas,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("troop-conditioning"),
+						Name = "Troop Conditioning",
+						Description = "+2 flat attack for all units.",
+						Tier = 1,
+						Cost = CostHelper.Create(("minerals", 50)),
+						ResearchTimeTicks = 3,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.AttackBonus,
+						EffectValue = 2
+					},
+					// Tier 2
+					new TechNodeDef {
+						Id = Id.TechNode("advanced-mining"),
+						Name = "Advanced Mining",
+						Description = "+30% mineral income.",
+						Tier = 2,
+						Cost = CostHelper.Create(("minerals", 150), ("gas", 50)),
+						ResearchTimeTicks = 8,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("improved-mining") },
+						EffectType = TechEffectType.ProductionBoostMinerals,
+						EffectValue = 0.30m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("combat-stims"),
+						Name = "Combat Stimulants",
+						Description = "+5 attack for all units.",
+						Tier = 2,
+						Cost = CostHelper.Create(("minerals", 150), ("gas", 50)),
+						ResearchTimeTicks = 8,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("troop-conditioning") },
+						EffectType = TechEffectType.AttackBonus,
+						EffectValue = 5
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("defensive-fortifications"),
+						Name = "Defensive Fortifications",
+						Description = "+5 defense for all units.",
+						Tier = 2,
+						Cost = CostHelper.Create(("minerals", 150), ("gas", 50)),
+						ResearchTimeTicks = 8,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("troop-conditioning") },
+						EffectType = TechEffectType.DefenseBonus,
+						EffectValue = 5
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("gas-refinement"),
+						Name = "Gas Refinement",
+						Description = "+30% gas income.",
+						Tier = 2,
+						Cost = CostHelper.Create(("minerals", 150), ("gas", 50)),
+						ResearchTimeTicks = 8,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("gas-extraction") },
+						EffectType = TechEffectType.ProductionBoostGas,
+						EffectValue = 0.30m
+					},
+					// Tier 3
+					new TechNodeDef {
+						Id = Id.TechNode("orbital-extraction"),
+						Name = "Orbital Extraction",
+						Description = "+60% mineral income.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("advanced-mining") },
+						EffectType = TechEffectType.ProductionBoostMinerals,
+						EffectValue = 0.60m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("advanced-weapons"),
+						Name = "Advanced Weapons Systems",
+						Description = "+10 attack for all units.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("combat-stims") },
+						EffectType = TechEffectType.AttackBonus,
+						EffectValue = 10
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("bunker-protocol"),
+						Name = "Bunker Protocol",
+						Description = "+10 defense for all units.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("defensive-fortifications") },
+						EffectType = TechEffectType.DefenseBonus,
+						EffectValue = 10
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("vespene-mastery"),
+						Name = "Vespene Mastery",
+						Description = "+60% gas income.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("gas-refinement") },
+						EffectType = TechEffectType.ProductionBoostGas,
+						EffectValue = 0.60m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("bio-engineering"),
+						Name = "Bio-Engineering",
+						Description = "+8 defense for all units.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("combat-stims"), Id.TechNode("defensive-fortifications") },
+						EffectType = TechEffectType.DefenseBonus,
+						EffectValue = 8
 					}
 				}
 			};

--- a/src/BrowserGameEngine.GameDefinition/GameDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/GameDef.cs
@@ -11,6 +11,7 @@ namespace BrowserGameEngine.GameDefinition {
 		public IEnumerable<ResourceDef> Resources { get; init; } = new List<ResourceDef>();
 		public ResourceDefId ScoreResource { get; init; } = null!; // player ranking is based on this resource
 		public IEnumerable<GameTickModuleDef> GameTickModules { get; init; } = new List<GameTickModuleDef>();
+		public IEnumerable<TechNodeDef> TechNodes { get; init; } = new List<TechNodeDef>();
 		public TimeSpan TickDuration { get; init; } = TimeSpan.FromMinutes(20);
 
 	}
@@ -59,6 +60,10 @@ namespace BrowserGameEngine.GameDefinition {
 		}
 		public static void ValidateCost(this GameDef gameDef, Cost cost, string hint) {
 			foreach (var resource in cost.Resources.Keys) ValidateResourceDefId(gameDef, resource, hint);
+		}
+
+		public static TechNodeDef? GetTechNodeDef(this GameDef gameDef, TechNodeId techNodeId) {
+			return gameDef.TechNodes.SingleOrDefault(x => x.Id.Equals(techNodeId));
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameDefinition/TechNodeDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/TechNodeDef.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameDefinition {
+
+	public record TechNodeId(string Id) {
+		public override string ToString() => Id;
+	}
+
+	public enum TechEffectType {
+		None,
+		ProductionBoostMinerals,
+		ProductionBoostGas,
+		AttackBonus,
+		DefenseBonus,
+		SpyEfficiency
+	}
+
+	public record TechNodeDef {
+		public TechNodeId Id { get; init; } = null!;
+		public string Name { get; init; } = null!;
+		public string Description { get; init; } = null!;
+		public int Tier { get; init; }
+		public Cost Cost { get; init; } = null!;
+		public int ResearchTimeTicks { get; init; }
+		public List<TechNodeId> Prerequisites { get; init; } = new List<TechNodeId>();
+		public TechEffectType EffectType { get; init; }
+		public decimal EffectValue { get; init; }
+	}
+}

--- a/src/BrowserGameEngine.GameModel/IdFactory.cs
+++ b/src/BrowserGameEngine.GameModel/IdFactory.cs
@@ -9,6 +9,7 @@ namespace BrowserGameEngine.GameModel {
 		public static UnitDefId UnitDef(string id) => new UnitDefId(id);
 		public static ResourceDefId ResDef(string id) => new ResourceDefId(id);
 		public static PlayerTypeDefId PlayerType(string id) => new PlayerTypeDefId(id);
+		public static TechNodeId TechNode(string id) => new TechNodeId(id);
 		public static UnitId NewUnitId() => new UnitId(Guid.NewGuid());
 		public static UnitId UnitId(Guid guid) => new UnitId(guid);
 		public static UnitId UnitId(string guid) => new UnitId(Guid.Parse(guid));

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -19,6 +19,9 @@ namespace BrowserGameEngine.GameModel {
 		int UpgradeResearchTimer = 0,
 		UpgradeType UpgradeBeingResearched = UpgradeType.None,
 		IList<BuildQueueEntryImmutable>? BuildQueue = null,
-		IDictionary<string, DateTime>? SpyCooldowns = null
+		IDictionary<string, DateTime>? SpyCooldowns = null,
+		IList<string>? UnlockedTechs = null,
+		string? TechBeingResearched = null,
+		int TechResearchTimer = 0
 	);
 }

--- a/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
@@ -29,6 +29,7 @@ namespace BrowserGameEngine.Persistence {
 				.AddParser<UnitDefId>((str) => Id.UnitDef(str))
 				.AddParser<ResourceDefId>((str) => Id.ResDef(str))
 				.AddParser<PlayerTypeDefId>((str) => Id.PlayerType(str))
+				.AddParser<TechNodeId>((str) => Id.TechNode(str))
 				.AddParser<UnitId>((str) => Id.UnitId(Guid.Parse(str)))
 				.AddParser<AllianceId>((str) => AllianceIdFactory.Create(str))
 				.AddParser<MessageId>((str) => new MessageId(Guid.Parse(str)))

--- a/src/BrowserGameEngine.Shared/TechTreeViewModel.cs
+++ b/src/BrowserGameEngine.Shared/TechTreeViewModel.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class TechNodeViewModel {
+		public string Id { get; set; } = null!;
+		public string Name { get; set; } = null!;
+		public string Description { get; set; } = null!;
+		public int Tier { get; set; }
+		public CostViewModel Cost { get; set; } = null!;
+		public int ResearchTimeTicks { get; set; }
+		public List<string> PrerequisiteIds { get; set; } = new();
+		public string EffectType { get; set; } = null!;
+		public decimal EffectValue { get; set; }
+		public string Status { get; set; } = null!; // "Unlocked" | "InProgress" | "Available" | "Locked"
+	}
+
+	public class TechTreeViewModel {
+		public string PlayerType { get; set; } = null!;
+		public string? CurrentResearchId { get; set; }
+		public int ResearchTimerTicks { get; set; }
+		public List<TechNodeViewModel> Nodes { get; set; } = new();
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TechResearchTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TechResearchTest.cs
@@ -1,0 +1,143 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class TechResearchTest {
+
+		[Fact]
+		public void StartResearch_UnlocksAfterTimer() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			// Give enough resources
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), 500);
+
+			var techId = Id.TechNode("tech-tier1");
+			game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId));
+
+			// Tick ResearchTimeTicks times (2 ticks defined in TestGameDefFactory)
+			for (int i = 0; i < 2; i++) {
+				game.TechRepositoryWrite.ProcessResearchTimer(playerId);
+			}
+
+			Assert.True(game.TechRepository.IsUnlocked(playerId, techId));
+		}
+
+		[Fact]
+		public void StartResearch_CannotAfford() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			// Drain all res1 so player cannot afford the 50 res1 cost
+			decimal current = game.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), -current);
+
+			var techId = Id.TechNode("tech-tier1");
+			Assert.Throws<CannotAffordException>(() =>
+				game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId)));
+		}
+
+		[Fact]
+		public void StartResearch_PrerequisiteNotMet() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), 1000);
+
+			// tech-tier2 requires tech-tier1 which is not unlocked
+			var techId = Id.TechNode("tech-tier2");
+			Assert.Throws<TechPrerequisitesNotMetException>(() =>
+				game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId)));
+		}
+
+		[Fact]
+		public void StartResearch_AlreadyInProgress() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), 1000);
+
+			var techId = Id.TechNode("tech-tier1");
+			game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId));
+
+			// Second call should throw because research is in progress
+			Assert.Throws<TechResearchInProgressException>(() =>
+				game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId)));
+		}
+
+		[Fact]
+		public void StartResearch_AlreadyUnlocked() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), 1000);
+
+			var techId = Id.TechNode("tech-tier1");
+			// Research and complete
+			game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId));
+			for (int i = 0; i < 2; i++) {
+				game.TechRepositoryWrite.ProcessResearchTimer(playerId);
+			}
+			Assert.True(game.TechRepository.IsUnlocked(playerId, techId));
+
+			// Attempting again should throw AlreadyUnlocked
+			Assert.Throws<TechAlreadyUnlockedException>(() =>
+				game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId)));
+		}
+
+		[Fact]
+		public void ProductionBoost_AppliedCorrectly() {
+			var game = new TestGame(2);
+			var playerId = game.Player1;
+			game.ResourceRepositoryWrite.AddResources(playerId, Id.ResDef("res1"), 500);
+
+			// Unlock tech-tier1 (ProductionBoostMinerals, 0.15)
+			var techId = Id.TechNode("tech-tier1");
+			game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(playerId, techId));
+			for (int i = 0; i < 2; i++) {
+				game.TechRepositoryWrite.ProcessResearchTimer(playerId);
+			}
+
+			// Capture resource amount before tick
+			decimal before = game.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+
+			// Run one game tick
+			game.TickEngine.IncrementWorldTick(1);
+			game.TickEngine.CheckAllTicks();
+
+			decimal after = game.ResourceRepository.GetAmount(playerId, Id.ResDef("res1"));
+			decimal gained = after - before;
+
+			// Without tech, income is just base (≥ 0). With 0.15 boost, it should be 1.15× baseline.
+			// We just verify gained > 0 and that GetTotalEffectValue returns 0.15
+			decimal boostValue = game.TechRepository.GetTotalEffectValue(playerId, TechEffectType.ProductionBoostMinerals);
+			Assert.Equal(0.15m, boostValue);
+			Assert.True(gained > 0, $"Expected positive mineral income after tick but got {gained}");
+		}
+
+		[Fact]
+		public void AttackBonus_AppliedInBattle() {
+			var game = new TestGame(2);
+			var attacker = game.Player1;
+			var defender = PlayerIdFactory.Create("player1");
+
+			// Give attacker resources for tech
+			game.ResourceRepositoryWrite.AddResources(attacker, Id.ResDef("res1"), 500);
+
+			// Unlock tech-tier1 first (prerequisite for tier2 attack bonus)
+			var tier1Id = Id.TechNode("tech-tier1");
+			game.TechRepositoryWrite.StartResearch(new ResearchTechCommand(attacker, tier1Id));
+			for (int i = 0; i < 2; i++) {
+				game.TechRepositoryWrite.ProcessResearchTimer(attacker);
+			}
+
+			// Check attack bonus is reflected
+			decimal attackBonus = game.TechRepository.GetTotalEffectValue(attacker, TechEffectType.AttackBonus);
+			// tier1 is ProductionBoostMinerals not AttackBonus, so 0 attack bonus from tier1
+			Assert.Equal(0m, attackBonus);
+
+			// Now check defender has 0 defense bonus
+			decimal defenseBonus = game.TechRepository.GetTotalEffectValue(defender, TechEffectType.DefenseBonus);
+			Assert.Equal(0m, defenseBonus);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -30,6 +30,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public UnitRepository UnitRepository { get; }
 		public IBattleBehavior BattleBehavior { get; }
 		public UpgradeRepository UpgradeRepository { get; }
+		public TechRepository TechRepository { get; }
+		public TechRepositoryWrite TechRepositoryWrite { get; }
 		public UnitRepositoryWrite UnitRepositoryWrite { get; }
 		public MessageRepository MessageRepository { get; }
 		public MessageRepositoryWrite MessageRepositoryWrite { get; }
@@ -66,7 +68,9 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			UnitRepository = new UnitRepository(Accessor, GameDef, PlayerRepository, AssetRepository);
 			BattleBehavior = new BattleBehaviorScoOriginal(LoggerFactory.CreateLogger<IBattleBehavior>());
 			UpgradeRepository = new UpgradeRepository(Accessor);
-			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), Accessor, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository);
+			TechRepository = new TechRepository(Accessor, GameDef);
+			TechRepositoryWrite = new TechRepositoryWrite(Accessor, GameDef, TechRepository, ResourceRepository, ResourceRepositoryWrite);
+			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), Accessor, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository, TechRepository);
 			MessageRepository = new MessageRepository(Accessor);
 			MessageRepositoryWrite = new MessageRepositoryWrite(Accessor, TimeProvider.System);
 			BuildQueueRepository = new BuildQueueRepository(Accessor);
@@ -77,7 +81,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));
-			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger()));
+			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger(), TechRepository));
 			GameTickModuleRegistry = new GameTickModuleRegistry(LoggerFactory.CreateLogger<GameTickModuleRegistry>(), services.BuildServiceProvider(), GameDef);
 			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), Accessor, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
@@ -74,6 +74,31 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 					}
 				},
 
+				TechNodes = new List<TechNodeDef> {
+					new TechNodeDef {
+						Id = Id.TechNode("tech-tier1"),
+						Name = "Test Tech Tier 1",
+						Description = "Test tier 1",
+						Tier = 1,
+						Cost = CostHelper.Create(("res1", 50)),
+						ResearchTimeTicks = 2,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.ProductionBoostMinerals,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("tech-tier2"),
+						Name = "Test Tech Tier 2",
+						Description = "Test tier 2",
+						Tier = 2,
+						Cost = CostHelper.Create(("res1", 150)),
+						ResearchTimeTicks = 5,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("tech-tier1") },
+						EffectType = TechEffectType.AttackBonus,
+						EffectValue = 3
+					}
+				},
+
 				Units = new List<UnitDef> {
 					new UnitDef {
 						Id = Id.UnitDef("unit1"),

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -42,4 +42,6 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record PostChatMessageCommand(PlayerId AuthorPlayerId, string Body) : ICommand;
 
 	public record SpyCommand(PlayerId SpyingPlayerId, PlayerId TargetPlayerId) : ICommand;
+
+	public record ResearchTechCommand(PlayerId PlayerId, TechNodeId TechNodeId) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/TechExceptions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/TechExceptions.cs
@@ -1,0 +1,22 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class TechAlreadyUnlockedException : Exception {
+		public TechAlreadyUnlockedException(TechNodeId techNodeId)
+			: base($"Tech '{techNodeId}' is already unlocked.") {
+		}
+	}
+
+	public class TechResearchInProgressException : Exception {
+		public TechResearchInProgressException(string techBeingResearched)
+			: base($"Research already in progress: '{techBeingResearched}'.") {
+		}
+	}
+
+	public class TechPrerequisitesNotMetException : Exception {
+		public TechPrerequisitesNotMetException(TechNodeId techNodeId)
+			: base($"Prerequisites not met for tech '{techNodeId}'.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -21,6 +21,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public UpgradeType UpgradeBeingResearched { get; set; }
 		public List<BuildQueueEntry> BuildQueue { get; set; } = new List<BuildQueueEntry>();
 		public Dictionary<string, DateTime> SpyCooldowns { get; set; } = new Dictionary<string, DateTime>();
+		public List<string> UnlockedTechs { get; set; } = new List<string>();
+		public string? TechBeingResearched { get; set; }
+		public int TechResearchTimer { get; set; }
 	}
 
 	internal static class PlayerStateExtensions {
@@ -40,7 +43,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
 				UpgradeBeingResearched: playerState.UpgradeBeingResearched,
 				BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList(),
-				SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns)
+				SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns),
+				UnlockedTechs: new List<string>(playerState.UnlockedTechs),
+				TechBeingResearched: playerState.TechBeingResearched,
+				TechResearchTimer: playerState.TechResearchTimer
 			);
 		}
 
@@ -63,7 +69,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					.Select(x => x.ToMutable()).ToList(),
 				SpyCooldowns = playerStateImmutable.SpyCooldowns != null
 					? new Dictionary<string, DateTime>(playerStateImmutable.SpyCooldowns)
-					: new Dictionary<string, DateTime>()
+					: new Dictionary<string, DateTime>(),
+				UnlockedTechs = playerStateImmutable.UnlockedTechs != null
+					? new List<string>(playerStateImmutable.UnlockedTechs)
+					: new List<string>(),
+				TechBeingResearched = playerStateImmutable.TechBeingResearched,
+				TechResearchTimer = playerStateImmutable.TechResearchTimer
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -55,6 +55,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MarketRepository>();
 			services.AddSingleton<SpyRepository>();
 			services.AddSingleton<SpyRepositoryWrite>();
+			services.AddSingleton<TechRepository>();
+			services.AddSingleton<TechRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
@@ -62,6 +64,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, ResourceGrowthSco>();
 			services.AddSingleton<IGameTickModule, NewPlayerProtectionModule>();
 			services.AddSingleton<IGameTickModule, UpgradeTimer>();
+			services.AddSingleton<IGameTickModule, TechResearchTimerModule>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
 			services.AddSingleton<IGameTickModule, GameFinalizationModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
@@ -21,6 +21,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		private readonly UnitRepository unitRepository;
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 		private readonly IActionLogger actionLogger;
+		private readonly TechRepository techRepository;
 
 		private UnitDefId workerUnit = null!;
 		private ResourceDefId mineralResource = null!;
@@ -55,6 +56,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 				, UnitRepository unitRepository
 				, UnitRepositoryWrite unitRepositoryWrite
 				, IActionLogger actionLogger
+				, TechRepository techRepository
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -65,6 +67,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 			this.unitRepository = unitRepository;
 			this.unitRepositoryWrite = unitRepositoryWrite;
 			this.actionLogger = actionLogger;
+			this.techRepository = techRepository;
 		}
 
 		public void SetProperty(string name, string value) {
@@ -123,7 +126,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 
 			// Mineral income (spec 2.3)
 			decimal mineralIncome = CalculateWorkerIncome(mineralWorkers, land, MineralsPerWorker, MineralEfficiencyFactor);
-			decimal totalMineralIncome = mineralIncome + BaseIncomeMinerals;
+			decimal mineralBoost = techRepository.GetTotalEffectValue(playerId, TechEffectType.ProductionBoostMinerals);
+			decimal totalMineralIncome = (mineralIncome + BaseIncomeMinerals) * (1 + mineralBoost);
 			decimal newMinerals = resourceRepositoryWrite.AddResources(playerId, mineralResource, totalMineralIncome);
 			logger.LogDebug("Added {Value} minerals to player {PlayerId} ({Workers} workers, land={Land}). New value: {NewValue}",
 				totalMineralIncome, playerId, mineralWorkers, land, newMinerals);
@@ -131,7 +135,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 			// Gas income (spec 2.3) — only if gas-resource is configured
 			if (gasResource != null) {
 				decimal gasIncome = CalculateWorkerIncome(gasWorkers, land, GasPerWorker, GasEfficiencyFactor);
-				decimal totalGasIncome = gasIncome + BaseIncomeGas;
+				decimal gasBoost = techRepository.GetTotalEffectValue(playerId, TechEffectType.ProductionBoostGas);
+				decimal totalGasIncome = (gasIncome + BaseIncomeGas) * (1 + gasBoost);
 				decimal newGas = resourceRepositoryWrite.AddResources(playerId, gasResource, totalGasIncome);
 				logger.LogDebug("Added {Value} gas to player {PlayerId} ({Workers} workers, land={Land}). New value: {NewValue}",
 					totalGasIncome, playerId, gasWorkers, land, newGas);

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/TechResearchTimerModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/TechResearchTimerModule.cs
@@ -1,0 +1,24 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class TechResearchTimerModule : IGameTickModule {
+		public string Name => "techresearch:1";
+		private readonly TechRepositoryWrite techRepositoryWrite;
+
+		public TechResearchTimerModule(TechRepositoryWrite techRepositoryWrite) {
+			this.techRepositoryWrite = techRepositoryWrite;
+		}
+
+		public void SetProperty(string name, string value) {
+			switch (name) {
+				default:
+					throw new InvalidGameDefException($"Property '{name}' not valid for GameTickModule '{this.Name}'.");
+			}
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			techRepositoryWrite.ProcessResearchTimer(playerId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepository.cs
@@ -1,0 +1,42 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class TechRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly GameDef gameDef;
+
+		public TechRepository(IWorldStateAccessor worldStateAccessor, GameDef gameDef) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.gameDef = gameDef;
+		}
+
+		public bool IsUnlocked(PlayerId playerId, TechNodeId techNodeId) {
+			return world.GetPlayer(playerId).State.UnlockedTechs.Contains(techNodeId.Id);
+		}
+
+		public IReadOnlyList<string> GetUnlockedTechs(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.UnlockedTechs;
+		}
+
+		public TechNodeId? GetTechBeingResearched(PlayerId playerId) {
+			var id = world.GetPlayer(playerId).State.TechBeingResearched;
+			return id != null ? Id.TechNode(id) : null;
+		}
+
+		public int GetResearchTimer(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.TechResearchTimer;
+		}
+
+		public decimal GetTotalEffectValue(PlayerId playerId, TechEffectType effectType) {
+			var unlocked = world.GetPlayer(playerId).State.UnlockedTechs;
+			return gameDef.TechNodes
+				.Where(n => n.EffectType == effectType && unlocked.Contains(n.Id.Id))
+				.Sum(n => n.EffectValue);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
@@ -1,0 +1,76 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class TechRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly GameDef gameDef;
+		private readonly TechRepository techRepository;
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+
+		public TechRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			GameDef gameDef,
+			TechRepository techRepository,
+			ResourceRepository resourceRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.gameDef = gameDef;
+			this.techRepository = techRepository;
+			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+		}
+
+		public void StartResearch(ResearchTechCommand command) {
+			lock (_lock) {
+				var techNodeDef = gameDef.GetTechNodeDef(command.TechNodeId);
+				if (techNodeDef == null) throw new System.Exception($"Tech node '{command.TechNodeId}' not found.");
+
+				if (techRepository.IsUnlocked(command.PlayerId, command.TechNodeId)) {
+					throw new TechAlreadyUnlockedException(command.TechNodeId);
+				}
+
+				var current = techRepository.GetTechBeingResearched(command.PlayerId);
+				if (current != null) {
+					throw new TechResearchInProgressException(current.Id);
+				}
+
+				foreach (var prereq in techNodeDef.Prerequisites) {
+					if (!techRepository.IsUnlocked(command.PlayerId, prereq)) {
+						throw new TechPrerequisitesNotMetException(command.TechNodeId);
+					}
+				}
+
+				if (!resourceRepository.CanAfford(command.PlayerId, techNodeDef.Cost)) {
+					throw new CannotAffordException(techNodeDef.Cost);
+				}
+
+				resourceRepositoryWrite.DeductCost(command.PlayerId, techNodeDef.Cost);
+				var state = world.GetPlayer(command.PlayerId).State;
+				state.TechBeingResearched = command.TechNodeId.Id;
+				state.TechResearchTimer = techNodeDef.ResearchTimeTicks;
+			}
+		}
+
+		public void ProcessResearchTimer(PlayerId playerId) {
+			lock (_lock) {
+				var state = world.GetPlayer(playerId).State;
+				if (state.TechBeingResearched == null || state.TechResearchTimer <= 0) {
+					return;
+				}
+
+				state.TechResearchTimer--;
+				if (state.TechResearchTimer == 0) {
+					state.UnlockedTechs.Add(state.TechBeingResearched);
+					state.TechBeingResearched = null;
+				}
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -22,6 +22,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly IBattleBehavior battleBehavior;
 		private readonly UpgradeRepository upgradeRepository;
+		private readonly TechRepository techRepository;
 
 		public UnitRepositoryWrite(ILogger<UnitRepositoryWrite> logger
 				, IWorldStateAccessor worldStateAccessor
@@ -33,6 +34,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, IBattleBehavior battleBehavior
 				, UpgradeRepository upgradeRepository
+				, TechRepository techRepository
 			) {
 			this.logger = logger;
 			this.worldStateAccessor = worldStateAccessor;
@@ -44,6 +46,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.battleBehavior = battleBehavior;
 			this.upgradeRepository = upgradeRepository;
+			this.techRepository = techRepository;
 		}
 
 		private List<Unit> Units(PlayerId playerId) => world.GetPlayer(playerId).State.Units;
@@ -228,8 +231,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public BattleResult Attack(PlayerId playerId, PlayerId enemyPlayerId) {
 			int attackerAttackLevel = upgradeRepository.GetAttackUpgradeLevel(playerId);
 			int defenderDefenseLevel = upgradeRepository.GetDefenseUpgradeLevel(enemyPlayerId);
-			var attackingUnits = ToBattleUnits(unitRepository.GetAttackingUnits(playerId, enemyPlayerId), attackerAttackLevel, 0).ToList();
-			var defendingUnits = ToBattleUnits(unitRepository.GetDefendingEnemyUnits(playerId, enemyPlayerId), 0, defenderDefenseLevel).ToList();
+			int techAttackBonus = (int)techRepository.GetTotalEffectValue(playerId, TechEffectType.AttackBonus);
+			int techDefenseBonus = (int)techRepository.GetTotalEffectValue(enemyPlayerId, TechEffectType.DefenseBonus);
+			var attackingUnits = ToBattleUnits(unitRepository.GetAttackingUnits(playerId, enemyPlayerId), attackerAttackLevel, 0, techAttackBonus, 0).ToList();
+			var defendingUnits = ToBattleUnits(unitRepository.GetDefendingEnemyUnits(playerId, enemyPlayerId), 0, defenderDefenseLevel, 0, techDefenseBonus).ToList();
 
 			BattleResult battleResult = new BattleResult {
 				Attacker = playerId,
@@ -276,7 +281,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			return string.Join(", ", attackingUnits.Select(x => $"({x.Count} × {x.UnitDefId})"));
 		}
 
-		private IEnumerable<BtlUnit> ToBattleUnits(IEnumerable<UnitImmutable> units, int attackLevel, int defenseLevel) {
+		private IEnumerable<BtlUnit> ToBattleUnits(IEnumerable<UnitImmutable> units, int attackLevel, int defenseLevel, int techAttackBonus = 0, int techDefenseBonus = 0) {
 			return units.Select(x => {
 				var unitDef = gameDef.GetUnitDef(x.UnitDefId)!;
 				int attackBonus = attackLevel > 0 ? unitDef.AttackBonuses[attackLevel - 1] : 0;
@@ -284,8 +289,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				return new BtlUnit {
 					UnitDefId = x.UnitDefId,
 					Count = x.Count,
-					Attack = unitDef.Attack + attackBonus,
-					Defense = unitDef.Defense + defenseBonus,
+					Attack = unitDef.Attack + attackBonus + techAttackBonus,
+					Defense = unitDef.Defense + defenseBonus + techDefenseBonus,
 					Hitpoints = unitDef.Hitpoints,
 				};
 			});


### PR DESCRIPTION
## Summary
- Implements the full Technology Research Tree as designed in BGE-353
- 12 tech nodes across 3 tiers with prerequisites, costs, and effects
- Effects applied at use-sites: production boosts in resource growth, attack/defense bonuses in battle
- Full UI: tier-grouped `/research` page with real-time status (Unlocked/InProgress/Available/Locked)
- 7 unit tests covering all major code paths

## Architecture
- `TechNodeDef` + `TechEffectType` in `GameDefinition`
- `Id.TechNode` factory + serializer registration in `Persistence`
- Tech fields on `PlayerState`/`PlayerStateImmutable` (backward-compatible with existing saves)
- `TechRepository` (reads) + `TechRepositoryWrite` (writes, locked) in `StatefulGameServer`
- `TechResearchTimerModule` (IGameTickModule) processes timer each tick
- `ResearchController` exposes `GET /api/research` and `POST /api/research?techId=`
- `Research.razor` page with auto-refresh every 10s

## Test plan
- [x] `dotnet build` passes (0 warnings, 0 errors)
- [x] `dotnet test` passes (188/188)
- [x] All 7 TechResearchTest cases pass
- [x] Verify `/games/{id}/research` page loads and shows tier-grouped nodes
- [x] Research a Tier 1 node, confirm it transitions InProgress → Unlocked after ticks
- [x] Confirm prerequisites block Tier 2 until Tier 1 is unlocked

Closes BGE-371