### PR TITLE
fix: address BGE-465 code review nits

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -66,7 +66,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 					attackerName = attacker.UserId != null
 						? userRepository.GetDisplayNameByUserId(attacker.UserId) ?? attacker.Name
 						: attacker.Name;
-				} catch {
+				} catch (Exception ex) {
+					logger.LogWarning(ex, "Could not resolve attacker display name for player {PlayerId}", a.AttackerPlayerId);
 					attackerName = a.AttackerPlayerId.ToString();
 				}
 				return new SpyAttemptViewModel {
@@ -193,7 +194,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 					targetName = target.UserId != null
 						? userRepository.GetDisplayNameByUserId(target.UserId) ?? target.Name
 						: target.Name;
-				} catch {
+				} catch (Exception ex) {
+					logger.LogWarning(ex, "Could not resolve target display name for player {PlayerId}", m.TargetPlayerId);
 					targetName = m.TargetPlayerId.ToString();
 				}
 				return new SpyMissionViewModel {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SpyMissionTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SpyMissionTest.cs
@@ -102,11 +102,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			}
 
 			var missions = game.SpyMissionRepository.GetMissions(Player1);
-			// If completed (not intercepted), target should have fewer resources
-			if (missions[0].Status == SpyMissionStatus.Completed) {
-				var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
-				Assert.True(targetAfter < targetBefore, "Sabotage should have reduced target resources.");
-			}
+			// No counter-intel tech in TestGame so detection probability = 0; mission always completes
+			Assert.Equal(SpyMissionStatus.Completed, missions[0].Status);
+			var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+			Assert.True(targetAfter < targetBefore, "Sabotage should have reduced target resources.");
 		}
 
 		[Fact]
@@ -127,12 +126,12 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			}
 
 			var missions = game.SpyMissionRepository.GetMissions(Player1);
-			if (missions[0].Status == SpyMissionStatus.Completed) {
-				var attackerAfter = game.ResourceRepository.GetAmount(Player1, growthResourceId);
-				var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
-				Assert.True(attackerAfter > attackerBefore, "Attacker should have gained resources from steal.");
-				Assert.True(targetAfter < targetBefore, "Target should have lost resources from steal.");
-			}
+			// No counter-intel tech in TestGame so detection probability = 0; mission always completes
+			Assert.Equal(SpyMissionStatus.Completed, missions[0].Status);
+			var attackerAfter = game.ResourceRepository.GetAmount(Player1, growthResourceId);
+			var targetAfter = game.ResourceRepository.GetAmount(Player2, growthResourceId);
+			Assert.True(attackerAfter > attackerBefore, "Attacker should have gained resources from steal.");
+			Assert.True(targetAfter < targetBefore, "Target should have lost resources from steal.");
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
@@ -83,7 +83,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		private void ResolveMission(PlayerId spyingPlayerId, SpyMission mission) {
 			var targetState = world.GetPlayer(mission.TargetPlayerId).State;
-			var rng = new Random();
+			var rng = Random.Shared;
 
 			var detectionProbability = techRepository.GetTotalEffectValue(mission.TargetPlayerId, TechEffectType.CounterIntelDetection);
 			var intercepted = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;


### PR DESCRIPTION
## Summary
- Replace bare `catch {}` with `catch (Exception ex)` + `logger.LogWarning` in `SpyController` (both attacker/target display name resolution)
- Use `Random.Shared` instead of `new Random()` in `SpyMissionRepositoryWrite.ResolveMission`
- Make `ProcessMissions_Sabotage_DeductsTargetResources` and `ProcessMissions_StealResources_TransfersToAttacker` tests deterministic: assert `Completed` unconditionally since `TestGame` has no counter-intel tech (detection probability = 0)

These are nits from the PR #151 review that were addressed after merge.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (231 tests)