### PR TITLE
feat: BGE-447 counter-intelligence spy detection backend + GET /api/spy/attempts

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -45,6 +45,34 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.gameDef = gameDef;
 		}
 
+		/// <summary>Returns all detected spy attempts against the current player, most recent first.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(IEnumerable<SpyAttemptViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<IEnumerable<SpyAttemptViewModel>> Attempts() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var currentPlayerId = currentUserContext.PlayerId!;
+			var attempts = spyRepository.GetDetectedSpyAttempts(currentPlayerId);
+			return attempts.Select(a => {
+				string attackerName;
+				try {
+					var attacker = playerRepository.Get(a.AttackerPlayerId);
+					attackerName = attacker.UserId != null
+						? userRepository.GetDisplayNameByUserId(attacker.UserId) ?? attacker.Name
+						: attacker.Name;
+				} catch {
+					attackerName = a.AttackerPlayerId.ToString();
+				}
+				return new SpyAttemptViewModel {
+					Id = a.Id,
+					AttackerName = attackerName,
+					ActionType = a.ActionType,
+					Detected = a.Detected,
+					Timestamp = a.Timestamp
+				};
+			}).ToList();
+		}
+
 		/// <summary>Returns all players except the current player, with per-target spy cooldown status, sorted by score descending.</summary>
 		[HttpGet]
 		[ProducesResponseType(typeof(IEnumerable<SpyPlayerEntryViewModel>), StatusCodes.Status200OK)]

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -799,6 +799,39 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Prerequisites = new List<TechNodeId> { Id.TechNode("combat-stims"), Id.TechNode("defensive-fortifications") },
 						EffectType = TechEffectType.DefenseBonus,
 						EffectValue = 8
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-basic"),
+						Name = "Counter-Intelligence",
+						Description = "Basic spy detection. 15% chance to detect incoming spy operations.",
+						Tier = 1,
+						Cost = CostHelper.Create(("minerals", 100), ("gas", 50)),
+						ResearchTimeTicks = 5,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-advanced"),
+						Name = "Advanced Counter-Intelligence",
+						Description = "Advanced surveillance systems. 30% cumulative chance to detect spy operations.",
+						Tier = 2,
+						Cost = CostHelper.Create(("minerals", 200), ("gas", 100)),
+						ResearchTimeTicks = 10,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("counter-intel-basic") },
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-mastery"),
+						Name = "Counter-Intelligence Mastery",
+						Description = "Elite spy detection network. 50% cumulative chance to detect spy operations.",
+						Tier = 3,
+						Cost = CostHelper.Create(("minerals", 300), ("gas", 150)),
+						ResearchTimeTicks = 15,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("counter-intel-advanced") },
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.20m
 					}
 				}
 			};

--- a/src/BrowserGameEngine.GameDefinition/TechNodeDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/TechNodeDef.cs
@@ -12,7 +12,8 @@ namespace BrowserGameEngine.GameDefinition {
 		ProductionBoostGas,
 		AttackBonus,
 		DefenseBonus,
-		SpyEfficiency
+		SpyEfficiency,
+		CounterIntelDetection
 	}
 
 	public record TechNodeDef {

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -23,6 +23,7 @@ namespace BrowserGameEngine.GameModel {
 		IList<string>? UnlockedTechs = null,
 		string? TechBeingResearched = null,
 		int TechResearchTimer = 0,
-		IDictionary<string, SpyResult>? LastSpyResults = null
+		IDictionary<string, SpyResult>? LastSpyResults = null,
+		IList<SpyAttemptLog>? SpyAttemptLogs = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/SpyAttemptLog.cs
+++ b/src/BrowserGameEngine.GameModel/SpyAttemptLog.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record SpyAttemptLog(
+		Guid Id,
+		PlayerId AttackerPlayerId,
+		string ActionType,
+		bool Detected,
+		DateTime Timestamp
+	);
+}

--- a/src/BrowserGameEngine.Shared/SpyAttemptViewModel.cs
+++ b/src/BrowserGameEngine.Shared/SpyAttemptViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public class SpyAttemptViewModel {
+		public Guid Id { get; set; }
+		public string AttackerName { get; set; } = string.Empty;
+		public string ActionType { get; set; } = string.Empty;
+		public bool Detected { get; set; }
+		public DateTime Timestamp { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/CounterIntelTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/CounterIntelTest.cs
@@ -1,0 +1,128 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class CounterIntelTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		/// <summary>Creates a 2-player world state with counter-intel techs pre-unlocked for Player2.</summary>
+		private static WorldStateImmutable CreateWorldWithCounterIntel(IList<string> player2Techs) {
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(2);
+			var players = baseState.Players.ToDictionary(
+				kv => kv.Key,
+				kv => kv.Key == Player2
+					? kv.Value with {
+						State = kv.Value.State with {
+							UnlockedTechs = player2Techs
+						}
+					}
+					: kv.Value
+			);
+			return baseState with { Players = players };
+		}
+
+		[Fact]
+		public void ExecuteSpy_NoCounterIntelTech_NeverDetected() {
+			// With no counter-intel tech, detection chance = 0, so spy is never detected
+			int detectedCount = 0;
+			for (int i = 0; i < 20; i++) {
+				var game = new TestGame(playerCount: 2);
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+				var logs = game.SpyRepository.GetDetectedSpyAttempts(Player2);
+				detectedCount += logs.Count;
+			}
+			Assert.Equal(0, detectedCount);
+		}
+
+		[Fact]
+		public void ExecuteSpy_WithCounterIntelTech_SomeAttemptsDetected() {
+			// With 50% detection (all 3 tiers), over 100 attempts expect significant detection
+			int detected = 0;
+			int total = 100;
+			var techs = new List<string> { "counter-intel-basic", "counter-intel-advanced", "counter-intel-mastery" };
+			for (int i = 0; i < total; i++) {
+				var initialState = CreateWorldWithCounterIntel(techs);
+				var game = new TestGame(initialState);
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+				var logs = game.SpyRepository.GetDetectedSpyAttempts(Player2);
+				detected += logs.Count;
+			}
+
+			// With 50% detection rate over 100 attempts, expect 30–70 (very safe range)
+			Assert.InRange(detected, 20, 80);
+		}
+
+		[Fact]
+		public void ExecuteSpy_DetectedAttempt_HasCorrectAttackerAndActionType() {
+			// Run with 50% detection until we get at least one detection
+			var techs = new List<string> { "counter-intel-basic", "counter-intel-advanced", "counter-intel-mastery" };
+			SpyAttemptLog? foundLog = null;
+			for (int attempt = 0; attempt < 200 && foundLog == null; attempt++) {
+				var initialState = CreateWorldWithCounterIntel(techs);
+				var game = new TestGame(initialState);
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+				var logs = game.SpyRepository.GetDetectedSpyAttempts(Player2);
+				foundLog = logs.FirstOrDefault();
+			}
+
+			Assert.NotNull(foundLog);
+			Assert.Equal(Player1, foundLog!.AttackerPlayerId);
+			Assert.Equal("Spy", foundLog.ActionType);
+			Assert.True(foundLog.Detected);
+		}
+
+		[Fact]
+		public void GetDetectedSpyAttempts_ReturnsOnlyDetectedAttempts() {
+			// Spy attempts without counter-intel are never detected
+			// So after running 5 spies (bypassing cooldown via fresh games), none should be detected
+			int total = 5;
+			int detected = 0;
+			for (int i = 0; i < total; i++) {
+				var game = new TestGame(playerCount: 2);
+				game.SpyRepositoryWrite.ExecuteSpy(new SpyCommand(Player1, Player2));
+				var logs = game.SpyRepository.GetDetectedSpyAttempts(Player2);
+				detected += logs.Count;
+			}
+			Assert.Equal(0, detected);
+		}
+
+		[Fact]
+		public void CounterIntelTechNodes_HaveCorrectCumulativeDetectionProbability() {
+			// All three counter-intel tech tiers should sum to 0.50 detection probability
+			var techs = new List<string> { "counter-intel-basic", "counter-intel-advanced", "counter-intel-mastery" };
+			var initialState = CreateWorldWithCounterIntel(techs);
+			var game = new TestGame(initialState);
+
+			var totalDetection = game.TechRepository.GetTotalEffectValue(Player2, TechEffectType.CounterIntelDetection);
+			Assert.Equal(0.50m, totalDetection);
+		}
+
+		[Fact]
+		public void CounterIntelTier1_HasCorrectDetectionProbability() {
+			var techs = new List<string> { "counter-intel-basic" };
+			var initialState = CreateWorldWithCounterIntel(techs);
+			var game = new TestGame(initialState);
+
+			var detection = game.TechRepository.GetTotalEffectValue(Player2, TechEffectType.CounterIntelDetection);
+			Assert.Equal(0.15m, detection);
+		}
+
+		[Fact]
+		public void CounterIntelTier2_HasCorrectCumulativeDetectionProbability() {
+			var techs = new List<string> { "counter-intel-basic", "counter-intel-advanced" };
+			var initialState = CreateWorldWithCounterIntel(techs);
+			var game = new TestGame(initialState);
+
+			var detection = game.TechRepository.GetTotalEffectValue(Player2, TechEffectType.CounterIntelDetection);
+			Assert.Equal(0.30m, detection);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/FogOfWarRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/FogOfWarRepositoryTest.cs
@@ -34,7 +34,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var spyRepo = new SpyRepository(accessor, time);
 			var resourceRepo = new ResourceRepository(accessor, gameDef);
 			var resourceRepoWrite = new ResourceRepositoryWrite(accessor, resourceRepo, gameDef);
-			var spyRepoWrite = new SpyRepositoryWrite(accessor, spyRepo, resourceRepoWrite, gameDef, time);
+			var techRepo = new TechRepository(accessor, gameDef);
+			var spyRepoWrite = new SpyRepositoryWrite(accessor, spyRepo, resourceRepoWrite, techRepo, gameDef, time);
 			var fog = new FogOfWarRepository(accessor, time);
 			return (fog, time, spyRepoWrite, spyRepo);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -77,7 +77,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), Accessor, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
 			MarketRepository = new MarketRepository(Accessor, ResourceRepository, ResourceRepositoryWrite);
 			SpyRepository = new SpyRepository(Accessor, TimeProvider.System);
-			SpyRepositoryWrite = new SpyRepositoryWrite(Accessor, SpyRepository, ResourceRepositoryWrite, GameDef, TimeProvider.System);
+			SpyRepositoryWrite = new SpyRepositoryWrite(Accessor, SpyRepository, ResourceRepositoryWrite, TechRepository, GameDef, TimeProvider.System);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGameDefFactory.cs
@@ -96,6 +96,39 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Prerequisites = new List<TechNodeId> { Id.TechNode("tech-tier1") },
 						EffectType = TechEffectType.AttackBonus,
 						EffectValue = 3
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-basic"),
+						Name = "Counter-Intelligence",
+						Description = "15% spy detection chance.",
+						Tier = 1,
+						Cost = CostHelper.Create(("res1", 100)),
+						ResearchTimeTicks = 3,
+						Prerequisites = new List<TechNodeId>(),
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-advanced"),
+						Name = "Advanced Counter-Intelligence",
+						Description = "+15% spy detection chance.",
+						Tier = 2,
+						Cost = CostHelper.Create(("res1", 200)),
+						ResearchTimeTicks = 5,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("counter-intel-basic") },
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.15m
+					},
+					new TechNodeDef {
+						Id = Id.TechNode("counter-intel-mastery"),
+						Name = "Counter-Intelligence Mastery",
+						Description = "+20% spy detection chance.",
+						Tier = 3,
+						Cost = CostHelper.Create(("res1", 300)),
+						ResearchTimeTicks = 8,
+						Prerequisites = new List<TechNodeId> { Id.TechNode("counter-intel-advanced") },
+						EffectType = TechEffectType.CounterIntelDetection,
+						EffectValue = 0.20m
 					}
 				},
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public string? TechBeingResearched { get; set; }
 		public int TechResearchTimer { get; set; }
 		public Dictionary<string, SpyResult> LastSpyResults { get; set; } = new Dictionary<string, SpyResult>();
+		public List<SpyAttemptLog> SpyAttemptLogs { get; set; } = new List<SpyAttemptLog>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -48,7 +49,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UnlockedTechs: new List<string>(playerState.UnlockedTechs),
 				TechBeingResearched: playerState.TechBeingResearched,
 				TechResearchTimer: playerState.TechResearchTimer,
-				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults)
+				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
+				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs)
 			);
 		}
 
@@ -79,7 +81,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				TechResearchTimer = playerStateImmutable.TechResearchTimer,
 				LastSpyResults = playerStateImmutable.LastSpyResults != null
 					? new Dictionary<string, SpyResult>(playerStateImmutable.LastSpyResults)
-					: new Dictionary<string, SpyResult>()
+					: new Dictionary<string, SpyResult>(),
+				SpyAttemptLogs = playerStateImmutable.SpyAttemptLogs != null
+					? new List<SpyAttemptLog>(playerStateImmutable.SpyAttemptLogs)
+					: new List<SpyAttemptLog>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepository.cs
@@ -1,6 +1,8 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class SpyRepository {
@@ -24,6 +26,13 @@ namespace BrowserGameEngine.StatefulGameServer {
 			var expiry = lastSpyTime + SpyConstants.CooldownDuration;
 			var now = timeProvider.GetUtcNow().UtcDateTime;
 			return expiry > now ? expiry : null;
+		}
+
+		public IReadOnlyList<SpyAttemptLog> GetDetectedSpyAttempts(PlayerId targetPlayerId) {
+			return world.GetPlayer(targetPlayerId).State.SpyAttemptLogs
+				.Where(a => a.Detected)
+				.OrderByDescending(a => a.Timestamp)
+				.ToList();
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -14,19 +14,24 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly SpyRepository spyRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+		private readonly TechRepository techRepository;
 		private readonly TimeProvider timeProvider;
 		private readonly Cost spyCost;
+
+		private const decimal BaseDetectChance = 0.15m;
 
 		public SpyRepositoryWrite(
 			IWorldStateAccessor worldStateAccessor,
 			SpyRepository spyRepository,
 			ResourceRepositoryWrite resourceRepositoryWrite,
+			TechRepository techRepository,
 			GameDef gameDef,
 			TimeProvider timeProvider
 		) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.spyRepository = spyRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
+			this.techRepository = techRepository;
 			this.timeProvider = timeProvider;
 			spyCost = Cost.FromSingle(GetGrowthResource(gameDef), SpyConstants.SpyCostAmount);
 		}
@@ -76,6 +81,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 						return new SpyUnitEstimate(g.Key, Math.Max(0, (int)(exactCount * noise)));
 					})
 					.ToList();
+
+				// Detection roll: probability is the sum of CounterIntelDetection tech effect values for the target
+				var detectionProbability = techRepository.GetTotalEffectValue(command.TargetPlayerId, TechEffectType.CounterIntelDetection);
+				var detected = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
+
+				targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
+					Id: Guid.NewGuid(),
+					AttackerPlayerId: command.SpyingPlayerId,
+					ActionType: "Spy",
+					Detected: detected,
+					Timestamp: now
+				));
 
 				var result = new SpyResult(
 					TargetPlayerId: command.TargetPlayerId,


### PR DESCRIPTION
## Summary
- Adds detection probability to spy operations based on **CounterIntelligence** tech tree upgrades
- Targets with counter-intel tech can discover incoming spy attempts
- Adds `GET /api/spy/attempts` endpoint returning detected attempts for the current player
- Adds 3 counter-intel tech nodes to SCO game def: basic (15%), advanced (+15%), mastery (+20% → 50% total)
- Stores `SpyAttemptLog` per player in game state (persisted with WorldState)

## Technical details
- New `TechEffectType.CounterIntelDetection` enum value
- New `SpyAttemptLog` model in `GameModel`
- `SpyRepositoryWrite.ExecuteSpy` rolls detection after spy resolves using `TechRepository.GetTotalEffectValue`
- Detection only logs to target's player state; attacker is not notified

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (202 tests, 7 new counter-intel tests)
- [ ] Verify `GET /api/spy/attempts` returns empty list when no counter-intel tech researched
- [ ] Research counter-intel tier 1, spy from another player, verify ~15% detection over many attempts
- [ ] Confirm detected attempts appear in `GET /api/spy/attempts` response

Closes BGE-447