### PR TITLE
perf: remove WriteIndented and cache JsonSerializerOptions in blob serializers

### DIFF
--- a/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GameStateJsonSerializer.cs
@@ -8,21 +8,18 @@ using KellySharp;
 
 namespace BrowserGameEngine.Persistence {
 	public class GameStateJsonSerializer {
+		private static readonly JsonSerializerOptions Options = new JsonSerializerOptions {
+			Converters = { GetIdConverters() }
+		};
+
 		public byte[] Serialize(WorldStateImmutable worldStateImmutable) {
-			return JsonSerializer.SerializeToUtf8Bytes<WorldStateImmutable>(worldStateImmutable, GetOptions());
+			return JsonSerializer.SerializeToUtf8Bytes<WorldStateImmutable>(worldStateImmutable, Options);
 		}
 
 		public WorldStateImmutable Deserialize(byte[] blob) {
-			var result = JsonSerializer.Deserialize<WorldStateImmutable>(blob, GetOptions());
+			var result = JsonSerializer.Deserialize<WorldStateImmutable>(blob, Options);
 			if (result is null) throw new InvalidDataException("Deserialized world state is null — blob may be empty or corrupted.");
 			return result;
-		}
-
-		private static JsonSerializerOptions GetOptions() {
-			return new JsonSerializerOptions {
-				WriteIndented = true,
-				Converters = { GetIdConverters() }
-			};
 		}
 
 		private static DictionaryJsonConverterFactory GetIdConverters() {

--- a/src/BrowserGameEngine.Persistence/GlobalStateJsonSerializer.cs
+++ b/src/BrowserGameEngine.Persistence/GlobalStateJsonSerializer.cs
@@ -3,14 +3,14 @@ using System.Text.Json;
 
 namespace BrowserGameEngine.Persistence {
 	public class GlobalStateJsonSerializer {
+		private static readonly JsonSerializerOptions Options = new JsonSerializerOptions();
+
 		public byte[] Serialize(GlobalStateImmutable state) {
-			return JsonSerializer.SerializeToUtf8Bytes(state, GetOptions());
+			return JsonSerializer.SerializeToUtf8Bytes(state, Options);
 		}
 
 		public GlobalStateImmutable Deserialize(byte[] blob) {
-			return JsonSerializer.Deserialize<GlobalStateImmutable>(blob, GetOptions())!;
+			return JsonSerializer.Deserialize<GlobalStateImmutable>(blob, Options)!;
 		}
-
-		private static JsonSerializerOptions GetOptions() => new() { WriteIndented = true };
 	}
 }


### PR DESCRIPTION
## Summary

Performance quick wins from [BGE-483](/BGE/issues/BGE-483) audit — serialization layer:

- **Remove `WriteIndented = true`** from `GameStateJsonSerializer` and `GlobalStateJsonSerializer`. Pretty-printing is unnecessary for S3 blob storage and adds ~25–40% overhead in both output size (S3 bytes, transfer cost) and CPU time per write.
- **Cache `JsonSerializerOptions` as a static field** instead of allocating a new instance on every `Serialize`/`Deserialize` call. `System.Text.Json` caches reflection metadata per-options-instance; creating a new instance each call defeats that cache, causing redundant allocation and slower metadata warm-up.

No functional changes — all 210 existing tests pass.

## Test plan

- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test` — 210 passed, 0 failed
- [ ] Verify S3 blob after deployment is valid compact JSON (not indented) and still round-trips correctly