### PR TITLE
feat: BGE-427 add Tech Tree nav link, rename Research to Upgrades

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -84,7 +84,12 @@
                 </li>
                 <li class="nav-item px-3">
                     <NavLink class="nav-link" href="@($"games/{gameId}/upgrades")">
-                        <span class="oi oi-beaker" aria-hidden="true"></span> Research
+                        <span class="oi oi-beaker" aria-hidden="true"></span> Upgrades
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/research")">
+                        <span class="oi oi-fork" aria-hidden="true"></span> Tech Tree
                     </NavLink>
                 </li>
                 <li class="nav-item px-3">


### PR DESCRIPTION
## Summary

- Renames the existing "Research" nav entry to "Upgrades" (keeps pointing to `/games/{gameId}/upgrades`)
- Adds a new "Tech Tree" nav entry pointing to `/games/{gameId}/research` (the page added in BGE-371)
- Placed adjacent to Upgrades in the PLAY section

## Changes

`NavMenu.razor` — PLAY section only, no backend changes.

## Test plan
- [ ] Load a game in the browser
- [ ] Verify "Upgrades" appears in the PLAY nav (was "Research")
- [ ] Verify "Tech Tree" appears in the PLAY nav below Upgrades
- [ ] Click "Tech Tree" — navigates to `/games/{gameId}/research`
- [ ] Click "Upgrades" — navigates to `/games/{gameId}/upgrades`