### PR TITLE
feat: BGE-434 SpyPlayerEntryViewModel + GET /api/spy/players + tests

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
@@ -18,24 +19,51 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ILogger<SpyController> logger;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly SpyRepositoryWrite spyRepositoryWrite;
+		private readonly SpyRepository spyRepository;
 		private readonly PlayerRepository playerRepository;
 		private readonly UserRepository userRepository;
+		private readonly ScoreRepository scoreRepository;
 		private readonly GameDef gameDef;
 
 		public SpyController(
 			ILogger<SpyController> logger,
 			CurrentUserContext currentUserContext,
 			SpyRepositoryWrite spyRepositoryWrite,
+			SpyRepository spyRepository,
 			PlayerRepository playerRepository,
 			UserRepository userRepository,
+			ScoreRepository scoreRepository,
 			GameDef gameDef
 		) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.spyRepositoryWrite = spyRepositoryWrite;
+			this.spyRepository = spyRepository;
 			this.playerRepository = playerRepository;
 			this.userRepository = userRepository;
+			this.scoreRepository = scoreRepository;
 			this.gameDef = gameDef;
+		}
+
+		/// <summary>Returns all players except the current player, with per-target spy cooldown status, sorted by score descending.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(IEnumerable<SpyPlayerEntryViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<IEnumerable<SpyPlayerEntryViewModel>> Players() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var currentPlayerId = currentUserContext.PlayerId!;
+			return playerRepository.GetAll()
+				.Where(p => p.PlayerId != currentPlayerId)
+				.Select(p => new SpyPlayerEntryViewModel {
+					PlayerId = p.PlayerId.Id,
+					PlayerName = p.UserId != null
+						? userRepository.GetDisplayNameByUserId(p.UserId) ?? p.Name
+						: p.Name,
+					Score = scoreRepository.GetScore(p.PlayerId),
+					CooldownExpiresAt = spyRepository.GetCooldownExpiry(currentPlayerId, p.PlayerId)
+				})
+				.OrderByDescending(p => p.Score)
+				.ToList();
 		}
 
 		/// <summary>Executes a spy mission against a target player, returning fuzzy intel at a mineral cost. Subject to a 30-minute per-target cooldown.</summary>

--- a/src/BrowserGameEngine.Shared/SpyPlayerEntryViewModel.cs
+++ b/src/BrowserGameEngine.Shared/SpyPlayerEntryViewModel.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public class SpyPlayerEntryViewModel {
+		public string PlayerId { get; set; } = "";
+		public string PlayerName { get; set; } = "";
+		public decimal Score { get; set; }
+		public DateTime? CooldownExpiresAt { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SpyPlayersTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SpyPlayersTest.cs
@@ -1,0 +1,42 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class SpyPlayersTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void SpyPlayers_ExcludesCurrentPlayer() {
+			var game = new TestGame(playerCount: 2);
+
+			var others = game.PlayerRepository.GetAll()
+				.Where(p => p.PlayerId != Player1)
+				.ToList();
+
+			Assert.DoesNotContain(others, p => p.PlayerId == Player1);
+			Assert.Contains(others, p => p.PlayerId == Player2);
+		}
+
+		[Fact]
+		public void SpyPlayers_ShowsActiveCooldown() {
+			var game = new TestGame(playerCount: 2);
+
+			game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+
+			var cooldown = game.SpyRepository.GetCooldownExpiry(Player1, Player2);
+			Assert.NotNull(cooldown);
+		}
+
+		[Fact]
+		public void SpyPlayers_NullCooldown_WhenNoneExecuted() {
+			var game = new TestGame(playerCount: 2);
+
+			var cooldown = game.SpyRepository.GetCooldownExpiry(Player1, Player2);
+
+			Assert.Null(cooldown);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SpyPlayerEntryViewModel` (PlayerId, PlayerName, Score, CooldownExpiresAt) to `BrowserGameEngine.Shared`
- Add `GET /api/spy/players` action on `SpyController` — returns all players except self with per-target cooldown status, sorted by score descending
- Inject `SpyRepository` and `ScoreRepository` into `SpyController` constructor
- Add `SpyPlayersTest` with 3 tests: ExcludesCurrentPlayer, ShowsActiveCooldown, NullCooldown_WhenNoneExecuted

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (191 tests)
- [x] `SpyPlayersTest` — all 3 new tests pass

Closes BGE-434