### PR TITLE
feat: BGE-449 notification system — persistent table, service, REST API

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -3,6 +3,7 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
@@ -19,6 +20,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly AllianceChatRepository allianceChatRepository;
 		private readonly AllianceChatRepositoryWrite allianceChatRepositoryWrite;
 		private readonly PlayerRepository playerRepository;
+		private readonly INotificationService notificationService;
 
 		public AlliancesController(
 			CurrentUserContext currentUserContext,
@@ -26,7 +28,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			AllianceRepositoryWrite allianceRepositoryWrite,
 			AllianceChatRepository allianceChatRepository,
 			AllianceChatRepositoryWrite allianceChatRepositoryWrite,
-			PlayerRepository playerRepository
+			PlayerRepository playerRepository,
+			INotificationService notificationService
 		) {
 			this.currentUserContext = currentUserContext;
 			this.allianceRepository = allianceRepository;
@@ -34,6 +37,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.allianceChatRepository = allianceChatRepository;
 			this.allianceChatRepositoryWrite = allianceChatRepositoryWrite;
 			this.playerRepository = playerRepository;
+			this.notificationService = notificationService;
 		}
 
 		/// <summary>Returns all alliances in the current game.</summary>
@@ -130,8 +134,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult Join(string id, [FromBody] JoinAllianceRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			try {
+				var allianceId = AllianceIdFactory.Create(id);
 				allianceRepositoryWrite.JoinAlliance(
-					new JoinAllianceCommand(currentUserContext.PlayerId!, AllianceIdFactory.Create(id), request.Password));
+					new JoinAllianceCommand(currentUserContext.PlayerId!, allianceId, request.Password));
+
+				// Notify alliance leader if join request is pending approval
+				var alliance = allianceRepository.Get(allianceId);
+				if (alliance != null) {
+					var joiningMember = alliance.Members.FirstOrDefault(m => m.PlayerId == currentUserContext.PlayerId && m.IsPending);
+					if (joiningMember != null) {
+						var joiningPlayer = playerRepository.Get(currentUserContext.PlayerId!);
+						notificationService.Notify(alliance.LeaderId, GameNotificationType.AllianceRequest,
+							$"Alliance join request from {joiningPlayer.Name}");
+					}
+				}
 				return Ok();
 			} catch (AllianceNotFoundException) {
 				return NotFound();

--- a/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
@@ -1,7 +1,10 @@
+using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,20 +15,26 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 	public class NotificationsController : ControllerBase {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly IPlayerNotificationService playerNotificationService;
+		private readonly INotificationService notificationService;
 
 		public NotificationsController(
 			CurrentUserContext currentUserContext,
-			IPlayerNotificationService playerNotificationService
+			IPlayerNotificationService playerNotificationService,
+			INotificationService notificationService
 		) {
 			this.currentUserContext = currentUserContext;
 			this.playerNotificationService = playerNotificationService;
+			this.notificationService = notificationService;
 		}
 
-		[HttpGet]
-		public ActionResult<List<BrowserGameEngine.Shared.PlayerNotificationViewModel>> GetNotifications() {
+		/// <summary>Returns real-time in-memory notifications for the current user.</summary>
+		[HttpGet("recent")]
+		[ProducesResponseType(typeof(List<PlayerNotificationViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<List<PlayerNotificationViewModel>> GetRecent() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var notifications = playerNotificationService.GetRecent(currentUserContext.UserId);
-			return Ok(notifications.Select(n => new BrowserGameEngine.Shared.PlayerNotificationViewModel(
+			return Ok(notifications.Select(n => new PlayerNotificationViewModel(
 				Id: n.Id,
 				Message: n.Message,
 				Kind: MapKind(n.Kind),
@@ -34,11 +43,63 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			)).ToList());
 		}
 
-		[HttpDelete]
-		public ActionResult ClearNotifications() {
+		/// <summary>Returns persistent game notifications for the current player.</summary>
+		/// <param name="unreadOnly">When true, returns only unread notifications.</param>
+		[HttpGet]
+		[ProducesResponseType(typeof(List<GameNotificationViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<List<GameNotificationViewModel>> GetNotifications([FromQuery] bool unreadOnly = false) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var notifications = notificationService.GetNotifications(currentUserContext.PlayerId!, unreadOnly);
+			return Ok(notifications.Select(MapToViewModel).ToList());
+		}
+
+		/// <summary>Marks a persistent notification as read.</summary>
+		/// <param name="id">The notification ID.</param>
+		[HttpPost("{id}/read")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult MarkRead(Guid id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			notificationService.MarkRead(currentUserContext.PlayerId!, id);
+			return Ok();
+		}
+
+		/// <summary>Marks all persistent notifications as read for the current player.</summary>
+		[HttpPost("read-all")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult MarkAllRead() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			notificationService.MarkAllRead(currentUserContext.PlayerId!);
+			return Ok();
+		}
+
+		/// <summary>Clears all in-memory real-time notifications.</summary>
+		[HttpDelete("recent")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult ClearRecent() {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			playerNotificationService.ClearAll(currentUserContext.UserId);
 			return Ok();
+		}
+
+		private static GameNotificationViewModel MapToViewModel(GameNotification n) {
+			return new GameNotificationViewModel {
+				Id = n.Id,
+				Type = n.Type switch {
+					GameNotificationType.AttackReceived => GameNotificationTypeViewModel.AttackReceived,
+					GameNotificationType.SpyAttempted => GameNotificationTypeViewModel.SpyAttempted,
+					GameNotificationType.AllianceRequest => GameNotificationTypeViewModel.AllianceRequest,
+					GameNotificationType.MessageReceived => GameNotificationTypeViewModel.MessageReceived,
+					_ => GameNotificationTypeViewModel.AttackReceived
+				},
+				Title = n.Title,
+				Body = n.Body,
+				CreatedAt = n.CreatedAt,
+				IsRead = n.IsRead
+			};
 		}
 
 		private static BrowserGameEngine.Shared.NotificationKind MapKind(BrowserGameEngine.StatefulGameServer.Notifications.NotificationKind kind) {

--- a/src/BrowserGameEngine.GameModel/GameNotification.cs
+++ b/src/BrowserGameEngine.GameModel/GameNotification.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public enum GameNotificationType {
+		AttackReceived,
+		SpyAttempted,
+		AllianceRequest,
+		MessageReceived
+	}
+
+	public record GameNotification(
+		Guid Id,
+		GameNotificationType Type,
+		string Title,
+		string? Body,
+		DateTime CreatedAt,
+		DateTime? ReadAt
+	) {
+		public bool IsRead => ReadAt.HasValue;
+	}
+}

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -24,6 +24,7 @@ namespace BrowserGameEngine.GameModel {
 		string? TechBeingResearched = null,
 		int TechResearchTimer = 0,
 		IDictionary<string, SpyResult>? LastSpyResults = null,
-		IList<SpyAttemptLog>? SpyAttemptLogs = null
+		IList<SpyAttemptLog>? SpyAttemptLogs = null,
+		IList<GameNotification>? Notifications = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/GameNotificationViewModel.cs
+++ b/src/BrowserGameEngine.Shared/GameNotificationViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public enum GameNotificationTypeViewModel {
+		AttackReceived,
+		SpyAttempted,
+		AllianceRequest,
+		MessageReceived
+	}
+
+	public class GameNotificationViewModel {
+		public Guid Id { get; set; }
+		public GameNotificationTypeViewModel Type { get; set; }
+		public string Title { get; set; } = string.Empty;
+		public string? Body { get; set; }
+		public DateTime CreatedAt { get; set; }
+		public bool IsRead { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/NotificationServiceTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/NotificationServiceTest.cs
@@ -1,0 +1,134 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class NotificationServiceTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void Notify_AddsNotificationToPlayer() {
+			var game = new TestGame(playerCount: 2);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack!", "You were attacked.");
+
+			var notifications = service.GetNotifications(Player1);
+			Assert.Single(notifications);
+			Assert.Equal(GameNotificationType.AttackReceived, notifications[0].Type);
+			Assert.Equal("Attack!", notifications[0].Title);
+			Assert.Equal("You were attacked.", notifications[0].Body);
+			Assert.False(notifications[0].IsRead);
+		}
+
+		[Fact]
+		public void MarkRead_SetsReadAt() {
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.MessageReceived, "Hello");
+			var notifications = service.GetNotifications(Player1);
+			var notifId = notifications[0].Id;
+
+			service.MarkRead(Player1, notifId);
+
+			var updated = service.GetNotifications(Player1);
+			Assert.True(updated[0].IsRead);
+		}
+
+		[Fact]
+		public void MarkAllRead_MarksAllNotificationsRead() {
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack 1");
+			service.Notify(Player1, GameNotificationType.MessageReceived, "Msg 1");
+			service.Notify(Player1, GameNotificationType.AllianceRequest, "Alliance 1");
+
+			service.MarkAllRead(Player1);
+
+			var notifications = service.GetNotifications(Player1);
+			Assert.Equal(3, notifications.Count);
+			Assert.All(notifications, n => Assert.True(n.IsRead));
+		}
+
+		[Fact]
+		public void GetNotifications_UnreadOnly_ReturnsOnlyUnread() {
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack 1");
+			service.Notify(Player1, GameNotificationType.MessageReceived, "Msg 1");
+
+			var allNotifs = service.GetNotifications(Player1);
+			var firstId = allNotifs[allNotifs.Count - 1].Id; // oldest
+			service.MarkRead(Player1, firstId);
+
+			var unread = service.GetNotifications(Player1, unreadOnly: true);
+			Assert.Single(unread);
+			Assert.False(unread[0].IsRead);
+		}
+
+		[Fact]
+		public void GetNotifications_OrderedByCreatedAtDescending() {
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.AttackReceived, "First");
+			service.Notify(Player1, GameNotificationType.MessageReceived, "Second");
+			service.Notify(Player1, GameNotificationType.AllianceRequest, "Third");
+
+			var notifications = service.GetNotifications(Player1);
+			Assert.Equal(3, notifications.Count);
+			// Most recent should be first
+			Assert.True(notifications[0].CreatedAt >= notifications[1].CreatedAt);
+			Assert.True(notifications[1].CreatedAt >= notifications[2].CreatedAt);
+		}
+
+		[Fact]
+		public void Notify_NonExistentPlayer_DoesNotThrow() {
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+			var fakePlayerId = PlayerIdFactory.Create("nonexistent");
+
+			// Should silently do nothing
+			var ex = Record.Exception(() => service.Notify(fakePlayerId, GameNotificationType.AttackReceived, "test"));
+			Assert.Null(ex);
+		}
+
+		[Fact]
+		public void Notifications_PersistedInPlayerStateImmutable() {
+			// Verify notifications are stored in player state (would survive serialization)
+			var game = new TestGame(playerCount: 1);
+			var service = new NotificationService(game.Accessor);
+
+			service.Notify(Player1, GameNotificationType.SpyAttempted, "Spy detected!");
+
+			// Check via repository (returns immutable snapshot)
+			var playerState = game.PlayerRepository.Get(Player1).State;
+			Assert.NotNull(playerState.Notifications);
+			Assert.Single(playerState.Notifications!);
+			Assert.Equal("Spy detected!", playerState.Notifications![0].Title);
+		}
+
+		[Fact]
+		public void SendMessage_CreatesMessageReceivedNotification() {
+			var game = new TestGame(playerCount: 2);
+			// Use a real NotificationService (not the NullNotificationService from TestGame)
+			var notificationService = new NotificationService(game.Accessor);
+			var messageRepositoryWrite = new MessageRepositoryWrite(game.Accessor, TimeProvider.System, notificationService);
+
+			messageRepositoryWrite.Send(new SendMessageCommand(Player1, Player2, "Hello", "World message body"));
+
+			var notifications = notificationService.GetNotifications(Player2);
+			Assert.Single(notifications);
+			Assert.Equal(GameNotificationType.MessageReceived, notifications[0].Type);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -72,7 +73,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			TechRepositoryWrite = new TechRepositoryWrite(Accessor, GameDef, TechRepository, ResourceRepository, ResourceRepositoryWrite);
 			UnitRepositoryWrite = new UnitRepositoryWrite(LoggerFactory.CreateLogger<UnitRepositoryWrite>(), Accessor, GameDef, UnitRepository, ResourceRepositoryWrite, ResourceRepository, PlayerRepository, PlayerRepositoryWrite, BattleBehavior, UpgradeRepository, TechRepository);
 			MessageRepository = new MessageRepository(Accessor);
-			MessageRepositoryWrite = new MessageRepositoryWrite(Accessor, TimeProvider.System);
+			MessageRepositoryWrite = new MessageRepositoryWrite(Accessor, TimeProvider.System, NullNotificationService.Instance);
 			BuildQueueRepository = new BuildQueueRepository(Accessor);
 			BuildQueueRepositoryWrite = new BuildQueueRepositoryWrite(LoggerFactory.CreateLogger<BuildQueueRepositoryWrite>(), Accessor, BuildQueueRepository, AssetRepository, AssetRepositoryWrite, UnitRepository, UnitRepositoryWrite, ResourceRepository, GameDef);
 			MarketRepository = new MarketRepository(Accessor, ResourceRepository, ResourceRepositoryWrite);

--- a/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
@@ -11,17 +11,20 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly MessageRepositoryWrite messageRepositoryWrite;
 		private readonly GameDef gameDef;
 		private readonly IPlayerNotificationService playerNotificationService;
+		private readonly INotificationService notificationService;
 
 		public BattleReportGenerator(
 			PlayerRepository playerRepository,
 			MessageRepositoryWrite messageRepositoryWrite,
 			GameDef gameDef,
-			IPlayerNotificationService playerNotificationService
+			IPlayerNotificationService playerNotificationService,
+			INotificationService notificationService
 		) {
 			this.playerRepository = playerRepository;
 			this.messageRepositoryWrite = messageRepositoryWrite;
 			this.gameDef = gameDef;
 			this.playerNotificationService = playerNotificationService;
+			this.notificationService = notificationService;
 		}
 
 		public void GenerateReports(BattleResult battleResult) {
@@ -62,6 +65,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 				$"Battle Report vs {attacker.Name}",
 				body
 			);
+
+			notificationService.Notify(battleResult.Defender, GameNotificationType.AttackReceived,
+				$"Attack from {attacker.Name}",
+				$"Outcome: {outcome}");
 
 			if (defender.UserId != null) {
 				playerNotificationService.Push(defender.UserId, $"Your base was attacked by {attacker.Name}! ({outcome})", NotificationKind.Warning);

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public int TechResearchTimer { get; set; }
 		public Dictionary<string, SpyResult> LastSpyResults { get; set; } = new Dictionary<string, SpyResult>();
 		public List<SpyAttemptLog> SpyAttemptLogs { get; set; } = new List<SpyAttemptLog>();
+		public List<GameNotification> Notifications { get; set; } = new List<GameNotification>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -50,7 +51,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				TechBeingResearched: playerState.TechBeingResearched,
 				TechResearchTimer: playerState.TechResearchTimer,
 				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
-				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs)
+				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
+				Notifications: new List<GameNotification>(playerState.Notifications)
 			);
 		}
 
@@ -84,7 +86,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					: new Dictionary<string, SpyResult>(),
 				SpyAttemptLogs = playerStateImmutable.SpyAttemptLogs != null
 					? new List<SpyAttemptLog>(playerStateImmutable.SpyAttemptLogs)
-					: new List<SpyAttemptLog>()
+					: new List<SpyAttemptLog>(),
+				Notifications = playerStateImmutable.Notifications != null
+					? new List<GameNotification>(playerStateImmutable.Notifications)
+					: new List<GameNotification>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -85,6 +85,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IWorldStateFactory>(worldStateFactory);
 			services.AddSingleton<IGameNotificationService, NullGameNotificationService>();
 			services.AddSingleton<IPlayerNotificationService, InMemoryPlayerNotificationService>();
+			services.AddSingleton<INotificationService, NotificationService>();
 			services.AddSingleton<GameLifecycleEngine>();
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/INotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/INotificationService.cs
@@ -1,0 +1,11 @@
+using BrowserGameEngine.GameModel;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	public interface INotificationService {
+		void Notify(PlayerId playerId, GameNotificationType type, string title, string? body = null);
+		void MarkRead(PlayerId playerId, System.Guid notificationId);
+		void MarkAllRead(PlayerId playerId);
+		IReadOnlyList<GameNotification> GetNotifications(PlayerId playerId, bool unreadOnly = false);
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
@@ -1,0 +1,64 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	public class NotificationService : INotificationService {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public NotificationService(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public void Notify(PlayerId playerId, GameNotificationType type, string title, string? body = null) {
+			if (!world.PlayerExists(playerId)) return;
+			var notification = new GameNotification(
+				Id: Guid.NewGuid(),
+				Type: type,
+				Title: title,
+				Body: body,
+				CreatedAt: DateTime.UtcNow,
+				ReadAt: null
+			);
+			lock (_lock) {
+				world.GetPlayer(playerId).State.Notifications.Add(notification);
+			}
+		}
+
+		public void MarkRead(PlayerId playerId, Guid notificationId) {
+			lock (_lock) {
+				var state = world.GetPlayer(playerId).State;
+				var idx = state.Notifications.FindIndex(n => n.Id == notificationId);
+				if (idx >= 0) {
+					state.Notifications[idx] = state.Notifications[idx] with { ReadAt = DateTime.UtcNow };
+				}
+			}
+		}
+
+		public void MarkAllRead(PlayerId playerId) {
+			lock (_lock) {
+				var state = world.GetPlayer(playerId).State;
+				var now = DateTime.UtcNow;
+				for (int i = 0; i < state.Notifications.Count; i++) {
+					if (!state.Notifications[i].IsRead) {
+						state.Notifications[i] = state.Notifications[i] with { ReadAt = now };
+					}
+				}
+			}
+		}
+
+		public IReadOnlyList<GameNotification> GetNotifications(PlayerId playerId, bool unreadOnly = false) {
+			var notifications = world.GetPlayer(playerId).State.Notifications;
+			IEnumerable<GameNotification> result = notifications.OrderByDescending(n => n.CreatedAt);
+			if (unreadOnly) {
+				result = result.Where(n => !n.IsRead);
+			}
+			return result.ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/NullNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/NullNotificationService.cs
@@ -1,0 +1,15 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.Notifications {
+	/// <summary>No-op implementation used in tests and when no world state accessor is available.</summary>
+	public class NullNotificationService : INotificationService {
+		public static readonly NullNotificationService Instance = new();
+
+		public void Notify(PlayerId playerId, GameNotificationType type, string title, string? body = null) { }
+		public void MarkRead(PlayerId playerId, Guid notificationId) { }
+		public void MarkAllRead(PlayerId playerId) { }
+		public IReadOnlyList<GameNotification> GetNotifications(PlayerId playerId, bool unreadOnly = false) => [];
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
@@ -1,6 +1,7 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Notifications;
 using System;
 using System.Threading;
 
@@ -10,10 +11,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
+		private readonly INotificationService notificationService;
 
-		public MessageRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+		public MessageRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider, INotificationService notificationService) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
+			this.notificationService = notificationService;
 		}
 
 		// Used by BattleReportGenerator for system messages (no sender)
@@ -45,6 +48,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 					IsRead = false
 				});
 			}
+			notificationService.Notify(command.RecipientId, GameNotificationType.MessageReceived,
+				$"New message: {command.Subject}");
 			return id;
 		}
 


### PR DESCRIPTION
## Summary
- Adds a **persistent** server-side notification system backed by `WorldState` (survives restarts)
- `GameNotification` record stored in `PlayerState.Notifications` — serialized with all other player data
- `INotificationService` / `NotificationService` with thread-safe world-state mutations
- Notifications generated for: attacks received, messages received, alliance join requests
- Full REST API for reading, marking as read, and filtering unread

## Endpoints
| Method | Route | Description |
|--------|-------|-------------|
| `GET` | `/api/notifications?unreadOnly=true` | Persistent game notifications |
| `POST` | `/api/notifications/{id}/read` | Mark one notification as read |
| `POST` | `/api/notifications/read-all` | Mark all as read |
| `GET` | `/api/notifications/recent` | Existing in-memory push notifications (moved) |

## Event hooks wired up
- **AttackReceived** — `BattleReportGenerator.GenerateReports()`
- **MessageReceived** — `MessageRepositoryWrite.Send()`
- **AllianceRequest** — `AlliancesController.Join()` (pending approval path)

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (203 tests, 8 new notification tests)
- [ ] Verify `GET /api/notifications` returns empty list on fresh player
- [ ] Send a private message, verify `MessageReceived` notification appears for recipient
- [ ] Execute an attack, verify `AttackReceived` notification on defender
- [ ] `POST /api/notifications/read-all`, verify all notifications become read
- [ ] Verify state persists after restart (check `games/{id}/state.json`)

Closes BGE-449