### PR TITLE
fix: BGE-452 fix Blazor error banner and dark card-footer

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -32,20 +32,32 @@
     }
 
     private async Task RunCountdownLoop(CancellationToken ct) {
-        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
-        while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
-            await InvokeAsync(StateHasChanged);
+        try {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+                await InvokeAsync(StateHasChanged);
+            }
+        } catch (OperationCanceledException) {
+            // Normal disposal path
         }
     }
 
     private async void OnRefresh() {
-        await Update();
-        await InvokeAsync(StateHasChanged);
+        try {
+            await Update();
+            await InvokeAsync(StateHasChanged);
+        } catch {
+            // Ignore — resources bar is non-critical
+        }
     }
 
     private async Task Update() {
-        resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
-        tickInfo = await Http.GetFromJsonAsync<TickInfoViewModel>("api/game/tick-info");
+        try {
+            resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
+            tickInfo = await Http.GetFromJsonAsync<TickInfoViewModel>("api/game/tick-info");
+        } catch {
+            // API may be unavailable or user not yet in a game — stay silent
+        }
     }
 
     private string FormatCountdown(DateTime nextTickAt) {

--- a/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
+++ b/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
@@ -552,6 +552,11 @@ tbody tr:hover {
     border-color: var(--color-border-default);
 }
 
+.card-footer {
+    background-color: var(--color-bg-elevated);
+    border-color: var(--color-border-default);
+}
+
 /* --- BGE-specific --------------------------------------------------- */
 .bge-asset {
     background-color: var(--color-bg-surface);


### PR DESCRIPTION
## Summary

- **Root cause of error banner**: `_PlayerResources.razor`'s `Update()` and `async void OnRefresh()` had no error handling. When `api/resources` or `api/game/tick-info` fails (user not yet in a game, transient network error, or API error), `GetFromJsonAsync` throws → unhandled exception → Blazor shows the red "An unhandled error has occurred" bar at the bottom of every page.
- **Fix**: Wrap `Update()` and `OnRefresh()` in try/catch so failures silently hide the resources bar (it only shows when data is available anyway). Also wrap `RunCountdownLoop` to cleanly handle `OperationCanceledException` on disposal.
- **CSS fix**: Added `.card-footer` dark-theme styling to match `.card-header`. Without it, Bootstrap's default light-gray footer background bleeds through on the Season Schedule game cards, looking visually inconsistent with the dark theme.

## Test plan

- [ ] Open the app while not enrolled in any game — no error banner shown
- [ ] Open the app while enrolled — resources bar shows correctly in top row
- [ ] Navigate to Season Schedule (`/games`) — game cards show with consistent dark footer (no light gray bleed)
- [ ] Reload page repeatedly — no Blazor error banner appears