### PR TITLE
feat: BGE-392 two-column sidebar nav redesign

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Chat.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Chat.razor
@@ -1,4 +1,5 @@
 @page "/chat"
+@page "/games/{GameId}/chat"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @implements IDisposable
@@ -82,6 +83,9 @@
 </div>
 
 @code {
+	[Parameter]
+	public string? GameId { get; set; }
+
 	private List<ChatMessageViewModel>? messages;
 	private string newMessageBody = "";
 	private string? lastMessageId;

--- a/src/BrowserGameEngine.BlazorClient/Pages/Diplomacy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Diplomacy.razor
@@ -1,0 +1,326 @@
+@page "/diplomacy"
+@page "/games/{GameId}/diplomacy"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@implements IDisposable
+
+<h1>Diplomacy</h1>
+
+@if (!string.IsNullOrEmpty(lastError)) {
+	<div class="alert alert-danger">@lastError</div>
+}
+@if (!string.IsNullOrEmpty(successMessage)) {
+	<div class="alert alert-success">@successMessage</div>
+}
+
+@if (status == null) {
+	<p><em>Loading...</em></p>
+} else {
+
+	@* ── Incoming proposals ─────────────────────────────────── *@
+	@if (status.PendingIncoming.Any()) {
+		<div class="card border-warning mb-4">
+			<div class="card-header bg-warning text-dark">
+				<strong>Incoming Proposals (@status.PendingIncoming.Count)</strong>
+			</div>
+			<div class="card-body p-0">
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>From</th>
+							<th>Type</th>
+							<th>Terms</th>
+							<th>Duration</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var p in status.PendingIncoming) {
+							<tr>
+								<td><strong>@p.ProposerPlayerName</strong></td>
+								<td>@ProposalTypeLabel(p.Type)</td>
+								<td>@ProposalTerms(p)</td>
+								<td>@p.DurationTicks ticks</td>
+								<td>
+									<button class="btn btn-sm btn-success me-1" @onclick="() => Respond(p.ProposalId, true)">Accept</button>
+									<button class="btn btn-sm btn-outline-danger" @onclick="() => Respond(p.ProposalId, false)">Decline</button>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	}
+
+	@* ── Active NAPs ────────────────────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header">
+			<strong>Active Non-Aggression Pacts</strong>
+		</div>
+		<div class="card-body p-0">
+			@if (!status.ActiveNaps.Any()) {
+				<p class="text-muted p-3 mb-0">No active NAPs.</p>
+			} else {
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>Partner</th>
+							<th>Ticks Remaining</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var nap in status.ActiveNaps) {
+							<tr>
+								<td>@nap.PartnerPlayerName</td>
+								<td>@nap.TicksRemaining</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			}
+		</div>
+	</div>
+
+	@* ── Active resource agreements ─────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header">
+			<strong>Active Resource Agreements</strong>
+		</div>
+		<div class="card-body p-0">
+			@if (!status.ActiveResourceAgreements.Any()) {
+				<p class="text-muted p-3 mb-0">No active resource agreements.</p>
+			} else {
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>Partner</th>
+							<th>Minerals/tick</th>
+							<th>Gas/tick</th>
+							<th>Ticks Remaining</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var a in status.ActiveResourceAgreements) {
+							<tr>
+								<td>@a.PartnerPlayerName</td>
+								<td>@a.MineralsPerTick</td>
+								<td>@a.GasPerTick</td>
+								<td>@a.TicksRemaining</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			}
+		</div>
+	</div>
+
+	@* ── Sent proposals ─────────────────────────────────────── *@
+	@if (status.PendingSent.Any()) {
+		<div class="card mb-4">
+			<div class="card-header">
+				<strong>Sent Proposals (awaiting response)</strong>
+			</div>
+			<div class="card-body p-0">
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>To</th>
+							<th>Type</th>
+							<th>Terms</th>
+							<th>Duration</th>
+							<th>Proposed</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var p in status.PendingSent) {
+							<tr>
+								<td>@p.TargetPlayerName</td>
+								<td>@ProposalTypeLabel(p.Type)</td>
+								<td>@ProposalTerms(p)</td>
+								<td>@p.DurationTicks ticks</td>
+								<td><small class="text-muted">@p.ProposedAt.ToLocalTime().ToString("g")</small></td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	}
+
+	@* ── Propose new agreement ──────────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header d-flex justify-content-between align-items-center">
+			<strong>Propose Agreement</strong>
+			<div>
+				<button class="btn btn-sm @(proposeMode == "nap" ? "btn-primary" : "btn-outline-primary") me-1"
+						@onclick='() => SetProposeMode("nap")'>Non-Aggression Pact</button>
+				<button class="btn btn-sm @(proposeMode == "resource" ? "btn-primary" : "btn-outline-primary")"
+						@onclick='() => SetProposeMode("resource")'>Resource Agreement</button>
+			</div>
+		</div>
+		@if (proposeMode != null) {
+			<div class="card-body">
+				<div class="mb-3">
+					<label class="form-label">Target Player</label>
+					@if (players == null) {
+						<input class="form-control" @bind="selectedTargetPlayerId" placeholder="Player ID" />
+					} else {
+						<select class="form-select" @bind="selectedTargetPlayerId">
+							<option value="">— Select a player —</option>
+							@foreach (var p in players) {
+								<option value="@p.PlayerId">@p.PlayerName</option>
+							}
+						</select>
+					}
+				</div>
+
+				<div class="mb-3">
+					<label class="form-label">Duration (ticks)</label>
+					<select class="form-select" style="max-width:200px" @bind="proposeDurationTicks">
+						<option value="50">50 ticks (short)</option>
+						<option value="100">100 ticks (medium)</option>
+						<option value="200">200 ticks (long)</option>
+					</select>
+				</div>
+
+				@if (proposeMode == "resource") {
+					<div class="row mb-3">
+						<div class="col-auto">
+							<label class="form-label">Minerals / tick</label>
+							<input type="number" class="form-control" style="max-width:120px"
+								   @bind="proposeMineralsPerTick" min="0" />
+						</div>
+						<div class="col-auto">
+							<label class="form-label">Gas / tick</label>
+							<input type="number" class="form-control" style="max-width:120px"
+								   @bind="proposeGasPerTick" min="0" />
+						</div>
+					</div>
+					<p class="text-muted small">Resources are transferred each tick for the agreement duration. Both parties send the same amounts to each other.</p>
+				}
+
+				<button class="btn btn-primary" @onclick="SubmitProposal"
+						disabled="@(string.IsNullOrEmpty(selectedTargetPlayerId) || proposing)">
+					@(proposing ? "Sending..." : "Send Proposal")
+				</button>
+				<button class="btn btn-link ms-2" @onclick='() => SetProposeMode(null)'>Cancel</button>
+			</div>
+		}
+	</div>
+}
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private DiplomacyStatusViewModel? status;
+	private List<PublicPlayerViewModel>? players;
+	private string? lastError;
+	private string? successMessage;
+	private CancellationTokenSource? _cts;
+
+	private string? proposeMode; // "nap" | "resource" | null
+	private string selectedTargetPlayerId = "";
+	private int proposeDurationTicks = 100;
+	private int proposeMineralsPerTick;
+	private int proposeGasPerTick;
+	private bool proposing;
+
+	protected override async Task OnInitializedAsync() {
+		await Task.WhenAll(LoadStatus(), LoadPlayers());
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(LoadStatus);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task LoadStatus() {
+		status = await Http.GetFromJsonAsync<DiplomacyStatusViewModel>("api/diplomacy/status");
+	}
+
+	private async Task LoadPlayers() {
+		try {
+			players = await Http.GetFromJsonAsync<List<PublicPlayerViewModel>>("api/playerranking") ?? new();
+		} catch {
+			players = new();
+		}
+	}
+
+	private void SetProposeMode(string? mode) {
+		proposeMode = mode;
+		selectedTargetPlayerId = "";
+		proposeDurationTicks = 100;
+		proposeMineralsPerTick = 0;
+		proposeGasPerTick = 0;
+		lastError = null;
+		successMessage = null;
+	}
+
+	private async Task SubmitProposal() {
+		if (string.IsNullOrEmpty(selectedTargetPlayerId)) return;
+		proposing = true;
+		lastError = null;
+		successMessage = null;
+
+		HttpResponseMessage response;
+		if (proposeMode == "nap") {
+			response = await Http.PostAsJsonAsync("api/diplomacy/propose/nap", new ProposeNapRequest {
+				TargetPlayerId = selectedTargetPlayerId,
+				DurationTicks = proposeDurationTicks
+			});
+		} else {
+			response = await Http.PostAsJsonAsync("api/diplomacy/propose/resource-agreement", new ProposeResourceAgreementRequest {
+				TargetPlayerId = selectedTargetPlayerId,
+				DurationTicks = proposeDurationTicks,
+				MineralsPerTick = proposeMineralsPerTick,
+				GasPerTick = proposeGasPerTick
+			});
+		}
+
+		proposing = false;
+		if (response.IsSuccessStatusCode) {
+			successMessage = "Proposal sent.";
+			SetProposeMode(null);
+			await LoadStatus();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task Respond(string proposalId, bool accept) {
+		lastError = null;
+		successMessage = null;
+		var response = await Http.PostAsJsonAsync(
+			$"api/diplomacy/proposals/{proposalId}/respond",
+			new RespondToProposalRequest { Accept = accept });
+		if (response.IsSuccessStatusCode) {
+			successMessage = accept ? "Proposal accepted." : "Proposal declined.";
+			await LoadStatus();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private static string ProposalTypeLabel(DiplomacyProposalType type) => type switch {
+		DiplomacyProposalType.Nap => "Non-Aggression Pact",
+		DiplomacyProposalType.ResourceAgreement => "Resource Agreement",
+		_ => type.ToString()
+	};
+
+	private static string ProposalTerms(DiplomacyProposalViewModel p) => p.Type switch {
+		DiplomacyProposalType.ResourceAgreement => $"{p.MineralsPerTick} minerals + {p.GasPerTick} gas/tick",
+		_ => "—"
+	};
+
+	public void Dispose() {
+		_cts?.Cancel();
+		_cts?.Dispose();
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -6,167 +6,189 @@
 @using BrowserGameEngine.BlazorClient.Code
 @implements IDisposable
 
-<div class="top-row pl-4 navbar navbar-dark">
-    <a class="navbar-brand" href="">Age of Agents</a>
-    <button class="navbar-toggler" @onclick="ToggleNavMenu">
+@* ── Mobile toggle ────────────────────────────────────────── *@
+<div class="nav-mobile-bar">
+    <span class="nav-brand-text">Age of Agents</span>
+    <button class="navbar-toggler" @onclick="ToggleNavMenu" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 </div>
 
-<div class="@NavMenuCssClass">
+@* ── Two-column sidebar ───────────────────────────────────── *@
+<div class="nav-two-col @(collapseNavMenu ? "nav-two-col--collapsed" : "")">
 
-    @* ── Workspace / game selector ─────────────────── *@
-    <div class="nav-section-label">MY GAMES</div>
-    @if (_myGames == null) {
-        <div class="px-3 py-2" style="color:var(--color-text-muted);font-size:0.8rem;">Loading...</div>
-    } else if (_myGames.Count == 0) {
-        <div class="px-3 py-1" style="color:var(--color-text-muted);font-size:0.8rem;">No active games</div>
-    } else {
-        @foreach (var game in _myGames) {
-            var isActive = CurrentGameService.CurrentGameId == game.GameId;
-            <button class="workspace-item @(isActive ? "workspace-item--active" : "")"
-                    @onclick="() => SwitchToGame(game)"
-                    title="Play as @game.PlayerName in @game.GameName">
-                <div class="workspace-dot @GetStatusDotClass(game.GameStatus)"></div>
-                <div class="workspace-info">
-                    <div class="workspace-name">@game.GameName</div>
-                    <div class="workspace-player">@game.PlayerName</div>
-                </div>
-                @if (isActive) {
-                    <span class="workspace-check">&#10003;</span>
+    @* ── Left strip: game switcher ────────────────────────── *@
+    <div class="nav-strip">
+        <div class="nav-strip-top">
+            <a href="" class="nav-strip-logo" title="Age of Agents">
+                <span class="nav-strip-logo-text">AoA</span>
+            </a>
+
+            @if (_myGames == null) {
+                <div class="nav-strip-spinner"></div>
+            } else {
+                @foreach (var game in _myGames) {
+                    var isActive = CurrentGameService.CurrentGameId == game.GameId;
+                    <button class="nav-game-icon @(isActive ? "nav-game-icon--active" : "")"
+                            @onclick="() => SwitchToGame(game)"
+                            title="@game.GameName — @game.PlayerName">
+                        <span class="nav-game-icon-letter">@(game.GameName?.Length > 0 ? game.GameName[0].ToString().ToUpper() : "G")</span>
+                        <span class="nav-game-status-dot @GetStatusDotClass(game.GameStatus)"></span>
+                    </button>
                 }
-            </button>
-        }
-    }
-    <a class="workspace-browse" href="lobby">
-        <span class="oi oi-plus" aria-hidden="true"></span> Browse / Join Games
-    </a>
+            }
 
-    @* ── In-game navigation (only when a game is active) ── *@
-    @if (CurrentGameService.CurrentGameId != null) {
-        <div class="nav-section-label">GAME</div>
-        <ul class="nav flex-column">
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/base")">
-                    <span class="oi oi-layers" aria-hidden="true"></span> Base
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/units")">
-                    <span class="oi oi-shield" aria-hidden="true"></span> Units
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/unitdefinitions")">
-                    <span class="oi oi-spreadsheet" aria-hidden="true"></span> Unit Types
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/upgrades")">
-                    <span class="oi oi-beaker" aria-hidden="true"></span> Upgrades
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/research")">
-                    <span class="oi oi-wrench" aria-hidden="true"></span> Tech Tree
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/market")">
-                    <span class="oi oi-cart" aria-hidden="true"></span> Market
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/ranking")">
-                    <span class="oi oi-bar-chart" aria-hidden="true"></span> Ranking
-                </NavLink>
-            </li>
-            <li class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{CurrentGameService.CurrentGameId}/messages")">
-                    <span class="oi oi-envelope-closed" aria-hidden="true"></span> Messages
-                </NavLink>
-            </li>
-        </ul>
-    }
-
-    @* ── General navigation ────────────────────────── *@
-    <div class="nav-section-label">GENERAL</div>
-    <ul class="nav flex-column">
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="oi oi-home" aria-hidden="true"></span> Home
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="alliances">
-                <span class="oi oi-people" aria-hidden="true"></span> Alliances
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="allianceranking">
-                <span class="oi oi-graph" aria-hidden="true"></span> Alliance Ranking
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="players">
-                <span class="oi oi-person" aria-hidden="true"></span> Players
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="chat">
-                <span class="oi oi-chat" aria-hidden="true"></span> Chat
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="messages">
-                <span class="oi oi-envelope-closed" aria-hidden="true"></span> Messages
-                @if (AlertService.UnseenCount > 0) {
-                    <span class="badge bg-danger ms-1">@AlertService.UnseenCount</span>
-                }
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="profile">
-                <span class="oi oi-account-login" aria-hidden="true"></span> Profile
-            </NavLink>
-        </li>
-        <AuthorizeView>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="achievements">
-                <span class="oi oi-star" aria-hidden="true"></span> Achievements
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="history">
-                <span class="oi oi-clock" aria-hidden="true"></span> History
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="admin/games">
-                <span class="oi oi-cog" aria-hidden="true"></span> Admin: Games
-            </NavLink>
-        </li>
-        </AuthorizeView>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="signout">
-                <span class="oi oi-account-logout" aria-hidden="true"></span> Sign Out
-            </NavLink>
-        </li>
-    </ul>
-
-    @if (version != null) {
-        <div class="px-3 py-2" style="font-size: 0.75rem; color: rgba(255,255,255,0.4);">
-            v@version.CommitHash
+            <a href="lobby" class="nav-strip-btn" title="Browse / Join Games">
+                <span class="oi oi-plus" aria-hidden="true"></span>
+            </a>
         </div>
-    }
+
+        <div class="nav-strip-bottom">
+            @if (version != null) {
+                <span class="nav-strip-version" title="v@version.CommitHash">v</span>
+            }
+            <a href="signout" class="nav-strip-btn nav-strip-btn--signout" title="Sign Out">
+                <span class="oi oi-account-logout" aria-hidden="true"></span>
+            </a>
+        </div>
+    </div>
+
+    @* ── Right panel: contextual nav ──────────────────────── *@
+    <div class="nav-panel">
+        @if (CurrentGameService.CurrentGameId != null) {
+            @* ── In-game navigation ──────────────────────── *@
+            var gameId = CurrentGameService.CurrentGameId;
+            var gameName = CurrentGameService.CurrentGame?.Name ?? "Game";
+
+            <div class="nav-panel-header">
+                <div class="nav-panel-game-name">@gameName</div>
+                <a href="games" class="nav-panel-all-games" title="All Games">&#8592; Games</a>
+            </div>
+
+            <div class="nav-section-label">PLAY</div>
+            <ul class="nav flex-column">
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/base")">
+                        <span class="oi oi-layers" aria-hidden="true"></span> Base
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/units")">
+                        <span class="oi oi-shield" aria-hidden="true"></span> Units
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/unitdefinitions")">
+                        <span class="oi oi-spreadsheet" aria-hidden="true"></span> Unit Types
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/upgrades")">
+                        <span class="oi oi-beaker" aria-hidden="true"></span> Research
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/market")">
+                        <span class="oi oi-cart" aria-hidden="true"></span> Market
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/ranking")">
+                        <span class="oi oi-bar-chart" aria-hidden="true"></span> Ranking
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/diplomacy")">
+                        <span class="oi oi-flag" aria-hidden="true"></span> Diplomacy
+                    </NavLink>
+                </li>
+            </ul>
+
+            <div class="nav-section-label">SOCIAL</div>
+            <ul class="nav flex-column">
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/alliances")">
+                        <span class="oi oi-people" aria-hidden="true"></span> Alliances
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/allianceranking")">
+                        <span class="oi oi-graph" aria-hidden="true"></span> Alliance Ranking
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/chat")">
+                        <span class="oi oi-chat" aria-hidden="true"></span> Chat
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/messages")">
+                        <span class="oi oi-envelope-closed" aria-hidden="true"></span> Messages
+                        @if (AlertService.UnseenCount > 0) {
+                            <span class="badge bg-danger ms-1">@AlertService.UnseenCount</span>
+                        }
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="players">
+                        <span class="oi oi-person" aria-hidden="true"></span> Players
+                    </NavLink>
+                </li>
+            </ul>
+        } else {
+            @* ── Lobby / general navigation ──────────────── *@
+            <div class="nav-panel-header">
+                <div class="nav-panel-game-name">Browse</div>
+            </div>
+
+            <div class="nav-section-label">GENERAL</div>
+            <ul class="nav flex-column">
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                        <span class="oi oi-home" aria-hidden="true"></span> Home
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="lobby">
+                        <span class="oi oi-list" aria-hidden="true"></span> Game Lobby
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="players">
+                        <span class="oi oi-person" aria-hidden="true"></span> Players
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="profile">
+                        <span class="oi oi-account-login" aria-hidden="true"></span> Profile
+                    </NavLink>
+                </li>
+                <AuthorizeView>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="achievements">
+                        <span class="oi oi-star" aria-hidden="true"></span> Achievements
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="history">
+                        <span class="oi oi-clock" aria-hidden="true"></span> History
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/games">
+                        <span class="oi oi-cog" aria-hidden="true"></span> Admin: Games
+                    </NavLink>
+                </li>
+                </AuthorizeView>
+            </ul>
+        }
+    </div>
 </div>
 
 @code {
     private bool collapseNavMenu = true;
     private VersionInfoViewModel? version;
     private List<MyGameViewModel>? _myGames;
-
-    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
     private void ToggleNavMenu() {
         collapseNavMenu = !collapseNavMenu;

--- a/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
+++ b/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
@@ -86,61 +86,291 @@ app {
     text-overflow: ellipsis;
 }
 
-/* --- Sidebar -------------------------------------------------------- */
+/* --- Mobile nav bar ------------------------------------------------- */
+.nav-mobile-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: var(--color-bg-elevated);
+    border-bottom: 1px solid var(--color-border-default);
+    padding: 0 1rem;
+    height: 3.5rem;
+}
+
+.nav-brand-text {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    letter-spacing: 0.02em;
+}
+
+.navbar-toggler {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: var(--color-border-default);
+    color: var(--color-text-primary);
+}
+
+/* --- Sidebar shell -------------------------------------------------- */
 .sidebar {
     background-color: var(--color-bg-surface);
     border-right: 1px solid var(--color-border-default);
 }
 
-.sidebar .top-row {
-    background-color: var(--color-bg-elevated);
-    border-bottom: 1px solid var(--color-border-default);
+/* --- Two-column nav layout ------------------------------------------ */
+.nav-two-col {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
 }
 
-.sidebar .navbar-brand {
-    font-size: 1.1rem;
-    color: var(--color-text-primary);
+/* Left strip — narrow game-switcher column */
+.nav-strip {
+    width: 54px;
+    flex-shrink: 0;
+    background-color: #0d1117;
+    border-right: 1px solid var(--color-border-subtle);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.5rem 0;
+    gap: 0;
+    overflow-y: auto;
+    scrollbar-width: none;
 }
 
-.sidebar .oi {
-    width: 2rem;
-    font-size: 1.1rem;
-    vertical-align: text-top;
-    top: -2px;
+.nav-strip::-webkit-scrollbar {
+    display: none;
 }
 
-.sidebar .nav-item {
-    font-size: 0.9rem;
+.nav-strip-top {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    flex: 1;
+    width: 100%;
     padding-bottom: 0.5rem;
 }
 
-.sidebar .nav-item:first-of-type {
-    padding-top: 1rem;
+.nav-strip-bottom {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    width: 100%;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--color-border-subtle);
 }
 
-.sidebar .nav-item:last-of-type {
-    padding-bottom: 1rem;
-}
-
-.sidebar .nav-item a {
-    color: var(--color-text-secondary);
-    border-radius: var(--radius-sm);
-    height: 3rem;
+/* Logo button */
+.nav-strip-logo {
     display: flex;
     align-items: center;
-    line-height: 3rem;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #1d4ed8 0%, #3b82f6 100%);
+    text-decoration: none;
+    margin-bottom: 0.4rem;
+    flex-shrink: 0;
+    transition: border-radius 0.15s ease;
+}
+
+.nav-strip-logo:hover {
+    border-radius: 14px;
     text-decoration: none;
 }
 
-.sidebar .nav-item a.active {
-    background-color: var(--color-bg-elevated);
-    color: var(--color-text-primary);
-    border-left: 3px solid var(--color-text-link);
+.nav-strip-logo-text {
+    font-size: 0.6rem;
+    font-weight: 800;
+    color: white;
+    letter-spacing: 0.03em;
 }
 
-.sidebar .nav-item a:hover {
-    background-color: var(--color-bg-elevated);
+/* Game icon buttons */
+.nav-game-icon {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    background: var(--color-bg-elevated);
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-radius 0.15s ease, background 0.15s ease;
+    color: var(--color-text-secondary);
+}
+
+.nav-game-icon:hover {
+    border-radius: 14px;
+    background: #374151;
+    color: white;
+}
+
+.nav-game-icon--active {
+    border-radius: 14px;
+    background: #1d4ed8;
+    color: white;
+}
+
+.nav-game-icon-letter {
+    font-size: 0.85rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+/* Status dot on game icon */
+.nav-game-status-dot {
+    position: absolute;
+    bottom: 2px;
+    right: 2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1.5px solid #0d1117;
+}
+
+/* Strip buttons (lobby +, sign out) */
+.nav-strip-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: transparent;
+    border: 1px dashed rgba(255,255,255,0.2);
+    color: rgba(255, 255, 255, 0.45);
+    text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    cursor: pointer;
+}
+
+.nav-strip-btn:hover {
+    background: rgba(255,255,255,0.1);
+    color: white;
+    border-color: rgba(255,255,255,0.5);
+    text-decoration: none;
+}
+
+.nav-strip-btn .oi {
+    font-size: 0.9rem;
+    width: auto;
+}
+
+.nav-strip-btn--signout {
+    border-style: solid;
+    border-color: transparent;
+}
+
+.nav-strip-version {
+    font-size: 0.6rem;
+    color: rgba(255,255,255,0.2);
+    user-select: none;
+    padding: 0.2rem 0;
+}
+
+/* Right panel — contextual navigation */
+.nav-panel {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    padding-bottom: 1rem;
+}
+
+.nav-panel-header {
+    padding: 0.75rem 0.75rem 0.25rem 0.75rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+    margin-bottom: 0.25rem;
+}
+
+.nav-panel-game-name {
+    font-size: 0.85rem;
+    font-weight: 700;
     color: var(--color-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nav-panel-all-games {
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    display: block;
+    margin-top: 0.1rem;
+}
+
+.nav-panel-all-games:hover {
+    color: var(--color-text-link);
+    text-decoration: none;
+}
+
+/* Nav items within panel */
+.nav-panel .nav-item {
+    font-size: 0.88rem;
+    padding-bottom: 0.2rem;
+}
+
+.nav-panel .nav-item:first-of-type {
+    padding-top: 0.25rem;
+}
+
+.nav-panel .nav-item a {
+    color: var(--color-text-secondary);
+    border-radius: var(--radius-sm);
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    line-height: 2.5rem;
+    text-decoration: none;
+    padding: 0 0.5rem;
+}
+
+.nav-panel .nav-item a.active {
+    background-color: rgba(59, 130, 246, 0.15);
+    color: var(--color-text-primary);
+    border-left: 2px solid var(--color-text-link);
+    padding-left: calc(0.5rem - 2px);
+}
+
+.nav-panel .nav-item a:hover {
+    background-color: rgba(255,255,255,0.06);
+    color: var(--color-text-primary);
+}
+
+.nav-panel .oi {
+    width: 1.5rem;
+    font-size: 0.9rem;
+    vertical-align: text-top;
+    top: -1px;
+    opacity: 0.7;
+}
+
+.nav-panel .nav-item a.active .oi,
+.nav-panel .nav-item a:hover .oi {
+    opacity: 1;
+}
+
+/* Spinner for loading state */
+.nav-strip-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid rgba(255,255,255,0.15);
+    border-top-color: rgba(255,255,255,0.5);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin: 0.3rem auto;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
 }
 
 /* --- Main content --------------------------------------------------- */
@@ -396,38 +626,57 @@ tbody tr:hover {
 }
 
 /* --- Race-variant sidebar stubs ------------------------------------ */
-/* Terran: industrial steel-gray left-border accent */
-.race-terran .sidebar {
-    border-left: 4px solid var(--color-race-terran);
-    background-color: #0e1520;
+/* Terran: industrial steel-gray */
+.race-terran .nav-strip {
+    background-color: #0c1018;
+    border-right-color: rgba(203, 213, 225, 0.15);
 }
 
-.race-terran .sidebar .top-row {
-    background-color: rgba(203, 213, 225, 0.08);
+.race-terran .nav-strip-logo {
+    background: linear-gradient(135deg, #475569 0%, #94a3b8 100%);
 }
 
-/* Zerg: organic amber left-border accent */
-.race-zerg .sidebar {
-    border-left: 4px solid var(--color-race-zerg);
-    background-color: #130e08;
+/* Zerg: organic amber */
+.race-zerg .nav-strip {
+    background-color: #100c07;
+    border-right-color: rgba(180, 83, 9, 0.3);
 }
 
-.race-zerg .sidebar .top-row {
-    background-color: rgba(180, 83, 9, 0.15);
+.race-zerg .nav-strip-logo {
+    background: linear-gradient(135deg, #92400e 0%, #f59e0b 100%);
 }
 
-/* Protoss: crystalline gold left-border accent */
-.race-protoss .sidebar {
-    border-left: 4px solid var(--color-race-protoss);
-    background-color: #111007;
+/* Protoss: crystalline gold */
+.race-protoss .nav-strip {
+    background-color: #0f0d07;
+    border-right-color: rgba(251, 191, 36, 0.2);
 }
 
-.race-protoss .sidebar .top-row {
-    background-color: rgba(251, 191, 36, 0.1);
+.race-protoss .nav-strip-logo {
+    background: linear-gradient(135deg, #854d0e 0%, #fbbf24 100%);
 }
 
 /* --- Responsive ----------------------------------------------------- */
 @media (max-width: 767.98px) {
+    .nav-mobile-bar {
+        display: flex;
+    }
+
+    .nav-two-col {
+        display: none;
+    }
+
+    .nav-two-col:not(.nav-two-col--collapsed) {
+        display: flex;
+        position: fixed;
+        top: 3.5rem;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 200;
+        overflow-y: auto;
+    }
+
     .main .top-row {
         height: auto;
         min-height: 3rem;
@@ -448,11 +697,27 @@ tbody tr:hover {
         flex-direction: row;
     }
 
+    .nav-mobile-bar {
+        display: none;
+    }
+
     .sidebar {
         width: 250px;
         height: 100vh;
         position: sticky;
         top: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .nav-two-col {
+        flex: 1;
+        height: 100%;
+    }
+
+    .nav-two-col--collapsed {
+        /* Never collapse on desktop */
+        display: flex !important;
     }
 
     .main .top-row {
@@ -469,139 +734,34 @@ tbody tr:hover {
     .navbar-toggler {
         display: none;
     }
-
-    .sidebar .collapse {
-        /* Never collapse the sidebar for wide screens */
-        display: block;
-    }
 }
 
-/* (duplicate .bge-asset removed — dark theme rules above apply) */
-
-
-/* ── Workspace / game selector ────────────────────────────────────────── */
-
-/* Section label (MY GAMES, GAME, GENERAL) */
+/* ── Nav section labels ───────────────────────────────────────────────── */
 .nav-section-label {
-    padding: 1rem 0.75rem 0.25rem 0.75rem;
-    font-size: 0.7rem;
+    padding: 0.75rem 0.75rem 0.2rem 0.75rem;
+    font-size: 0.68rem;
     font-weight: 700;
     letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.45);
+    color: rgba(255, 255, 255, 0.35);
     text-transform: uppercase;
 }
 
-/* Workspace card button (one per game) */
-.workspace-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
-    text-align: left;
-    background: transparent;
-    border: none;
-    border-radius: 0.375rem;
-    margin: 0.15rem 0.5rem;
-    padding: 0.4rem 0.5rem;
-    cursor: pointer;
-    color: rgba(255, 255, 255, 0.75);
-    transition: background 0.12s ease;
-    width: calc(100% - 1rem);
-}
-
-.workspace-item:hover {
-    background: rgba(255, 255, 255, 0.12);
-    color: white;
-}
-
-.workspace-item--active {
-    background: rgba(255, 255, 255, 0.18);
-    color: white;
-    border-left: 3px solid #4da6ff;
-    padding-left: calc(0.5rem - 3px);
-}
-
-/* Status dot */
-.workspace-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    margin-top: 1px;
-}
-
-.workspace-dot--active {
+/* ── Workspace status dots (reused on nav-game-status-dot) ───────────── */
+.workspace-dot--active,
+.nav-game-status-dot.workspace-dot--active {
     background: #4ade80;
     box-shadow: 0 0 5px rgba(74, 222, 128, 0.6);
 }
 
-.workspace-dot--upcoming {
+.workspace-dot--upcoming,
+.nav-game-status-dot.workspace-dot--upcoming {
     background: #fbbf24;
     box-shadow: 0 0 5px rgba(251, 191, 36, 0.5);
 }
 
-.workspace-dot--finished {
+.workspace-dot--finished,
+.nav-game-status-dot.workspace-dot--finished {
     background: #6b7280;
-}
-
-/* Game name + player name lines */
-.workspace-info {
-    flex: 1;
-    min-width: 0;
-}
-
-.workspace-name {
-    font-size: 0.85rem;
-    font-weight: 600;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1.2;
-}
-
-.workspace-player {
-    font-size: 0.72rem;
-    color: rgba(255, 255, 255, 0.5);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1.2;
-}
-
-.workspace-item--active .workspace-player {
-    color: rgba(255, 255, 255, 0.65);
-}
-
-/* Checkmark for active workspace */
-.workspace-check {
-    font-size: 0.8rem;
-    color: #4da6ff;
-    flex-shrink: 0;
-}
-
-/* Browse / Join Games link */
-.workspace-browse {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    margin: 0.25rem 0.5rem 0.5rem;
-    padding: 0.3rem 0.5rem;
-    font-size: 0.78rem;
-    color: rgba(255, 255, 255, 0.45);
-    border-radius: 0.25rem;
-    text-decoration: none;
-    transition: color 0.12s ease, background 0.12s ease;
-}
-
-.workspace-browse:hover {
-    color: rgba(255, 255, 255, 0.85);
-    background: rgba(255, 255, 255, 0.08);
-    text-decoration: none;
-}
-
-.workspace-browse .oi {
-    font-size: 0.7rem;
-    width: auto;
 }
 
 /* Tutorial checklist */

--- a/src/BrowserGameEngine.Shared/DiplomacyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/DiplomacyViewModels.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public enum DiplomacyProposalType { Nap, ResourceAgreement }
+
+	public class DiplomacyProposalViewModel {
+		public required string ProposalId { get; set; }
+		public DiplomacyProposalType Type { get; set; }
+		public required string ProposerPlayerId { get; set; }
+		public required string ProposerPlayerName { get; set; }
+		public required string TargetPlayerId { get; set; }
+		public required string TargetPlayerName { get; set; }
+		/// <summary>How long the agreement lasts once accepted, in ticks.</summary>
+		public int DurationTicks { get; set; }
+		/// <summary>Minerals transferred per tick (ResourceAgreement only).</summary>
+		public int MineralsPerTick { get; set; }
+		/// <summary>Gas transferred per tick (ResourceAgreement only).</summary>
+		public int GasPerTick { get; set; }
+		public DateTime ProposedAt { get; set; }
+	}
+
+	public class ActiveNapViewModel {
+		public required string NapId { get; set; }
+		public required string PartnerPlayerId { get; set; }
+		public required string PartnerPlayerName { get; set; }
+		public int TicksRemaining { get; set; }
+	}
+
+	public class ActiveResourceAgreementViewModel {
+		public required string AgreementId { get; set; }
+		public required string PartnerPlayerId { get; set; }
+		public required string PartnerPlayerName { get; set; }
+		public int MineralsPerTick { get; set; }
+		public int GasPerTick { get; set; }
+		public int TicksRemaining { get; set; }
+	}
+
+	/// <summary>Full diplomacy state for the current player.</summary>
+	public class DiplomacyStatusViewModel {
+		public List<DiplomacyProposalViewModel> PendingIncoming { get; set; } = new();
+		public List<DiplomacyProposalViewModel> PendingSent { get; set; } = new();
+		public List<ActiveNapViewModel> ActiveNaps { get; set; } = new();
+		public List<ActiveResourceAgreementViewModel> ActiveResourceAgreements { get; set; } = new();
+	}
+
+	/// <summary>Propose a Non-Aggression Pact to another player.</summary>
+	public class ProposeNapRequest {
+		public required string TargetPlayerId { get; set; }
+		/// <summary>Duration in ticks. Suggested values: 50, 100, 200.</summary>
+		public int DurationTicks { get; set; }
+	}
+
+	/// <summary>Propose a resource-sharing agreement to another player.</summary>
+	public class ProposeResourceAgreementRequest {
+		public required string TargetPlayerId { get; set; }
+		public int DurationTicks { get; set; }
+		public int MineralsPerTick { get; set; }
+		public int GasPerTick { get; set; }
+	}
+
+	/// <summary>Accept or decline a pending incoming proposal.</summary>
+	public class RespondToProposalRequest {
+		public bool Accept { get; set; }
+	}
+
+	/// <summary>
+	/// Lightweight per-player diplomacy indicator — used to annotate
+	/// the Ranking and PublicProfile pages without reloading full status.
+	/// </summary>
+	public class PlayerDiplomacyRelationViewModel {
+		/// <summary>The current player has an active NAP with this player.</summary>
+		public bool HasActiveNap { get; set; }
+		/// <summary>The current player has an active resource-sharing agreement with this player.</summary>
+		public bool HasResourceAgreement { get; set; }
+		/// <summary>There is a pending proposal between the two players (either direction).</summary>
+		public bool HasPendingProposal { get; set; }
+	}
+}


### PR DESCRIPTION
## Summary

Redesigns the nav sidebar into a two-column layout.

- **Left strip (54px):** Game switcher icons — one circular button per game with first-letter avatar, colored status dot (green=active, amber=upcoming, gray=finished), tooltip. Plus lobby button and sign-out icon at bottom.
- **Right panel:** Contextual navigation based on active game:
  - **In-game:** PLAY section (Base, Units, Unit Types, Research, Market, Ranking, Diplomacy) + SOCIAL section (Alliances, Alliance Ranking, Chat, Messages, Players)
  - **No game selected:** General nav (Home, Game Lobby, Players, Profile, Achievements, History, Admin)
- Alliances, Alliance Ranking, Chat, and Messages are now **game-scoped** under the active game
- Added `/games/{GameId}/chat` route to `Chat.razor` so game-scoped chat link works
- Race-variant theming updated for the new strip element
- Mobile: hamburger toggle shows/hides the full two-column nav as an overlay

Rebased onto master (PR #121 was auto-closed when its base branch was squash-merged in PR #117).

## Test plan

- [ ] Log in and verify the two-column sidebar renders (strip + panel)
- [ ] With no active game: panel shows "Browse" header with General nav items
- [ ] Click a game icon in the strip: switches to that game, panel shows PLAY + SOCIAL sections
- [ ] Verify Alliances, Chat, Messages links route to `/games/{id}/...`
- [ ] Mobile: toggle button shows/hides nav overlay
- [ ] Sign out link in strip bottom works

Closes BGE-392