### PR TITLE
fix: BGE-394 embed version at build time

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/VersionController.cs
@@ -1,13 +1,15 @@
 using BrowserGameEngine.Shared;
 using Microsoft.AspNetCore.Mvc;
-using System;
+using System.Reflection;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	[ApiController]
 	[Route("api/version")]
 	public class VersionController : ControllerBase {
 		private static readonly string CommitHash =
-			Environment.GetEnvironmentVariable("APP_VERSION") ?? "dev";
+			typeof(VersionController).Assembly
+				.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+				?.InformationalVersion ?? "dev";
 
 		/// <summary>Returns the deployed version (git commit hash) of the server.</summary>
 		[HttpGet]

--- a/src/BrowserGameEngine.FrontendServer/Dockerfile
+++ b/src/BrowserGameEngine.FrontendServer/Dockerfile
@@ -21,11 +21,10 @@ WORKDIR "/src/BrowserGameEngine.FrontendServer"
 RUN dotnet build "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/publish
+ARG COMMIT_SHA=dev
+RUN dotnet publish "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/publish /p:InformationalVersion=$COMMIT_SHA
 
 FROM base AS final
-ARG COMMIT_SHA=dev
-ENV APP_VERSION=$COMMIT_SHA
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "BrowserGameEngine.FrontendServer.dll"]


### PR DESCRIPTION
## Summary

- The version displayed as \`v@version.CommitHash\` in production because ECS task definition environment variables were overriding the Docker image's \`APP_VERSION\`, with an unsubstituted template placeholder
- Fix: bake \`InformationalVersion\` into the assembly at \`dotnet publish\` time using \`/p:InformationalVersion=\$COMMIT_SHA\` in the Dockerfile \`publish\` stage
- \`VersionController\` now reads from \`AssemblyInformationalVersionAttribute\` (compile-time, not overridable by ECS env vars)
- Removed the now-redundant \`ARG COMMIT_SHA\`/\`ENV APP_VERSION\` from the \`final\` stage

## Test plan

- [x] \`dotnet build\` passes (0 warnings)
- [x] \`dotnet test\` passes (181/181)
- [ ] After deploy, version in navbar should show actual commit SHA (short or full), not \`v@version.CommitHash\`

Closes BGE-394