### PR TITLE
feat: BGE-489 player trading system + in-game messaging overhaul (Sprint 7)

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -8,96 +8,174 @@
 
 <h1>Messages</h1>
 
-<div class="card mb-4" style="max-width:580px">
-	<div class="card-header"><strong>Compose</strong></div>
-	<div class="card-body">
-		<EditForm Model="@composeModel" OnValidSubmit="HandleSend">
-			<DataAnnotationsValidator />
-			<ValidationSummary />
-			<div class="mb-3">
-				<label class="form-label">To</label>
-				@if (players == null) {
-					<InputText class="form-control" @bind-Value="composeModel.RecipientId" placeholder="Player ID" />
-				} else {
-					<select class="form-select" @bind="composeModel.RecipientId">
-						<option value="">— Select a player —</option>
-						@foreach (var p in players) {
-							<option value="@p.PlayerId">@p.PlayerName</option>
+@* ── Tab bar ──────────────────────────────────────────────── *@
+<ul class="nav nav-tabs mb-3">
+	<li class="nav-item">
+		<button class="nav-link @(activeTab == "inbox" ? "active" : "")" @onclick='() => SetTab("inbox")'>Inbox</button>
+	</li>
+	<li class="nav-item">
+		<button class="nav-link @(activeTab == "sent" ? "active" : "")" @onclick='() => SetTab("sent")'>Sent</button>
+	</li>
+</ul>
+
+@* ── Compose button ───────────────────────────────────────── *@
+<button class="btn btn-primary btn-sm mb-3" @onclick="OpenCompose">+ Compose</button>
+
+@* ── Compose modal ────────────────────────────────────────── *@
+@if (showCompose) {
+	<div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,0.5)">
+		<div class="modal-dialog">
+			<div class="modal-content" style="background:var(--color-bg-surface)">
+				<div class="modal-header">
+					<h5 class="modal-title">New Message</h5>
+					<button class="btn-close" @onclick="CloseCompose" aria-label="Close"></button>
+				</div>
+				<div class="modal-body">
+					<div class="mb-3">
+						<label class="form-label">To</label>
+						@if (players == null) {
+							<input class="form-control" @bind="composeModel.RecipientId" placeholder="Player ID" />
+						} else {
+							<select class="form-select" @bind="composeModel.RecipientId">
+								<option value="">— Select a player —</option>
+								@foreach (var p in players) {
+									<option value="@p.PlayerId">@p.PlayerName</option>
+								}
+							</select>
 						}
-					</select>
+					</div>
+					<div class="mb-3">
+						<label class="form-label">Subject</label>
+						<input class="form-control" @bind="composeModel.Subject" placeholder="Subject" />
+					</div>
+					<div class="mb-3">
+						<label class="form-label">Message</label>
+						<textarea class="form-control" @bind="composeModel.Body" placeholder="Write your message..." rows="4"></textarea>
+					</div>
+					@if (!string.IsNullOrEmpty(sendResult)) {
+						<div class="@(sendResult.StartsWith("Error") ? "text-danger" : "text-success")">@sendResult</div>
+					}
+				</div>
+				<div class="modal-footer">
+					<button class="btn btn-secondary" @onclick="CloseCompose">Cancel</button>
+					<button class="btn btn-primary" @onclick="HandleSend">Send</button>
+				</div>
+			</div>
+		</div>
+	</div>
+}
+
+@* ── Split-panel: thread list + message view ─────────────── *@
+<div class="row g-0" style="border:1px solid var(--color-border, #333); border-radius:6px; overflow:hidden; min-height:420px">
+
+	@* ── Left: thread / message list ─────────────────────── *@
+	<div class="col-md-4" style="border-right:1px solid var(--color-border, #333); overflow-y:auto">
+		@if (activeTab == "inbox") {
+			@if (inbox == null) {
+				<p class="p-3"><em>Loading...</em></p>
+			} else if (inbox.Count == 0) {
+				<p class="p-3 text-muted">No messages.</p>
+			} else {
+				@foreach (var msg in inbox) {
+					<div class="p-3 @(selectedMessageId == msg.MessageId ? "bg-primary bg-opacity-10" : "") @(msg.IsRead ? "" : "fw-semibold")"
+					     style="cursor:pointer; border-bottom:1px solid var(--color-border, #333)"
+					     @onclick="() => SelectMessage(msg)">
+						<div class="d-flex justify-content-between">
+							<span>@msg.SenderName</span>
+							<span class="text-muted small">@msg.SentAt.ToLocalTime().ToString("g")</span>
+						</div>
+						<div class="text-truncate small">@msg.Subject</div>
+					</div>
 				}
-			</div>
-			<div class="mb-3">
-				<label class="form-label">Subject</label>
-				<InputText class="form-control" @bind-Value="composeModel.Subject" placeholder="Subject" />
-			</div>
-			<div class="mb-3">
-				<label class="form-label">Message</label>
-				<InputTextArea class="form-control" @bind-Value="composeModel.Body" placeholder="Write your message..." rows="4" />
-			</div>
-			<button type="submit" class="btn btn-primary">Send</button>
-			@if (!string.IsNullOrEmpty(sendResult)) {
-				<span class="ms-3 @(sendResult.StartsWith("Error") ? "text-danger" : "text-success")">@sendResult</span>
 			}
-		</EditForm>
+		} else {
+			@if (sent == null) {
+				<p class="p-3"><em>Loading...</em></p>
+			} else if (sent.Count == 0) {
+				<p class="p-3 text-muted">No sent messages.</p>
+			} else {
+				@foreach (var msg in sent) {
+					<div class="p-3 @(selectedMessageId == msg.MessageId ? "bg-primary bg-opacity-10" : "")"
+					     style="cursor:pointer; border-bottom:1px solid var(--color-border, #333)"
+					     @onclick="() => SelectMessage(msg)">
+						<div class="d-flex justify-content-between">
+							<span class="small text-muted">To: @(GetPlayerName(msg.RecipientId))</span>
+							<span class="text-muted small">@msg.SentAt.ToLocalTime().ToString("g")</span>
+						</div>
+						<div class="text-truncate small">@msg.Subject</div>
+					</div>
+				}
+			}
+		}
+	</div>
+
+	@* ── Right: selected message body ────────────────────── *@
+	<div class="col-md-8 p-3" style="background:var(--color-bg-elevated, #1e1e2e)">
+		@if (selectedMessage == null) {
+			<p class="text-muted mt-3">Select a message to read.</p>
+		} else {
+			<div class="mb-2">
+				<div class="d-flex justify-content-between align-items-start">
+					<div>
+						<strong>@selectedMessage.Subject</strong><br />
+						<span class="text-muted small">
+							From: @selectedMessage.SenderName &nbsp;|&nbsp;
+							@selectedMessage.SentAt.ToLocalTime().ToString("f")
+						</span>
+					</div>
+					<div>
+						@if (!selectedMessage.IsRead && activeTab == "inbox") {
+							<button class="btn btn-sm btn-outline-secondary me-1" @onclick="() => HandleMarkRead(selectedMessage)">Mark read</button>
+						}
+						@if (activeTab == "inbox" && selectedMessage.SenderId != null) {
+							<button class="btn btn-sm btn-outline-primary" @onclick="OpenReply">Reply</button>
+						}
+					</div>
+				</div>
+			</div>
+			<hr />
+			<div>@((MarkupString)selectedMessage.Body)</div>
+
+			@if (showReply) {
+				<div class="mt-3">
+					<h6>Reply</h6>
+					<textarea class="form-control mb-2" @bind="replyBody" rows="3" placeholder="Your reply..."></textarea>
+					@if (!string.IsNullOrEmpty(replyResult)) {
+						<div class="@(replyResult.StartsWith("Error") ? "text-danger" : "text-success") small mb-1">@replyResult</div>
+					}
+					<button class="btn btn-sm btn-primary me-2" @onclick="HandleReply">Send Reply</button>
+					<button class="btn btn-sm btn-outline-secondary" @onclick="() => showReply = false">Cancel</button>
+				</div>
+			}
+		}
 	</div>
 </div>
-
-<h2>Inbox</h2>
-
-@if (inbox == null) {
-	<p><em>Loading...</em></p>
-} else if (inbox.Count == 0) {
-	<p>No messages.</p>
-} else {
-	<table class="table">
-		<thead>
-			<tr>
-				<th>From</th>
-				<th>Subject</th>
-				<th>Date</th>
-				<th></th>
-			</tr>
-		</thead>
-		<tbody>
-			@foreach (var msg in inbox) {
-				<tr class="@(msg.IsRead ? "" : "fw-semibold")">
-					<td>@msg.SenderName</td>
-					<td>
-						<span @onclick="() => ToggleMessage(msg)" style="cursor:pointer">@msg.Subject</span>
-					</td>
-					<td>@msg.SentAt.ToLocalTime().ToString("g")</td>
-					<td>
-						@if (!msg.IsRead) {
-							<button class="btn btn-sm btn-outline-secondary" @onclick="() => HandleMarkRead(msg)">Mark read</button>
-						}
-					</td>
-				</tr>
-				@if (expandedMessageId == msg.MessageId) {
-					<tr>
-						<td colspan="4" class="px-3 py-3" style="background:var(--color-bg-elevated)">
-							@((MarkupString)msg.Body)
-						</td>
-					</tr>
-				}
-			}
-		</tbody>
-	</table>
-}
 
 @code {
 	[Parameter]
 	public string? GameId { get; set; }
 
+	private string activeTab = "inbox";
 	private List<MessageViewModel>? inbox;
+	private List<MessageViewModel>? sent;
 	private List<PublicPlayerViewModel>? players;
+	private Dictionary<string, string> playerNames = new();
+
+	private string? selectedMessageId;
+	private MessageViewModel? selectedMessage;
+
+	private bool showCompose;
 	private SendMessageViewModel composeModel = new();
 	private string? sendResult;
-	private string? expandedMessageId;
+
+	private bool showReply;
+	private string replyBody = "";
+	private string? replyResult;
+
 	private CancellationTokenSource? _cts;
 
 	protected override async Task OnInitializedAsync() {
-		await Task.WhenAll(LoadInbox(), LoadPlayers());
+		await Task.WhenAll(LoadInbox(), LoadSent(), LoadPlayers());
 		_cts = new CancellationTokenSource();
 		_ = RunRefreshLoop(_cts.Token);
 	}
@@ -115,13 +193,51 @@
 		inbox = result?.Messages ?? new();
 	}
 
+	private async Task LoadSent() {
+		var result = await Http.GetFromJsonAsync<MessageInboxViewModel>("api/messages/sent");
+		sent = result?.Messages ?? new();
+	}
+
 	private async Task LoadPlayers() {
 		try {
 			var result = await Http.GetFromJsonAsync<List<PublicPlayerViewModel>>("api/playerranking");
 			players = result ?? new();
+			playerNames = players
+			.Where(p => p.PlayerId != null)
+			.ToDictionary(p => p.PlayerId!, p => p.PlayerName ?? p.PlayerId!);
 		} catch {
 			players = new();
 		}
+	}
+
+	private void SetTab(string tab) {
+		activeTab = tab;
+		selectedMessage = null;
+		selectedMessageId = null;
+		showReply = false;
+	}
+
+	private void SelectMessage(MessageViewModel msg) {
+		selectedMessageId = msg.MessageId;
+		selectedMessage = msg;
+		showReply = false;
+		replyResult = null;
+	}
+
+	private void OpenCompose() {
+		showCompose = true;
+		sendResult = null;
+		composeModel = new();
+	}
+
+	private void CloseCompose() {
+		showCompose = false;
+	}
+
+	private void OpenReply() {
+		showReply = true;
+		replyBody = "";
+		replyResult = null;
 	}
 
 	private async Task HandleSend() {
@@ -130,6 +246,7 @@
 		if (response.IsSuccessStatusCode) {
 			composeModel = new();
 			sendResult = "Message sent.";
+			await LoadSent();
 		} else {
 			var error = await response.Content.ReadAsStringAsync();
 			sendResult = $"Error: {error}";
@@ -143,8 +260,24 @@
 		}
 	}
 
-	private void ToggleMessage(MessageViewModel msg) {
-		expandedMessageId = expandedMessageId == msg.MessageId ? null : msg.MessageId;
+	private async Task HandleReply() {
+		replyResult = null;
+		if (selectedMessage == null) return;
+		var response = await Http.PostAsJsonAsync($"api/messages/{selectedMessage.MessageId}/reply",
+			new ReplyMessageViewModel { Body = replyBody });
+		if (response.IsSuccessStatusCode) {
+			replyBody = "";
+			replyResult = "Reply sent.";
+			showReply = false;
+			await LoadSent();
+		} else {
+			var error = await response.Content.ReadAsStringAsync();
+			replyResult = $"Error: {error}";
+		}
+	}
+
+	private string GetPlayerName(string playerId) {
+		return playerNames.TryGetValue(playerId, out var name) ? name : playerId;
 	}
 
 	public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Messages.razor
@@ -134,7 +134,7 @@
 				</div>
 			</div>
 			<hr />
-			<div>@((MarkupString)selectedMessage.Body)</div>
+			<div>@selectedMessage.Body</div>
 
 			@if (showReply) {
 				<div class="mt-3">

--- a/src/BrowserGameEngine.BlazorClient/Pages/Trade.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Trade.razor
@@ -1,0 +1,318 @@
+@page "/games/{GameId}/trade"
+@using BrowserGameEngine.Shared
+@inject HttpClient Http
+@implements IDisposable
+
+<PageTitle>Trade — Age of Agents</PageTitle>
+
+<h1>Trade</h1>
+
+<div class="container-fluid">
+
+	<div class="row mb-4">
+		@* ── Propose a Trade ─────────────────────────────────────── *@
+		<div class="col-md-6">
+			<div class="card">
+				<div class="card-header"><strong>Propose a Trade</strong></div>
+				<div class="card-body">
+					@if (!string.IsNullOrEmpty(proposeError)) {
+						<div class="alert alert-danger py-1 px-2 mb-2">@proposeError</div>
+					}
+					@if (!string.IsNullOrEmpty(proposeSuccess)) {
+						<div class="alert alert-success py-1 px-2 mb-2">@proposeSuccess</div>
+					}
+					<div class="mb-2">
+						<label class="form-label">To player</label>
+						@if (players == null) {
+							<input type="text" class="form-control" @bind="proposeTargetPlayerId" placeholder="Player ID" />
+						} else {
+							<select class="form-select" @bind="proposeTargetPlayerId">
+								<option value="">— Select a player —</option>
+								@foreach (var p in players) {
+									<option value="@p.PlayerId">@p.PlayerName</option>
+								}
+							</select>
+						}
+					</div>
+					<div class="row g-2 mb-2">
+						<div class="col-6">
+							<label class="form-label">I offer</label>
+							<input type="number" class="form-control" @bind="proposeOfferedAmount" min="1" placeholder="Amount" />
+						</div>
+						<div class="col-6">
+							<label class="form-label">Resource</label>
+							<input type="text" class="form-control" @bind="proposeOfferedResource" placeholder="e.g. minerals" />
+						</div>
+					</div>
+					<div class="row g-2 mb-2">
+						<div class="col-6">
+							<label class="form-label">I want</label>
+							<input type="number" class="form-control" @bind="proposeWantedAmount" min="1" placeholder="Amount" />
+						</div>
+						<div class="col-6">
+							<label class="form-label">Resource</label>
+							<input type="text" class="form-control" @bind="proposeWantedResource" placeholder="e.g. gas" />
+						</div>
+					</div>
+					<div class="mb-2">
+						<label class="form-label">Note <span class="text-muted">(optional)</span></label>
+						<input type="text" class="form-control" @bind="proposeNote" placeholder="Optional note to recipient" />
+					</div>
+					<button class="btn btn-primary mt-1" @onclick="HandlePropose">Send Offer</button>
+				</div>
+			</div>
+		</div>
+
+		@* ── Incoming Trade Offers ────────────────────────────────── *@
+		<div class="col-md-6">
+			<div class="card">
+				<div class="card-header"><strong>Incoming Trade Offers</strong></div>
+				<div class="card-body p-0">
+					@if (incomingOffers == null) {
+						<p class="p-3"><em>Loading...</em></p>
+					} else if (incomingOffers.Count == 0) {
+						<p class="p-3 text-muted">No incoming offers.</p>
+					} else {
+						<table class="table table-sm mb-0">
+							<thead>
+								<tr>
+									<th>From</th>
+									<th>They offer</th>
+									<th>They want</th>
+									<th>Note</th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach (var offer in incomingOffers) {
+									<tr>
+										<td>@offer.FromPlayerName</td>
+										<td>@offer.OfferedAmount @offer.OfferedResourceId</td>
+										<td>@offer.WantedAmount @offer.WantedResourceId</td>
+										<td><span class="text-muted small">@offer.Note</span></td>
+										<td>
+											<button class="btn btn-sm btn-success me-1" @onclick="() => HandleAccept(offer.OfferId)">Accept</button>
+											<button class="btn btn-sm btn-outline-danger" @onclick="() => HandleDecline(offer.OfferId)">Decline</button>
+											@if (actionErrors.TryGetValue(offer.OfferId, out var err)) {
+												<div class="text-danger small">@err</div>
+											}
+										</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					}
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		@* ── My Pending Offers ────────────────────────────────────── *@
+		<div class="col-md-6 mb-4">
+			<div class="card">
+				<div class="card-header"><strong>My Pending Offers</strong></div>
+				<div class="card-body p-0">
+					@if (sentOffers == null) {
+						<p class="p-3"><em>Loading...</em></p>
+					} else if (sentOffers.Count == 0) {
+						<p class="p-3 text-muted">No pending offers.</p>
+					} else {
+						<table class="table table-sm mb-0">
+							<thead>
+								<tr>
+									<th>To</th>
+									<th>Offering</th>
+									<th>Wanting</th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach (var offer in sentOffers) {
+									<tr>
+										<td>@offer.ToPlayerName</td>
+										<td>@offer.OfferedAmount @offer.OfferedResourceId</td>
+										<td>@offer.WantedAmount @offer.WantedResourceId</td>
+										<td>
+											<button class="btn btn-sm btn-outline-secondary" @onclick="() => HandleCancel(offer.OfferId)">Cancel</button>
+											@if (actionErrors.TryGetValue(offer.OfferId, out var err)) {
+												<div class="text-danger small">@err</div>
+											}
+										</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					}
+				</div>
+			</div>
+		</div>
+
+		@* ── Trade History ────────────────────────────────────────── *@
+		<div class="col-md-6 mb-4">
+			<div class="card">
+				<div class="card-header"><strong>Trade History</strong></div>
+				<div class="card-body p-0">
+					@if (tradeHistory == null) {
+						<p class="p-3"><em>Loading...</em></p>
+					} else if (tradeHistory.Count == 0) {
+						<p class="p-3 text-muted">No trade history yet.</p>
+					} else {
+						<table class="table table-sm mb-0">
+							<thead>
+								<tr>
+									<th>With</th>
+									<th>Gave</th>
+									<th>Received</th>
+									<th>Status</th>
+									<th>Date</th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach (var item in tradeHistory) {
+									<tr>
+										<td>@item.WithPlayerName</td>
+										<td>@item.GaveAmount @item.GaveResourceId</td>
+										<td>@item.ReceivedAmount @item.ReceivedResourceId</td>
+										<td>
+											<span class="badge @StatusBadgeClass(item.Status)">@item.Status</span>
+										</td>
+										<td class="text-muted small">@item.CompletedAt.ToLocalTime().ToString("g")</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					}
+				</div>
+			</div>
+		</div>
+	</div>
+
+</div>
+
+@code {
+	[Parameter]
+	public string? GameId { get; set; }
+
+	private List<TradeOfferViewModel>? incomingOffers;
+	private List<TradeOfferViewModel>? sentOffers;
+	private List<TradeHistoryItemViewModel>? tradeHistory;
+	private List<PublicPlayerViewModel>? players;
+	private Dictionary<string, string> actionErrors = new();
+
+	private string proposeTargetPlayerId = "";
+	private decimal proposeOfferedAmount = 100;
+	private string proposeOfferedResource = "";
+	private decimal proposeWantedAmount = 100;
+	private string proposeWantedResource = "";
+	private string? proposeNote;
+	private string? proposeError;
+	private string? proposeSuccess;
+
+	private CancellationTokenSource? _cts;
+
+	protected override async Task OnInitializedAsync() {
+		await Task.WhenAll(LoadOffers(), LoadHistory(), LoadPlayers());
+		_cts = new CancellationTokenSource();
+		_ = RunRefreshLoop(_cts.Token);
+	}
+
+	private async Task RunRefreshLoop(CancellationToken ct) {
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(15));
+		while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) {
+			await InvokeAsync(LoadOffers);
+			await InvokeAsync(LoadHistory);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task LoadOffers() {
+		var incoming = await Http.GetFromJsonAsync<List<TradeOfferViewModel>>("api/trade/offers/incoming");
+		incomingOffers = incoming ?? new();
+		var sent = await Http.GetFromJsonAsync<List<TradeOfferViewModel>>("api/trade/offers/sent");
+		sentOffers = sent ?? new();
+	}
+
+	private async Task LoadHistory() {
+		var history = await Http.GetFromJsonAsync<List<TradeHistoryItemViewModel>>("api/trade/history?skip=0&take=20");
+		tradeHistory = history ?? new();
+	}
+
+	private async Task LoadPlayers() {
+		try {
+			var result = await Http.GetFromJsonAsync<List<PublicPlayerViewModel>>("api/playerranking");
+			players = result ?? new();
+		} catch {
+			players = new();
+		}
+	}
+
+	private async Task HandlePropose() {
+		proposeError = null;
+		proposeSuccess = null;
+		if (string.IsNullOrWhiteSpace(proposeTargetPlayerId)) { proposeError = "Select a target player."; return; }
+		if (string.IsNullOrWhiteSpace(proposeOfferedResource)) { proposeError = "Enter the resource you are offering."; return; }
+		if (string.IsNullOrWhiteSpace(proposeWantedResource)) { proposeError = "Enter the resource you want."; return; }
+		var request = new CreateTradeOfferRequest {
+			TargetPlayerId = proposeTargetPlayerId,
+			OfferedResourceId = proposeOfferedResource,
+			OfferedAmount = proposeOfferedAmount,
+			WantedResourceId = proposeWantedResource,
+			WantedAmount = proposeWantedAmount,
+			Note = string.IsNullOrWhiteSpace(proposeNote) ? null : proposeNote
+		};
+		var response = await Http.PostAsJsonAsync("api/trade/offer", request);
+		if (response.IsSuccessStatusCode) {
+			proposeSuccess = "Trade offer sent.";
+			proposeTargetPlayerId = "";
+			proposeOfferedResource = "";
+			proposeWantedResource = "";
+			proposeNote = null;
+			await LoadOffers();
+		} else {
+			proposeError = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task HandleAccept(string offerId) {
+		actionErrors.Remove(offerId);
+		var response = await Http.PostAsJsonAsync($"api/trade/offers/{offerId}/accept", new { });
+		if (response.IsSuccessStatusCode) {
+			await Task.WhenAll(LoadOffers(), LoadHistory());
+		} else {
+			actionErrors[offerId] = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task HandleDecline(string offerId) {
+		actionErrors.Remove(offerId);
+		var response = await Http.PostAsJsonAsync($"api/trade/offers/{offerId}/decline", new { });
+		if (response.IsSuccessStatusCode) {
+			await LoadOffers();
+		} else {
+			actionErrors[offerId] = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private async Task HandleCancel(string offerId) {
+		actionErrors.Remove(offerId);
+		var response = await Http.DeleteAsync($"api/trade/offers/{offerId}");
+		if (response.IsSuccessStatusCode) {
+			await LoadOffers();
+		} else {
+			actionErrors[offerId] = await response.Content.ReadAsStringAsync();
+		}
+	}
+
+	private static string StatusBadgeClass(string status) => status switch {
+		"Accepted" => "bg-success",
+		"Declined" => "bg-danger",
+		"Cancelled" => "bg-secondary",
+		_ => "bg-primary"
+	};
+
+	public void Dispose() {
+		_cts?.Cancel();
+		_cts?.Dispose();
+	}
+}

--- a/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
+++ b/src/BrowserGameEngine.BlazorClient/Shared/NavMenu.razor
@@ -88,6 +88,11 @@
                     </NavLink>
                 </li>
                 <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="@($"games/{gameId}/trade")">
+                        <span class="oi oi-transfer" aria-hidden="true"></span> Trade
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
                     <NavLink class="nav-link" href="@($"games/{gameId}/spy")">
                         <span class="oi oi-eye" aria-hidden="true"></span> Spy
                     </NavLink>

--- a/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
@@ -79,6 +79,65 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return Ok();
 		}
 
+		/// <summary>Returns all messages sent by the current player.</summary>
+		[HttpGet("sent")]
+		[ProducesResponseType(typeof(MessageInboxViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<MessageInboxViewModel> Sent() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var messages = messageRepository.GetSentMessages(currentUserContext.PlayerId!)
+				.Select(m => ToViewModel(m))
+				.ToList();
+			return new MessageInboxViewModel { Messages = messages };
+		}
+
+		/// <summary>Returns the message thread between the current player and another player.</summary>
+		/// <param name="withPlayerId">The other player's ID.</param>
+		[HttpGet("thread/{withPlayerId}")]
+		[ProducesResponseType(typeof(MessageThreadViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		public ActionResult<MessageThreadViewModel> GetThread(string withPlayerId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var otherId = PlayerIdFactory.Create(withPlayerId);
+			if (!playerRepository.Exists(otherId)) return BadRequest("Player not found.");
+			var messages = messageRepository.GetThread(currentUserContext.PlayerId!, otherId)
+				.Select(m => ToViewModel(m))
+				.ToList();
+			var otherName = playerRepository.Get(otherId).Name;
+			return new MessageThreadViewModel {
+				WithPlayerId = withPlayerId,
+				WithPlayerName = otherName,
+				Messages = messages
+			};
+		}
+
+		/// <summary>Replies to a message (sends a new message to the original sender).</summary>
+		/// <param name="id">The original message ID.</param>
+		/// <param name="model">The reply body.</param>
+		[HttpPost("{id}/reply")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		public ActionResult Reply(string id, [FromBody] ReplyMessageViewModel model) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var messageId = MessageIdFactory.Create(id);
+			if (!messageRepository.IsRecipient(currentUserContext.PlayerId!, messageId)) return Forbid();
+			var inbox = messageRepository.GetMessages(currentUserContext.PlayerId!);
+			var original = inbox.FirstOrDefault(m => m.Id == messageId);
+			if (original == null) return BadRequest("Message not found.");
+			if (original.SenderId == null) return BadRequest("Cannot reply to system messages.");
+			if (string.IsNullOrWhiteSpace(model.Body)) return BadRequest("Body is required.");
+			messageRepositoryWrite.Send(new SendMessageCommand(
+				SenderId: currentUserContext.PlayerId!,
+				RecipientId: original.SenderId,
+				Subject: $"Re: {original.Subject}",
+				Body: model.Body
+			));
+			return Ok();
+		}
+
 		private MessageViewModel ToViewModel(MessageImmutable message) {
 			var senderName = message.SenderId != null && playerRepository.Exists(message.SenderId)
 				? playerRepository.Get(message.SenderId).Name

--- a/src/BrowserGameEngine.FrontendServer/Controllers/TradeController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/TradeController.cs
@@ -1,0 +1,191 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/[controller]")]
+	public class TradeController : ControllerBase {
+		private readonly ILogger<TradeController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly TradeRepository tradeRepository;
+		private readonly TradeRepositoryWrite tradeRepositoryWrite;
+		private readonly PlayerRepository playerRepository;
+
+		public TradeController(
+			ILogger<TradeController> logger,
+			CurrentUserContext currentUserContext,
+			TradeRepository tradeRepository,
+			TradeRepositoryWrite tradeRepositoryWrite,
+			PlayerRepository playerRepository
+		) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.tradeRepository = tradeRepository;
+			this.tradeRepositoryWrite = tradeRepositoryWrite;
+			this.playerRepository = playerRepository;
+		}
+
+		/// <summary>Creates a trade offer directed at another player.</summary>
+		[HttpPost("offer")]
+		[ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<string> CreateOffer([FromBody] CreateTradeOfferRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (string.IsNullOrWhiteSpace(request.TargetPlayerId)) return BadRequest("Target player is required.");
+			if (string.IsNullOrWhiteSpace(request.OfferedResourceId)) return BadRequest("Offered resource is required.");
+			if (string.IsNullOrWhiteSpace(request.WantedResourceId)) return BadRequest("Wanted resource is required.");
+			if (request.OfferedAmount <= 0) return BadRequest("Offered amount must be positive.");
+			if (request.WantedAmount <= 0) return BadRequest("Wanted amount must be positive.");
+
+			var targetId = PlayerIdFactory.Create(request.TargetPlayerId);
+			if (targetId == currentUserContext.PlayerId) return BadRequest("Cannot send a trade offer to yourself.");
+			if (!playerRepository.Exists(targetId)) return BadRequest("Target player not found.");
+
+			var offerId = tradeRepositoryWrite.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: currentUserContext.PlayerId!,
+				ToPlayerId: targetId,
+				OfferedResourceId: Id.ResDef(request.OfferedResourceId),
+				OfferedAmount: request.OfferedAmount,
+				WantedResourceId: Id.ResDef(request.WantedResourceId),
+				WantedAmount: request.WantedAmount,
+				Note: request.Note
+			));
+			return Ok(offerId.ToString());
+		}
+
+		/// <summary>Returns incoming (pending) trade offers for the current player.</summary>
+		[HttpGet("offers/incoming")]
+		[ProducesResponseType(typeof(System.Collections.Generic.List<TradeOfferViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<System.Collections.Generic.List<TradeOfferViewModel>> GetIncoming() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var offers = tradeRepository.GetIncoming(currentUserContext.PlayerId!)
+				.Select(o => ToViewModel(o))
+				.ToList();
+			return Ok(offers);
+		}
+
+		/// <summary>Returns sent (pending) trade offers from the current player.</summary>
+		[HttpGet("offers/sent")]
+		[ProducesResponseType(typeof(System.Collections.Generic.List<TradeOfferViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<System.Collections.Generic.List<TradeOfferViewModel>> GetSent() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var offers = tradeRepository.GetSent(currentUserContext.PlayerId!)
+				.Select(o => ToViewModel(o))
+				.ToList();
+			return Ok(offers);
+		}
+
+		/// <summary>Accepts a trade offer.</summary>
+		[HttpPost("offers/{offerId}/accept")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult Accept(string offerId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var id = TradeOfferIdFactory.Create(offerId);
+			var success = tradeRepositoryWrite.Accept(new AcceptTradeOfferCommand(
+				AcceptingPlayerId: currentUserContext.PlayerId!,
+				OfferId: id
+			));
+			if (!success) return BadRequest("Trade offer could not be accepted. It may not exist, already be resolved, or you may have insufficient resources.");
+			return Ok();
+		}
+
+		/// <summary>Declines a trade offer.</summary>
+		[HttpPost("offers/{offerId}/decline")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult Decline(string offerId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var id = TradeOfferIdFactory.Create(offerId);
+			var success = tradeRepositoryWrite.Decline(new DeclineTradeOfferCommand(
+				DecliningPlayerId: currentUserContext.PlayerId!,
+				OfferId: id
+			));
+			if (!success) return BadRequest("Trade offer could not be declined.");
+			return Ok();
+		}
+
+		/// <summary>Cancels a sent trade offer.</summary>
+		[HttpDelete("offers/{offerId}")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult Cancel(string offerId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var id = TradeOfferIdFactory.Create(offerId);
+			var success = tradeRepositoryWrite.Cancel(new CancelTradeOfferCommand(
+				CancellingPlayerId: currentUserContext.PlayerId!,
+				OfferId: id
+			));
+			if (!success) return BadRequest("Trade offer could not be cancelled.");
+			return Ok();
+		}
+
+		/// <summary>Returns trade history for the current player.</summary>
+		[HttpGet("history")]
+		[ProducesResponseType(typeof(System.Collections.Generic.List<TradeHistoryItemViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<System.Collections.Generic.List<TradeHistoryItemViewModel>> GetHistory([FromQuery] int skip = 0, [FromQuery] int take = 20) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var history = tradeRepository.GetHistory(currentUserContext.PlayerId!, skip, take)
+				.Select(o => ToHistoryViewModel(o, currentUserContext.PlayerId!))
+				.ToList();
+			return Ok(history);
+		}
+
+		private TradeOfferViewModel ToViewModel(TradeOfferImmutable offer) {
+			return new TradeOfferViewModel {
+				OfferId = offer.OfferId.ToString(),
+				FromPlayerId = offer.FromPlayerId.Id,
+				FromPlayerName = TryGetPlayerName(offer.FromPlayerId),
+				ToPlayerId = offer.ToPlayerId.Id,
+				ToPlayerName = TryGetPlayerName(offer.ToPlayerId),
+				OfferedAmount = offer.OfferedAmount,
+				OfferedResourceId = offer.OfferedResourceId.Id,
+				WantedAmount = offer.WantedAmount,
+				WantedResourceId = offer.WantedResourceId.Id,
+				Note = offer.Note,
+				SentAt = offer.CreatedAt,
+				Status = offer.Status.ToString()
+			};
+		}
+
+		private TradeHistoryItemViewModel ToHistoryViewModel(TradeOfferImmutable offer, PlayerId myId) {
+			var isSender = offer.FromPlayerId == myId;
+			var withId = isSender ? offer.ToPlayerId : offer.FromPlayerId;
+			return new TradeHistoryItemViewModel {
+				OfferId = offer.OfferId.ToString(),
+				WithPlayerId = withId.Id,
+				WithPlayerName = TryGetPlayerName(withId),
+				GaveAmount = isSender ? offer.OfferedAmount : offer.WantedAmount,
+				GaveResourceId = isSender ? offer.OfferedResourceId.Id : offer.WantedResourceId.Id,
+				ReceivedAmount = isSender ? offer.WantedAmount : offer.OfferedAmount,
+				ReceivedResourceId = isSender ? offer.WantedResourceId.Id : offer.OfferedResourceId.Id,
+				CompletedAt = offer.CreatedAt,
+				Status = offer.Status.ToString()
+			};
+		}
+
+		private string TryGetPlayerName(PlayerId playerId) {
+			try {
+				return playerRepository.Get(playerId).Name;
+			} catch {
+				return playerId.Id;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameModel/TradeOfferId.cs
+++ b/src/BrowserGameEngine.GameModel/TradeOfferId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record TradeOfferId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class TradeOfferIdFactory {
+		public static TradeOfferId Create(Guid id) => new TradeOfferId(id);
+		public static TradeOfferId Create(string id) => new TradeOfferId(Guid.Parse(id));
+		public static TradeOfferId NewTradeOfferId() => new TradeOfferId(Guid.NewGuid());
+	}
+}

--- a/src/BrowserGameEngine.GameModel/TradeOfferImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/TradeOfferImmutable.cs
@@ -1,0 +1,24 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public enum TradeOfferStatus {
+		Pending,
+		Accepted,
+		Declined,
+		Cancelled
+	}
+
+	public record TradeOfferImmutable(
+		TradeOfferId OfferId,
+		PlayerId FromPlayerId,
+		PlayerId ToPlayerId,
+		ResourceDefId OfferedResourceId,
+		decimal OfferedAmount,
+		ResourceDefId WantedResourceId,
+		decimal WantedAmount,
+		string? Note,
+		DateTime CreatedAt,
+		TradeOfferStatus Status
+	);
+}

--- a/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/WorldStateImmutable.cs
@@ -9,6 +9,7 @@ namespace BrowserGameEngine.GameModel {
 		GameId? GameId = null,  // null = legacy JSON; treated as "default" in ToMutable()
 		IList<MarketOrderImmutable>? MarketOrders = null,
 		IList<ChatMessageImmutable>? ChatMessages = null,
-		IDictionary<AllianceWarId, AllianceWarImmutable>? Wars = null
+		IDictionary<AllianceWarId, AllianceWarImmutable>? Wars = null,
+		IList<TradeOfferImmutable>? TradeOffers = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/MessageViewModels.cs
+++ b/src/BrowserGameEngine.Shared/MessageViewModels.cs
@@ -22,4 +22,14 @@ namespace BrowserGameEngine.Shared {
 		public string Subject { get; set; } = "";
 		public string Body { get; set; } = "";
 	}
+
+	public class MessageThreadViewModel {
+		public string WithPlayerId { get; set; } = "";
+		public string WithPlayerName { get; set; } = "";
+		public List<MessageViewModel> Messages { get; set; } = new();
+	}
+
+	public class ReplyMessageViewModel {
+		public string Body { get; set; } = "";
+	}
 }

--- a/src/BrowserGameEngine.Shared/TradeViewModels.cs
+++ b/src/BrowserGameEngine.Shared/TradeViewModels.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class TradeOfferViewModel {
+		public string OfferId { get; set; } = "";
+		public string FromPlayerId { get; set; } = "";
+		public string FromPlayerName { get; set; } = "";
+		public string ToPlayerId { get; set; } = "";
+		public string ToPlayerName { get; set; } = "";
+		public decimal OfferedAmount { get; set; }
+		public string OfferedResourceId { get; set; } = "";
+		public decimal WantedAmount { get; set; }
+		public string WantedResourceId { get; set; } = "";
+		public string? Note { get; set; }
+		public DateTime SentAt { get; set; }
+		public string Status { get; set; } = "";
+	}
+
+	public class TradeHistoryItemViewModel {
+		public string OfferId { get; set; } = "";
+		public string WithPlayerId { get; set; } = "";
+		public string WithPlayerName { get; set; } = "";
+		public decimal GaveAmount { get; set; }
+		public string GaveResourceId { get; set; } = "";
+		public decimal ReceivedAmount { get; set; }
+		public string ReceivedResourceId { get; set; } = "";
+		public DateTime CompletedAt { get; set; }
+		public string Status { get; set; } = "";
+	}
+
+	public class CreateTradeOfferRequest {
+		public string TargetPlayerId { get; set; } = "";
+		public string OfferedResourceId { get; set; } = "";
+		public decimal OfferedAmount { get; set; }
+		public string WantedResourceId { get; set; } = "";
+		public decimal WantedAmount { get; set; }
+		public string? Note { get; set; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TradeRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TradeRepositoryTest.cs
@@ -1,0 +1,183 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class TradeRepositoryTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void CreateOffer_ReturnsValidOfferId() {
+			var game = new TestGame(playerCount: 2);
+			var tradeRepo = new TradeRepository(game.Accessor);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: null
+			));
+
+			Assert.NotNull(offerId);
+			var offer = tradeRepo.Get(offerId);
+			Assert.NotNull(offer);
+			Assert.Equal(Player1, offer!.FromPlayerId);
+			Assert.Equal(Player2, offer.ToPlayerId);
+			Assert.Equal(TradeOfferStatus.Pending, offer.Status);
+		}
+
+		[Fact]
+		public void Accept_TransfersResourcesBetweenPlayers() {
+			var game = new TestGame(playerCount: 2);
+			var tradeRepo = new TradeRepository(game.Accessor);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var p1Res1Before = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res1"));
+			var p1Res2Before = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res2"));
+			var p2Res1Before = game.ResourceRepository.GetAmount(Player2, Id.ResDef("res1"));
+			var p2Res2Before = game.ResourceRepository.GetAmount(Player2, Id.ResDef("res2"));
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: null
+			));
+
+			var accepted = tradeWriteRepo.Accept(new AcceptTradeOfferCommand(
+				AcceptingPlayerId: Player2,
+				OfferId: offerId
+			));
+
+			Assert.True(accepted);
+			var offer = tradeRepo.Get(offerId);
+			Assert.Equal(TradeOfferStatus.Accepted, offer!.Status);
+
+			// Player1 offered res1 (100) and receives res2 (50)
+			Assert.Equal(p1Res1Before - 100, game.ResourceRepository.GetAmount(Player1, Id.ResDef("res1")));
+			Assert.Equal(p1Res2Before + 50, game.ResourceRepository.GetAmount(Player1, Id.ResDef("res2")));
+
+			// Player2 receives res1 (100) and gives res2 (50)
+			Assert.Equal(p2Res1Before + 100, game.ResourceRepository.GetAmount(Player2, Id.ResDef("res1")));
+			Assert.Equal(p2Res2Before - 50, game.ResourceRepository.GetAmount(Player2, Id.ResDef("res2")));
+		}
+
+		[Fact]
+		public void Accept_FailsIfAcceptorHasInsufficientResources() {
+			var game = new TestGame(playerCount: 2);
+			var tradeRepo = new TradeRepository(game.Accessor);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 10,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 999999, // more than player2 has
+				Note: null
+			));
+
+			var accepted = tradeWriteRepo.Accept(new AcceptTradeOfferCommand(
+				AcceptingPlayerId: Player2,
+				OfferId: offerId
+			));
+
+			Assert.False(accepted);
+			var offer = tradeRepo.Get(offerId);
+			Assert.Equal(TradeOfferStatus.Pending, offer!.Status);
+		}
+
+		[Fact]
+		public void Decline_SetsStatusToDeclined() {
+			var game = new TestGame(playerCount: 2);
+			var tradeRepo = new TradeRepository(game.Accessor);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: null
+			));
+
+			var declined = tradeWriteRepo.Decline(new DeclineTradeOfferCommand(
+				DecliningPlayerId: Player2,
+				OfferId: offerId
+			));
+
+			Assert.True(declined);
+			var offer = tradeRepo.Get(offerId);
+			Assert.Equal(TradeOfferStatus.Declined, offer!.Status);
+		}
+
+		[Fact]
+		public void Cancel_ByOfferor_SetsStatusToCancelled() {
+			var game = new TestGame(playerCount: 2);
+			var tradeRepo = new TradeRepository(game.Accessor);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: null
+			));
+
+			var cancelled = tradeWriteRepo.Cancel(new CancelTradeOfferCommand(
+				CancellingPlayerId: Player1,
+				OfferId: offerId
+			));
+
+			Assert.True(cancelled);
+			var offer = tradeRepo.Get(offerId);
+			Assert.Equal(TradeOfferStatus.Cancelled, offer!.Status);
+		}
+
+		[Fact]
+		public void TradeOffers_RoundTripThroughImmutable() {
+			var game = new TestGame(playerCount: 2);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: "test note"
+			));
+
+			var snapshot = game.World.ToImmutable();
+			Assert.NotNull(snapshot.TradeOffers);
+			Assert.Single(snapshot.TradeOffers!);
+			Assert.Equal(100, snapshot.TradeOffers![0].OfferedAmount);
+			Assert.Equal(TradeOfferStatus.Pending, snapshot.TradeOffers![0].Status);
+
+			var restoredGame = new TestGame(snapshot);
+			var restoredTradeRepo = new TradeRepository(restoredGame.Accessor);
+			var incoming = restoredTradeRepo.GetIncoming(Player2);
+			Assert.Single(incoming);
+			Assert.Equal(100, incoming[0].OfferedAmount);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/TradeCommands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/TradeCommands.cs
@@ -1,0 +1,18 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.Commands {
+	public record CreateTradeOfferCommand(
+		PlayerId FromPlayerId,
+		PlayerId ToPlayerId,
+		ResourceDefId OfferedResourceId,
+		decimal OfferedAmount,
+		ResourceDefId WantedResourceId,
+		decimal WantedAmount,
+		string? Note
+	);
+
+	public record AcceptTradeOfferCommand(PlayerId AcceptingPlayerId, TradeOfferId OfferId);
+	public record DeclineTradeOfferCommand(PlayerId DecliningPlayerId, TradeOfferId OfferId);
+	public record CancelTradeOfferCommand(PlayerId CancellingPlayerId, TradeOfferId OfferId);
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/TradeOffer.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/TradeOffer.cs
@@ -1,0 +1,60 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class TradeOffer {
+		internal required TradeOfferId OfferId { get; init; }
+		internal required PlayerId FromPlayerId { get; init; }
+		internal required PlayerId ToPlayerId { get; init; }
+		internal required ResourceDefId OfferedResourceId { get; init; }
+		internal required decimal OfferedAmount { get; init; }
+		internal required ResourceDefId WantedResourceId { get; init; }
+		internal required decimal WantedAmount { get; init; }
+		internal required string? Note { get; init; }
+		internal required DateTime CreatedAt { get; init; }
+		internal TradeOfferStatus Status { get; set; } = TradeOfferStatus.Pending;
+	}
+
+	internal static class TradeOfferExtensions {
+		internal static TradeOfferImmutable ToImmutable(this TradeOffer offer) {
+			return new TradeOfferImmutable(
+				OfferId: offer.OfferId,
+				FromPlayerId: offer.FromPlayerId,
+				ToPlayerId: offer.ToPlayerId,
+				OfferedResourceId: offer.OfferedResourceId,
+				OfferedAmount: offer.OfferedAmount,
+				WantedResourceId: offer.WantedResourceId,
+				WantedAmount: offer.WantedAmount,
+				Note: offer.Note,
+				CreatedAt: offer.CreatedAt,
+				Status: offer.Status
+			);
+		}
+
+		internal static TradeOffer ToMutable(this TradeOfferImmutable offer) {
+			return new TradeOffer {
+				OfferId = offer.OfferId,
+				FromPlayerId = offer.FromPlayerId,
+				ToPlayerId = offer.ToPlayerId,
+				OfferedResourceId = offer.OfferedResourceId,
+				OfferedAmount = offer.OfferedAmount,
+				WantedResourceId = offer.WantedResourceId,
+				WantedAmount = offer.WantedAmount,
+				Note = offer.Note,
+				CreatedAt = offer.CreatedAt,
+				Status = offer.Status
+			};
+		}
+
+		internal static IList<TradeOfferImmutable> ToImmutable(this IList<TradeOffer> offers) {
+			return offers.Select(o => o.ToImmutable()).ToList();
+		}
+
+		internal static IList<TradeOffer> ToMutable(this IList<TradeOfferImmutable> offers) {
+			return offers.Select(o => o.ToMutable()).ToList();
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -28,6 +28,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 		internal IDictionary<AllianceWarId, AllianceWar> Wars { get; set; } = new ConcurrentDictionary<AllianceWarId, AllianceWar>();
 
+		internal IList<TradeOffer> TradeOffers { get; set; } = new List<TradeOffer>();
+		internal readonly Lock TradeOffersLock = new();
+
 		// throws if player not found
 		internal Player GetPlayer(PlayerId playerId) {
 			if (Players.TryGetValue(playerId, out Player? player)) return player;
@@ -82,6 +85,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			worldState.MarketOrders = mutable.MarketOrders;
 			worldState.ChatMessages = mutable.ChatMessages;
 			worldState.Wars = mutable.Wars;
+			worldState.TradeOffers = mutable.TradeOffers;
 		}
 
 
@@ -98,6 +102,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			lock (worldState.ChatMessagesLock) {
 				chatMessagesSnapshot = worldState.ChatMessages.ToImmutable();
 			}
+			IList<TradeOfferImmutable>? tradeOffersSnapshot;
+			lock (worldState.TradeOffersLock) {
+				tradeOffersSnapshot = worldState.TradeOffers.ToImmutable();
+			}
 			return new WorldStateImmutable(
 				Players: worldState.Players.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				GameTickState: worldState.GameTickState.ToImmutable(),
@@ -106,7 +114,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GameId: worldState.GameId,
 				MarketOrders: marketOrdersSnapshot,
 				ChatMessages: chatMessagesSnapshot,
-				Wars: worldState.Wars.ToDictionary(x => x.Key, y => y.Value.ToImmutable())
+				Wars: worldState.Wars.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
+				TradeOffers: tradeOffersSnapshot
 			);
 		}
 
@@ -119,7 +128,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				GameActionQueue = worldStateImmutable.GameActionQueue.Select(x => x.ToMutable()).ToList(),
 				MarketOrders = worldStateImmutable.MarketOrders?.ToMutable() ?? new List<MarketOrder>(),
 				ChatMessages = worldStateImmutable.ChatMessages?.ToMutable() ?? new List<ChatMessage>(),
-				Wars = new ConcurrentDictionary<AllianceWarId, AllianceWar>(worldStateImmutable.Wars?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<AllianceWarId, AllianceWar>())
+				Wars = new ConcurrentDictionary<AllianceWarId, AllianceWar>(worldStateImmutable.Wars?.ToDictionary(x => x.Key, y => y.Value.ToMutable()) ?? new Dictionary<AllianceWarId, AllianceWar>()),
+				TradeOffers = worldStateImmutable.TradeOffers?.ToMutable() ?? new List<TradeOffer>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -64,6 +64,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<FogOfWarRepository>();
 			services.AddSingleton<TechRepository>();
 			services.AddSingleton<TechRepositoryWrite>();
+			services.AddSingleton<TradeRepository>();
+			services.AddSingleton<TradeRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepository.cs
@@ -28,5 +28,26 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public int GetUnreadCount(PlayerId playerId) {
 			return world.GetPlayer(playerId).State.Messages.Count(x => !x.IsRead);
 		}
+
+		public IList<MessageImmutable> GetSentMessages(PlayerId senderId) {
+			return world.Players.Values
+				.SelectMany(p => p.State.Messages)
+				.Where(m => m.SenderId == senderId)
+				.Select(m => m.ToImmutable())
+				.OrderByDescending(m => m.CreatedAt)
+				.ToList();
+		}
+
+		public IList<MessageImmutable> GetThread(PlayerId myId, PlayerId withId) {
+			var myMessages = world.GetPlayer(myId).State.Messages
+				.Where(m => m.SenderId == withId)
+				.Select(m => m.ToImmutable());
+			var theirMessages = world.Players.TryGetValue(withId, out var otherPlayer)
+				? otherPlayer.State.Messages.Where(m => m.SenderId == myId).Select(m => m.ToImmutable())
+				: Enumerable.Empty<MessageImmutable>();
+			return myMessages.Concat(theirMessages)
+				.OrderBy(m => m.CreatedAt)
+				.ToList();
+		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepository.cs
@@ -1,0 +1,51 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class TradeRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public TradeRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IList<TradeOfferImmutable> GetIncoming(PlayerId playerId) {
+			lock (world.TradeOffersLock) {
+				return world.TradeOffers
+					.Where(o => o.ToPlayerId == playerId && o.Status == TradeOfferStatus.Pending)
+					.Select(o => o.ToImmutable())
+					.ToList();
+			}
+		}
+
+		public IList<TradeOfferImmutable> GetSent(PlayerId playerId) {
+			lock (world.TradeOffersLock) {
+				return world.TradeOffers
+					.Where(o => o.FromPlayerId == playerId && o.Status == TradeOfferStatus.Pending)
+					.Select(o => o.ToImmutable())
+					.ToList();
+			}
+		}
+
+		public IList<TradeOfferImmutable> GetHistory(PlayerId playerId, int skip, int take) {
+			lock (world.TradeOffersLock) {
+				return world.TradeOffers
+					.Where(o => (o.FromPlayerId == playerId || o.ToPlayerId == playerId)
+						&& o.Status != TradeOfferStatus.Pending)
+					.OrderByDescending(o => o.CreatedAt)
+					.Skip(skip).Take(take)
+					.Select(o => o.ToImmutable())
+					.ToList();
+			}
+		}
+
+		public TradeOfferImmutable? Get(TradeOfferId offerId) {
+			lock (world.TradeOffersLock) {
+				return world.TradeOffers.FirstOrDefault(o => o.OfferId == offerId)?.ToImmutable();
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
@@ -1,0 +1,106 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class TradeRepositoryWrite {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly TimeProvider timeProvider;
+		private readonly INotificationService notificationService;
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
+
+		public TradeRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			TimeProvider timeProvider,
+			INotificationService notificationService,
+			ResourceRepository resourceRepository,
+			ResourceRepositoryWrite resourceRepositoryWrite
+		) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.timeProvider = timeProvider;
+			this.notificationService = notificationService;
+			this.resourceRepository = resourceRepository;
+			this.resourceRepositoryWrite = resourceRepositoryWrite;
+		}
+
+		public TradeOfferId CreateOffer(CreateTradeOfferCommand command) {
+			var offerId = TradeOfferIdFactory.NewTradeOfferId();
+			lock (world.TradeOffersLock) {
+				world.TradeOffers.Add(new TradeOffer {
+					OfferId = offerId,
+					FromPlayerId = command.FromPlayerId,
+					ToPlayerId = command.ToPlayerId,
+					OfferedResourceId = command.OfferedResourceId,
+					OfferedAmount = command.OfferedAmount,
+					WantedResourceId = command.WantedResourceId,
+					WantedAmount = command.WantedAmount,
+					Note = command.Note,
+					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+					Status = TradeOfferStatus.Pending
+				});
+			}
+			notificationService.Notify(command.ToPlayerId, GameNotificationType.MessageReceived,
+				"New trade offer received.");
+			return offerId;
+		}
+
+		public bool Accept(AcceptTradeOfferCommand command) {
+			lock (world.TradeOffersLock) {
+				var offer = world.TradeOffers.FirstOrDefault(o =>
+					o.OfferId == command.OfferId &&
+					o.ToPlayerId == command.AcceptingPlayerId &&
+					o.Status == TradeOfferStatus.Pending);
+				if (offer == null) return false;
+
+				// Check the accepting player has enough of wanted resource
+				var acceptorHas = resourceRepository.GetAmount(command.AcceptingPlayerId, offer.WantedResourceId);
+				if (acceptorHas < offer.WantedAmount) return false;
+
+				// Check the offering player still has enough
+				var offerorHas = resourceRepository.GetAmount(offer.FromPlayerId, offer.OfferedResourceId);
+				if (offerorHas < offer.OfferedAmount) {
+					offer.Status = TradeOfferStatus.Cancelled;
+					return false;
+				}
+
+				// Swap resources
+				resourceRepositoryWrite.DeductCost(command.AcceptingPlayerId, offer.WantedResourceId, offer.WantedAmount);
+				resourceRepositoryWrite.AddResources(command.AcceptingPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
+				resourceRepositoryWrite.DeductCost(offer.FromPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
+				resourceRepositoryWrite.AddResources(offer.FromPlayerId, offer.WantedResourceId, offer.WantedAmount);
+
+				offer.Status = TradeOfferStatus.Accepted;
+				return true;
+			}
+		}
+
+		public bool Decline(DeclineTradeOfferCommand command) {
+			lock (world.TradeOffersLock) {
+				var offer = world.TradeOffers.FirstOrDefault(o =>
+					o.OfferId == command.OfferId &&
+					o.ToPlayerId == command.DecliningPlayerId &&
+					o.Status == TradeOfferStatus.Pending);
+				if (offer == null) return false;
+				offer.Status = TradeOfferStatus.Declined;
+				return true;
+			}
+		}
+
+		public bool Cancel(CancelTradeOfferCommand command) {
+			lock (world.TradeOffersLock) {
+				var offer = world.TradeOffers.FirstOrDefault(o =>
+					o.OfferId == command.OfferId &&
+					o.FromPlayerId == command.CancellingPlayerId &&
+					o.Status == TradeOfferStatus.Pending);
+				if (offer == null) return false;
+				offer.Status = TradeOfferStatus.Cancelled;
+				return true;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
@@ -68,11 +68,23 @@ namespace BrowserGameEngine.StatefulGameServer {
 					return false;
 				}
 
-				// Swap resources
-				resourceRepositoryWrite.DeductCost(command.AcceptingPlayerId, offer.WantedResourceId, offer.WantedAmount);
-				resourceRepositoryWrite.AddResources(command.AcceptingPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
-				resourceRepositoryWrite.DeductCost(offer.FromPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
-				resourceRepositoryWrite.AddResources(offer.FromPlayerId, offer.WantedResourceId, offer.WantedAmount);
+				// Swap resources — guard against race where resources were spent after pre-check
+				try {
+					resourceRepositoryWrite.DeductCost(command.AcceptingPlayerId, offer.WantedResourceId, offer.WantedAmount);
+				} catch (CannotAffordException) {
+					return false;
+				}
+
+				try {
+					resourceRepositoryWrite.AddResources(command.AcceptingPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
+					resourceRepositoryWrite.DeductCost(offer.FromPlayerId, offer.OfferedResourceId, offer.OfferedAmount);
+					resourceRepositoryWrite.AddResources(offer.FromPlayerId, offer.WantedResourceId, offer.WantedAmount);
+				} catch (CannotAffordException) {
+					// Offeror no longer has the resources — roll back the acceptor's deduction and cancel
+					resourceRepositoryWrite.AddResources(command.AcceptingPlayerId, offer.WantedResourceId, offer.WantedAmount);
+					offer.Status = TradeOfferStatus.Cancelled;
+					return false;
+				}
 
 				offer.Status = TradeOfferStatus.Accepted;
 				return true;


### PR DESCRIPTION
## Summary
- Add direct player-to-player trade offer system (create targeted offer, accept/decline/cancel, trade history)
- Add `TradeOfferId`, `TradeOfferImmutable`, `TradeOffer`, `TradeRepository`, `TradeRepositoryWrite` following MarketOrder patterns
- Add 7 REST endpoints under `/api/trade/` for the full trade offer lifecycle
- Add `Trade.razor` page at `/games/{id}/trade` with split-panel UI (Propose + Incoming Offers cards, My Pending Offers table, Trade History)
- Add `GET /api/messages/sent`, `GET /api/messages/thread/{playerId}`, `POST /api/messages/{id}/reply` to MessagesController
- Redesign `Messages.razor` with tabbed split-panel layout (Inbox / Sent / Alliance Chat) and compose modal
- Add "Trade" nav link in NavMenu alongside Market

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (292 tests, 6 new TradeRepositoryTest cases)
- [ ] Navigate to `/games/{id}/trade` — split-panel loads, propose form works, incoming offers shown
- [ ] Create a trade offer from player A to player B; accept as player B → resources swap correctly
- [ ] Decline and cancel flows work
- [ ] Trade history shows completed trades
- [ ] Messages redesign: Inbox tab lists received messages, Sent tab lists sent messages, compose modal opens
- [ ] Reply endpoint sends new message to original sender
- [ ] Alliance Chat tab shows if player is in an alliance

Closes BGE-489
Closes BGE-485