### PR TITLE
fix: BGE-426 clarify Chat.razor GameId is route-only

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Chat.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Chat.razor
@@ -83,6 +83,9 @@
 </div>
 
 @code {
+	// Route parameter — present so /games/{GameId}/chat links work from the game-scoped nav.
+	// Not used in API calls: ChatController uses CurrentUserContext (set via the game switcher)
+	// to scope messages to the correct game, consistent with other game-scoped pages (e.g. Units.razor).
 	[Parameter]
 	public string? GameId { get; set; }
 


### PR DESCRIPTION
## Summary

Adds a 3-line comment to `Chat.razor` clarifying that `GameId` is a route parameter for navigation purposes only.

## Why

The `/games/{GameId}/chat` route is required for game-scoped nav links (added in BGE-392). However `GameId` is not used in API calls — `ChatController` scopes messages to the correct game via `CurrentUserContext` (set when the user switches games via the game switcher). This is consistent with other game-scoped pages like `Units.razor` which follow the same pattern.

The comment prevents future confusion about the "silently ignored" parameter.

## Changes

- `Chat.razor`: +3 comment lines above `[Parameter] public string? GameId`

## Test plan

- [x] Build passes (`dotnet build --configuration Release`)
- [ ] No functional change — chat behavior unchanged

Closes BGE-426