### PR TITLE
fix: BGE-398/399/400/401 thread safety — locks, tick isolation, loop cap

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
@@ -17,10 +18,13 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		internal GameTickState GameTickState { get; set; } = new GameTickState();
 
 		internal IList<GameAction> GameActionQueue { get; set; } = new List<GameAction>();
+		internal readonly Lock ActionQueueLock = new();
 
 		internal IList<MarketOrder> MarketOrders { get; set; } = new List<MarketOrder>();
+		internal readonly Lock MarketOrdersLock = new();
 
 		internal IList<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
+		internal readonly Lock ChatMessagesLock = new();
 
 
 		// throws if player not found
@@ -74,14 +78,26 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 
 		public static WorldStateImmutable ToImmutable(this WorldState worldState) {
+			IList<GameActionImmutable> actionQueueSnapshot;
+			lock (worldState.ActionQueueLock) {
+				actionQueueSnapshot = worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList();
+			}
+			IList<MarketOrderImmutable>? marketOrdersSnapshot;
+			lock (worldState.MarketOrdersLock) {
+				marketOrdersSnapshot = worldState.MarketOrders.ToImmutable();
+			}
+			IList<ChatMessageImmutable>? chatMessagesSnapshot;
+			lock (worldState.ChatMessagesLock) {
+				chatMessagesSnapshot = worldState.ChatMessages.ToImmutable();
+			}
 			return new WorldStateImmutable(
 				Players: worldState.Players.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameTickState: worldState.GameTickState.ToImmutable(),
-				GameActionQueue: worldState.GameActionQueue.Select(x => x.ToImmutable()).ToList(),
+				GameActionQueue: actionQueueSnapshot,
 				Alliances: worldState.Alliances.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameId: worldState.GameId,
-				MarketOrders: worldState.MarketOrders.ToImmutable(),
-				ChatMessages: worldState.ChatMessages.ToImmutable()
+				MarketOrders: marketOrdersSnapshot,
+				ChatMessages: chatMessagesSnapshot
 			);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly TimeProvider timeProvider;
 
+		private readonly Lock _tickLock = new();
 		private volatile bool isPaused = false;
 		private long tickDurationOverrideTicks = 0; // 0 = no override; use Interlocked for thread safety
 
@@ -45,7 +46,14 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		}
 
 		public void CheckAllTicks() {
-			while (!CheckTick()) { } // repeat until all players are up to date
+			int maxIterations = Math.Max(worldState.Players.Count * 10, 1000);
+			int iterations = 0;
+			while (!CheckTick()) {
+				if (++iterations >= maxIterations) {
+					logger.LogCritical("CheckAllTicks exceeded {MaxIterations} iterations — aborting to prevent hang.", maxIterations);
+					break;
+				}
+			}
 		}
 
 		/// <summary>
@@ -94,7 +102,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 			// even if a player is behind multiple ticks, only do one tick at the time.
 			foreach (var playerId in playerIds) {
 				foreach (var module in gameTickModuleRegistry.Modules) {
-					module.CalculateTick(playerId);
+					try {
+						module.CalculateTick(playerId);
+					} catch (Exception ex) {
+						logger.LogError(ex, "Tick module {Module} threw for player {PlayerId} — skipping.", module.GetType().Name, playerId);
+					}
 				}
 				var newTick = playerRepositoryWrite.IncrementTick(playerId);
 				if (newTick.Tick < currentTick.Tick) allPlayersUpToDate = false;
@@ -105,22 +117,26 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 
 		public GameTick IncrementWorldTick(int count = 1) {
 			var duration = EffectiveTickDuration;
-			for (int i = 0; i < count; i++) {
-				var currentTick = worldState.GameTickState.CurrentGameTick;
-				worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick + 1 };
-				worldState.GameTickState.LastUpdate += duration;
-				logger.LogDebug("Incremented World Tick to #{CurrentTick}. LastUpdate: {LastUpdate}", worldState.GameTickState.CurrentGameTick.Tick, worldState.GameTickState.LastUpdate);
+			lock (_tickLock) {
+				for (int i = 0; i < count; i++) {
+					var currentTick = worldState.GameTickState.CurrentGameTick;
+					worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick + 1 };
+					worldState.GameTickState.LastUpdate += duration;
+					logger.LogDebug("Incremented World Tick to #{CurrentTick}. LastUpdate: {LastUpdate}", worldState.GameTickState.CurrentGameTick.Tick, worldState.GameTickState.LastUpdate);
+				}
+				return worldState.GameTickState.CurrentGameTick;
 			}
-			return worldState.GameTickState.CurrentGameTick;
 		}
 
 		/// <summary>
 		/// For unit testing
 		/// </summary>
 		public void DecrementWorldTick() {
-			var currentTick = worldState.GameTickState.CurrentGameTick;
-			worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick - 1 };
-			worldState.GameTickState.LastUpdate -= gameDef.TickDuration;
+			lock (_tickLock) {
+				var currentTick = worldState.GameTickState.CurrentGameTick;
+				worldState.GameTickState.CurrentGameTick = currentTick with { Tick = currentTick.Tick - 1 };
+				worldState.GameTickState.LastUpdate -= gameDef.TickDuration;
+			}
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/ActionQueue/ActionQueueRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/ActionQueue/ActionQueueRepository.cs
@@ -1,16 +1,15 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class ActionQueueRepository {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
+		private System.Threading.Lock ActionQueueLock => world.ActionQueueLock;
 
 		public ActionQueueRepository(IWorldStateAccessor worldStateAccessor) {
 			this.worldStateAccessor = worldStateAccessor;
@@ -20,7 +19,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private IEnumerable<GameAction> GetActions(PlayerId playerId) => Actions.Where(x => x.PlayerId.Equals(playerId));
 
 		internal IList<GameAction> GetAndRemoveDueActions(PlayerId playerId, string name, GameTick gameTick) {
-			lock (_lock) {
+			lock (ActionQueueLock) {
 				var actions = GetActions(playerId).Where(x => x.Name == name && x.IsDue(gameTick)).ToList(); // copy
 				foreach (var action in actions) {
 					Actions.Remove(action);
@@ -30,16 +29,20 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		internal bool IsQueued(PlayerId playerId, string name, IDictionary<string, string> properties) {
-			return GetActions(playerId).Any(x => x.Name == name && MatchesProperties(x.Properties, properties));
+			lock (ActionQueueLock) {
+				return GetActions(playerId).Any(x => x.Name == name && MatchesProperties(x.Properties, properties));
+			}
 		}
 
 		/// <summary>
 		/// Returns the number of ticks that are still left for an action
 		/// </summary>
 		internal GameTick TicksLeft(PlayerId playerId, string name, Dictionary<string, string> properties) {
-			var action = GetActions(playerId).Where(x => x.Name == name && MatchesProperties(x.Properties, properties)).SingleOrDefault();
-			if (action == null) return new GameTick(0);
-			return world.TicksLeft(action.DueTick);
+			lock (ActionQueueLock) {
+				var action = GetActions(playerId).Where(x => x.Name == name && MatchesProperties(x.Properties, properties)).SingleOrDefault();
+				if (action == null) return new GameTick(0);
+				return world.TicksLeft(action.DueTick);
+			}
 		}
 
 		private bool MatchesProperties(Dictionary<string, string> properties, IDictionary<string, string> expected) {
@@ -51,19 +54,19 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		internal void Remove(GameAction action) {
-			lock (_lock) {
+			lock (ActionQueueLock) {
 				Actions.Remove(action);
 			}
 		}
 
 		internal void AddAction(GameAction action) {
-			lock (_lock) {
+			lock (ActionQueueLock) {
 				Actions.Add(action);
 			}
 		}
 
 		internal void RemoveActions(PlayerId playerId, string name, IDictionary<string, string> properties) {
-			lock (_lock) {
+			lock (ActionQueueLock) {
 				var toRemove = GetActions(playerId)
 					.Where(x => x.Name == name && MatchesProperties(x.Properties, properties))
 					.ToList();
@@ -74,7 +77,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void RemoveAllPlayerActions(PlayerId playerId) {
-			lock (_lock) {
+			lock (ActionQueueLock) {
 				var toRemove = GetActions(playerId).ToList();
 				foreach (var action in toRemove) {
 					Actions.Remove(action);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
@@ -8,9 +8,9 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 	public class ChatRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
+		private System.Threading.Lock ChatMessagesLock => world.ChatMessagesLock;
 		private readonly TimeProvider timeProvider;
 		private const int MaxMessages = 200;
 
@@ -20,7 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 		}
 
 		public IList<ChatMessageImmutable> GetMessages(int count = 50) {
-			lock (_lock) {
+			lock (ChatMessagesLock) {
 				return world.ChatMessages
 					.Select(m => m.ToImmutable())
 					.TakeLast(count)
@@ -36,7 +36,7 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 				return new List<ChatMessageImmutable>();
 			}
 
-			lock (_lock) {
+			lock (ChatMessagesLock) {
 				var messages = world.ChatMessages;
 				int idx = -1;
 				for (int i = 0; i < messages.Count; i++) {
@@ -60,7 +60,7 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 
 		public ChatMessageId PostMessage(PostChatMessageCommand command) {
 			var messageId = ChatMessageIdFactory.NewChatMessageId();
-			lock (_lock) {
+			lock (ChatMessagesLock) {
 				world.ValidatePlayer(command.AuthorPlayerId);
 				world.ChatMessages.Add(new ChatMessage {
 					MessageId = messageId,

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Market/MarketRepository.cs
@@ -8,9 +8,9 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class MarketRepository {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
+		private System.Threading.Lock MarketOrdersLock => world.MarketOrdersLock;
 		private readonly ResourceRepository resourceRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
 
@@ -25,7 +25,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public IList<MarketOrderImmutable> GetOpenOrders() {
-			lock (_lock) {
+			lock (MarketOrdersLock) {
 				return world.MarketOrders
 					.Where(o => o.Status == MarketOrderStatus.Open)
 					.Select(o => o.ToImmutable())
@@ -38,7 +38,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public MarketOrderId CreateOrder(CreateMarketOrderCommand cmd) {
-			lock (_lock) {
+			lock (MarketOrdersLock) {
 				world.ValidatePlayer(cmd.PlayerId);
 
 				if (cmd.OfferedAmount <= 0) throw new InvalidOperationException("Offered amount must be positive.");
@@ -65,7 +65,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void AcceptOrder(AcceptMarketOrderCommand cmd) {
-			lock (_lock) {
+			lock (MarketOrdersLock) {
 				world.ValidatePlayer(cmd.BuyerPlayerId);
 
 				var order = GetOrderMutable(cmd.OrderId)
@@ -89,7 +89,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void CancelOrder(CancelMarketOrderCommand cmd) {
-			lock (_lock) {
+			lock (MarketOrdersLock) {
 				world.ValidatePlayer(cmd.PlayerId);
 
 				var order = GetOrderMutable(cmd.OrderId)

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -20,7 +20,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ChangePlayerName(ChangePlayerNameCommand command) {
-			Players[command.PlayerId].Name = command.NewName;
+			lock (_lock) {
+				Players[command.PlayerId].Name = command.NewName;
+			}
 		}
 
 		public void AssignWorkers(AssignWorkersCommand command, int totalWorkers) {


### PR DESCRIPTION
## Summary
- **BGE-398 (critical)**: Add `_tickLock` to `GameTickEngine`; protects `IncrementWorldTick`/`DecrementWorldTick` against concurrent calls from background timer and `AdminController.ForceTick`
- **BGE-399 (high)**: Wrap `PlayerRepositoryWrite.ChangePlayerName` in `_lock` — the only write method that was missing it
- **BGE-400 (high)**: Isolate per-module exceptions in `UpdatePlayers` (stuck players fixed); add `maxIterations` cap to `CheckAllTicks` to prevent infinite hang
- **BGE-401 (high)**: Add `ActionQueueLock`, `MarketOrdersLock`, `ChatMessagesLock` to `WorldState`; `ToImmutable()` now snapshots each collection under the shared lock; write repos switched to use shared locks; `ActionQueueRepository.IsQueued`/`TicksLeft` now protected

## Test plan
- [x] `dotnet build` passes (0 warnings)
- [x] `dotnet test` passes (188/188)
- [ ] Manual: verify game ticks still increment correctly in dev environment
- [ ] Manual: verify chat/market operations work concurrently

Closes BGE-398
Closes BGE-399
Closes BGE-400
Closes BGE-401