### PR TITLE
feat: BGE-467 alliance invite & war system

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -21,6 +21,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly AllianceChatRepositoryWrite allianceChatRepositoryWrite;
 		private readonly PlayerRepository playerRepository;
 		private readonly INotificationService notificationService;
+		private readonly AllianceInviteRepository allianceInviteRepository;
+		private readonly AllianceInviteRepositoryWrite allianceInviteRepositoryWrite;
+		private readonly AllianceWarRepository allianceWarRepository;
+		private readonly AllianceWarRepositoryWrite allianceWarRepositoryWrite;
 
 		public AlliancesController(
 			CurrentUserContext currentUserContext,
@@ -29,7 +33,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			AllianceChatRepository allianceChatRepository,
 			AllianceChatRepositoryWrite allianceChatRepositoryWrite,
 			PlayerRepository playerRepository,
-			INotificationService notificationService
+			INotificationService notificationService,
+			AllianceInviteRepository allianceInviteRepository,
+			AllianceInviteRepositoryWrite allianceInviteRepositoryWrite,
+			AllianceWarRepository allianceWarRepository,
+			AllianceWarRepositoryWrite allianceWarRepositoryWrite
 		) {
 			this.currentUserContext = currentUserContext;
 			this.allianceRepository = allianceRepository;
@@ -38,6 +46,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.allianceChatRepositoryWrite = allianceChatRepositoryWrite;
 			this.playerRepository = playerRepository;
 			this.notificationService = notificationService;
+			this.allianceInviteRepository = allianceInviteRepository;
+			this.allianceInviteRepositoryWrite = allianceInviteRepositoryWrite;
+			this.allianceWarRepository = allianceWarRepository;
+			this.allianceWarRepositoryWrite = allianceWarRepositoryWrite;
 		}
 
 		/// <summary>Returns all alliances in the current game.</summary>
@@ -285,6 +297,196 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			} catch (NotAllianceMemberException e) {
 				return StatusCode(403, e.Message);
 			}
+		}
+
+		/// <summary>Invites a player to the alliance (leader only).</summary>
+		/// <param name="id">The alliance ID.</param>
+		/// <param name="request">The invite request containing the target player ID.</param>
+		[HttpPost("{id}/invite")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
+		public ActionResult InvitePlayer(string id, [FromBody] InvitePlayerRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var targetPlayerId = PlayerIdFactory.Create(request.TargetPlayerId);
+			if (!playerRepository.Exists(targetPlayerId)) return NotFound();
+			try {
+				allianceInviteRepositoryWrite.InvitePlayer(
+					new InvitePlayerToAllianceCommand(currentUserContext.PlayerId!, targetPlayerId));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (NotAllianceLeaderException e) {
+				return StatusCode(403, e.Message);
+			} catch (AlreadyInAllianceException e) {
+				return Conflict(e.Message);
+			} catch (InviteAlreadyExistsException e) {
+				return Conflict(e.Message);
+			}
+		}
+
+		/// <summary>Accepts an alliance invite.</summary>
+		/// <param name="id">The alliance ID.</param>
+		/// <param name="request">The accept invite request containing the invite ID.</param>
+		[HttpPost("{id}/accept-invite")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult AcceptInvite(string id, [FromBody] AcceptInviteRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceInviteRepositoryWrite.AcceptInvite(
+					new AcceptAllianceInviteCommand(currentUserContext.PlayerId!, AllianceInviteIdFactory.Create(request.InviteId)));
+				return Ok();
+			} catch (InviteNotFoundException) {
+				return NotFound();
+			}
+		}
+
+		/// <summary>Declines an alliance invite.</summary>
+		/// <param name="id">The alliance ID.</param>
+		/// <param name="request">The decline invite request containing the invite ID.</param>
+		[HttpPost("{id}/decline-invite")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult DeclineInvite(string id, [FromBody] AcceptInviteRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceInviteRepositoryWrite.DeclineInvite(
+					new DeclineAllianceInviteCommand(currentUserContext.PlayerId!, AllianceInviteIdFactory.Create(request.InviteId)));
+				return Ok();
+			} catch (InviteNotFoundException) {
+				return NotFound();
+			}
+		}
+
+		/// <summary>Returns all active invites for the current player.</summary>
+		[HttpGet("my-invites")]
+		[ProducesResponseType(typeof(IEnumerable<AllianceInviteViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<IEnumerable<AllianceInviteViewModel>> GetMyInvites() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var invites = allianceInviteRepository.GetActiveInvitesForPlayer(currentUserContext.PlayerId!);
+			return Ok(invites.Select(i => {
+				string allianceName;
+				try { allianceName = allianceRepository.Get(i.AllianceId)?.Name ?? i.AllianceId.ToString(); }
+				catch { allianceName = i.AllianceId.ToString(); }
+				string inviterName;
+				try { inviterName = playerRepository.Get(i.InviterPlayerId).Name; }
+				catch { inviterName = i.InviterPlayerId.Id; }
+				return new AllianceInviteViewModel {
+					InviteId = i.InviteId.ToString(),
+					AllianceId = i.AllianceId.ToString(),
+					AllianceName = allianceName,
+					InviterPlayerName = inviterName,
+					ExpiresAt = i.ExpiresAt
+				};
+			}));
+		}
+
+		/// <summary>Declares war on another alliance (leader only).</summary>
+		/// <param name="id">The declaring alliance ID.</param>
+		/// <param name="request">The declare war request containing the target alliance ID.</param>
+		[HttpPost("{id}/declare-war")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
+		public ActionResult DeclareWar(string id, [FromBody] DeclareWarRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceWarRepositoryWrite.DeclareWar(
+					new DeclareAllianceWarCommand(currentUserContext.PlayerId!, AllianceIdFactory.Create(request.TargetAllianceId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (NotAllianceLeaderException e) {
+				return StatusCode(403, e.Message);
+			} catch (AllianceNotFoundException) {
+				return NotFound();
+			} catch (AlreadyAtWarException e) {
+				return Conflict(e.Message);
+			}
+		}
+
+		/// <summary>Proposes or accepts peace for a war (based on current war state).</summary>
+		/// <param name="warId">The war ID.</param>
+		/// <param name="request">The peace request.</param>
+		[HttpPost("wars/{warId}/peace")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
+		public ActionResult Peace(string warId, [FromBody] PeaceRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				var warIdTyped = AllianceWarIdFactory.Create(warId);
+				var war = allianceWarRepository.GetWar(warIdTyped);
+				var player = playerRepository.Get(currentUserContext.PlayerId!);
+
+				if (war.Status == GameModel.AllianceWarStatus.Active) {
+					allianceWarRepositoryWrite.ProposePeace(new ProposeAlliancePeaceCommand(currentUserContext.PlayerId!, warIdTyped));
+					return Ok();
+				} else if (war.Status == GameModel.AllianceWarStatus.PeaceProposed) {
+					// Proposer cannot accept own proposal — map the leader exception from AcceptPeace to 409
+					try {
+						allianceWarRepositoryWrite.AcceptPeace(new AcceptAlliancePeaceCommand(currentUserContext.PlayerId!, warIdTyped));
+						return Ok();
+					} catch (NotAllianceLeaderException e) {
+						// If the leader tried to accept their own proposal, treat as conflict
+						return Conflict(e.Message);
+					}
+				} else {
+					return BadRequest("War is not in an active state.");
+				}
+			} catch (WarNotFoundException) {
+				return NotFound();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (PeaceAlreadyProposedException e) {
+				return Conflict(e.Message);
+			} catch (NotAtWarException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		/// <summary>Returns all active and recent wars for an alliance.</summary>
+		/// <param name="id">The alliance ID.</param>
+		[HttpGet("{id}/wars")]
+		[ProducesResponseType(typeof(IEnumerable<AllianceWarViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<IEnumerable<AllianceWarViewModel>> GetWars(string id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var allianceId = AllianceIdFactory.Create(id);
+			if (allianceRepository.Get(allianceId) == null) return NotFound();
+			var wars = allianceWarRepository.GetActiveWars(allianceId);
+			return Ok(wars.Select(w => {
+				string attackerName;
+				try { attackerName = allianceRepository.Get(w.AttackerAllianceId)?.Name ?? w.AttackerAllianceId.ToString(); }
+				catch { attackerName = w.AttackerAllianceId.ToString(); }
+				string defenderName;
+				try { defenderName = allianceRepository.Get(w.DefenderAllianceId)?.Name ?? w.DefenderAllianceId.ToString(); }
+				catch { defenderName = w.DefenderAllianceId.ToString(); }
+				return new AllianceWarViewModel {
+					WarId = w.WarId.ToString(),
+					AttackerAllianceId = w.AttackerAllianceId.ToString(),
+					AttackerAllianceName = attackerName,
+					DefenderAllianceId = w.DefenderAllianceId.ToString(),
+					DefenderAllianceName = defenderName,
+					Status = w.Status.ToString(),
+					DeclaredAt = w.DeclaredAt,
+					ProposerAllianceId = w.ProposerAllianceId?.ToString()
+				};
+			}));
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
@@ -17,6 +17,7 @@ namespace BrowserGameEngine.GameModel {
 		DateTime Created,
 		IList<AllianceMemberImmutable> Members,
 		string? Message = null,
-		IList<AlliancePostImmutable>? Posts = null
+		IList<AlliancePostImmutable>? Posts = null,
+		IList<AllianceInviteImmutable>? Invites = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/AllianceInviteId.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceInviteId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record AllianceInviteId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class AllianceInviteIdFactory {
+		public static AllianceInviteId Create(Guid id) => new AllianceInviteId(id);
+		public static AllianceInviteId Create(string id) => new AllianceInviteId(Guid.Parse(id));
+		public static AllianceInviteId NewAllianceInviteId() => new AllianceInviteId(Guid.NewGuid());
+	}
+}

--- a/src/BrowserGameEngine.GameModel/AllianceInviteImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceInviteImmutable.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record AllianceInviteImmutable(
+		AllianceInviteId InviteId,
+		AllianceId AllianceId,
+		PlayerId InviterPlayerId,
+		PlayerId InviteePlayerId,
+		DateTime CreatedAt,
+		DateTime ExpiresAt
+	);
+}

--- a/src/BrowserGameEngine.GameModel/AllianceWarId.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceWarId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record AllianceWarId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class AllianceWarIdFactory {
+		public static AllianceWarId Create(Guid id) => new AllianceWarId(id);
+		public static AllianceWarId Create(string id) => new AllianceWarId(Guid.Parse(id));
+		public static AllianceWarId NewAllianceWarId() => new AllianceWarId(Guid.NewGuid());
+	}
+}

--- a/src/BrowserGameEngine.GameModel/AllianceWarImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceWarImmutable.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public enum AllianceWarStatus { Active, PeaceProposed, Ended }
+
+	public record AllianceWarImmutable(
+		AllianceWarId WarId,
+		AllianceId AttackerAllianceId,
+		AllianceId DefenderAllianceId,
+		AllianceWarStatus Status,
+		DateTime DeclaredAt,
+		AllianceId? ProposerAllianceId = null,
+		DateTime? EndedAt = null
+	);
+}

--- a/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
@@ -8,6 +8,7 @@ namespace BrowserGameEngine.GameModel {
 		IDictionary<AllianceId, AllianceImmutable>? Alliances = null,
 		GameId? GameId = null,  // null = legacy JSON; treated as "default" in ToMutable()
 		IList<MarketOrderImmutable>? MarketOrders = null,
-		IList<ChatMessageImmutable>? ChatMessages = null
+		IList<ChatMessageImmutable>? ChatMessages = null,
+		IDictionary<AllianceWarId, AllianceWarImmutable>? Wars = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -68,4 +68,39 @@ namespace BrowserGameEngine.Shared {
 	public class PostAllianceChatRequest {
 		public required string Body { get; set; }
 	}
+
+	public class AllianceInviteViewModel {
+		public required string InviteId { get; set; }
+		public required string AllianceId { get; set; }
+		public required string AllianceName { get; set; }
+		public required string InviterPlayerName { get; set; }
+		public DateTime ExpiresAt { get; set; }
+	}
+
+	public class AllianceWarViewModel {
+		public required string WarId { get; set; }
+		public required string AttackerAllianceId { get; set; }
+		public required string AttackerAllianceName { get; set; }
+		public required string DefenderAllianceId { get; set; }
+		public required string DefenderAllianceName { get; set; }
+		public required string Status { get; set; }
+		public DateTime DeclaredAt { get; set; }
+		public string? ProposerAllianceId { get; set; }
+	}
+
+	public class InvitePlayerRequest {
+		public required string TargetPlayerId { get; set; }
+	}
+
+	public class DeclareWarRequest {
+		public required string TargetAllianceId { get; set; }
+	}
+
+	public class AcceptInviteRequest {
+		public required string InviteId { get; set; }
+	}
+
+	public class PeaceRequest {
+		public required string WarId { get; set; }
+	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceInviteTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceInviteTest.cs
@@ -1,0 +1,113 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class AllianceInviteTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+		private static readonly PlayerId Player3 = PlayerIdFactory.Create("player2");
+
+		private static AllianceId SetupAllianceWithLeader(TestGame game, PlayerId leader, string name = "TestAlliance") {
+			return game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(leader, name, "password"));
+		}
+
+		[Fact]
+		public void InviteAndAccept_PlayerBecomesFullMember() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = SetupAllianceWithLeader(game, Player1);
+
+			game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2));
+			var invites = game.AllianceInviteRepository.GetActiveInvitesForPlayer(Player2).ToList();
+			Assert.Single(invites);
+
+			var inviteId = invites[0].InviteId;
+			game.AllianceInviteRepositoryWrite.AcceptInvite(new AcceptAllianceInviteCommand(Player2, inviteId));
+
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			var member = alliance.Members.FirstOrDefault(m => m.PlayerId == Player2);
+			Assert.NotNull(member);
+			Assert.False(member.IsPending);
+		}
+
+		[Fact]
+		public void DeclineInvite_RemovesInvite() {
+			var game = new TestGame(playerCount: 3);
+			SetupAllianceWithLeader(game, Player1);
+
+			game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2));
+			var invites = game.AllianceInviteRepository.GetActiveInvitesForPlayer(Player2).ToList();
+			Assert.Single(invites);
+
+			var inviteId = invites[0].InviteId;
+			game.AllianceInviteRepositoryWrite.DeclineInvite(new DeclineAllianceInviteCommand(Player2, inviteId));
+
+			var invitesAfter = game.AllianceInviteRepository.GetActiveInvitesForPlayer(Player2).ToList();
+			Assert.Empty(invitesAfter);
+		}
+
+		[Fact]
+		public void ExpiredInvite_CannotBeAccepted() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = SetupAllianceWithLeader(game, Player1);
+
+			game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2));
+
+			// Get the invite ID before expiring it
+			var invites = game.AllianceInviteRepository.GetActiveInvitesForPlayer(Player2).ToList();
+			Assert.Single(invites);
+			var inviteId = invites[0].InviteId;
+
+			// Use snapshot to manipulate the world state via immutable/mutable round-trip
+			var snapshot = game.World.ToImmutable();
+			var allianceSnapshot = snapshot.Alliances![allianceId];
+			var inviteSnapshot = allianceSnapshot.Invites!.Single();
+			// Rebuild snapshot with expired invite
+			var expiredInvite = inviteSnapshot with { ExpiresAt = System.DateTime.UtcNow.AddHours(-1) };
+			var expiredInvites = new System.Collections.Generic.List<AllianceInviteImmutable> { expiredInvite };
+			var updatedAlliance = allianceSnapshot with { Invites = expiredInvites };
+			var updatedAlliances = new System.Collections.Generic.Dictionary<AllianceId, AllianceImmutable>(snapshot.Alliances!) { [allianceId] = updatedAlliance };
+			var updatedSnapshot = snapshot with { Alliances = updatedAlliances };
+			game.World.ReplaceFrom(updatedSnapshot);
+
+			Assert.Throws<InviteNotFoundException>(() =>
+				game.AllianceInviteRepositoryWrite.AcceptInvite(new AcceptAllianceInviteCommand(Player2, inviteId)));
+		}
+
+		[Fact]
+		public void InvitePlayerAlreadyInAlliance_Throws() {
+			var game = new TestGame(playerCount: 3);
+			SetupAllianceWithLeader(game, Player1);
+			SetupAllianceWithLeader(game, Player2, "OtherAlliance");
+
+			Assert.Throws<AlreadyInAllianceException>(() =>
+				game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2)));
+		}
+
+		[Fact]
+		public void DuplicateActiveInvite_Throws() {
+			var game = new TestGame(playerCount: 3);
+			SetupAllianceWithLeader(game, Player1);
+
+			game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2));
+
+			Assert.Throws<InviteAlreadyExistsException>(() =>
+				game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player1, Player2)));
+		}
+
+		[Fact]
+		public void NonLeaderInvite_Throws() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = SetupAllianceWithLeader(game, Player1);
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "password"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+
+			// Player2 is a member but not leader
+			Assert.Throws<NotAllianceLeaderException>(() =>
+				game.AllianceInviteRepositoryWrite.InvitePlayer(new InvitePlayerToAllianceCommand(Player2, Player3)));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceWarTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceWarTest.cs
@@ -1,0 +1,98 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class AllianceWarTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+		private static readonly PlayerId Player3 = PlayerIdFactory.Create("player2");
+
+		private static AllianceId SetupAlliance(TestGame game, PlayerId leader, string name) {
+			return game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(leader, name, "password"));
+		}
+
+		[Fact]
+		public void DeclareWar_ProposeAndAcceptPeace_StatusEnded() {
+			var game = new TestGame(playerCount: 3);
+			var alliance1Id = SetupAlliance(game, Player1, "Alliance1");
+			var alliance2Id = SetupAlliance(game, Player2, "Alliance2");
+
+			game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player1, alliance2Id));
+
+			var wars = game.AllianceWarRepository.GetActiveWars(alliance1Id).ToList();
+			Assert.Single(wars);
+			Assert.Equal(AllianceWarStatus.Active, wars[0].Status);
+
+			var warId = wars[0].WarId;
+
+			// Alliance1 proposes peace
+			game.AllianceWarRepositoryWrite.ProposePeace(new ProposeAlliancePeaceCommand(Player1, warId));
+			var warAfterProposal = game.AllianceWarRepository.GetWar(warId);
+			Assert.Equal(AllianceWarStatus.PeaceProposed, warAfterProposal.Status);
+			Assert.Equal(alliance1Id, warAfterProposal.ProposerAllianceId);
+
+			// Alliance2 accepts peace
+			game.AllianceWarRepositoryWrite.AcceptPeace(new AcceptAlliancePeaceCommand(Player2, warId));
+			var warAfterAccept = game.AllianceWarRepository.GetWar(warId);
+			Assert.Equal(AllianceWarStatus.Ended, warAfterAccept.Status);
+			Assert.NotNull(warAfterAccept.EndedAt);
+		}
+
+		[Fact]
+		public void ProposerCannotAcceptOwnPeaceProposal_Throws() {
+			var game = new TestGame(playerCount: 3);
+			var alliance1Id = SetupAlliance(game, Player1, "Alliance1");
+			var alliance2Id = SetupAlliance(game, Player2, "Alliance2");
+
+			game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player1, alliance2Id));
+			var warId = game.AllianceWarRepository.GetActiveWars(alliance1Id).Single().WarId;
+
+			game.AllianceWarRepositoryWrite.ProposePeace(new ProposeAlliancePeaceCommand(Player1, warId));
+
+			// Proposer tries to accept own proposal — should throw
+			Assert.Throws<NotAllianceLeaderException>(() =>
+				game.AllianceWarRepositoryWrite.AcceptPeace(new AcceptAlliancePeaceCommand(Player1, warId)));
+		}
+
+		[Fact]
+		public void DeclareWarAgainOnSameAlliance_Throws() {
+			var game = new TestGame(playerCount: 3);
+			var alliance1Id = SetupAlliance(game, Player1, "Alliance1");
+			var alliance2Id = SetupAlliance(game, Player2, "Alliance2");
+
+			game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player1, alliance2Id));
+
+			Assert.Throws<AlreadyAtWarException>(() =>
+				game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player1, alliance2Id)));
+		}
+
+		[Fact]
+		public void DeclareWar_NonLeader_Throws() {
+			var game = new TestGame(playerCount: 3);
+			var alliance1Id = SetupAlliance(game, Player1, "Alliance1");
+			var alliance2Id = SetupAlliance(game, Player2, "Alliance2");
+
+			// Player3 is not in any alliance
+			Assert.Throws<NotAllianceMemberException>(() =>
+				game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player3, alliance2Id)));
+		}
+
+		[Fact]
+		public void GetActiveWars_ExcludesEndedWars() {
+			var game = new TestGame(playerCount: 3);
+			var alliance1Id = SetupAlliance(game, Player1, "Alliance1");
+			var alliance2Id = SetupAlliance(game, Player2, "Alliance2");
+
+			game.AllianceWarRepositoryWrite.DeclareWar(new DeclareAllianceWarCommand(Player1, alliance2Id));
+			var warId = game.AllianceWarRepository.GetActiveWars(alliance1Id).Single().WarId;
+
+			game.AllianceWarRepositoryWrite.ProposePeace(new ProposeAlliancePeaceCommand(Player1, warId));
+			game.AllianceWarRepositoryWrite.AcceptPeace(new AcceptAlliancePeaceCommand(Player2, warId));
+
+			var activeWars = game.AllianceWarRepository.GetActiveWars(alliance1Id).ToList();
+			Assert.Empty(activeWars);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -21,6 +21,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public ScoreRepository ScoreRepository { get; }
 		public AllianceRepository AllianceRepository { get; }
 		public AllianceRepositoryWrite AllianceRepositoryWrite { get; }
+		public AllianceInviteRepository AllianceInviteRepository { get; }
+		public AllianceInviteRepositoryWrite AllianceInviteRepositoryWrite { get; }
+		public AllianceWarRepository AllianceWarRepository { get; }
+		public AllianceWarRepositoryWrite AllianceWarRepositoryWrite { get; }
 		public PlayerRepository PlayerRepository { get; }
 		public PlayerRepositoryWrite PlayerRepositoryWrite { get; }
 		public ResourceRepository ResourceRepository { get; }
@@ -59,6 +63,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			ScoreRepository = new ScoreRepository(GameDef, Accessor);
 			AllianceRepository = new AllianceRepository(Accessor);
 			AllianceRepositoryWrite = new AllianceRepositoryWrite(Accessor, AllianceRepository);
+			AllianceInviteRepository = new AllianceInviteRepository(Accessor);
+			AllianceInviteRepositoryWrite = new AllianceInviteRepositoryWrite(Accessor, AllianceInviteRepository);
+			AllianceWarRepository = new AllianceWarRepository(Accessor);
+			AllianceWarRepositoryWrite = new AllianceWarRepositoryWrite(Accessor);
 			PlayerRepository = new PlayerRepository(Accessor, ScoreRepository, AllianceRepository);
 			PlayerRepositoryWrite = new PlayerRepositoryWrite(Accessor, TimeProvider.System);
 			ResourceRepository = new ResourceRepository(Accessor, GameDef);

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -6,6 +6,12 @@ using System.Text;
 
 namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record CreateAllianceCommand(PlayerId PlayerId, string AllianceName, string Password) : ICommand;
+	public record InvitePlayerToAllianceCommand(PlayerId InviterPlayerId, PlayerId InviteePlayerId) : ICommand;
+	public record AcceptAllianceInviteCommand(PlayerId PlayerId, AllianceInviteId InviteId) : ICommand;
+	public record DeclineAllianceInviteCommand(PlayerId PlayerId, AllianceInviteId InviteId) : ICommand;
+	public record DeclareAllianceWarCommand(PlayerId PlayerId, AllianceId TargetAllianceId) : ICommand;
+	public record ProposeAlliancePeaceCommand(PlayerId PlayerId, AllianceWarId WarId) : ICommand;
+	public record AcceptAlliancePeaceCommand(PlayerId PlayerId, AllianceWarId WarId) : ICommand;
 	public record JoinAllianceCommand(PlayerId PlayerId, AllianceId AllianceId, string Password) : ICommand;
 	public record AcceptMemberCommand(PlayerId PlayerId, PlayerId MemberPlayerId) : ICommand;
 	public record RejectMemberCommand(PlayerId PlayerId, PlayerId MemberPlayerId) : ICommand;

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/AlreadyAtWarException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/AlreadyAtWarException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AlreadyAtWarException : Exception {
+		public AlreadyAtWarException() : base("These alliances are already at war.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/InviteAlreadyExistsException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/InviteAlreadyExistsException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class InviteAlreadyExistsException : Exception {
+		public InviteAlreadyExistsException() : base("An active invite already exists for this player.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/InviteNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/InviteNotFoundException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class InviteNotFoundException : Exception {
+		public InviteNotFoundException() : base("Invite not found or has expired.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAtWarException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/NotAtWarException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class NotAtWarException : Exception {
+		public NotAtWarException() : base("These alliances are not currently at war.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/PeaceAlreadyProposedException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/PeaceAlreadyProposedException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class PeaceAlreadyProposedException : Exception {
+		public PeaceAlreadyProposedException() : base("A peace proposal is already pending for this war.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/WarNotFoundException.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/WarNotFoundException.cs
@@ -1,0 +1,9 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class WarNotFoundException : Exception {
+		public WarNotFoundException(AllianceWarId warId) : base($"War '{warId}' does not exist.") {
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
@@ -19,6 +19,15 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public DateTime CreatedAt { get; set; }
 	}
 
+	internal class AllianceInvite {
+		public required AllianceInviteId InviteId { get; init; }
+		public required AllianceId AllianceId { get; set; }
+		public required PlayerId InviterPlayerId { get; set; }
+		public required PlayerId InviteePlayerId { get; set; }
+		public DateTime CreatedAt { get; set; }
+		public DateTime ExpiresAt { get; set; }
+	}
+
 	internal class Alliance {
 		public required AllianceId AllianceId { get; init; }
 		public required string Name { get; set; }
@@ -28,6 +37,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<AllianceMember> Members { get; set; } = new List<AllianceMember>();
 		public string? Message { get; set; }
 		public List<AlliancePost> Posts { get; set; } = new List<AlliancePost>();
+		public List<AllianceInvite> Invites { get; set; } = new List<AllianceInvite>();
 	}
 
 	internal static class AllianceExtensions {
@@ -69,6 +79,28 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			};
 		}
 
+		internal static AllianceInviteImmutable ToImmutable(this AllianceInvite invite) {
+			return new AllianceInviteImmutable(
+				InviteId: invite.InviteId,
+				AllianceId: invite.AllianceId,
+				InviterPlayerId: invite.InviterPlayerId,
+				InviteePlayerId: invite.InviteePlayerId,
+				CreatedAt: invite.CreatedAt,
+				ExpiresAt: invite.ExpiresAt
+			);
+		}
+
+		internal static AllianceInvite ToMutable(this AllianceInviteImmutable invite) {
+			return new AllianceInvite {
+				InviteId = invite.InviteId,
+				AllianceId = invite.AllianceId,
+				InviterPlayerId = invite.InviterPlayerId,
+				InviteePlayerId = invite.InviteePlayerId,
+				CreatedAt = invite.CreatedAt,
+				ExpiresAt = invite.ExpiresAt
+			};
+		}
+
 		internal static AllianceImmutable ToImmutable(this Alliance alliance) {
 			return new AllianceImmutable(
 				AllianceId: alliance.AllianceId,
@@ -78,7 +110,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created: alliance.Created,
 				Members: alliance.Members.Select(m => m.ToImmutable()).ToList(),
 				Message: alliance.Message,
-				Posts: alliance.Posts.Select(p => p.ToImmutable()).ToList()
+				Posts: alliance.Posts.Select(p => p.ToImmutable()).ToList(),
+				Invites: alliance.Invites.Select(i => i.ToImmutable()).ToList()
 			);
 		}
 
@@ -91,7 +124,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created = alliance.Created,
 				Members = alliance.Members.Select(m => m.ToMutable()).ToList(),
 				Message = alliance.Message,
-				Posts = alliance.Posts?.Select(p => p.ToMutable()).ToList() ?? new List<AlliancePost>()
+				Posts = alliance.Posts?.Select(p => p.ToMutable()).ToList() ?? new List<AlliancePost>(),
+				Invites = alliance.Invites?.Select(i => i.ToMutable()).ToList() ?? new List<AllianceInvite>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AllianceWar.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AllianceWar.cs
@@ -1,0 +1,35 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class AllianceWar {
+		public required AllianceWarId WarId { get; init; }
+		public required AllianceId AttackerAllianceId { get; set; }
+		public required AllianceId DefenderAllianceId { get; set; }
+		public AllianceWarStatus Status { get; set; }
+		public DateTime DeclaredAt { get; set; }
+		public AllianceId? ProposerAllianceId { get; set; }
+		public DateTime? EndedAt { get; set; }
+	}
+
+	internal static class AllianceWarExtensions {
+		internal static AllianceWarImmutable ToImmutable(this AllianceWar war) => new AllianceWarImmutable(
+			WarId: war.WarId,
+			AttackerAllianceId: war.AttackerAllianceId,
+			DefenderAllianceId: war.DefenderAllianceId,
+			Status: war.Status,
+			DeclaredAt: war.DeclaredAt,
+			ProposerAllianceId: war.ProposerAllianceId,
+			EndedAt: war.EndedAt);
+
+		internal static AllianceWar ToMutable(this AllianceWarImmutable war) => new AllianceWar {
+			WarId = war.WarId,
+			AttackerAllianceId = war.AttackerAllianceId,
+			DefenderAllianceId = war.DefenderAllianceId,
+			Status = war.Status,
+			DeclaredAt = war.DeclaredAt,
+			ProposerAllianceId = war.ProposerAllianceId,
+			EndedAt = war.EndedAt
+		};
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		internal IList<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
 		internal readonly Lock ChatMessagesLock = new();
 
+		internal IDictionary<AllianceWarId, AllianceWar> Wars { get; set; } = new ConcurrentDictionary<AllianceWarId, AllianceWar>();
 
 		// throws if player not found
 		internal Player GetPlayer(PlayerId playerId) {
@@ -37,6 +38,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		internal Alliance GetAlliance(AllianceId allianceId) {
 			if (Alliances.TryGetValue(allianceId, out Alliance? alliance)) return alliance;
 			throw new AllianceNotFoundException(allianceId);
+		}
+
+		// throws if war not found
+		internal AllianceWar GetWar(AllianceWarId warId) {
+			if (Wars.TryGetValue(warId, out AllianceWar? war)) return war;
+			throw new WarNotFoundException(warId);
 		}
 
 		internal bool PlayerExists(PlayerId playerId) {
@@ -74,6 +81,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			worldState.GameActionQueue = mutable.GameActionQueue;
 			worldState.MarketOrders = mutable.MarketOrders;
 			worldState.ChatMessages = mutable.ChatMessages;
+			worldState.Wars = mutable.Wars;
 		}
 
 
@@ -97,7 +105,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Alliances: worldState.Alliances.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameId: worldState.GameId,
 				MarketOrders: marketOrdersSnapshot,
-				ChatMessages: chatMessagesSnapshot
+				ChatMessages: chatMessagesSnapshot,
+				Wars: worldState.Wars.ToDictionary(x => x.Key, y => y.Value.ToImmutable())
 			);
 		}
 
@@ -109,7 +118,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GameTickState = worldStateImmutable.GameTickState.ToMutable(),
 				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList(),
 				MarketOrders = worldStateImmutable.MarketOrders?.ToMutable() ?? new List<MarketOrder>(),
-				ChatMessages = worldStateImmutable.ChatMessages?.ToMutable() ?? new List<ChatMessage>()
+				ChatMessages = worldStateImmutable.ChatMessages?.ToMutable() ?? new List<ChatMessage>(),
+				Wars = new ConcurrentDictionary<AllianceWarId, AllianceWar>(worldStateImmutable.Wars?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<AllianceWarId, AllianceWar>())
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -37,6 +37,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<AllianceRepositoryWrite>();
 			services.AddSingleton<AllianceChatRepository>();
 			services.AddSingleton<AllianceChatRepositoryWrite>();
+			services.AddSingleton<AllianceInviteRepository>();
+			services.AddSingleton<AllianceInviteRepositoryWrite>();
+			services.AddSingleton<AllianceWarRepository>();
+			services.AddSingleton<AllianceWarRepositoryWrite>();
 			services.AddSingleton<ChatRepositoryWrite>();
 			services.AddSingleton<AllianceScoreRepository>();
 			services.AddSingleton<AssetRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceInviteRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceInviteRepository.cs
@@ -1,0 +1,38 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceInviteRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public AllianceInviteRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IEnumerable<AllianceInviteImmutable> GetActiveInvitesForPlayer(PlayerId playerId) {
+			var now = DateTime.UtcNow;
+			return world.Alliances.Values
+				.SelectMany(a => a.Invites)
+				.Where(i => i.InviteePlayerId == playerId && i.ExpiresAt > now)
+				.Select(i => i.ToImmutable());
+		}
+
+		public IEnumerable<AllianceInviteImmutable> GetActiveInvitesForAlliance(AllianceId allianceId) {
+			var now = DateTime.UtcNow;
+			if (!world.Alliances.TryGetValue(allianceId, out var alliance)) return Enumerable.Empty<AllianceInviteImmutable>();
+			return alliance.Invites
+				.Where(i => i.ExpiresAt > now)
+				.Select(i => i.ToImmutable());
+		}
+
+		public bool HasPendingInvite(AllianceId allianceId, PlayerId inviteePlayerId) {
+			var now = DateTime.UtcNow;
+			if (!world.Alliances.TryGetValue(allianceId, out var alliance)) return false;
+			return alliance.Invites.Any(i => i.InviteePlayerId == inviteePlayerId && i.ExpiresAt > now);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceInviteRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceInviteRepositoryWrite.cs
@@ -1,0 +1,96 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceInviteRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly AllianceInviteRepository allianceInviteRepository;
+
+		public AllianceInviteRepositoryWrite(IWorldStateAccessor worldStateAccessor, AllianceInviteRepository allianceInviteRepository) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.allianceInviteRepository = allianceInviteRepository;
+		}
+
+		public void InvitePlayer(InvitePlayerToAllianceCommand command) {
+			lock (_lock) {
+				var inviter = world.GetPlayer(command.InviterPlayerId);
+				if (inviter.AllianceId == null) throw new NotAllianceMemberException();
+				var alliance = world.GetAlliance(inviter.AllianceId);
+				if (alliance.LeaderId != command.InviterPlayerId) throw new NotAllianceLeaderException();
+
+				if (!world.PlayerExists(command.InviteePlayerId)) throw new PlayerNotFoundException(command.InviteePlayerId);
+				var invitee = world.GetPlayer(command.InviteePlayerId);
+				if (invitee.AllianceId != null) throw new AlreadyInAllianceException();
+
+				if (allianceInviteRepository.HasPendingInvite(inviter.AllianceId, command.InviteePlayerId)) {
+					throw new InviteAlreadyExistsException();
+				}
+
+				var now = DateTime.UtcNow;
+				var invite = new AllianceInvite {
+					InviteId = AllianceInviteIdFactory.NewAllianceInviteId(),
+					AllianceId = inviter.AllianceId,
+					InviterPlayerId = command.InviterPlayerId,
+					InviteePlayerId = command.InviteePlayerId,
+					CreatedAt = now,
+					ExpiresAt = now.AddHours(24)
+				};
+				alliance.Invites.Add(invite);
+			}
+		}
+
+		public void AcceptInvite(AcceptAllianceInviteCommand command) {
+			lock (_lock) {
+				var now = DateTime.UtcNow;
+				AllianceInvite? foundInvite = null;
+				GameModelInternal.Alliance? foundAlliance = null;
+
+				foreach (var alliance in world.Alliances.Values) {
+					var invite = alliance.Invites.FirstOrDefault(i => i.InviteId == command.InviteId && i.InviteePlayerId == command.PlayerId && i.ExpiresAt > now);
+					if (invite != null) {
+						foundInvite = invite;
+						foundAlliance = alliance;
+						break;
+					}
+				}
+
+				if (foundInvite == null || foundAlliance == null) throw new InviteNotFoundException();
+
+				var player = world.GetPlayer(command.PlayerId);
+				foundAlliance.Members.Add(new AllianceMember {
+					PlayerId = command.PlayerId,
+					IsPending = false,
+					JoinedAt = now,
+					VoteCount = 0
+				});
+				player.AllianceId = foundAlliance.AllianceId;
+				foundAlliance.Invites.Remove(foundInvite);
+			}
+		}
+
+		public void DeclineInvite(DeclineAllianceInviteCommand command) {
+			lock (_lock) {
+				AllianceInvite? foundInvite = null;
+				GameModelInternal.Alliance? foundAlliance = null;
+
+				foreach (var alliance in world.Alliances.Values) {
+					var invite = alliance.Invites.FirstOrDefault(i => i.InviteId == command.InviteId && i.InviteePlayerId == command.PlayerId);
+					if (invite != null) {
+						foundInvite = invite;
+						foundAlliance = alliance;
+						break;
+					}
+				}
+
+				if (foundInvite == null || foundAlliance == null) throw new InviteNotFoundException();
+				foundAlliance.Invites.Remove(foundInvite);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceWarRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceWarRepository.cs
@@ -1,0 +1,25 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceWarRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public AllianceWarRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IEnumerable<AllianceWarImmutable> GetActiveWars(AllianceId allianceId) {
+			return world.Wars.Values
+				.Where(w => (w.AttackerAllianceId == allianceId || w.DefenderAllianceId == allianceId) && w.Status != AllianceWarStatus.Ended)
+				.Select(w => w.ToImmutable());
+		}
+
+		public AllianceWarImmutable GetWar(AllianceWarId warId) {
+			return world.GetWar(warId).ToImmutable();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceWarRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceWarRepositoryWrite.cs
@@ -1,0 +1,91 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceWarRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public AllianceWarRepositoryWrite(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public void DeclareWar(DeclareAllianceWarCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null) throw new NotAllianceMemberException();
+				var attackerAlliance = world.GetAlliance(player.AllianceId);
+				if (attackerAlliance.LeaderId != command.PlayerId) throw new NotAllianceLeaderException();
+
+				if (!world.Alliances.ContainsKey(command.TargetAllianceId)) throw new AllianceNotFoundException(command.TargetAllianceId);
+
+				var alreadyAtWar = world.Wars.Values.Any(w =>
+					w.Status != AllianceWarStatus.Ended &&
+					((w.AttackerAllianceId == player.AllianceId && w.DefenderAllianceId == command.TargetAllianceId) ||
+					 (w.AttackerAllianceId == command.TargetAllianceId && w.DefenderAllianceId == player.AllianceId)));
+
+				if (alreadyAtWar) throw new AlreadyAtWarException();
+
+				var warId = AllianceWarIdFactory.NewAllianceWarId();
+				var war = new AllianceWar {
+					WarId = warId,
+					AttackerAllianceId = player.AllianceId,
+					DefenderAllianceId = command.TargetAllianceId,
+					Status = AllianceWarStatus.Active,
+					DeclaredAt = DateTime.UtcNow
+				};
+				world.Wars[warId] = war;
+			}
+		}
+
+		public void ProposePeace(ProposeAlliancePeaceCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null) throw new NotAllianceMemberException();
+
+				var war = world.GetWar(command.WarId);
+
+				if (war.AttackerAllianceId != player.AllianceId && war.DefenderAllianceId != player.AllianceId) {
+					throw new NotAllianceMemberException();
+				}
+
+				var alliance = world.GetAlliance(player.AllianceId);
+				if (alliance.LeaderId != command.PlayerId) throw new NotAllianceLeaderException();
+
+				if (war.Status != AllianceWarStatus.Active) throw new PeaceAlreadyProposedException();
+
+				war.Status = AllianceWarStatus.PeaceProposed;
+				war.ProposerAllianceId = player.AllianceId;
+			}
+		}
+
+		public void AcceptPeace(AcceptAlliancePeaceCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null) throw new NotAllianceMemberException();
+
+				var war = world.GetWar(command.WarId);
+
+				if (war.AttackerAllianceId != player.AllianceId && war.DefenderAllianceId != player.AllianceId) {
+					throw new NotAllianceMemberException();
+				}
+
+				var alliance = world.GetAlliance(player.AllianceId);
+				if (alliance.LeaderId != command.PlayerId) throw new NotAllianceLeaderException();
+
+				if (war.Status != AllianceWarStatus.PeaceProposed) throw new NotAtWarException();
+
+				// The proposer cannot accept their own proposal
+				if (war.ProposerAllianceId == player.AllianceId) throw new NotAllianceLeaderException();
+
+				war.Status = AllianceWarStatus.Ended;
+				war.EndedAt = DateTime.UtcNow;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Invite flow**: Alliance leaders can invite players by ID; invitees can accept or decline; invites expire after 24 hours
- **War system**: Alliance leaders can declare war on other alliances; either side can propose peace; the other side accepts to end the war
- 7 new REST endpoints, 4 new repository classes, 6 new exception types, 10 new tests (all 221 tests pass)

## Changes

### GameModel
- `AllianceInviteId` / `AllianceWarId` — new ID types following existing pattern
- `AllianceInviteImmutable` — invite record (inviter, invitee, allianceId, createdAt, expiresAt)
- `AllianceWarImmutable` — war record with `AllianceWarStatus` enum (Active, PeaceProposed, Ended)
- `AllianceImmutable` — extended with optional `Invites` list
- `WorldStateImmutable` — extended with optional `Wars` dictionary

### StatefulGameServer
- `AllianceInvite` / `AllianceWar` mutable internal classes + ToImmutable/ToMutable extensions
- `WorldState` — added `Wars` ConcurrentDictionary + `GetWar()` helper
- `AllianceInviteRepository` / `AllianceInviteRepositoryWrite` — read/write repos for invite flow
- `AllianceWarRepository` / `AllianceWarRepositoryWrite` — read/write repos for war system
- 6 new exception types: `InviteAlreadyExistsException`, `InviteNotFoundException`, `AlreadyAtWarException`, `WarNotFoundException`, `PeaceAlreadyProposedException`, `NotAtWarException`
- All 4 new repos registered via `AddSingleton` in `GameServerExtensions`

### Shared / FrontendServer
- New view models: `AllianceInviteViewModel`, `AllianceWarViewModel`, request types
- New controller endpoints: POST `/{id}/invite`, POST `/{id}/accept-invite`, POST `/{id}/decline-invite`, GET `/my-invites`, POST `/{id}/declare-war`, POST `/wars/{warId}/peace`, GET `/{id}/wars`
- Peace endpoint auto-routes: if war is Active → ProposePeace; if PeaceProposed and caller is not proposer → AcceptPeace; proposer accept attempt → 409

## Test plan

- [x] `AllianceInviteTest`: invite → accept → member; decline removes invite; expired invite throws; duplicate invite throws; already-in-alliance throws; non-leader throws
- [x] `AllianceWarTest`: declare war → propose peace → accept peace → Ended; proposer cannot accept own proposal; duplicate war throws; non-leader/non-member throws; ended wars excluded from GetActiveWars
- [x] All 221 tests pass (`dotnet test`)