### PR TITLE
fix: resolve Blazor UI crash and broken notification endpoints

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Base.razor
@@ -209,7 +209,7 @@
     }
 
     private async Task ClearNotifications() {
-        await Http.DeleteAsync("api/notifications");
+        await Http.DeleteAsync("api/notifications/recent");
         notifications = new List<PlayerNotificationViewModel>();
     }
 
@@ -217,7 +217,7 @@
         model = await Http.GetFromJsonAsync<AssetsViewModel>("api/assets");
         resources = await Http.GetFromJsonAsync<PlayerResourcesViewModel>("api/resources");
         try {
-            notifications = await Http.GetFromJsonAsync<List<PlayerNotificationViewModel>>("api/notifications");
+            notifications = await Http.GetFromJsonAsync<List<PlayerNotificationViewModel>>("api/notifications/recent");
         } catch {
             // Non-critical
         }

--- a/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/SelectEnemy.razor
@@ -34,7 +34,7 @@
 
     @if (spyReport != null) {
         <details open class="mt-3">
-            <summary><strong>Spy Report — @spyReport.TargetPlayerName</strong> <small class="text-muted">(@spyReport.ReportTime.ToLocalTime():HH:mm:ss)</small></summary>
+            <summary><strong>Spy Report — @spyReport.TargetPlayerName</strong> <small class="text-muted">(@spyReport.ReportTime.ToLocalTime().ToString("HH:mm:ss"))</small></summary>
             <div class="mt-2">
                 <p><strong>Approximate Resources:</strong> ~@((int)spyReport.ApproximateMinerals) minerals, ~@((int)spyReport.ApproximateGas) gas</p>
                 @if (spyReport.UnitEstimates.Any()) {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -5,7 +5,7 @@
 
 @if (resources != null) {
     <div class="d-flex flex-wrap gap-3 align-items-center small">
-        <span><strong>@resources.PrimaryResource.Cost.Single().Key</strong>: <span class="text-resource">@resources.PrimaryResource.Cost.Single().Value</span></span>
+        <span><strong>@resources.PrimaryResource.Cost.First().Key</strong>: <span class="text-resource">@resources.PrimaryResource.Cost.First().Value</span></span>
         @foreach (var res in resources.SecondaryResources.Cost) {
             <span><strong>@res.Key</strong>: <span class="text-resource">@res.Value</span></span>
         }

--- a/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/MainLayout.razor
@@ -166,7 +166,7 @@
 
     private async Task FetchNotificationsAsync() {
         try {
-            var result = await Http.GetFromJsonAsync<List<PlayerNotificationViewModel>>("api/notifications");
+            var result = await Http.GetFromJsonAsync<List<PlayerNotificationViewModel>>("api/notifications/recent");
             if (result != null) {
                 _notifications = result;
                 await InvokeAsync(StateHasChanged);
@@ -178,7 +178,7 @@
 
     private async Task DismissAll() {
         try {
-            await Http.DeleteAsync("api/notifications");
+            await Http.DeleteAsync("api/notifications/recent");
             _notifications = new List<PlayerNotificationViewModel>();
             _showNotifications = false;
         } catch {

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -173,7 +173,6 @@
                         <span class="oi oi-account-login" aria-hidden="true"></span> Profile
                     </NavLink>
                 </li>
-                <AuthorizeView>
                 <li class="nav-item px-3">
                     <NavLink class="nav-link" href="achievements">
                         <span class="oi oi-star" aria-hidden="true"></span> Achievements
@@ -189,7 +188,6 @@
                         <span class="oi oi-cog" aria-hidden="true"></span> Admin: Games
                     </NavLink>
                 </li>
-                </AuthorizeView>
             </ul>
         }
     </div>


### PR DESCRIPTION
## Summary
- **Remove `<AuthorizeView>` from NavMenu** — no `AuthenticationStateProvider` was registered, causing `InvalidOperationException` on every page load (the "An unhandled error has occurred" error on ageofagents.net)
- **Fix notification API URLs** — MainLayout and Base.razor were calling `api/notifications` (returns `GameNotificationViewModel`) but deserializing as `PlayerNotificationViewModel`; corrected to `api/notifications/recent`. Also fixed DELETE calls to use the correct `/recent` route.
- **Replace `.Single()` with `.First()`** in `_PlayerResources.razor` — `.Single()` throws if the Cost dictionary has != 1 entry
- **Fix spy report date format** in `SelectEnemy.razor` — `@expr:HH:mm:ss` rendered `:HH:mm:ss` as literal text; changed to `.ToString("HH:mm:ss")`

## Test plan
- [ ] Verify ageofagents.net loads without "unhandled error"
- [ ] Verify notification bell in top bar fetches and displays notifications
- [ ] Verify "Clear" button on Base page activity feed works
- [ ] Verify resource bar shows primary resource correctly
- [ ] Verify spy report time displays correctly on SelectEnemy page
- [ ] Verify Achievements, History, and Admin nav links are visible in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)