### PR TITLE
fix: BGE-404 add [Authorize] to AdminController for defense-in-depth

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,6 +19,7 @@ using System.Threading.Tasks;
 namespace BrowserGameEngine.FrontendServer.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/admin")]
 public class AdminController : ControllerBase
 {


### PR DESCRIPTION
## Summary

- Adds `[Authorize]` attribute to `AdminController` at the class level
- Adds the required `using Microsoft.AspNetCore.Authorization;` import
- The existing per-endpoint `if (!options.Value.DevAuth) return NotFound()` checks are preserved as the feature guard

## Why

Previously the only auth gate was `DevAuth=false` returning 404. If `DevAuth` were accidentally set to `true` in prod (env var typo, copied config), all admin endpoints — set-resources, reset-player, force-tick, load-snapshot, etc. — would be accessible to unauthenticated users. This is defense-in-depth: a valid session is now always required regardless of `DevAuth` state.

## Changes

This is a clean single-change PR — only `AdminController.cs` is modified (+2 lines). Replaces the contaminated PR #120.

## Test plan

- [x] Build passes (`dotnet build --configuration Release`)
- [ ] Admin endpoints in dev (DevAuth=true) still require a logged-in session
- [ ] Admin endpoints in prod (DevAuth=false) continue to return 404 as before

Closes BGE-404