### PR TITLE
fix: add game-scoped route to UnitDefinition page

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/UnitDefinition.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/UnitDefinition.razor
@@ -1,4 +1,5 @@
 @page "/unitdefinitions"
+@page "/games/{GameId}/unitdefinitions"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 
@@ -32,6 +33,9 @@
 }
 
 @code {
+    [Parameter]
+    public string? GameId { get; set; }
+
     private UnitDefinitionViewModel[]? model;
 
     protected override async Task OnInitializedAsync() {


### PR DESCRIPTION
## Summary
- Added `@page "/games/{GameId}/unitdefinitions"` route and `GameId` parameter to `UnitDefinition.razor`
- Without this, navigating to `/games/league-round-1/unitdefinitions` caused a full page reload (flicker) instead of client-side Blazor routing

## Test plan
- Navigate to `/games/<game-id>/unitdefinitions` and confirm no flicker/reload