### PR TITLE
feat: BGE-465 spy offensive actions backend

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -20,6 +20,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly SpyRepositoryWrite spyRepositoryWrite;
 		private readonly SpyRepository spyRepository;
+		private readonly SpyMissionRepositoryWrite spyMissionRepositoryWrite;
+		private readonly SpyMissionRepository spyMissionRepository;
 		private readonly PlayerRepository playerRepository;
 		private readonly UserRepository userRepository;
 		private readonly ScoreRepository scoreRepository;
@@ -30,6 +32,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			CurrentUserContext currentUserContext,
 			SpyRepositoryWrite spyRepositoryWrite,
 			SpyRepository spyRepository,
+			SpyMissionRepositoryWrite spyMissionRepositoryWrite,
+			SpyMissionRepository spyMissionRepository,
 			PlayerRepository playerRepository,
 			UserRepository userRepository,
 			ScoreRepository scoreRepository,
@@ -39,6 +43,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.currentUserContext = currentUserContext;
 			this.spyRepositoryWrite = spyRepositoryWrite;
 			this.spyRepository = spyRepository;
+			this.spyMissionRepositoryWrite = spyMissionRepositoryWrite;
+			this.spyMissionRepository = spyMissionRepository;
 			this.playerRepository = playerRepository;
 			this.userRepository = userRepository;
 			this.scoreRepository = scoreRepository;
@@ -143,6 +149,63 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			} catch (CannotAffordException e) {
 				return BadRequest(e.Message);
 			}
+		}
+
+		/// <summary>Dispatches an offensive spy mission against a target player.</summary>
+		[HttpPost]
+		[Route("api/spy/send")]
+		[ProducesResponseType(typeof(SendSpyMissionResponse), StatusCodes.Status201Created)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<SendSpyMissionResponse> Send([FromBody] SendSpyMissionRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (!Enum.TryParse<SpyMissionType>(request.MissionType, ignoreCase: true, out var missionType)) {
+				return BadRequest($"Unknown mission type: {request.MissionType}");
+			}
+			try {
+				var (missionId, estimatedResolveAt) = spyMissionRepositoryWrite.SendMission(new SpyMissionCommand(
+					currentUserContext.PlayerId!,
+					PlayerIdFactory.Create(request.TargetPlayerId),
+					missionType
+				));
+				return StatusCode(StatusCodes.Status201Created, new SendSpyMissionResponse {
+					MissionId = missionId,
+					EstimatedResolveAt = estimatedResolveAt
+				});
+			} catch (CannotAffordException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		/// <summary>Returns all outgoing spy missions for the current player, most recent first.</summary>
+		[HttpGet]
+		[Route("api/spy/missions")]
+		[ProducesResponseType(typeof(IEnumerable<SpyMissionViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<IEnumerable<SpyMissionViewModel>> Missions() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var currentPlayerId = currentUserContext.PlayerId!;
+			var missions = spyMissionRepository.GetMissions(currentPlayerId);
+			return missions.Select(m => {
+				string targetName;
+				try {
+					var target = playerRepository.Get(m.TargetPlayerId);
+					targetName = target.UserId != null
+						? userRepository.GetDisplayNameByUserId(target.UserId) ?? target.Name
+						: target.Name;
+				} catch {
+					targetName = m.TargetPlayerId.ToString();
+				}
+				return new SpyMissionViewModel {
+					Id = m.Id,
+					TargetPlayerId = m.TargetPlayerId.ToString(),
+					TargetPlayerName = targetName,
+					MissionType = m.MissionType.ToString(),
+					Status = m.Status.ToString(),
+					CreatedAt = m.CreatedAt,
+					Result = m.Result
+				};
+			}).ToList();
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -40,6 +40,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("techresearch:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
+					new GameTickModuleDef("spymission:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("gamefinalization:1", new Dictionary<string, string> { }.ToFrozenDictionary())
 				},
 

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.GameModel {
 		int TechResearchTimer = 0,
 		IDictionary<string, SpyResult>? LastSpyResults = null,
 		IList<SpyAttemptLog>? SpyAttemptLogs = null,
-		IList<GameNotification>? Notifications = null
+		IList<GameNotification>? Notifications = null,
+		IList<SpyMissionImmutable>? SpyMissions = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/SpyMissionImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/SpyMissionImmutable.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public enum SpyMissionType {
+		Sabotage,
+		Intelligence,
+		StealResources
+	}
+
+	public enum SpyMissionStatus {
+		InTransit,
+		Completed,
+		Intercepted
+	}
+
+	public record SpyMissionImmutable(
+		Guid Id,
+		PlayerId TargetPlayerId,
+		SpyMissionType MissionType,
+		SpyMissionStatus Status,
+		int TimerTicks,
+		string? Result,
+		DateTime CreatedAt
+	);
+}

--- a/src/BrowserGameEngine.Shared/SpyMissionViewModel.cs
+++ b/src/BrowserGameEngine.Shared/SpyMissionViewModel.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public class SendSpyMissionRequest {
+		public string TargetPlayerId { get; set; } = string.Empty;
+		public string MissionType { get; set; } = string.Empty;
+	}
+
+	public class SendSpyMissionResponse {
+		public Guid MissionId { get; set; }
+		public DateTime EstimatedResolveAt { get; set; }
+	}
+
+	public class SpyMissionViewModel {
+		public Guid Id { get; set; }
+		public string TargetPlayerId { get; set; } = string.Empty;
+		public string TargetPlayerName { get; set; } = string.Empty;
+		public string MissionType { get; set; } = string.Empty;
+		public string Status { get; set; } = string.Empty;
+		public DateTime CreatedAt { get; set; }
+		public string? Result { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SpyMissionTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SpyMissionTest.cs
@@ -1,0 +1,162 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class SpyMissionTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void SendMission_ValidPlayer_ReturnsMissionIdAndResolveTime() {
+			var game = new TestGame(playerCount: 2);
+
+			var (missionId, estimatedResolveAt) = game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+
+			Assert.NotEqual(System.Guid.Empty, missionId);
+			Assert.True(estimatedResolveAt > System.DateTime.UtcNow);
+		}
+
+		[Fact]
+		public void SendMission_DeductsCost() {
+			var growthResourceId = Id.ResDef("res1");
+			var game = new TestGame(playerCount: 2);
+			var before = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+
+			var after = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+			Assert.True(after < before, "Cost should have been deducted.");
+		}
+
+		[Fact]
+		public void SendMission_InsufficientResources_ThrowsCannotAfford() {
+			var game = new TestGame(playerCount: 2);
+			var amount = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res1"));
+			game.ResourceRepositoryWrite.DeductCost(Player1, Id.ResDef("res1"), amount);
+
+			Assert.Throws<CannotAffordException>(() =>
+				game.SpyMissionRepositoryWrite.SendMission(
+					new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence)));
+		}
+
+		[Fact]
+		public void SendMission_CreatesInTransitMission() {
+			var game = new TestGame(playerCount: 2);
+
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Sabotage));
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			Assert.Single(missions);
+			Assert.Equal(SpyMissionStatus.InTransit, missions[0].Status);
+			Assert.Equal(SpyMissionType.Sabotage, missions[0].MissionType);
+			Assert.Equal(Player2, missions[0].TargetPlayerId);
+		}
+
+		[Fact]
+		public void ProcessMissions_BeforeTimerExpires_RemainsInTransit() {
+			var game = new TestGame(playerCount: 2);
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+
+			// Process once — timer should still be > 0
+			game.SpyMissionRepositoryWrite.ProcessMissions(Player1);
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			Assert.Equal(SpyMissionStatus.InTransit, missions[0].Status);
+		}
+
+		[Fact]
+		public void ProcessMissions_AfterTimerExpires_MissionCompletes() {
+			var game = new TestGame(playerCount: 2);
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+
+			// Intelligence timer = 3 ticks
+			for (int i = 0; i < 3; i++) {
+				game.SpyMissionRepositoryWrite.ProcessMissions(Player1);
+			}
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			// Mission is either Completed or Intercepted
+			Assert.NotEqual(SpyMissionStatus.InTransit, missions[0].Status);
+		}
+
+		[Fact]
+		public void ProcessMissions_Sabotage_DeductsTargetResources() {
+			// Ensure target has resources to deduct and attacker has no counter-intel (0 detection chance)
+			var game = new TestGame(playerCount: 2);
+			var growthResourceId = Id.ResDef("res1");
+			var targetBefore = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Sabotage));
+
+			// Sabotage timer = 5 ticks
+			for (int i = 0; i < 5; i++) {
+				game.SpyMissionRepositoryWrite.ProcessMissions(Player1);
+			}
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			// If completed (not intercepted), target should have fewer resources
+			if (missions[0].Status == SpyMissionStatus.Completed) {
+				var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+				Assert.True(targetAfter < targetBefore, "Sabotage should have reduced target resources.");
+			}
+		}
+
+		[Fact]
+		public void ProcessMissions_StealResources_TransfersToAttacker() {
+			var game = new TestGame(playerCount: 2);
+			var growthResourceId = Id.ResDef("res1");
+
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.StealResources));
+
+			// Record balances after sending (cost deducted)
+			var attackerBefore = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+			var targetBefore = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+
+			// StealResources timer = 4 ticks
+			for (int i = 0; i < 4; i++) {
+				game.SpyMissionRepositoryWrite.ProcessMissions(Player1);
+			}
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			if (missions[0].Status == SpyMissionStatus.Completed) {
+				var attackerAfter = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+				var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+				Assert.True(attackerAfter > attackerBefore, "Attacker should have gained resources from steal.");
+				Assert.True(targetAfter < targetBefore, "Target should have lost resources from steal.");
+			}
+		}
+
+		[Fact]
+		public void GetActiveMissions_ReturnsOnlyInTransit() {
+			var game = new TestGame(playerCount: 2);
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+
+			var active = game.SpyMissionRepository.GetActiveMissions(Player1);
+			Assert.Single(active);
+			Assert.Equal(SpyMissionStatus.InTransit, active[0].Status);
+		}
+
+		[Fact]
+		public void SendMission_MultipleMissions_AllTracked() {
+			var game = new TestGame(playerCount: 2);
+
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Intelligence));
+			game.SpyMissionRepositoryWrite.SendMission(
+				new SpyMissionCommand(Player1, Player2, SpyMissionType.Sabotage));
+
+			var missions = game.SpyMissionRepository.GetMissions(Player1);
+			Assert.Equal(2, missions.Count);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -45,6 +45,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public MarketRepository MarketRepository { get; }
 		public SpyRepository SpyRepository { get; }
 		public SpyRepositoryWrite SpyRepositoryWrite { get; }
+		public SpyMissionRepository SpyMissionRepository { get; }
+		public SpyMissionRepositoryWrite SpyMissionRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -87,6 +89,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			MarketRepository = new MarketRepository(Accessor, ResourceRepository, ResourceRepositoryWrite);
 			SpyRepository = new SpyRepository(Accessor, TimeProvider.System);
 			SpyRepositoryWrite = new SpyRepositoryWrite(Accessor, SpyRepository, ResourceRepositoryWrite, TechRepository, GameDef, TimeProvider.System);
+			SpyMissionRepository = new SpyMissionRepository(Accessor);
+			SpyMissionRepositoryWrite = new SpyMissionRepositoryWrite(Accessor, ResourceRepositoryWrite, ResourceRepository, TechRepository, NullNotificationService.Instance, TimeProvider.System, GameDef);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -49,5 +49,7 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 
 	public record SpyCommand(PlayerId SpyingPlayerId, PlayerId TargetPlayerId) : ICommand;
 
+	public record SpyMissionCommand(PlayerId SpyingPlayerId, PlayerId TargetPlayerId, SpyMissionType MissionType) : ICommand;
+
 	public record ResearchTechCommand(PlayerId PlayerId, TechNodeId TechNodeId) : ICommand;
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -27,6 +27,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public Dictionary<string, SpyResult> LastSpyResults { get; set; } = new Dictionary<string, SpyResult>();
 		public List<SpyAttemptLog> SpyAttemptLogs { get; set; } = new List<SpyAttemptLog>();
 		public List<GameNotification> Notifications { get; set; } = new List<GameNotification>();
+		public List<SpyMission> SpyMissions { get; set; } = new List<SpyMission>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -52,7 +53,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				TechResearchTimer: playerState.TechResearchTimer,
 				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
 				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
-				Notifications: new List<GameNotification>(playerState.Notifications)
+				Notifications: new List<GameNotification>(playerState.Notifications),
+				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList()
 			);
 		}
 
@@ -89,7 +91,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					: new List<SpyAttemptLog>(),
 				Notifications = playerStateImmutable.Notifications != null
 					? new List<GameNotification>(playerStateImmutable.Notifications)
-					: new List<GameNotification>()
+					: new List<GameNotification>(),
+				SpyMissions = (playerStateImmutable.SpyMissions ?? new List<SpyMissionImmutable>())
+					.Select(x => x.ToMutable()).ToList()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/SpyMission.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/SpyMission.cs
@@ -1,0 +1,40 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class SpyMission {
+		public Guid Id { get; set; }
+		public PlayerId TargetPlayerId { get; set; } = default!;
+		public SpyMissionType MissionType { get; set; }
+		public SpyMissionStatus Status { get; set; }
+		public int TimerTicks { get; set; }
+		public string? Result { get; set; }
+		public DateTime CreatedAt { get; set; }
+	}
+
+	internal static class SpyMissionExtensions {
+		internal static SpyMissionImmutable ToImmutable(this SpyMission m) {
+			return new SpyMissionImmutable(
+				Id: m.Id,
+				TargetPlayerId: m.TargetPlayerId,
+				MissionType: m.MissionType,
+				Status: m.Status,
+				TimerTicks: m.TimerTicks,
+				Result: m.Result,
+				CreatedAt: m.CreatedAt
+			);
+		}
+
+		internal static SpyMission ToMutable(this SpyMissionImmutable m) {
+			return new SpyMission {
+				Id = m.Id,
+				TargetPlayerId = m.TargetPlayerId,
+				MissionType = m.MissionType,
+				Status = m.Status,
+				TimerTicks = m.TimerTicks,
+				Result = m.Result,
+				CreatedAt = m.CreatedAt
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -59,6 +59,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MarketRepository>();
 			services.AddSingleton<SpyRepository>();
 			services.AddSingleton<SpyRepositoryWrite>();
+			services.AddSingleton<SpyMissionRepository>();
+			services.AddSingleton<SpyMissionRepositoryWrite>();
 			services.AddSingleton<FogOfWarRepository>();
 			services.AddSingleton<TechRepository>();
 			services.AddSingleton<TechRepositoryWrite>();
@@ -71,6 +73,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, UpgradeTimer>();
 			services.AddSingleton<IGameTickModule, TechResearchTimerModule>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
+			services.AddSingleton<IGameTickModule, SpyMissionModule>();
 			services.AddSingleton<IGameTickModule, GameFinalizationModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpyMissionModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpyMissionModule.cs
@@ -1,0 +1,24 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class SpyMissionModule : IGameTickModule {
+		public string Name => "spymission:1";
+		private readonly SpyMissionRepositoryWrite spyMissionRepositoryWrite;
+
+		public SpyMissionModule(SpyMissionRepositoryWrite spyMissionRepositoryWrite) {
+			this.spyMissionRepositoryWrite = spyMissionRepositoryWrite;
+		}
+
+		public void SetProperty(string name, string value) {
+			switch (name) {
+				default:
+					throw new InvalidGameDefException($"Property '{name}' not valid for GameTickModule '{this.Name}'.");
+			}
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			spyMissionRepositoryWrite.ProcessMissions(playerId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionConstants.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionConstants.cs
@@ -1,0 +1,26 @@
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	internal static class SpyMissionConstants {
+		internal const decimal SabotageCost = 100m;
+		internal const decimal IntelligenceCost = 50m;
+		internal const decimal StealResourcesCost = 75m;
+
+		internal const decimal SabotageDamageAmount = 500m;
+		internal const decimal StealAmount = 200m;
+
+		internal static int GetTimerTicks(SpyMissionType missionType) => missionType switch {
+			SpyMissionType.Intelligence => 3,
+			SpyMissionType.StealResources => 4,
+			SpyMissionType.Sabotage => 5,
+			_ => 3
+		};
+
+		internal static decimal GetMissionCost(SpyMissionType missionType) => missionType switch {
+			SpyMissionType.Intelligence => IntelligenceCost,
+			SpyMissionType.StealResources => StealResourcesCost,
+			SpyMissionType.Sabotage => SabotageCost,
+			_ => IntelligenceCost
+		};
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepository.cs
@@ -1,0 +1,29 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SpyMissionRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public SpyMissionRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IReadOnlyList<SpyMissionImmutable> GetMissions(PlayerId spyingPlayerId) {
+			return world.GetPlayer(spyingPlayerId).State.SpyMissions
+				.OrderByDescending(m => m.CreatedAt)
+				.Select(m => m.ToImmutable())
+				.ToList();
+		}
+
+		public IReadOnlyList<SpyMissionImmutable> GetActiveMissions(PlayerId spyingPlayerId) {
+			return world.GetPlayer(spyingPlayerId).State.SpyMissions
+				.Where(m => m.Status == SpyMissionStatus.InTransit)
+				.Select(m => m.ToImmutable())
+				.ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
@@ -1,0 +1,161 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class SpyMissionRepositoryWrite {
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+		private readonly ResourceRepository resourceRepository;
+		private readonly TechRepository techRepository;
+		private readonly INotificationService notificationService;
+		private readonly TimeProvider timeProvider;
+		private readonly GameDef gameDef;
+
+		public SpyMissionRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			ResourceRepositoryWrite resourceRepositoryWrite,
+			ResourceRepository resourceRepository,
+			TechRepository techRepository,
+			INotificationService notificationService,
+			TimeProvider timeProvider,
+			GameDef gameDef
+		) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+			this.resourceRepository = resourceRepository;
+			this.techRepository = techRepository;
+			this.notificationService = notificationService;
+			this.timeProvider = timeProvider;
+			this.gameDef = gameDef;
+		}
+
+		public (Guid MissionId, DateTime EstimatedResolveAt) SendMission(SpyMissionCommand command) {
+			lock (_lock) {
+				world.ValidatePlayer(command.SpyingPlayerId);
+				world.ValidatePlayer(command.TargetPlayerId);
+
+				var cost = GetMissionCost(command.MissionType);
+				resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, cost);
+
+				var timerTicks = SpyMissionConstants.GetTimerTicks(command.MissionType);
+				var now = timeProvider.GetUtcNow().UtcDateTime;
+				var estimatedResolveAt = now + gameDef.TickDuration * timerTicks;
+
+				var mission = new SpyMission {
+					Id = Guid.NewGuid(),
+					TargetPlayerId = command.TargetPlayerId,
+					MissionType = command.MissionType,
+					Status = SpyMissionStatus.InTransit,
+					TimerTicks = timerTicks,
+					Result = null,
+					CreatedAt = now
+				};
+
+				world.GetPlayer(command.SpyingPlayerId).State.SpyMissions.Add(mission);
+
+				return (mission.Id, estimatedResolveAt);
+			}
+		}
+
+		public void ProcessMissions(PlayerId spyingPlayerId) {
+			lock (_lock) {
+				var playerState = world.GetPlayer(spyingPlayerId).State;
+				var activeMissions = playerState.SpyMissions
+					.Where(m => m.Status == SpyMissionStatus.InTransit)
+					.ToList();
+
+				foreach (var mission in activeMissions) {
+					mission.TimerTicks--;
+					if (mission.TimerTicks > 0) continue;
+
+					ResolveMission(spyingPlayerId, mission);
+				}
+			}
+		}
+
+		private void ResolveMission(PlayerId spyingPlayerId, SpyMission mission) {
+			var targetState = world.GetPlayer(mission.TargetPlayerId).State;
+			var rng = new Random();
+
+			var detectionProbability = techRepository.GetTotalEffectValue(mission.TargetPlayerId, TechEffectType.CounterIntelDetection);
+			var intercepted = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
+
+			targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
+				Id: Guid.NewGuid(),
+				AttackerPlayerId: spyingPlayerId,
+				ActionType: mission.MissionType.ToString(),
+				Detected: intercepted,
+				Timestamp: timeProvider.GetUtcNow().UtcDateTime
+			));
+
+			if (intercepted) {
+				mission.Status = SpyMissionStatus.Intercepted;
+				mission.Result = "Mission intercepted by target counter-intelligence.";
+				notificationService.Notify(spyingPlayerId, GameNotificationType.SpyAttempted,
+					"Spy Intercepted", $"Your {mission.MissionType} mission was intercepted.");
+				notificationService.Notify(mission.TargetPlayerId, GameNotificationType.SpyAttempted,
+					"Spy Caught", $"A spy was caught attempting {mission.MissionType}.");
+				return;
+			}
+
+			var result = ExecuteMissionEffect(spyingPlayerId, mission, rng);
+			mission.Status = SpyMissionStatus.Completed;
+			mission.Result = result;
+			notificationService.Notify(spyingPlayerId, GameNotificationType.SpyAttempted,
+				"Spy Mission Complete", $"Your {mission.MissionType} mission against {mission.TargetPlayerId} succeeded. {result}");
+		}
+
+		private string ExecuteMissionEffect(PlayerId spyingPlayerId, SpyMission mission, Random rng) {
+			switch (mission.MissionType) {
+				case SpyMissionType.Intelligence: {
+					var targetState = world.GetPlayer(mission.TargetPlayerId).State;
+					var resourceSummary = string.Join(", ", targetState.Resources
+						.Select(kv => $"{kv.Key.Id}:{Math.Round(kv.Value, 0)}"));
+					return $"Intel gathered: {resourceSummary}";
+				}
+				case SpyMissionType.Sabotage: {
+					var growthResource = GetGrowthResource();
+					var targetAmount = resourceRepository.GetAmount(mission.TargetPlayerId, growthResource);
+					var damage = Math.Min(targetAmount, SpyMissionConstants.SabotageDamageAmount);
+					if (damage > 0) {
+						resourceRepositoryWrite.DeductCost(mission.TargetPlayerId, growthResource, damage);
+					}
+					return $"Sabotaged {Math.Round(damage, 0)} {growthResource.Id}.";
+				}
+				case SpyMissionType.StealResources: {
+					var growthResource = GetGrowthResource();
+					var targetAmount = resourceRepository.GetAmount(mission.TargetPlayerId, growthResource);
+					var stolen = Math.Min(targetAmount, SpyMissionConstants.StealAmount);
+					if (stolen > 0) {
+						resourceRepositoryWrite.DeductCost(mission.TargetPlayerId, growthResource, stolen);
+						resourceRepositoryWrite.AddResources(spyingPlayerId, growthResource, stolen);
+					}
+					return $"Stole {Math.Round(stolen, 0)} {growthResource.Id}.";
+				}
+				default:
+					return "Mission completed.";
+			}
+		}
+
+		private Cost GetMissionCost(SpyMissionType missionType) {
+			return Cost.FromSingle(GetGrowthResource(), SpyMissionConstants.GetMissionCost(missionType));
+		}
+
+		private ResourceDefId GetGrowthResource() {
+			foreach (var module in gameDef.GameTickModules) {
+				if (module.Properties.TryGetValue("growth-resource", out var resourceId)) {
+					return new ResourceDefId(resourceId);
+				}
+			}
+			return gameDef.ScoreResource;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `SpyMissionType` enum (Sabotage, Intelligence, StealResources) and `SpyMissionStatus` (InTransit, Completed, Intercepted)
- `SpyMissionImmutable` record in `GameModel`; mutable `SpyMission` in `GameModelInternal`; `PlayerState.SpyMissions` list with full serialization round-trip
- `SpyMissionRepositoryWrite.SendMission`: deducts cost, creates InTransit mission, returns missionId + estimatedResolveAt
- `SpyMissionRepositoryWrite.ProcessMissions`: tick-based timer countdown with counter-intel interception detection
  - **Sabotage**: damages target resources on completion
  - **Intelligence**: snapshots target resource totals
  - **StealResources**: transfers resources from target to attacker
  - Detection fires `SpyAttempted` notifications to both sender and target
- `SpyMissionModule` (`IGameTickModule "spymission:1"`) wired into the SCO game tick sequence
- `POST /api/spy/send` — dispatch a spy mission (body: `{ targetPlayerId, missionType }`, returns 201 with `{ missionId, estimatedResolveAt }`)
- `GET /api/spy/missions` — list all outgoing missions with status and result summary

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (231 tests, 10 new SpyMissionTest cases)
- [ ] POST /api/spy/send returns 201 with missionId
- [ ] GET /api/spy/missions returns list with InTransit status
- [ ] After ticks, mission transitions to Completed or Intercepted
- [ ] Sabotage reduces target resources on completion
- [ ] StealResources transfers resources on completion

Closes BGE-465