### PR TITLE
feat: BGE-450 notification bell — icons, navigation, close-on-backdrop, polish

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -14,34 +14,49 @@
 <div class="main">
     <div class="top-row px-4 d-flex align-items-center justify-content-between">
         <_PlayerResources />
-        <div class="d-flex align-items-center gap-3">
-            <div class="position-relative" style="cursor:pointer;" @onclick="ToggleNotifications">
-                <span style="font-size:1.4rem;" title="Notifications">&#128276;</span>
-                @if (_notifications.Count > 0) {
-                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size:0.65rem;">
-                        @(_notifications.Count > 9 ? "9+" : _notifications.Count.ToString())
+        <div class="notif-bell-wrapper">
+            <button class="notif-bell-btn" @onclick="ToggleNotifications" title="Notifications" aria-label="Notifications">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                    <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+                </svg>
+                @if (_unreadCount > 0) {
+                    <span class="notif-badge" aria-label="@_unreadCount unread notifications">
+                        @(_unreadCount > 9 ? "9+" : _unreadCount.ToString())
                     </span>
                 }
-            </div>
+            </button>
+
             @if (_showNotifications) {
-                <div class="position-absolute bg-white border rounded shadow" style="top:3.5rem;right:1rem;width:340px;max-height:400px;overflow-y:auto;z-index:1050;">
-                    <div class="d-flex align-items-center justify-content-between px-3 py-2 border-bottom">
-                        <strong>Notifications</strong>
+                <div class="notif-backdrop" @onclick="CloseNotifications"></div>
+                <div class="notif-panel">
+                    <div class="notif-panel-header">
+                        <span class="notif-panel-title">Notifications</span>
                         @if (_notifications.Count > 0) {
-                            <button class="btn btn-sm btn-outline-secondary" @onclick="DismissAll">Clear all</button>
+                            <button class="notif-mark-all-btn" @onclick="DismissAll">Mark all read</button>
                         }
                     </div>
                     @if (_notifications.Count == 0) {
-                        <div class="px-3 py-3 text-muted text-center">No notifications</div>
+                        <div class="notif-empty">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;margin-bottom:0.5rem;">
+                                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                                <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+                            </svg>
+                            <div>No new notifications</div>
+                        </div>
                     } else {
-                        @foreach (var n in _notifications) {
-                            <div class="d-flex align-items-start px-3 py-2 border-bottom @GetNotificationClass(n.Kind)">
-                                <div class="flex-grow-1">
-                                    <div style="font-size:0.85rem;">@n.Message</div>
-                                    <div class="text-muted" style="font-size:0.75rem;">@FormatNotificationTime(n.CreatedAt)</div>
-                                </div>
-                            </div>
-                        }
+                        <div class="notif-list">
+                            @foreach (var n in _notifications) {
+                                <button class="notif-item notif-item--@GetNotificationVariant(n.Kind)" @onclick="() => NavigateToNotification(n)">
+                                    <div class="notif-item-icon">@GetNotificationIcon(n.Kind)</div>
+                                    <div class="notif-item-body">
+                                        <div class="notif-item-msg">@n.Message</div>
+                                        <div class="notif-item-time">@FormatNotificationTime(n.CreatedAt)</div>
+                                    </div>
+                                    <div class="notif-item-arrow">›</div>
+                                </button>
+                            }
+                        </div>
                     }
                 </div>
             }
@@ -94,6 +109,7 @@
 
     private List<PlayerNotificationViewModel> _notifications = new();
     private bool _showNotifications = false;
+    private int _unreadCount => _notifications.Count(n => !n.IsRead);
 
     protected override void OnInitialized() {
         CurrentGameService.OnChanged += OnGameChanged;
@@ -174,10 +190,45 @@
         _showNotifications = !_showNotifications;
     }
 
-    private static string GetNotificationClass(NotificationKind kind) => kind switch {
-        NotificationKind.Warning => "bg-warning bg-opacity-10",
-        NotificationKind.GameEvent => "bg-info bg-opacity-10",
-        _ => ""
+    private void CloseNotifications() {
+        _showNotifications = false;
+    }
+
+    private void NavigateToNotification(PlayerNotificationViewModel n) {
+        _showNotifications = false;
+        var gameId = CurrentGameService.CurrentGameId;
+        if (gameId == null) return;
+
+        var destination = n.Kind switch {
+            NotificationKind.AttackReceived => $"games/{gameId}/base",
+            NotificationKind.AllianceRequest => $"games/{gameId}/diplomacy",
+            NotificationKind.MessageReceived => $"games/{gameId}/messages",
+            NotificationKind.SpyAttempted => $"games/{gameId}/spy",
+            NotificationKind.GameEvent => $"games/{gameId}/base",
+            NotificationKind.Warning => $"games/{gameId}/base",
+            _ => $"games/{gameId}/base"
+        };
+        Nav.NavigateTo(destination);
+    }
+
+    private static string GetNotificationIcon(NotificationKind kind) => kind switch {
+        NotificationKind.Warning => "⚠",
+        NotificationKind.GameEvent => "⚔",
+        NotificationKind.AttackReceived => "🛡",
+        NotificationKind.AllianceRequest => "🤝",
+        NotificationKind.MessageReceived => "✉",
+        NotificationKind.SpyAttempted => "🕵",
+        _ => "ℹ"
+    };
+
+    private static string GetNotificationVariant(NotificationKind kind) => kind switch {
+        NotificationKind.Warning => "warning",
+        NotificationKind.AttackReceived => "danger",
+        NotificationKind.GameEvent => "event",
+        NotificationKind.AllianceRequest => "info",
+        NotificationKind.MessageReceived => "info",
+        NotificationKind.SpyAttempted => "warning",
+        _ => "default"
     };
 
     private static string FormatNotificationTime(DateTime createdAt) {

--- a/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
+++ b/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
@@ -732,3 +732,208 @@ tbody tr:hover {
     background: #2e5080;
     transform: scale(1.08);
 }
+
+/* =====================================================================
+   Notification Bell
+   ===================================================================== */
+
+.notif-bell-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.notif-bell-btn {
+    position: relative;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.notif-bell-btn:hover {
+    color: var(--color-text-primary);
+    background: var(--color-bg-elevated);
+    border-color: var(--color-border-default);
+}
+
+.notif-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translate(30%, -30%);
+    background: #dc2626;
+    color: #fff;
+    font-size: 0.6rem;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0.2em 0.4em;
+    border-radius: 999px;
+    min-width: 1.4em;
+    text-align: center;
+    pointer-events: none;
+    box-shadow: 0 0 0 2px var(--color-bg-surface);
+}
+
+/* Backdrop overlay — closes dropdown on outside click */
+.notif-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1040;
+    background: transparent;
+}
+
+.notif-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: 340px;
+    max-height: 420px;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 1050;
+    overflow: hidden;
+}
+
+.notif-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-border-default);
+    flex-shrink: 0;
+}
+
+.notif-panel-title {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--color-text-primary);
+}
+
+.notif-mark-all-btn {
+    background: none;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.6rem;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.notif-mark-all-btn:hover {
+    color: var(--color-text-primary);
+    border-color: var(--color-border-input);
+}
+
+.notif-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2.5rem 1rem;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    gap: 0.25rem;
+}
+
+.notif-list {
+    overflow-y: auto;
+    flex: 1;
+}
+
+.notif-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    width: 100%;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--color-border-subtle);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s;
+}
+
+.notif-item:last-child {
+    border-bottom: none;
+}
+
+.notif-item:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.notif-item-icon {
+    font-size: 1rem;
+    line-height: 1.4;
+    flex-shrink: 0;
+    width: 1.5rem;
+    text-align: center;
+    opacity: 0.85;
+}
+
+.notif-item-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.notif-item-msg {
+    font-size: 0.82rem;
+    line-height: 1.4;
+    color: var(--color-text-primary);
+    word-break: break-word;
+}
+
+.notif-item-time {
+    font-size: 0.72rem;
+    color: var(--color-text-muted);
+    margin-top: 0.2rem;
+}
+
+.notif-item-arrow {
+    font-size: 1.1rem;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    align-self: center;
+    opacity: 0.5;
+    transition: opacity 0.12s;
+}
+
+.notif-item:hover .notif-item-arrow {
+    opacity: 1;
+}
+
+/* Kind-specific left-border accents */
+.notif-item--warning {
+    border-left: 3px solid var(--color-text-warning);
+}
+
+.notif-item--danger {
+    border-left: 3px solid var(--color-text-error);
+}
+
+.notif-item--event {
+    border-left: 3px solid #3B82F6;
+}
+
+.notif-item--info {
+    border-left: 3px solid #22C55E;
+}
+
+.notif-item--default {
+    border-left: 3px solid transparent;
+}

--- a/src/BrowserGameEngine.Shared/NotificationViewModels.cs
+++ b/src/BrowserGameEngine.Shared/NotificationViewModels.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace BrowserGameEngine.Shared {
-	public enum NotificationKind { Info, Warning, GameEvent }
+	public enum NotificationKind { Info, Warning, GameEvent, AttackReceived, AllianceRequest, MessageReceived, SpyAttempted }
 
 	public record PlayerNotificationViewModel(
 		string Id,


### PR DESCRIPTION
## Summary

Polishes the notification bell UI introduced in BGE-450:

- **Type icons** per `NotificationKind`: ⚔ GameEvent, 🛡 AttackReceived, ✉ MessageReceived, 🕵 SpyAttempted, ⚠ Warning, ℹ Info
- **Clickable navigation** — clicking a notification closes the panel and navigates to the relevant in-game page (base, diplomacy, messages, spy)
- **Close on outside click** — transparent backdrop overlay dismisses the panel when clicking anywhere outside
- **Kind-specific left-border accents** (red = danger, amber = warning, blue = event, green = info)
- **Polished SVG bell** with red unread badge dot (replacing old emoji)
- **"Mark all read"** button (renamed from "Clear all")
- Extended `NotificationKind` enum with `AttackReceived`, `AllianceRequest`, `MessageReceived`, `SpyAttempted` ready for BGE-449 backend

## Notes

BGE-449 (notification backend) is still `todo`. The UI is fully implemented and will work seamlessly once BGE-449 ships. Until then it falls back gracefully to the existing `Info/Warning/GameEvent` kinds.

## Test plan

- [ ] Bell icon renders in top-right of navbar with correct SVG
- [ ] Red badge appears with count when notifications exist
- [ ] Clicking bell toggles the dropdown panel
- [ ] Clicking outside the panel (backdrop) closes it
- [ ] Notification rows show the correct icon for each kind
- [ ] Clicking a notification navigates to the correct game page
- [ ] "Mark all read" clears notifications and closes panel
- [ ] Empty state shows "No new notifications" with dimmed bell icon
- [ ] Build passes with 0 warnings: `dotnet build`