### PR TITLE
fix: BGE-396 unhandled error — ResearchController IsValid guard + Diplomacy stub

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Diplomacy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Diplomacy.razor
@@ -1,0 +1,326 @@
+@page "/diplomacy"
+@page "/games/{GameId}/diplomacy"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@implements IDisposable
+
+<h1>Diplomacy</h1>
+
+@if (!string.IsNullOrEmpty(lastError)) {
+	<div class="alert alert-danger">@lastError</div>
+}
+@if (!string.IsNullOrEmpty(successMessage)) {
+	<div class="alert alert-success">@successMessage</div>
+}
+
+@if (status == null) {
+	<p><em>Loading...</em></p>
+} else {
+
+	@* ── Incoming proposals ─────────────────────────────────── *@
+	@if (status.PendingIncoming.Any()) {
+		<div class="card border-warning mb-4">
+			<div class="card-header bg-warning text-dark">
+				<strong>Incoming Proposals (@status.PendingIncoming.Count)</strong>
+			</div>
+			<div class="card-body p-0">
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>From</th>
+							<th>Type</th>
+							<th>Terms</th>
+							<th>Duration</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var p in status.PendingIncoming) {
+							<tr>
+								<td><strong>@p.ProposerPlayerName</strong></td>
+								<td>@ProposalTypeLabel(p.Type)</td>
+								<td>@ProposalTerms(p)</td>
+								<td>@p.DurationTicks ticks</td>
+								<td>
+									<button class="btn btn-sm btn-success me-1" @onclick="() => Respond(p.ProposalId, true)">Accept</button>
+									<button class="btn btn-sm btn-outline-danger" @onclick="() => Respond(p.ProposalId, false)">Decline</button>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	}
+
+	@* ── Active NAPs ────────────────────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header">
+			<strong>Active Non-Aggression Pacts</strong>
+		</div>
+		<div class="card-body p-0">
+			@if (!status.ActiveNaps.Any()) {
+				<p class="text-muted p-3 mb-0">No active NAPs.</p>
+			} else {
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>Partner</th>
+							<th>Ticks Remaining</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var nap in status.ActiveNaps) {
+							<tr>
+								<td>@nap.PartnerPlayerName</td>
+								<td>@nap.TicksRemaining</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			}
+		</div>
+	</div>
+
+	@* ── Active resource agreements ─────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header">
+			<strong>Active Resource Agreements</strong>
+		</div>
+		<div class="card-body p-0">
+			@if (!status.ActiveResourceAgreements.Any()) {
+				<p class="text-muted p-3 mb-0">No active resource agreements.</p>
+			} else {
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>Partner</th>
+							<th>Minerals/tick</th>
+							<th>Gas/tick</th>
+							<th>Ticks Remaining</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var a in status.ActiveResourceAgreements) {
+							<tr>
+								<td>@a.PartnerPlayerName</td>
+								<td>@a.MineralsPerTick</td>
+								<td>@a.GasPerTick</td>
+								<td>@a.TicksRemaining</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			}
+		</div>
+	</div>
+
+	@* ── Sent proposals ─────────────────────────────────────── *@
+	@if (status.PendingSent.Any()) {
+		<div class="card mb-4">
+			<div class="card-header">
+				<strong>Sent Proposals (awaiting response)</strong>
+			</div>
+			<div class="card-body p-0">
+				<table class="table table-sm mb-0">
+					<thead>
+						<tr>
+							<th>To</th>
+							<th>Type</th>
+							<th>Terms</th>
+							<th>Duration</th>
+							<th>Proposed</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var p in status.PendingSent) {
+							<tr>
+								<td>@p.TargetPlayerName</td>
+								<td>@ProposalTypeLabel(p.Type)</td>
+								<td>@ProposalTerms(p)</td>
+								<td>@p.DurationTicks ticks</td>
+								<td><small class="text-muted">@p.ProposedAt.ToLocalTime().ToString("g")</small></td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	}
+
+	@* ── Propose new agreement ──────────────────────────────── *@
+	<div class="card mb-4">
+		<div class="card-header d-flex justify-content-between align-items-center">
+			<strong>Propose Agreement</strong>
+			<div>
+				<button class="btn btn-sm @(proposeMode == "nap" ? "btn-primary" : "btn-outline-primary") me-1"
+						@onclick='() => SetProposeMode("nap")'>Non-Aggression Pact</button>
+				<button class="btn btn-sm @(proposeMode == "resource" ? "btn-primary" : "btn-outline-primary")"
+						@onclick='() => SetProposeMode("resource")'>Resource Agreement</button>
+			</div>
+		</div>
+		@if (proposeMode != null) {
+			<div class="card-body">
+				<div class="mb-3">
+					<label class="form-label">Target Player</label>
+					@if (players == null) {
+						<input class="form-control" @bind="selectedTargetPlayerId" placeholder="Player ID" />
+					} else {
+						<select class="form-select" @bind="selectedTargetPlayerId">
+							<option value="">— Select a player —</option>
+							@foreach (var p in players) {
+								<option value="@p.PlayerId">@p.PlayerName</option>
+							}
+						</select>
+					}
+				</div>
+
+				<div class="mb-3">
+					<label class="form-label">Duration (ticks)</label>
+					<select class="form-select" style="max-width:200px" @bind="proposeDurationTicks">
+						<option value="50">50 ticks (short)</option>
+						<option value="100">100 ticks (medium)</option>
+						<option value="200">200 ticks (long)</option>
+					</select>
+				</div>
+
+				@if (proposeMode == "resource") {
+					<div class="row mb-3">
+						<div class="col-auto">
+							<label class="form-label">Minerals / tick</label>
+							<input type="number" class="form-control" style="max-width:120px"
+								   @bind="proposeMineralsPerTick" min="0" />
+						</div>
+						<div class="col-auto">
+							<label class="form-label">Gas / tick</label>
+							<input type="number" class="form-control" style="max-width:120px"
+								   @bind="proposeGasPerTick" min="0" />
+						</div>
+					</div>
+					<p class="text-muted small">Resources are transferred each tick for the agreement duration. Both parties send the same amounts to each other.</p>
+				}
+
+				<button class="btn btn-primary" @onclick="SubmitProposal"
+						disabled="@(string.IsNullOrEmpty(selectedTargetPlayerId) || proposing)">
+					@(proposing ? "Sending..." : "Send Proposal")
+				</button>
+				<button class="btn btn-link ms-2" @onclick='() => SetProposeMode(null)'>Cancel</button>
+			</div>
+		}
+	</div>
+}
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private DiplomacyStatusViewModel? status;
+	private List<PublicPlayerViewModel>? players;
+	private string? lastError;
+	private string? successMessage;
+	private CancellationTokenSource? _cts;
+
+	private string? proposeMode; // "nap" | "resource" | null
+	private string selectedTargetPlayerId = "";
+	private int proposeDurationTicks = 100;
+	private int proposeMineralsPerTick;
+	private int proposeGasPerTick;
+	private bool proposing;
+
+	protected override async Task OnInitializedAsync() {
+		await Task.WhenAll(LoadStatus(), LoadPlayers());
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(LoadStatus);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task LoadStatus() {
+		status = await Http.GetFromJsonAsync<DiplomacyStatusViewModel>("api/diplomacy/status");
+	}
+
+	private async Task LoadPlayers() {
+		try {
+			players = await Http.GetFromJsonAsync<List<PublicPlayerViewModel>>("api/playerranking") ?? new();
+		} catch {
+			players = new();
+		}
+	}
+
+	private void SetProposeMode(string? mode) {
+		proposeMode = mode;
+		selectedTargetPlayerId = "";
+		proposeDurationTicks = 100;
+		proposeMineralsPerTick = 0;
+		proposeGasPerTick = 0;
+		lastError = null;
+		successMessage = null;
+	}
+
+	private async Task SubmitProposal() {
+		if (string.IsNullOrEmpty(selectedTargetPlayerId)) return;
+		proposing = true;
+		lastError = null;
+		successMessage = null;
+
+		HttpResponseMessage response;
+		if (proposeMode == "nap") {
+			response = await Http.PostAsJsonAsync("api/diplomacy/propose/nap", new ProposeNapRequest {
+				TargetPlayerId = selectedTargetPlayerId,
+				DurationTicks = proposeDurationTicks
+			});
+		} else {
+			response = await Http.PostAsJsonAsync("api/diplomacy/propose/resource-agreement", new ProposeResourceAgreementRequest {
+				TargetPlayerId = selectedTargetPlayerId,
+				DurationTicks = proposeDurationTicks,
+				MineralsPerTick = proposeMineralsPerTick,
+				GasPerTick = proposeGasPerTick
+			});
+		}
+
+		proposing = false;
+		if (response.IsSuccessStatusCode) {
+			successMessage = "Proposal sent.";
+			SetProposeMode(null);
+			await LoadStatus();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task Respond(string proposalId, bool accept) {
+		lastError = null;
+		successMessage = null;
+		var response = await Http.PostAsJsonAsync(
+			$"api/diplomacy/proposals/{proposalId}/respond",
+			new RespondToProposalRequest { Accept = accept });
+		if (response.IsSuccessStatusCode) {
+			successMessage = accept ? "Proposal accepted." : "Proposal declined.";
+			await LoadStatus();
+		} else {
+			lastError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private static string ProposalTypeLabel(DiplomacyProposalType type) => type switch {
+		DiplomacyProposalType.Nap => "Non-Aggression Pact",
+		DiplomacyProposalType.ResourceAgreement => "Resource Agreement",
+		_ => type.ToString()
+	};
+
+	private static string ProposalTerms(DiplomacyProposalViewModel p) => p.Type switch {
+		DiplomacyProposalType.ResourceAgreement => $"{p.MineralsPerTick} minerals + {p.GasPerTick} gas/tick",
+		_ => "—"
+	};
+
+	public void Dispose() {
+		_cts?.Cancel();
+		_cts?.Dispose();
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
@@ -224,7 +224,11 @@
 	}
 
 	private async Task Update() {
-		model = await Http.GetFromJsonAsync<TechTreeViewModel>("api/research");
+		try {
+			model = await Http.GetFromJsonAsync<TechTreeViewModel>("api/research");
+		} catch {
+			// Leave model as-is if refresh fails; initial null shows loading state
+		}
 	}
 
 	public void Dispose() {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/DiplomacyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/DiplomacyController.cs
@@ -1,0 +1,26 @@
+using BrowserGameEngine.Shared;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]/{action?}")]
+	public class DiplomacyController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+
+		public DiplomacyController(CurrentUserContext currentUserContext) {
+			this.currentUserContext = currentUserContext;
+		}
+
+		[HttpGet]
+		[Route("api/diplomacy/status")]
+		[ProducesResponseType(typeof(DiplomacyStatusViewModel), StatusCodes.Status200OK)]
+		public ActionResult<DiplomacyStatusViewModel> Status() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			// Diplomacy feature stub — returns empty state until fully implemented
+			return new DiplomacyStatusViewModel();
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResearchController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResearchController.cs
@@ -39,7 +39,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		/// <summary>Returns the current player's tech tree state.</summary>
 		[HttpGet]
 		[ProducesResponseType(typeof(TechTreeViewModel), StatusCodes.Status200OK)]
-		public TechTreeViewModel Get() {
+		public ActionResult<TechTreeViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
 			var playerId = currentUserContext.PlayerId!;
 			var currentResearch = techRepository.GetTechBeingResearched(playerId);
 			var nodes = gameDef.TechNodes.Select(node => {

--- a/src/BrowserGameEngine.Shared/DiplomacyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/DiplomacyViewModels.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public enum DiplomacyProposalType { Nap, ResourceAgreement }
+
+	public class DiplomacyProposalViewModel {
+		public required string ProposalId { get; set; }
+		public DiplomacyProposalType Type { get; set; }
+		public required string ProposerPlayerId { get; set; }
+		public required string ProposerPlayerName { get; set; }
+		public required string TargetPlayerId { get; set; }
+		public required string TargetPlayerName { get; set; }
+		/// <summary>How long the agreement lasts once accepted, in ticks.</summary>
+		public int DurationTicks { get; set; }
+		/// <summary>Minerals transferred per tick (ResourceAgreement only).</summary>
+		public int MineralsPerTick { get; set; }
+		/// <summary>Gas transferred per tick (ResourceAgreement only).</summary>
+		public int GasPerTick { get; set; }
+		public DateTime ProposedAt { get; set; }
+	}
+
+	public class ActiveNapViewModel {
+		public required string NapId { get; set; }
+		public required string PartnerPlayerId { get; set; }
+		public required string PartnerPlayerName { get; set; }
+		public int TicksRemaining { get; set; }
+	}
+
+	public class ActiveResourceAgreementViewModel {
+		public required string AgreementId { get; set; }
+		public required string PartnerPlayerId { get; set; }
+		public required string PartnerPlayerName { get; set; }
+		public int MineralsPerTick { get; set; }
+		public int GasPerTick { get; set; }
+		public int TicksRemaining { get; set; }
+	}
+
+	/// <summary>Full diplomacy state for the current player.</summary>
+	public class DiplomacyStatusViewModel {
+		public List<DiplomacyProposalViewModel> PendingIncoming { get; set; } = new();
+		public List<DiplomacyProposalViewModel> PendingSent { get; set; } = new();
+		public List<ActiveNapViewModel> ActiveNaps { get; set; } = new();
+		public List<ActiveResourceAgreementViewModel> ActiveResourceAgreements { get; set; } = new();
+	}
+
+	/// <summary>Propose a Non-Aggression Pact to another player.</summary>
+	public class ProposeNapRequest {
+		public required string TargetPlayerId { get; set; }
+		/// <summary>Duration in ticks. Suggested values: 50, 100, 200.</summary>
+		public int DurationTicks { get; set; }
+	}
+
+	/// <summary>Propose a resource-sharing agreement to another player.</summary>
+	public class ProposeResourceAgreementRequest {
+		public required string TargetPlayerId { get; set; }
+		public int DurationTicks { get; set; }
+		public int MineralsPerTick { get; set; }
+		public int GasPerTick { get; set; }
+	}
+
+	/// <summary>Accept or decline a pending incoming proposal.</summary>
+	public class RespondToProposalRequest {
+		public bool Accept { get; set; }
+	}
+
+	/// <summary>
+	/// Lightweight per-player diplomacy indicator — used to annotate
+	/// the Ranking and PublicProfile pages without reloading full status.
+	/// </summary>
+	public class PlayerDiplomacyRelationViewModel {
+		/// <summary>The current player has an active NAP with this player.</summary>
+		public bool HasActiveNap { get; set; }
+		/// <summary>The current player has an active resource-sharing agreement with this player.</summary>
+		public bool HasResourceAgreement { get; set; }
+		/// <summary>There is a pending proposal between the two players (either direction).</summary>
+		public bool HasPendingProposal { get; set; }
+	}
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `ResearchController.Get()` was missing the `if (!currentUserContext.IsValid) return Unauthorized()` guard. A user without an active game player triggered a null `PlayerId`, causing a 500. `Research.razor`'s unprotected `GetFromJsonAsync` threw an `HttpRequestException`, producing the Blazor "An unhandled error has occurred. Reload" overlay.
- **ResearchController.Get**: add `IsValid` guard; return type changed to `ActionResult<TechTreeViewModel>` to support it
- **Research.razor**: wrap `Update()` in try/catch so poll-refresh failures are silent
- **DiplomacyController**: stub returning empty `DiplomacyStatusViewModel` so the Diplomacy page loads without crashing (full feature in a future ticket)
- **Diplomacy.razor + DiplomacyViewModels.cs**: committed so the `/games/{id}/diplomacy` route resolves

## Test plan
- [x] `dotnet build` passes (0 warnings)
- [x] `dotnet test` passes (188/188)
- [ ] Manual: navigate to Tech Tree without an active player — should get 401, not 500
- [ ] Manual: navigate to Diplomacy — should show empty state, not crash

Closes BGE-396