### PR TITLE
feat: BGE-377 fog of war — hide opponent resources and units unless scouted

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -37,6 +37,9 @@
                         <th>#</th>
                         <th>Name</th>
                         <th>Score</th>
+                        <th>Minerals</th>
+                        <th>Gas</th>
+                        <th>Home Units</th>
                         <th>Type</th>
                         <th>Status</th>
                         <th>Protection</th>
@@ -48,6 +51,9 @@
                         <td><strong>#@rank</strong></td>
                         <td>@item.PlayerName</td>
                         <td>@item.Score</td>
+                        <td>@if (item.ApproxMinerals.HasValue) { @item.ApproxMinerals.Value.ToString("N0") } else { <span class="text-muted fst-italic" title="Scout this player to reveal their resources">?</span> }</td>
+                        <td>@if (item.ApproxGas.HasValue) { @item.ApproxGas.Value.ToString("N0") } else { <span class="text-muted fst-italic" title="Scout this player to reveal their resources">?</span> }</td>
+                        <td>@if (item.ApproxHomeUnitCount.HasValue) { @item.ApproxHomeUnitCount.Value.ToString("N0") } else { <span class="text-muted fst-italic" title="Scout this player to reveal their units">?</span> }</td>
                         <td>@(item.IsAgent ? "[Bot]" : "Human")</td>
                         <td>@(item.IsOnline ? "Online" : "Offline")</td>
                         <td>@(item.ProtectionTicksRemaining > 0 ? $"{item.ProtectionTicksRemaining} ticks" : "")</td>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -1,4 +1,5 @@
-﻿using BrowserGameEngine.Shared;
+﻿using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,25 +19,35 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly PlayerRepository playerRepository;
 		private readonly UserRepository userRepository;
 		private readonly OnlineStatusRepository onlineStatusRepository;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly FogOfWarRepository fogOfWarRepository;
 
 		public PlayerRankingController(ILogger<PlayerRankingController> logger
 				, ScoreRepository scoreRepository
 				, PlayerRepository playerRepository
 				, UserRepository userRepository
 				, OnlineStatusRepository onlineStatusRepository
+				, CurrentUserContext currentUserContext
+				, FogOfWarRepository fogOfWarRepository
 			) {
 			this.logger = logger;
 			this.scoreRepository = scoreRepository;
 			this.playerRepository = playerRepository;
 			this.userRepository = userRepository;
 			this.onlineStatusRepository = onlineStatusRepository;
+			this.currentUserContext = currentUserContext;
+			this.fogOfWarRepository = fogOfWarRepository;
 		}
 
-		/// <summary>Returns the current game's player ranking list with scores and online status.</summary>
+		/// <summary>Returns the current game's player ranking list with scores and online status. Resource and unit counts are fog-of-war gated.</summary>
 		[HttpGet]
 		[ProducesResponseType(typeof(System.Collections.Generic.IEnumerable<PublicPlayerViewModel>), StatusCodes.Status200OK)]
 		public IEnumerable<PublicPlayerViewModel> Get() {
-			return playerRepository.GetAll().Select(p => p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository));
+			return playerRepository.GetAll().Select(p => {
+				bool isOwnPlayer = currentUserContext.PlayerId != null && p.PlayerId == currentUserContext.PlayerId;
+				SpyResult? intel = isOwnPlayer ? null : fogOfWarRepository.GetValidIntel(currentUserContext.PlayerId!, p.PlayerId);
+				return p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository, intel, isOwnPlayer);
+			});
 		}
 
 	}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	public static class ViewModelExtensions {
+		private static readonly ResourceDefId MineralsId = new ResourceDefId("minerals");
+		private static readonly ResourceDefId GasId = new ResourceDefId("gas");
+
 		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository, UserRepository userRepository, OnlineStatusRepository onlineStatusRepository) {
 			return new PublicPlayerViewModel {
 				PlayerId = player.PlayerId.Id,
@@ -21,6 +24,24 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				LastOnline = player.LastOnline,
 				IsOnline = onlineStatusRepository.IsOnline(player.PlayerId)
 			};
+		}
+
+		public static PublicPlayerViewModel ToPublicPlayerViewModel(this PlayerImmutable player, ScoreRepository scoreRepository, UserRepository userRepository, OnlineStatusRepository onlineStatusRepository, SpyResult? intel, bool isOwnPlayer) {
+			var vm = player.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository);
+			if (isOwnPlayer) {
+				player.State.Resources.TryGetValue(MineralsId, out var exactMinerals);
+				player.State.Resources.TryGetValue(GasId, out var exactGas);
+				vm.ApproxMinerals = exactMinerals;
+				vm.ApproxGas = exactGas;
+				vm.ApproxHomeUnitCount = player.State.Units.Where(u => u.Position == null).Sum(u => u.Count);
+			} else if (intel != null) {
+				intel.ApproximateResources.TryGetValue(MineralsId, out var approxMinerals);
+				intel.ApproximateResources.TryGetValue(GasId, out var approxGas);
+				vm.ApproxMinerals = approxMinerals;
+				vm.ApproxGas = approxGas;
+				vm.ApproxHomeUnitCount = intel.UnitEstimates.Sum(e => e.ApproximateCount);
+			}
+			return vm;
 		}
 
 		public static UnitViewModel ToUnitViewModel(this UnitImmutable unit, UnitRepository unitRepository, CurrentUserContext currentUserContext, GameDef gameDef, PlayerRepository? playerRepository = null) {

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -22,6 +22,7 @@ namespace BrowserGameEngine.GameModel {
 		IDictionary<string, DateTime>? SpyCooldowns = null,
 		IList<string>? UnlockedTechs = null,
 		string? TechBeingResearched = null,
-		int TechResearchTimer = 0
+		int TechResearchTimer = 0,
+		IDictionary<string, SpyResult>? LastSpyResults = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
@@ -15,5 +15,8 @@ namespace BrowserGameEngine.Shared {
 		public bool IsAgent { get; set; }
 		public DateTime? LastOnline { get; set; }
 		public bool IsOnline { get; set; }
+		public decimal? ApproxMinerals { get; set; }
+		public decimal? ApproxGas { get; set; }
+		public int? ApproxHomeUnitCount { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/FogOfWarRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/FogOfWarRepositoryTest.cs
@@ -1,0 +1,89 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	/// <summary>Simple controllable time provider for tests.</summary>
+	internal class ManualTimeProvider : TimeProvider {
+		private DateTimeOffset _now;
+
+		public ManualTimeProvider(DateTimeOffset start) {
+			_now = start;
+		}
+
+		public override DateTimeOffset GetUtcNow() => _now;
+
+		public void Advance(TimeSpan span) {
+			_now = _now.Add(span);
+		}
+	}
+
+	public class FogOfWarRepositoryTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		private static (FogOfWarRepository fog, ManualTimeProvider time, SpyRepositoryWrite spyWrite, SpyRepository spyRepo) CreateFogComponents() {
+			var time = new ManualTimeProvider(new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var world = new TestWorldStateFactory().CreateDevWorldState(2).ToMutable();
+			var gameDef = new TestGameDefFactory().CreateGameDef();
+			var accessor = new SingletonWorldStateAccessor(world);
+			var spyRepo = new SpyRepository(accessor, time);
+			var resourceRepo = new ResourceRepository(accessor, gameDef);
+			var resourceRepoWrite = new ResourceRepositoryWrite(accessor, resourceRepo, gameDef);
+			var spyRepoWrite = new SpyRepositoryWrite(accessor, spyRepo, resourceRepoWrite, gameDef, time);
+			var fog = new FogOfWarRepository(accessor, time);
+			return (fog, time, spyRepoWrite, spyRepo);
+		}
+
+		[Fact]
+		public void GetValidIntel_WithinWindow_ReturnsIntel() {
+			var (fog, _, spyWrite, _) = CreateFogComponents();
+			spyWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			var intel = fog.GetValidIntel(Player1, Player2);
+
+			Assert.NotNull(intel);
+			Assert.Equal(Player2, intel!.TargetPlayerId);
+		}
+
+		[Fact]
+		public void GetValidIntel_AfterWindowExpired_ReturnsNull() {
+			var (fog, time, spyWrite, _) = CreateFogComponents();
+			spyWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			// Advance past the 30-minute visibility window
+			time.Advance(TimeSpan.FromMinutes(31));
+
+			var intel = fog.GetValidIntel(Player1, Player2);
+
+			Assert.Null(intel);
+		}
+
+		[Fact]
+		public void GetValidIntel_NoSpyExecuted_ReturnsNull() {
+			var (fog, _, _, _) = CreateFogComponents();
+
+			var intel = fog.GetValidIntel(Player1, Player2);
+
+			Assert.Null(intel);
+		}
+
+		[Fact]
+		public void ExecuteSpy_PersistsLastSpyResult_InPlayerState() {
+			var time = new ManualTimeProvider(new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var game = new TestGame(playerCount: 2);
+			// Use TestGame's SpyRepositoryWrite (uses TimeProvider.System) to confirm the field is populated
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			var player1State = game.PlayerRepository.Get(Player1).State;
+			Assert.True(player1State.LastSpyResults != null && player1State.LastSpyResults.ContainsKey(Player2.ToString()));
+			var stored = player1State.LastSpyResults![Player2.ToString()];
+			Assert.Equal(Player2, stored.TargetPlayerId);
+			Assert.True(stored.CooldownExpiresAt > stored.ReportTime);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -24,6 +24,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<string> UnlockedTechs { get; set; } = new List<string>();
 		public string? TechBeingResearched { get; set; }
 		public int TechResearchTimer { get; set; }
+		public Dictionary<string, SpyResult> LastSpyResults { get; set; } = new Dictionary<string, SpyResult>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -46,7 +47,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns),
 				UnlockedTechs: new List<string>(playerState.UnlockedTechs),
 				TechBeingResearched: playerState.TechBeingResearched,
-				TechResearchTimer: playerState.TechResearchTimer
+				TechResearchTimer: playerState.TechResearchTimer,
+				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults)
 			);
 		}
 
@@ -74,7 +76,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					? new List<string>(playerStateImmutable.UnlockedTechs)
 					: new List<string>(),
 				TechBeingResearched = playerStateImmutable.TechBeingResearched,
-				TechResearchTimer = playerStateImmutable.TechResearchTimer
+				TechResearchTimer = playerStateImmutable.TechResearchTimer,
+				LastSpyResults = playerStateImmutable.LastSpyResults != null
+					? new Dictionary<string, SpyResult>(playerStateImmutable.LastSpyResults)
+					: new Dictionary<string, SpyResult>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -55,6 +55,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MarketRepository>();
 			services.AddSingleton<SpyRepository>();
 			services.AddSingleton<SpyRepositoryWrite>();
+			services.AddSingleton<FogOfWarRepository>();
 			services.AddSingleton<TechRepository>();
 			services.AddSingleton<TechRepositoryWrite>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/FogOfWarRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/FogOfWarRepository.cs
@@ -1,0 +1,27 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class FogOfWarRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private readonly TimeProvider timeProvider;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public FogOfWarRepository(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.timeProvider = timeProvider;
+		}
+
+		/// <summary>Returns the viewer's stored intel on the target if it is still within the visibility window; null otherwise.</summary>
+		public SpyResult? GetValidIntel(PlayerId viewerPlayerId, PlayerId targetPlayerId) {
+			if (!world.PlayerExists(viewerPlayerId)) return null;
+			var viewerState = world.GetPlayer(viewerPlayerId).State;
+			var key = targetPlayerId.ToString();
+			if (!viewerState.LastSpyResults.TryGetValue(key, out var intel)) return null;
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			if (intel.CooldownExpiresAt <= now) return null;
+			return intel;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -58,6 +58,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				var now = timeProvider.GetUtcNow().UtcDateTime;
 				world.GetPlayer(command.SpyingPlayerId).State.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
 
+
 				var targetState = world.GetPlayer(command.TargetPlayerId).State;
 				var rng = new Random();
 
@@ -77,13 +78,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 					})
 					.ToList();
 
-				return new SpyResult(
+				var result = new SpyResult(
 					TargetPlayerId: command.TargetPlayerId,
 					ApproximateResources: approxResources,
 					UnitEstimates: unitGroups,
 					ReportTime: now,
 					CooldownExpiresAt: now + CooldownDuration
 				);
+
+				world.GetPlayer(command.SpyingPlayerId).State.LastSpyResults[command.TargetPlayerId.ToString()] = result;
+
+				return result;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `LastSpyResults` to `PlayerStateImmutable` and mutable `PlayerState` (round-trips via `ToImmutable`/`ToMutable`)
- Persist the `SpyResult` snapshot in `SpyRepositoryWrite.ExecuteSpy` so fog-of-war data is stable across page refreshes
- New `FogOfWarRepository` returns stored intel if within the 30-minute visibility window; null otherwise
- Add `ApproxMinerals`, `ApproxGas`, `ApproxHomeUnitCount` (nullable) to `PublicPlayerViewModel` — null means fogged
- `PlayerRankingController` injects `CurrentUserContext` + `FogOfWarRepository`; populates exact values for own player, snapshot values for scouted opponents, null for un-scouted
- `PlayerRanking.razor` gains three new columns (Minerals, Gas, Home Units); un-scouted cells render `?` with a scout tooltip

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (192 tests including 4 new `FogOfWarRepositoryTest` cases)
- [ ] Verify ranking page shows exact values for your own player row
- [ ] Verify un-scouted opponents show `?` in all three columns
- [ ] After executing a spy mission on a player, verify their approximate values appear
- [ ] Advance past 30 minutes (or fast-forward via test) and verify columns return to `?`

Closes BGE-377