### PR TITLE
feat: UX overhaul — worker bars, cost badges, unit grouping, loading states

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -5,91 +5,96 @@
 @inject IJSRuntime JS
 @implements IDisposable
 
+<PageTitle>My Players — Age of Agents</PageTitle>
+
 <h1>My Players</h1>
 
 @if (players == null) {
-	<p><em>Loading...</em></p>
+	<div class="bge-loading"><div class="bge-spinner"></div> Loading...</div>
 } else {
-	<div class="card mb-4" style="max-width:480px">
-		<div class="card-header"><strong>Create Player</strong></div>
-		<div class="card-body">
-			<EditForm Model="@createModel" OnValidSubmit="HandleCreatePlayer">
-				<DataAnnotationsValidator />
-				<ValidationSummary />
-				<div class="mb-3">
-					<label class="form-label" for="PlayerName">Player name</label>
-					<InputText id="PlayerName" class="form-control" @bind-Value="createModel.PlayerName" placeholder="Enter a name" />
+	<div class="row g-3 mb-4">
+		@foreach (var player in players) {
+			<div class="col-12 col-md-6 col-lg-4">
+				<div class="card h-100 @(players.Count > 1 ? "" : "")">
+					<div class="card-body d-flex flex-column">
+						<div class="d-flex align-items-center gap-2 mb-2">
+							<div class="profile-avatar-placeholder" style="width:40px;height:40px;font-size:1.1rem;border-width:1px">
+								@(player.PlayerName?.Length > 0 ? player.PlayerName[0].ToString().ToUpper() : "?")
+							</div>
+							<div>
+								<div style="font-weight:700; font-size:0.95rem">@player.PlayerName</div>
+								<div style="font-size:0.72rem" class="text-muted">
+									@(player.HasApiKey ? "API key active" : "No API key")
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="card-footer d-flex gap-2 flex-wrap">
+						@if (players.Count > 1) {
+							<button class="btn btn-sm btn-primary" @onclick="() => HandleSwitchPlayer(player.PlayerId)">
+								Switch to
+							</button>
+						}
+						@if (player.HasApiKey) {
+							<button class="btn btn-sm btn-outline-danger" @onclick="() => HandleRevokeKey(player.PlayerId)">Revoke Key</button>
+						} else {
+							<button class="btn btn-sm btn-outline-secondary" @onclick="() => HandleGenerateKey(player.PlayerId)">Generate Key</button>
+						}
+					</div>
 				</div>
-				<button type="submit" class="btn btn-primary">Create Player</button>
-			</EditForm>
-			@if (!string.IsNullOrEmpty(createError)) {
-				<div class="alert alert-danger mt-2">@createError</div>
-			}
+			</div>
+		}
+
+		@* Create new player card *@
+		<div class="col-12 col-md-6 col-lg-4">
+			<div class="card h-100" style="border-style:dashed; border-color:var(--color-border-input)">
+				<div class="card-body">
+					<div style="font-weight:600; font-size:0.85rem; margin-bottom:0.75rem">Create New Player</div>
+					<EditForm Model="@createModel" OnValidSubmit="HandleCreatePlayer">
+						<DataAnnotationsValidator />
+						<div class="mb-2">
+							<InputText class="form-control form-control-sm" @bind-Value="createModel.PlayerName" placeholder="Player name" />
+							<ValidationMessage For="@(() => createModel.PlayerName)" />
+						</div>
+						<button type="submit" class="btn btn-sm btn-success w-100">Create</button>
+					</EditForm>
+					@if (!string.IsNullOrEmpty(createError)) {
+						<div class="alert alert-danger mt-2 py-1 px-2" style="font-size:0.78rem">@createError</div>
+					}
+				</div>
+			</div>
 		</div>
 	</div>
-
-	<h2>Your Players</h2>
-	@if (players.Count == 0) {
-		<div class="text-muted">No players yet. Create one above to get started.</div>
-	} else {
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Name</th>
-					<th>API Key</th>
-					<th>Actions</th>
-				</tr>
-			</thead>
-			<tbody>
-				@foreach (var player in players) {
-					<tr>
-						<td>@player.PlayerName</td>
-						<td>@(player.HasApiKey ? "Active" : "—")</td>
-						<td class="d-flex flex-wrap gap-1">
-							@if (players.Count > 1) {
-								<button class="btn btn-sm btn-primary" @onclick="() => HandleSwitchPlayer(player.PlayerId)">Switch to</button>
-							}
-							@if (player.HasApiKey) {
-								<button class="btn btn-sm btn-outline-danger" @onclick="() => HandleRevokeKey(player.PlayerId)">Revoke Key</button>
-							} else {
-								<button class="btn btn-sm btn-outline-secondary" @onclick="() => HandleGenerateKey(player.PlayerId)">Generate Key</button>
-							}
-							<button class="btn btn-sm btn-outline-secondary" disabled title="Not yet available">Delete</button>
-						</td>
-					</tr>
-				}
-			</tbody>
-		</table>
-	}
 }
 
 @if (!string.IsNullOrEmpty(newApiKey)) {
-	<div style="border:1px solid #ccc; padding:1em; margin-top:1em;">
-		<strong>New API Key (shown once — copy now):</strong><br />
+	<div class="api-key-box">
+		<div style="font-weight:600; font-size:0.85rem; margin-bottom:0.35rem">New API Key — copy now, shown once only</div>
 		<code>@newApiKey</code>
-		<br />
-		<button @onclick="() => CopyToClipboard(newApiKey)">Copy</button>
-		<button @onclick="() => newApiKey = null">Dismiss</button>
+		<div class="d-flex gap-2 mt-2">
+			<button class="btn btn-sm btn-primary" @onclick="() => CopyToClipboard(newApiKey)">Copy to Clipboard</button>
+			<button class="btn btn-sm btn-secondary" @onclick="() => newApiKey = null">Dismiss</button>
+		</div>
 	</div>
 }
 
-<h2>Game Preferences</h2>
+<h2 class="mt-4">Preferences</h2>
 @if (preferences == null) {
-	<p><em>Loading preferences...</em></p>
+	<div class="bge-loading" style="padding:1rem"><div class="bge-spinner"></div></div>
 } else {
-	<div>
-		<label>
-			<input type="checkbox" checked="@preferences.WantsGameNotification"
-				@onchange="e => HandlePreferenceChange(nameof(preferences.WantsGameNotification), (bool)e.Value!)" />
-			Notify me when a new game starts
-		</label>
-	</div>
-	<div>
-		<label>
-			<input type="checkbox" checked="@preferences.AutoJoinNextGame"
-				@onchange="e => HandlePreferenceChange(nameof(preferences.AutoJoinNextGame), (bool)e.Value!)" />
-			Auto-join next game
-		</label>
+	<div class="bge-section" style="max-width:400px">
+		<div class="bge-section-body">
+			<label class="d-flex align-items-center gap-2 mb-2" style="cursor:pointer">
+				<input type="checkbox" checked="@preferences.WantsGameNotification"
+					@onchange="e => HandlePreferenceChange(nameof(preferences.WantsGameNotification), (bool)e.Value!)" />
+				<span style="font-size:0.85rem">Notify me when a new game starts</span>
+			</label>
+			<label class="d-flex align-items-center gap-2" style="cursor:pointer">
+				<input type="checkbox" checked="@preferences.AutoJoinNextGame"
+					@onchange="e => HandlePreferenceChange(nameof(preferences.AutoJoinNextGame), (bool)e.Value!)" />
+				<span style="font-size:0.85rem">Auto-join next game</span>
+			</label>
+		</div>
 	</div>
 }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Players.razor
@@ -15,7 +15,7 @@
 	<div class="row g-3 mb-4">
 		@foreach (var player in players) {
 			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card h-100 @(players.Count > 1 ? "" : "")">
+				<div class="card h-100">
 					<div class="card-body d-flex flex-column">
 						<div class="d-flex align-items-center gap-2 mb-2">
 							<div class="profile-avatar-placeholder" style="width:40px;height:40px;font-size:1.1rem;border-width:1px">
@@ -40,6 +40,7 @@
 						} else {
 							<button class="btn btn-sm btn-outline-secondary" @onclick="() => HandleGenerateKey(player.PlayerId)">Generate Key</button>
 						}
+						<button class="btn btn-sm btn-outline-secondary" disabled title="Not yet available">Delete</button>
 					</div>
 				</div>
 			</div>
@@ -52,6 +53,7 @@
 					<div style="font-weight:600; font-size:0.85rem; margin-bottom:0.75rem">Create New Player</div>
 					<EditForm Model="@createModel" OnValidSubmit="HandleCreatePlayer">
 						<DataAnnotationsValidator />
+						<ValidationSummary />
 						<div class="mb-2">
 							<InputText class="form-control form-control-sm" @bind-Value="createModel.PlayerName" placeholder="Player name" />
 							<ValidationMessage For="@(() => createModel.PlayerName)" />

--- a/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Units.razor
@@ -7,68 +7,107 @@
 
 <PageTitle>Units — Age of Agents</PageTitle>
 
-
 <h1>Units</h1>
 
 @if (!string.IsNullOrEmpty(lastError)) {
-    <span class="error">@lastError</span>
+    <div class="alert alert-danger">@lastError</div>
 }
 
 <_BuildQueue />
 
 @if (model == null) {
-    <p><em>Loading...</em></p>
+    <div class="bge-loading"><div class="bge-spinner"></div> Loading units...</div>
+} else if (model.Units == null || !model.Units.Any()) {
+    <div class="bge-empty">
+        <div class="bge-empty-icon">&#9876;</div>
+        <div class="bge-empty-title">No units yet</div>
+        <div class="bge-empty-desc">Build units from your base buildings to start training your army.</div>
+    </div>
 } else {
-    <button class="btn btn-primary" @onclick="MergeAll">
-        Merge All Troops
-    </button>
+    <div class="d-flex gap-2 mb-3 flex-wrap align-items-center">
+        <button class="btn btn-sm btn-secondary" @onclick="MergeAll" title="Combine all unit stacks of the same type into single stacks">
+            Merge All
+        </button>
+        <span class="text-muted" style="font-size:0.78rem">
+            @model.Units.Sum(u => u.Count) units in @model.Units.Count stacks
+        </span>
+    </div>
 
-    <div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Count</th>
-                <th>Properties</th>
-                <th>Position</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            @if (model.Units != null) {
-                @foreach (var item in model.Units.OrderByDescending(x => x.Count).ThenBy(x => x.Definition.Name)) {
-                    <tr>
-                        <td>@item.Definition?.Name</td>
-                        <td>@item.Count</td>
-                        <td><_UnitProperties UnitDef="item.Definition" /></td>
-                        <td>
-                            @if (item.PositionPlayerId != null) {
-                                <NavLink class="nav-link" href="@($"enemybase/{Uri.EscapeDataString(item.PositionPlayerId)}")">
-                                    @(item.PositionPlayerName ?? item.PositionPlayerId)
-                                </NavLink>
-                            }
-                        </td>
-                        <td>
-                            <button class="btn btn-primary" @onclick="async () => await Merge(item.Definition!.Id!)">
-                                Merge units of this type
-                            </button>
+    @if (model.Units.Any(u => u.PositionPlayerId != null)) {
+        <div class="bge-section mb-3">
+            <div class="bge-section-header" style="cursor:default">
+                <span class="bge-section-title">Deployed (@model.Units.Where(u => u.PositionPlayerId != null).Sum(u => u.Count) units)</span>
+                <span class="status-tag status-tag-attacking">In Combat</span>
+            </div>
+            <div class="bge-section-body p-0">
+                <div class="table-responsive" style="border:none; border-radius:0">
+                <table class="table table-sm mb-0">
+                    <thead><tr><th>Unit</th><th style="text-align:right">Count</th><th>Stats</th><th>Location</th><th>Actions</th></tr></thead>
+                    <tbody>
+                        @foreach (var item in model.Units.Where(u => u.PositionPlayerId != null).OrderByDescending(x => x.Count).ThenBy(x => x.Definition.Name)) {
+                            <tr>
+                                <td><strong>@item.Definition?.Name</strong></td>
+                                <td style="text-align:right"><span class="text-resource">@item.Count</span></td>
+                                <td><_UnitProperties UnitDef="item.Definition" /></td>
+                                <td>
+                                    <NavLink class="nav-link p-0" style="font-size:0.82rem" href="@($"enemybase/{Uri.EscapeDataString(item.PositionPlayerId!)}")">
+                                        @(item.PositionPlayerName ?? item.PositionPlayerId)
+                                    </NavLink>
+                                </td>
+                                <td>
+                                    <div class="action-group">
+                                        <button class="btn btn-sm btn-secondary" @onclick="async () => await Merge(item.Definition!.Id!)">Merge</button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                </div>
+            </div>
+        </div>
+    }
 
-                            @if (item.Count > 1) {
-                                @if (!IsShowSplit(item.UnitId)) {
-                                    <button class="btn btn-primary" @onclick="() => ToggleShowSplit(item.UnitId)">
-                                        Split troops
-                                    </button>
-                                } else {
-                                    <_SplitUnitForm UnitId="item.UnitId" SplitDoneEvent="Update" InitCount="item.Count / 2" />
-                                }
-                            }
-                            <NavLink class="btn btn-sm btn-danger" href="@($"selectenemy/{item.UnitId}")">Attack</NavLink>
-                        </td>
-                    </tr>
-                }
+    <div class="bge-section">
+        <div class="bge-section-header" style="cursor:default">
+            <span class="bge-section-title">Home Base (@model.Units.Where(u => u.PositionPlayerId == null).Sum(u => u.Count) units)</span>
+            <span class="status-tag status-tag-home">Defending</span>
+        </div>
+        <div class="bge-section-body p-0">
+            @if (!model.Units.Any(u => u.PositionPlayerId == null)) {
+                <div class="bge-empty" style="padding:1.5rem">
+                    <div class="bge-empty-desc">All units are deployed.</div>
+                </div>
+            } else {
+                <div class="table-responsive" style="border:none; border-radius:0">
+                <table class="table table-sm mb-0">
+                    <thead><tr><th>Unit</th><th style="text-align:right">Count</th><th>Stats</th><th>Actions</th></tr></thead>
+                    <tbody>
+                        @foreach (var item in model.Units.Where(u => u.PositionPlayerId == null).OrderByDescending(x => x.Count).ThenBy(x => x.Definition.Name)) {
+                            <tr>
+                                <td><strong>@item.Definition?.Name</strong></td>
+                                <td style="text-align:right"><span class="text-resource">@item.Count</span></td>
+                                <td><_UnitProperties UnitDef="item.Definition" /></td>
+                                <td>
+                                    <div class="action-group">
+                                        <NavLink class="btn btn-sm btn-danger" href="@($"selectenemy/{item.UnitId}")">Attack</NavLink>
+                                        <button class="btn btn-sm btn-secondary" @onclick="async () => await Merge(item.Definition!.Id!)">Merge</button>
+                                        @if (item.Count > 1) {
+                                            @if (!IsShowSplit(item.UnitId)) {
+                                                <button class="btn btn-sm btn-secondary" @onclick="() => ToggleShowSplit(item.UnitId)">Split</button>
+                                            } else {
+                                                <_SplitUnitForm UnitId="item.UnitId" SplitDoneEvent="Update" InitCount="item.Count / 2" />
+                                            }
+                                        }
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                </div>
             }
-        </tbody>
-    </table>
+        </div>
     </div>
 }
 
@@ -105,8 +144,7 @@
         if (response.IsSuccessStatusCode) {
             await Update();
         } else {
-            var error = await response.Content.ReadAsStringAsync();
-            lastError = error;
+            lastError = await response.Content.ReadAsStringAsync();
         }
     }
 
@@ -115,8 +153,7 @@
         if (response.IsSuccessStatusCode) {
             await Update();
         } else {
-            var error = await response.Content.ReadAsStringAsync();
-            lastError = error;
+            lastError = await response.Content.ReadAsStringAsync();
         }
     }
 

--- a/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_BuildQueue.razor
@@ -1,41 +1,58 @@
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
-<h3>Build Queue</h3>
-
 @if (!string.IsNullOrEmpty(lastError)) {
-    <span class="error">@lastError</span>
+    <div class="alert alert-danger py-1 px-2" style="font-size:0.82rem;">@lastError</div>
 }
 
 @if (model == null) {
-    <p><em>Loading...</em></p>
+    @* Silent loading — queue is non-critical *@
 } else if (!model.Entries.Any()) {
-    <p>No items in the build queue.</p>
+    <div class="bge-section mb-3">
+        <div class="bge-section-header" style="cursor:default">
+            <span class="bge-section-title">Build Queue</span>
+            <span class="text-muted" style="font-size:0.72rem">empty</span>
+        </div>
+    </div>
 } else {
-    <table class="table table-sm">
-        <thead>
-            <tr>
-                <th>Priority</th>
-                <th>Type</th>
-                <th>Name</th>
-                <th>Count</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var entry in model.Entries.OrderBy(x => x.Priority)) {
-                <tr>
-                    <td>@entry.Priority</td>
-                    <td>@(entry.Type == "asset" ? "Building" : "Unit")</td>
-                    <td>@entry.Name</td>
-                    <td>@entry.Count</td>
-                    <td>
-                        <button class="btn btn-sm btn-danger" @onclick="() => RemoveEntry(entry.Id)">Remove</button>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
+    <div class="bge-section mb-3">
+        <div class="bge-section-header" style="cursor:default">
+            <span class="bge-section-title">Build Queue</span>
+            <span class="badge bg-primary">@model.Entries.Count items</span>
+        </div>
+        <div class="bge-section-body p-0">
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th style="width:40px">#</th>
+                        <th>Item</th>
+                        <th style="text-align:right">Count</th>
+                        <th style="width:70px"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var entry in model.Entries.OrderBy(x => x.Priority)) {
+                        <tr>
+                            <td class="text-muted">@entry.Priority</td>
+                            <td>
+                                <span class="badge @(entry.Type == "asset" ? "bg-info" : "bg-secondary") me-1" style="font-size:0.65rem">
+                                    @(entry.Type == "asset" ? "Building" : "Unit")
+                                </span>
+                                @entry.Name
+                            </td>
+                            <td style="text-align:right" class="text-resource">@entry.Count</td>
+                            <td>
+                                <button class="btn btn-sm btn-outline-danger" style="font-size:0.7rem; padding:0.15rem 0.4rem"
+                                    @onclick="() => RemoveEntry(entry.Id)" title="Remove from queue">
+                                    Remove
+                                </button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
 }
 
 @code {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_Cost.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_Cost.razor
@@ -1,12 +1,9 @@
-﻿<div>
-    @foreach(var c in Cost.Cost) {
-        <div>
-            @c.Key: @c.Value
-        </div>
+@* Inline cost display with resource-styled badges *@
+<span class="cost-inline">
+    @foreach (var c in Cost.Cost) {
+        <span class="cost-badge"><span class="cost-label">@c.Key</span> <span class="cost-value">@c.Value</span></span>
     }
-    
-</div>
-
+</span>
 
 @code {
     [Parameter]

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -86,7 +86,7 @@
 
     private string CountdownClass(DateTime nextTickAt) {
         var remaining = nextTickAt - DateTime.UtcNow;
-        return remaining.TotalSeconds < 5 ? "countdown-urgent" : "";
+        return remaining.TotalSeconds < 60 ? "countdown-urgent" : "";
     }
 
     public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_PlayerResources.razor
@@ -5,15 +5,27 @@
 
 @if (resources != null) {
     <div class="d-flex flex-wrap gap-3 align-items-center small">
-        <span><strong>@resources.PrimaryResource.Cost.First().Key</strong>: <span class="text-resource">@resources.PrimaryResource.Cost.First().Value</span></span>
+        @foreach (var res in resources.PrimaryResource.Cost) {
+            <span class="resource-item" title="@res.Key">
+                <strong style="text-transform:capitalize">@res.Key</strong>
+                <span class="text-resource">@FormatNumber(res.Value)</span>
+            </span>
+        }
         @foreach (var res in resources.SecondaryResources.Cost) {
-            <span><strong>@res.Key</strong>: <span class="text-resource">@res.Value</span></span>
+            <span class="resource-item" title="@res.Key">
+                <strong style="text-transform:capitalize">@res.Key</strong>
+                <span class="text-resource">@FormatNumber(res.Value)</span>
+            </span>
         }
         @if (tickInfo != null) {
-            <span><strong>Server:</strong> @tickInfo.ServerTime.ToString("HH:mm:ss") UTC</span>
-            <span><strong>Next tick:</strong> <span class="@CountdownClass(tickInfo.NextTickAt)">@FormatCountdown(tickInfo.NextTickAt)</span></span>
+            <span class="resource-item" style="opacity:0.6">
+                <span>Tick</span>
+                <span class="@CountdownClass(tickInfo.NextTickAt)">@FormatCountdown(tickInfo.NextTickAt)</span>
+            </span>
             @if (tickInfo.UnreadMessageCount > 0) {
-                <span class="badge bg-danger">@tickInfo.UnreadMessageCount unread</span>
+                <a href="messages" class="badge bg-danger text-decoration-none" title="@tickInfo.UnreadMessageCount unread messages">
+                    @tickInfo.UnreadMessageCount unread
+                </a>
             }
         }
     </div>
@@ -60,6 +72,12 @@
         }
     }
 
+    private static string FormatNumber(decimal value) {
+        if (value >= 1_000_000) return $"{value / 1_000_000:0.#}M";
+        if (value >= 10_000) return $"{value / 1_000:0.#}K";
+        return value.ToString("#,0");
+    }
+
     private string FormatCountdown(DateTime nextTickAt) {
         var remaining = nextTickAt - DateTime.UtcNow;
         if (remaining <= TimeSpan.Zero) return "now";
@@ -68,7 +86,7 @@
 
     private string CountdownClass(DateTime nextTickAt) {
         var remaining = nextTickAt - DateTime.UtcNow;
-        return remaining.TotalSeconds < 60 ? "countdown-urgent" : "";
+        return remaining.TotalSeconds < 5 ? "countdown-urgent" : "";
     }
 
     public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/_WorkerAssignment.razor
@@ -4,20 +4,60 @@
 @inject TutorialService Tutorial
 
 @if (!string.IsNullOrEmpty(lastError)) {
-	<span class="error">@lastError</span>
+	<div class="alert alert-danger py-1 px-2 mb-2" style="font-size:0.82rem;">@lastError</div>
 }
 @if (model != null) {
-	<div>
-		<h3>Workers</h3>
-		<div>Total: @model.TotalWorkers</div>
-		<div>Idle: @(model.TotalWorkers - mineralWorkers - gasWorkers)</div>
-		<div>
-			<label>Minerals: <InputNumber @bind-Value="mineralWorkers" /></label>
+	<div class="bge-workers">
+		<div class="d-flex align-items-center justify-content-between mb-2">
+			<h3>Workers</h3>
+			<span class="badge bg-secondary">@model.TotalWorkers total</span>
 		</div>
-		<div>
-			<label>Gas: <InputNumber @bind-Value="gasWorkers" /></label>
+
+		<div class="worker-bars mb-3">
+			@{ var idle = model.TotalWorkers - mineralWorkers - gasWorkers; }
+			@if (model.TotalWorkers > 0) {
+				<div class="worker-bar">
+					@if (mineralWorkers > 0) {
+						<div class="worker-bar-seg worker-bar-minerals" style="width:@((double)mineralWorkers / model.TotalWorkers * 100)%"
+							title="@mineralWorkers mining minerals">@mineralWorkers</div>
+					}
+					@if (gasWorkers > 0) {
+						<div class="worker-bar-seg worker-bar-gas" style="width:@((double)gasWorkers / model.TotalWorkers * 100)%"
+							title="@gasWorkers harvesting gas">@gasWorkers</div>
+					}
+					@if (idle > 0) {
+						<div class="worker-bar-seg worker-bar-idle" style="width:@((double)idle / model.TotalWorkers * 100)%"
+							title="@idle idle">@idle</div>
+					}
+				</div>
+				<div class="worker-legend">
+					<span class="worker-legend-item"><span class="worker-dot worker-dot-minerals"></span> Minerals</span>
+					<span class="worker-legend-item"><span class="worker-dot worker-dot-gas"></span> Gas</span>
+					<span class="worker-legend-item"><span class="worker-dot worker-dot-idle"></span> Idle</span>
+				</div>
+			}
 		</div>
-		<button @onclick="Assign">Assign</button>
+
+		<div class="d-flex gap-3 align-items-end flex-wrap">
+			<div>
+				<label class="form-label mb-1">Minerals</label>
+				<input type="number" class="form-control form-control-sm" min="0" max="@model.TotalWorkers"
+					style="width:80px" @bind="mineralWorkers" />
+			</div>
+			<div>
+				<label class="form-label mb-1">Gas</label>
+				<input type="number" class="form-control form-control-sm" min="0" max="@model.TotalWorkers"
+					style="width:80px" @bind="gasWorkers" />
+			</div>
+			<div>
+				<button class="btn btn-sm btn-primary" @onclick="Assign" disabled="@assigning">
+					@(assigning ? "Assigning..." : "Assign")
+				</button>
+			</div>
+			@if (idle > 0) {
+				<div class="text-warning" style="font-size:0.78rem;">@idle idle workers</div>
+			}
+		</div>
 	</div>
 }
 
@@ -26,6 +66,7 @@
 	private string? lastError;
 	private int mineralWorkers;
 	private int gasWorkers;
+	private bool assigning;
 
 	protected override async Task OnInitializedAsync() {
 		await Load();
@@ -41,7 +82,9 @@
 
 	private async Task Assign() {
 		lastError = null;
+		assigning = true;
 		var response = await Http.PostAsJsonAsync($"api/workers/assign?mineralWorkers={mineralWorkers}&gasWorkers={gasWorkers}", "");
+		assigning = false;
 		if (response.IsSuccessStatusCode) {
 			await Tutorial.MarkStepAsync(1);
 			await Load();

--- a/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
+++ b/src/BrowserGameEngine.BlazorClient/wwwroot/css/app.css
@@ -1359,3 +1359,297 @@ tbody tr:hover {
 .notif-item--default {
     border-left: 3px solid transparent;
 }
+
+/* =====================================================================
+   UX Enhancement Components
+   ===================================================================== */
+
+/* --- Cost badges ---------------------------------------------------- */
+.cost-inline {
+    display: inline-flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.cost-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    padding: 0.15rem 0.45rem;
+    font-size: 0.78rem;
+    white-space: nowrap;
+}
+
+.cost-label {
+    color: var(--color-text-muted);
+    text-transform: capitalize;
+}
+
+.cost-value {
+    color: var(--color-text-resource);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+/* --- Worker assignment bars ----------------------------------------- */
+.bge-workers {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.25rem;
+}
+
+.bge-workers h3 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+    margin-bottom: 0;
+}
+
+.worker-bar {
+    display: flex;
+    height: 24px;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-subtle);
+}
+
+.worker-bar-seg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #fff;
+    min-width: 20px;
+    transition: width 0.3s ease;
+}
+
+.worker-bar-minerals { background: #2563EB; }
+.worker-bar-gas { background: #7C3AED; }
+.worker-bar-idle { background: var(--color-bg-hover); color: var(--color-text-muted); }
+
+.worker-legend {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.35rem;
+    font-size: 0.72rem;
+    color: var(--color-text-muted);
+}
+
+.worker-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.worker-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.worker-dot-minerals { background: #2563EB; }
+.worker-dot-gas { background: #7C3AED; }
+.worker-dot-idle { background: var(--color-bg-hover); border: 1px solid var(--color-border-default); }
+
+/* --- Resource bar (top row) improvements ----------------------------- */
+.resource-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.resource-icon {
+    font-size: 0.9rem;
+    opacity: 0.6;
+}
+
+/* --- Loading spinner ------------------------------------------------- */
+.bge-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 2rem;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+}
+
+.bge-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--color-border-default);
+    border-top-color: var(--color-accent-primary);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+}
+
+/* --- Empty state ----------------------------------------------------- */
+.bge-empty {
+    text-align: center;
+    padding: 2.5rem 1.5rem;
+    color: var(--color-text-muted);
+}
+
+.bge-empty-icon {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+    opacity: 0.3;
+}
+
+.bge-empty-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.3rem;
+}
+
+.bge-empty-desc {
+    font-size: 0.82rem;
+    max-width: 280px;
+    margin: 0 auto;
+    line-height: 1.4;
+}
+
+/* --- Section cards (Base page organization) -------------------------- */
+.bge-section {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+}
+
+.bge-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.65rem 1rem;
+    background: var(--color-bg-elevated);
+    border-bottom: 1px solid var(--color-border-subtle);
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.12s;
+}
+
+.bge-section-header:hover {
+    background: var(--color-bg-hover);
+}
+
+.bge-section-title {
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.bge-section-toggle {
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    transition: transform 0.2s;
+}
+
+.bge-section-body {
+    padding: 1rem 1.25rem;
+}
+
+/* --- Game switcher tooltip ------------------------------------------- */
+.nav-game-icon[title] {
+    position: relative;
+}
+
+/* --- Status tags ----------------------------------------------------- */
+.status-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.status-tag-home {
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--color-text-success);
+    border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.status-tag-traveling {
+    background: rgba(251, 191, 36, 0.1);
+    color: var(--color-text-warning);
+    border: 1px solid rgba(251, 191, 36, 0.2);
+}
+
+.status-tag-attacking {
+    background: rgba(248, 113, 113, 0.1);
+    color: var(--color-text-error);
+    border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+/* --- Inline action group --------------------------------------------- */
+.action-group {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+/* --- Tooltip-like help text ------------------------------------------ */
+.help-hint {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    line-height: 14px;
+    text-align: center;
+    font-size: 0.65rem;
+    font-weight: 700;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: 50%;
+    color: var(--color-text-muted);
+    cursor: help;
+    vertical-align: middle;
+    margin-left: 0.25rem;
+}
+
+/* --- API key display ------------------------------------------------ */
+.api-key-box {
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    padding: 0.75rem 1rem;
+    margin-top: 1rem;
+}
+
+.api-key-box code {
+    background: var(--color-bg-primary);
+    padding: 0.3rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    word-break: break-all;
+    display: block;
+    margin: 0.5rem 0;
+}
+
+/* --- Table improvements ---------------------------------------------- */
+.table-responsive {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+}
+
+.table-responsive .table {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
Major UX improvements across core gameplay components, focused on clarity and polish.

### Changes
- **Worker Assignment**: Visual stacked bar showing mineral/gas/idle distribution with color legend
- **Cost Display**: Inline resource badges (styled chips) replacing plain `key: value` text
- **Units Page**: Split into "Home Base" (defending) and "Deployed" (in combat) sections with status tags, empty states, and unit counts
- **Build Queue**: Collapsible section card with item type badges (Building/Unit), cleaner layout
- **Resource Bar**: Number formatting (K/M for large values), tick countdown, clickable unread message badge linking to messages
- **Players Page**: Card-based layout with avatar initials, create-player as a dashed "add" card, styled API key display
- **Loading States**: Consistent spinner component replacing "Loading..." text everywhere
- **Empty States**: Helpful messages with icons and descriptions when no data exists
- **New CSS Components**: Section cards, worker bars, cost badges, status tags, action groups, loading spinners, empty states, responsive table wrappers

### Design Principles Applied
- Saturated neutrals with blue tint for cohesion
- Visual hierarchy through contrast, not size
- Tabular-nums for resource values
- Consistent border-radius and spacing tokens
- Hover transitions on interactive elements
- Responsive table wrappers

## Test plan
- [ ] Worker assignment: verify bar updates when workers are reassigned
- [ ] Cost badges: verify inline display on Base page assets and Upgrades page
- [ ] Units: verify home/deployed grouping, empty states
- [ ] Build queue: verify section collapses when empty, shows badge count
- [ ] Resource bar: verify large numbers show K/M format
- [ ] Players page: verify card layout, create player, switch player
- [ ] Loading spinners: verify shown during initial page loads
- [ ] All 210 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)