### PR TITLE
fix: BGE-402/403 persistence safety — null-check deserializer, atomic file write

### DIFF
--- a/src/BrowserGameEngine.Persistence/FileStorage.cs
+++ b/src/BrowserGameEngine.Persistence/FileStorage.cs
@@ -33,7 +33,9 @@ namespace BrowserGameEngine.Persistence {
 		public async Task Store(string name, byte[] blob) {
 			var file = GetFile(name);
 			file.Directory?.Create();
-			await File.WriteAllBytesAsync(file.FullName, blob);
+			var tmpPath = file.FullName + ".tmp";
+			await File.WriteAllBytesAsync(tmpPath, blob);
+			File.Move(tmpPath, file.FullName, overwrite: true);
 		}
 
 		public IEnumerable<string> List(string folderPrefix) {

--- a/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
 using BrowserGameEngine.GameDefinition;
@@ -12,7 +13,9 @@ namespace BrowserGameEngine.Persistence {
 		}
 
 		public WorldStateImmutable Deserialize(byte[] blob) {
-			return JsonSerializer.Deserialize<WorldStateImmutable>(blob, GetOptions())!;
+			var result = JsonSerializer.Deserialize<WorldStateImmutable>(blob, GetOptions());
+			if (result is null) throw new InvalidDataException("Deserialized world state is null — blob may be empty or corrupted.");
+			return result;
 		}
 
 		private static JsonSerializerOptions GetOptions() {


### PR DESCRIPTION
## Summary
- **BGE-402**: Remove null-forgiving `!` from `GameStateJsonSerializer.Deserialize()`. Add explicit null check that throws `InvalidDataException` with a clear message if the blob is empty/truncated/corrupted — prevents a silent null propagating to `ReplaceFrom()` and causing a `NullReferenceException` mid-replacement
- **BGE-403**: Use atomic write-then-rename in `FileStorage.Store()`: write to a `.tmp` sibling file first, then `File.Move(..., overwrite: true)`. On POSIX this rename is atomic at the directory level — readers always see either the old complete file or the new complete file, never a partial write. S3Storage uses `PutObjectAsync` which is already atomic (unchanged)

## Test plan
- [x] `dotnet build` passes (0 warnings)
- [x] `dotnet test` passes (188/188)
- [ ] Manual: verify game state persists correctly in dev environment

Closes BGE-402
Closes BGE-403