### PR TITLE
fix: BGE-425 spy cooldown constant, dynamic cost label, Base resources audit

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/EnemyBase.razor
@@ -17,7 +17,7 @@
         Attack
     </button>
     <button class="btn btn-secondary ms-2" @onclick="SendSpy" disabled="@spyLoading">
-        @(spyLoading ? "Spying..." : "Send Spy (50 minerals)")
+        @(spyLoading ? "Spying..." : $"Send Spy ({model.SpyCostLabel})")
     </button>
 
     @if (!string.IsNullOrEmpty(lastError)) {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -28,6 +28,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 		private readonly BattleReportGenerator battleReportGenerator;
 		private readonly OnlineStatusRepository onlineStatusRepository;
+		private readonly SpyRepositoryWrite spyRepositoryWrite;
 
 		public BattleController(ILogger<PlayerRankingController> logger
 				, GameDef gameDef
@@ -39,6 +40,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, UnitRepositoryWrite unitRepositoryWrite
 				, BattleReportGenerator battleReportGenerator
 				, OnlineStatusRepository onlineStatusRepository
+				, SpyRepositoryWrite spyRepositoryWrite
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -50,6 +52,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.unitRepositoryWrite = unitRepositoryWrite;
 			this.battleReportGenerator = battleReportGenerator;
 			this.onlineStatusRepository = onlineStatusRepository;
+			this.spyRepositoryWrite = spyRepositoryWrite;
 		}
 
 		/// <summary>Lists players that the current player can attack.</summary>
@@ -95,6 +98,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult<EnemyBaseViewModel> EnemyBase([FromQuery] string enemyPlayerId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
+				var spyCost = spyRepositoryWrite.GetSpyCost();
+				var spyCostLabel = string.Join(", ", spyCost.ToPlainDictionary().Select(kv => $"{(int)kv.Value} {kv.Key}"));
 				return new EnemyBaseViewModel {
 					PlayerAttackingUnits = new UnitsViewModel {
 						Units = unitRepository.GetAttackingUnits(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId))
@@ -103,7 +108,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 					EnemyDefendingUnits = new UnitsViewModel {
 						Units = unitRepository.GetDefendingEnemyUnits(currentUserContext.PlayerId!, PlayerIdFactory.Create(enemyPlayerId))
 							.Select(x => x.ToUnitViewModel(unitRepository, currentUserContext, gameDef)).ToList()
-					}
+					},
+					SpyCostLabel = spyCostLabel
 				};
 			} catch (CannotViewEnemyBaseException e) {
 				return BadRequest(e.Message);

--- a/src/BrowserGameEngine.Shared/EnemyBaseViewModel.cs
+++ b/src/BrowserGameEngine.Shared/EnemyBaseViewModel.cs
@@ -8,5 +8,6 @@ namespace BrowserGameEngine.Shared {
 	public class EnemyBaseViewModel {
 		public required UnitsViewModel PlayerAttackingUnits { get; set; }
 		public required UnitsViewModel EnemyDefendingUnits { get; set; }
+		public string SpyCostLabel { get; set; } = "";
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyConstants.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyConstants.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	internal static class SpyConstants {
+		internal static readonly TimeSpan CooldownDuration = TimeSpan.FromMinutes(30);
+		internal const decimal SpyCostAmount = 50m;
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
@@ -8,8 +8,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
 
-		private static readonly TimeSpan CooldownDuration = TimeSpan.FromMinutes(30);
-
 		public SpyRepository(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
@@ -23,7 +21,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			var cooldowns = world.GetPlayer(spyingPlayerId).State.SpyCooldowns;
 			var key = targetPlayerId.ToString();
 			if (!cooldowns.TryGetValue(key, out var lastSpyTime)) return null;
-			var expiry = lastSpyTime + CooldownDuration;
+			var expiry = lastSpyTime + SpyConstants.CooldownDuration;
 			var now = timeProvider.GetUtcNow().UtcDateTime;
 			return expiry > now ? expiry : null;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -17,9 +17,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly TimeProvider timeProvider;
 		private readonly Cost spyCost;
 
-		private const decimal SpyCostAmount = 50m;
-		private static readonly TimeSpan CooldownDuration = TimeSpan.FromMinutes(30);
-
 		public SpyRepositoryWrite(
 			IWorldStateAccessor worldStateAccessor,
 			SpyRepository spyRepository,
@@ -31,7 +28,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.spyRepository = spyRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
 			this.timeProvider = timeProvider;
-			spyCost = Cost.FromSingle(GetGrowthResource(gameDef), SpyCostAmount);
+			spyCost = Cost.FromSingle(GetGrowthResource(gameDef), SpyConstants.SpyCostAmount);
 		}
 
 		private static ResourceDefId GetGrowthResource(GameDef gameDef) {
@@ -42,6 +39,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 			return gameDef.ScoreResource;
 		}
+
+		public Cost GetSpyCost() => spyCost;
 
 		public SpyResult ExecuteSpy(SpyCommand command) {
 			lock (_lock) {
@@ -82,7 +81,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 					ApproximateResources: approxResources,
 					UnitEstimates: unitGroups,
 					ReportTime: now,
-					CooldownExpiresAt: now + CooldownDuration
+					CooldownExpiresAt: now + SpyConstants.CooldownDuration
 				);
 			}
 		}


### PR DESCRIPTION
## Summary

Addresses the three polish nits flagged in the BGE-390 PR review:

- **Shared spy cooldown constant**: Extracted `CooldownDuration` and `SpyCostAmount` into a new `SpyConstants` class so `SpyRepository` and `SpyRepositoryWrite` share one source of truth and can no longer drift.
- **Dynamic spy cost label**: Added `SpyRepositoryWrite.GetSpyCost()` and `EnemyBaseViewModel.SpyCostLabel` so the "Send Spy" button in `EnemyBase.razor` reads the actual cost from `GameDef` at runtime instead of hardcoding `"50 minerals"`.
- **Base resources audit**: Confirmed `<_PlayerResources />` is rendered in `MainLayout.razor` (line 16), so resources remain visible on every page including Base. No restore needed.

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test` — 188/188 passed
- [ ] Manual smoke: visit Enemy Base page and verify spy button shows correct cost label