### PR TITLE
fix: BGE-479 add Incoming Intel tab to Spy page

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Spy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Spy.razor
@@ -6,99 +6,161 @@
 <PageTitle>Spy — Age of Agents</PageTitle>
 
 <h1>Spy</h1>
-<p class="text-muted">Gather intelligence on other players. Each mission costs 50 minerals with a 30-minute cooldown per target.</p>
+
+<ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+        <button class="nav-link @(activeTab == "outgoing" ? "active" : "")" @onclick='() => activeTab = "outgoing"'>
+            Spy Operations
+        </button>
+    </li>
+    <li class="nav-item">
+        <button class="nav-link @(activeTab == "incoming" ? "active" : "")" @onclick='() => activeTab = "incoming"'>
+            Incoming Intel
+            @if (intelAttempts != null && intelAttempts.Length > 0) {
+                <span class="badge bg-danger ms-1">@intelAttempts.Length</span>
+            }
+        </button>
+    </li>
+</ul>
 
 @if (!string.IsNullOrEmpty(pageError)) {
     <div class="alert alert-danger">@pageError</div>
 }
 
-@if (players == null) {
-    <p><em>Loading...</em></p>
-} else if (players.Length == 0) {
-    <p class="text-muted">No other players to spy on.</p>
-} else {
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Player</th>
-                <th>Score</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var player in players) {
+@if (activeTab == "outgoing") {
+    <p class="text-muted">Gather intelligence on other players. Each mission costs 50 minerals with a 30-minute cooldown per target.</p>
+
+    @if (players == null) {
+        <p><em>Loading...</em></p>
+    } else if (players.Length == 0) {
+        <p class="text-muted">No other players to spy on.</p>
+    } else {
+        <table class="table">
+            <thead>
                 <tr>
-                    <td>@player.PlayerName</td>
-                    <td>@((int)player.Score)</td>
-                    <td>
-                        @if (player.CooldownExpiresAt.HasValue) {
-                            var remaining = player.CooldownExpiresAt.Value - DateTime.UtcNow;
-                            var display = remaining > TimeSpan.Zero ? remaining.ToString(@"mm\:ss") : "0:00";
-                            <button class="btn btn-secondary btn-sm" disabled title="Spy on cooldown">
-                                <span class="oi oi-eye" aria-hidden="true"></span> @display
-                            </button>
-                        } else {
-                            <button class="btn btn-secondary btn-sm"
-                                    @onclick="() => SendSpy(player.PlayerId)"
-                                    disabled="@(spyLoadings.TryGetValue(player.PlayerId, out var loading) && loading)">
-                                @if (spyLoadings.TryGetValue(player.PlayerId, out var isLoading) && isLoading) {
-                                    <span>Spying...</span>
-                                } else {
-                                    <span><span class="oi oi-eye" aria-hidden="true"></span> Spy</span>
-                                }
-                            </button>
-                        }
-                        @if (spyErrors.TryGetValue(player.PlayerId, out var err) && err != null) {
-                            <span class="text-danger ms-2 small">@err</span>
-                        }
-                    </td>
+                    <th>Player</th>
+                    <th>Score</th>
+                    <th></th>
                 </tr>
-                @if (spyReports.TryGetValue(player.PlayerId, out var report)) {
+            </thead>
+            <tbody>
+                @foreach (var player in players) {
                     <tr>
-                        <td colspan="3">
-                            <details open class="mt-1 mb-2">
-                                <summary><strong>Spy Report — @report.TargetPlayerName</strong> <small class="text-muted">(@report.ReportTime.ToLocalTime().ToString("HH:mm:ss"))</small></summary>
-                                <div class="mt-2">
-                                    <p><strong>Approximate Resources:</strong> ~@((int)report.ApproximateMinerals) minerals, ~@((int)report.ApproximateGas) gas</p>
-                                    @if (report.UnitEstimates.Any()) {
-                                        <table class="table table-sm">
-                                            <thead><tr><th>Unit</th><th>~Count</th></tr></thead>
-                                            <tbody>
-                                                @foreach (var u in report.UnitEstimates.OrderByDescending(x => x.ApproximateCount)) {
-                                                    <tr><td>@u.UnitTypeName</td><td>~@u.ApproximateCount</td></tr>
-                                                }
-                                            </tbody>
-                                        </table>
+                        <td>@player.PlayerName</td>
+                        <td>@((int)player.Score)</td>
+                        <td>
+                            @if (player.CooldownExpiresAt.HasValue) {
+                                var remaining = player.CooldownExpiresAt.Value - DateTime.UtcNow;
+                                var display = remaining > TimeSpan.Zero ? remaining.ToString(@"mm\:ss") : "0:00";
+                                <button class="btn btn-secondary btn-sm" disabled title="Spy on cooldown">
+                                    <span class="oi oi-eye" aria-hidden="true"></span> @display
+                                </button>
+                            } else {
+                                <button class="btn btn-secondary btn-sm"
+                                        @onclick="() => SendSpy(player.PlayerId)"
+                                        disabled="@(spyLoadings.TryGetValue(player.PlayerId, out var loading) && loading)">
+                                    @if (spyLoadings.TryGetValue(player.PlayerId, out var isLoading) && isLoading) {
+                                        <span>Spying...</span>
                                     } else {
-                                        <p class="text-muted">No units detected at base.</p>
+                                        <span><span class="oi oi-eye" aria-hidden="true"></span> Spy</span>
                                     }
-                                    <p class="text-muted"><small>Next spy available: @report.CooldownExpiresAt.ToLocalTime()</small></p>
-                                </div>
-                            </details>
+                                </button>
+                            }
+                            @if (spyErrors.TryGetValue(player.PlayerId, out var err) && err != null) {
+                                <span class="text-danger ms-2 small">@err</span>
+                            }
                         </td>
                     </tr>
+                    @if (spyReports.TryGetValue(player.PlayerId, out var report)) {
+                        <tr>
+                            <td colspan="3">
+                                <details open class="mt-1 mb-2">
+                                    <summary><strong>Spy Report — @report.TargetPlayerName</strong> <small class="text-muted">(@report.ReportTime.ToLocalTime().ToString("HH:mm:ss"))</small></summary>
+                                    <div class="mt-2">
+                                        <p><strong>Approximate Resources:</strong> ~@((int)report.ApproximateMinerals) minerals, ~@((int)report.ApproximateGas) gas</p>
+                                        @if (report.UnitEstimates.Any()) {
+                                            <table class="table table-sm">
+                                                <thead><tr><th>Unit</th><th>~Count</th></tr></thead>
+                                                <tbody>
+                                                    @foreach (var u in report.UnitEstimates.OrderByDescending(x => x.ApproximateCount)) {
+                                                        <tr><td>@u.UnitTypeName</td><td>~@u.ApproximateCount</td></tr>
+                                                    }
+                                                </tbody>
+                                            </table>
+                                        } else {
+                                            <p class="text-muted">No units detected at base.</p>
+                                        }
+                                        <p class="text-muted"><small>Next spy available: @report.CooldownExpiresAt.ToLocalTime()</small></p>
+                                    </div>
+                                </details>
+                            </td>
+                        </tr>
+                    }
                 }
-            }
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    }
+}
+
+@if (activeTab == "incoming") {
+    <p class="text-muted">Detected spy attempts against you. Requires Counter-Intelligence tech to detect spies.</p>
+
+    @if (intelAttempts == null) {
+        <p><em>Loading...</em></p>
+    } else if (intelAttempts.Length == 0) {
+        <p class="text-muted">No detected spy attempts. Upgrade Counter-Intelligence in the Tech Tree to improve detection.</p>
+    } else {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Attacker</th>
+                    <th>Operation Type</th>
+                    <th>Detected At</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var attempt in intelAttempts) {
+                    <tr>
+                        <td>@attempt.AttackerName</td>
+                        <td><span class="badge bg-warning text-dark">@attempt.ActionType</span></td>
+                        <td>@attempt.Timestamp.ToLocalTime().ToString("MMM d, HH:mm")</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
 }
 
 @code {
     [Parameter]
     public string? GameId { get; set; }
 
+    private string activeTab = "outgoing";
     private SpyPlayerEntryViewModel[]? players;
+    private SpyAttemptViewModel[]? intelAttempts;
     private readonly Dictionary<string, SpyReportViewModel> spyReports = new();
     private readonly Dictionary<string, bool> spyLoadings = new();
     private readonly Dictionary<string, string?> spyErrors = new();
     private string? pageError;
 
     protected override async Task OnInitializedAsync() {
+        await Task.WhenAll(LoadPlayers(), LoadIntelAttempts());
+    }
+
+    private async Task LoadPlayers() {
         try {
             players = await Http.GetFromJsonAsync<SpyPlayerEntryViewModel[]>("api/spy/players");
         } catch (Exception ex) {
             pageError = ex.Message;
             players = Array.Empty<SpyPlayerEntryViewModel>();
+        }
+    }
+
+    private async Task LoadIntelAttempts() {
+        try {
+            intelAttempts = await Http.GetFromJsonAsync<SpyAttemptViewModel[]>("api/spy/attempts");
+        } catch {
+            intelAttempts = Array.Empty<SpyAttemptViewModel>();
         }
     }
 


### PR DESCRIPTION
## Summary
- Added tabbed UI to Spy page with "Spy Operations" and "Incoming Intel" tabs
- Incoming Intel tab fetches `api/spy/attempts` and shows detected spy attempts (attacker, operation type, timestamp)
- Badge on Incoming Intel tab shows count of detected attempts
- Both tabs load in parallel via `Task.WhenAll`
- BGE-478 investigation: root cause is in uncommitted staged changes in the working directory that reference `<_PlayerResources />` (underscore-prefixed component) from `Shared/MainLayout.razor` — the `Pages/` namespace is not imported in `_Imports.razor`, so the component tag renders as literal text. The fix for BGE-478 is to rename the component or add the namespace import. No change to master was required for BGE-478 as master is clean.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (221 tests)
- [ ] Navigate to /spy — verify two tabs appear: "Spy Operations" and "Incoming Intel"
- [ ] Verify Incoming Intel tab shows spy attempts detected against you
- [ ] Verify badge count appears when there are detected attempts
- [ ] Verify both tabs load without errors

Closes BGE-479