### PR TITLE
fix: DevAuth login losing session on navigation

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -18,17 +18,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly PlayerRepository playerRepository;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
+		private readonly UserRepositoryWrite userRepositoryWrite;
 
 		public AuthenticationController(ILogger<AuthenticationController> logger
 				, IOptions<BgeOptions> options
 				, CurrentUserContext currentUserContext
 				, PlayerRepository playerRepository
 				, PlayerRepositoryWrite playerRepositoryWrite
+				, UserRepositoryWrite userRepositoryWrite
 			) {
 			this.options = options;
 			this.currentUserContext = currentUserContext;
 			this.playerRepository = playerRepository;
 			this.playerRepositoryWrite = playerRepositoryWrite;
+			this.userRepositoryWrite = userRepositoryWrite;
 		}
 
 		[HttpGet("~/signin")]
@@ -74,8 +77,13 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (string.IsNullOrWhiteSpace(playerid)) return BadRequest();
 
 			var playerId = PlayerIdFactory.Create(playerid);
+			var user = userRepositoryWrite.GetOrCreateUser(
+				githubId: playerid,
+				githubLogin: playerid,
+				displayName: playerid
+			);
 			if (!playerRepository.Exists(playerId)) {
-				playerRepositoryWrite.CreatePlayer(playerId);
+				playerRepositoryWrite.CreatePlayer(playerId, user.UserId);
 			}
 
 			// Create a claims identity so the cookie auth and CurrentUserMiddleware work correctly

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -79,7 +79,9 @@ builder.Services.AddAuthentication(options => {
 })
     .AddCookie(options => {
         options.Cookie.Name = "BGE.AuthCookie";
-        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        options.Cookie.SecurePolicy = builder.Environment.IsDevelopment()
+            ? CookieSecurePolicy.SameAsRequest
+            : CookieSecurePolicy.Always;
         options.Cookie.SameSite = SameSiteMode.Lax;
         options.LoginPath = "/signin";
         options.Events.OnRedirectToLogin = context => {
@@ -100,7 +102,9 @@ if (!string.IsNullOrWhiteSpace(githubClientId) && !string.IsNullOrWhiteSpace(git
         options.ClientSecret = githubClientSecret;
         options.SaveTokens = true;
         options.CorrelationCookie.SameSite = SameSiteMode.Lax;
-        options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+        options.CorrelationCookie.SecurePolicy = builder.Environment.IsDevelopment()
+            ? CookieSecurePolicy.SameAsRequest
+            : CookieSecurePolicy.Always;
     });
 } else {
     Log.Warning("GitHub OAuth is disabled because GitHub:ClientId or GitHub:ClientSecret is not configured.");
@@ -116,7 +120,10 @@ if (!string.IsNullOrEmpty(s3BucketForDp)) {
             opts.XmlRepository = new S3DataProtectionKeyRepository(s3ClientForDp, s3BucketForDp, s3KeyPrefixForDp));
     Log.Information("Data Protection keys will be persisted to S3 at {Bucket}/{Prefix}", s3BucketForDp, s3KeyPrefixForDp);
 } else {
-    Log.Warning("Data Protection keys are ephemeral (no S3 bucket configured). This is fine for local dev.");
+    var keysDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "bge", "data-protection-keys");
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(new DirectoryInfo(keysDir));
+    Log.Information("Data Protection keys will be persisted locally to {KeysDir}", keysDir);
 }
 
 await ConfigureGameServices(builder.Services);


### PR DESCRIPTION
## Summary
- **Root cause**: `SignInDev` created players without a User record, so `CurrentUserMiddleware.GetPlayersForUser()` found no linked player — `IsValid` stayed `false` and all `[Authorize]` endpoints returned 401, redirecting to `/signin`
- Link player to User record by calling `GetOrCreateUser` before `CreatePlayer` in DevAuth flow
- Use `SameAsRequest` cookie secure policy in Development (was `Always`, which breaks HTTP)
- Persist Data Protection keys to local filesystem instead of keeping them ephemeral (survives restarts)

## Test plan
- [x] `dotnet build` passes
- [x] All 210 tests pass
- [ ] Manual: run `dotnet run`, log in via DevAuth, click Profile — session persists
- [ ] Manual: restart server, refresh page — session still persists (data protection keys on disk)