### PR TITLE
feat: BGE-471 alliance UI — war status indicators, invite, declare war, peace

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -65,11 +65,68 @@
                     <input class="form-control" type="password" @bind="newPassword" placeholder="New password..." />
                     <button class="btn btn-sm btn-secondary mt-1" @onclick="SetPassword">Change Password</button>
                 </div>
+                <div class="mb-2">
+                    <label>Invite Player</label>
+                    <div class="input-group">
+                        <select class="form-select" @bind="invitePlayerId">
+                            <option value="">— Select a player —</option>
+                            @foreach (var p in (allPlayers ?? Array.Empty<PublicPlayerViewModel>())) {
+                                <option value="@p.PlayerId">@p.PlayerName</option>
+                            }
+                        </select>
+                        <button class="btn btn-sm btn-outline-success" @onclick="InvitePlayer">Invite</button>
+                    </div>
+                    @if (!string.IsNullOrEmpty(inviteResult)) {
+                        <div class="small @(inviteResult.StartsWith("Error") ? "text-danger" : "text-success") mt-1">@inviteResult</div>
+                    }
+                </div>
+                <div class="mb-2">
+                    <label>Declare War</label>
+                    <div class="input-group">
+                        <select class="form-select" @bind="warTargetAllianceId">
+                            <option value="">— Select an alliance —</option>
+                            @foreach (var a in (allAlliances ?? Array.Empty<AllianceListItem>())) {
+                                @if (a.AllianceId != detail?.AllianceId) {
+                                    <option value="@a.AllianceId">@a.Name</option>
+                                }
+                            }
+                        </select>
+                        <button class="btn btn-sm btn-outline-danger" @onclick="DeclareWar">Declare War</button>
+                    </div>
+                    @if (!string.IsNullOrEmpty(warResult)) {
+                        <div class="small @(warResult.StartsWith("Error") ? "text-danger" : "text-success") mt-1">@warResult</div>
+                    }
+                </div>
             </div>
         </div>
     }
 
-    @if (myStatus.IsMember && !myStatus.IsPending) {
+    @if (wars != null && wars.Count > 0) {
+        <h3>Wars</h3>
+        <div class="card mb-3">
+            <div class="card-body">
+                @foreach (var war in wars) {
+                    <div class="d-flex justify-content-between align-items-center mb-2 p-2" style="border:1px solid var(--color-border-default); border-radius:var(--radius-md)">
+                        <div>
+                            <span class="badge @(war.Status == "PeaceProposed" ? "bg-warning text-dark" : "bg-danger")">@war.Status</span>
+                            <span class="ms-2">vs <strong>@(war.AttackerAllianceId == detail?.AllianceId ? war.DefenderAllianceName : war.AttackerAllianceName)</strong></span>
+                            <span class="text-muted ms-2" style="font-size:0.8rem">since @war.DeclaredAt.ToString("yyyy-MM-dd")</span>
+                            @if (war.Status == "PeaceProposed" && war.ProposerAllianceId != detail?.AllianceId) {
+                                <span class="badge bg-info ms-2">Peace offered to us</span>
+                            }
+                        </div>
+                        @if (myStatus != null && myStatus.IsLeader && !myStatus.IsPending) {
+                            <button class="btn btn-sm btn-outline-warning" @onclick="() => HandlePeace(war)">
+                                @(war.Status == "PeaceProposed" && war.ProposerAllianceId != detail?.AllianceId ? "Accept Peace" : "Propose Peace")
+                            </button>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    }
+
+    @if (myStatus!.IsMember && !myStatus.IsPending) {
         <h3>Chat</h3>
         <div class="card mb-3">
             <div class="card-body">
@@ -105,11 +162,20 @@
     private AllianceDetailViewModel? detail;
     private MyAllianceStatusViewModel? myStatus;
     private List<AllianceChatPostViewModel>? chatPosts;
+    private List<AllianceWarViewModel>? wars;
+    private PublicPlayerViewModel[]? allPlayers;
+    private AllianceListItem[]? allAlliances;
     private string newMessage = "";
     private string newPassword = "";
     private string newChatBody = "";
+    private string invitePlayerId = "";
+    private string? inviteResult;
+    private string warTargetAllianceId = "";
+    private string? warResult;
     private string? lastError;
     private CancellationTokenSource? _cts;
+
+    private record AllianceListItem(string AllianceId, string Name);
 
     protected override async Task OnInitializedAsync() {
         await Update();
@@ -131,7 +197,30 @@
         if (myStatus?.IsMember == true && myStatus.IsPending == false) {
             chatPosts = await Http.GetFromJsonAsync<List<AllianceChatPostViewModel>>($"api/alliances/{AllianceId}/posts");
         }
+        await LoadWars();
+        if (myStatus?.IsLeader == true && myStatus.IsPending == false) {
+            try {
+                allPlayers = await Http.GetFromJsonAsync<PublicPlayerViewModel[]>("api/playerranking");
+            } catch {
+                allPlayers = Array.Empty<PublicPlayerViewModel>();
+            }
+            try {
+                var allianceList = await Http.GetFromJsonAsync<AllianceViewModel[]>("api/alliances");
+                allAlliances = allianceList?.Select(a => new AllianceListItem(a.AllianceId, a.Name)).ToArray()
+                    ?? Array.Empty<AllianceListItem>();
+            } catch {
+                allAlliances = Array.Empty<AllianceListItem>();
+            }
+        }
         lastError = null;
+    }
+
+    private async Task LoadWars() {
+        try {
+            wars = await Http.GetFromJsonAsync<List<AllianceWarViewModel>>($"api/alliances/{AllianceId}/wars");
+        } catch {
+            wars = new();
+        }
     }
 
     private async Task Accept(string playerId) {
@@ -175,6 +264,36 @@
         var r = await Http.PostAsJsonAsync($"api/alliances/{AllianceId}/posts", new PostAllianceChatRequest { Body = newChatBody });
         if (r.IsSuccessStatusCode) { newChatBody = ""; await Update(); }
         else lastError = await r.Content.ReadAsStringAsync();
+    }
+
+    private async Task InvitePlayer() {
+        inviteResult = null;
+        if (string.IsNullOrEmpty(invitePlayerId)) return;
+        var response = await Http.PostAsJsonAsync($"api/alliances/{AllianceId}/invite",
+            new InvitePlayerRequest { TargetPlayerId = invitePlayerId });
+        inviteResult = response.IsSuccessStatusCode ? "Invite sent." : $"Error: {await response.Content.ReadAsStringAsync()}";
+        invitePlayerId = "";
+    }
+
+    private async Task DeclareWar() {
+        warResult = null;
+        if (string.IsNullOrEmpty(warTargetAllianceId)) return;
+        var response = await Http.PostAsJsonAsync($"api/alliances/{AllianceId}/declare-war",
+            new DeclareWarRequest { TargetAllianceId = warTargetAllianceId });
+        if (response.IsSuccessStatusCode) {
+            warResult = "War declared.";
+            await LoadWars();
+        } else {
+            warResult = $"Error: {await response.Content.ReadAsStringAsync()}";
+        }
+        warTargetAllianceId = "";
+    }
+
+    private async Task HandlePeace(AllianceWarViewModel war) {
+        var response = await Http.PostAsJsonAsync($"api/alliances/wars/{war.WarId}/peace",
+            new PeaceRequest { WarId = war.WarId });
+        if (response.IsSuccessStatusCode) await LoadWars();
+        else lastError = await response.Content.ReadAsStringAsync();
     }
 
     public void Dispose() {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -25,6 +25,27 @@
     <div class="alert alert-danger">@lastError</div>
 }
 
+@if (myInvites != null && myInvites.Count > 0) {
+    <div class="card mb-3">
+        <div class="card-header">Pending Invites</div>
+        <div class="card-body">
+            @foreach (var invite in myInvites) {
+                <div class="d-flex justify-content-between align-items-center mb-2 p-2" style="border:1px solid var(--color-border-default); border-radius:var(--radius-md)">
+                    <div>
+                        <strong>@invite.AllianceName</strong>
+                        <span class="text-muted ms-2">invited by @invite.InviterPlayerName</span>
+                        <span class="text-muted ms-2" style="font-size:0.8rem">expires @invite.ExpiresAt.ToString("yyyy-MM-dd")</span>
+                    </div>
+                    <div>
+                        <button class="btn btn-sm btn-success me-1" @onclick="() => AcceptInvite(invite)">Accept</button>
+                        <button class="btn btn-sm btn-outline-danger" @onclick="() => DeclineInvite(invite)">Decline</button>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}
+
 @if (myStatus != null && !myStatus.IsMember) {
     <div class="card mb-3">
         <div class="card-header">Create Alliance</div>
@@ -49,6 +70,7 @@
             <tr>
                 <th>Name</th>
                 <th>Members</th>
+                <th>Status</th>
                 <th>Created</th>
                 <th></th>
             </tr>
@@ -58,6 +80,13 @@
                 <tr>
                     <td><a href="alliances/@a.AllianceId">@a.Name</a></td>
                     <td>@a.MemberCount</td>
+                    <td>
+                        @if (a.IsAtWar) {
+                            <span class="badge bg-danger">At War</span>
+                        } else {
+                            <span class="badge bg-success">Peaceful</span>
+                        }
+                    </td>
                     <td>@a.Created.ToString("yyyy-MM-dd")</td>
                     <td>
                         @if (myStatus != null && !myStatus.IsMember) {
@@ -88,6 +117,7 @@
 
     private AllianceViewModel[]? alliances;
     private MyAllianceStatusViewModel? myStatus;
+    private List<AllianceInviteViewModel>? myInvites;
     private string createName = "";
     private string createPassword = "";
     private string joinPassword = "";
@@ -112,6 +142,11 @@
     private async Task Update() {
         alliances = await Http.GetFromJsonAsync<AllianceViewModel[]>("api/alliances");
         myStatus = await Http.GetFromJsonAsync<MyAllianceStatusViewModel>("api/alliances/my-status");
+        try {
+            myInvites = await Http.GetFromJsonAsync<List<AllianceInviteViewModel>>("api/alliances/my-invites");
+        } catch {
+            myInvites = new();
+        }
         lastError = null;
     }
 
@@ -148,6 +183,24 @@
 
     private async Task LeaveAlliance() {
         var response = await Http.DeleteAsync("api/alliances/leave");
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task AcceptInvite(AllianceInviteViewModel invite) {
+        var response = await Http.PostAsJsonAsync($"api/alliances/{invite.AllianceId}/accept-invite", new AcceptInviteRequest { InviteId = invite.InviteId });
+        if (response.IsSuccessStatusCode) {
+            await Update();
+        } else {
+            lastError = await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private async Task DeclineInvite(AllianceInviteViewModel invite) {
+        var response = await Http.PostAsJsonAsync($"api/alliances/{invite.AllianceId}/decline-invite", new AcceptInviteRequest { InviteId = invite.InviteId });
         if (response.IsSuccessStatusCode) {
             await Update();
         } else {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -61,7 +61,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				Name = a.Name,
 				Message = a.Message,
 				MemberCount = a.Members.Count(m => !m.IsPending),
-				Created = a.Created
+				Created = a.Created,
+				IsAtWar = allianceWarRepository.GetActiveWars(a.AllianceId).Any()
 			}));
 		}
 

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -17,6 +17,7 @@ namespace BrowserGameEngine.Shared {
 		public string? Message { get; set; }
 		public int MemberCount { get; set; }
 		public DateTime Created { get; set; }
+		public bool IsAtWar { get; set; }
 	}
 
 	public class AllianceDetailViewModel {


### PR DESCRIPTION
## Summary
- Add `IsAtWar` field to `AllianceViewModel` (populated from `AllianceWarRepository.GetActiveWars`)
- Show war status badge (At War / Peaceful) on each row of the alliance list in `Alliances.razor`
- Add pending invites section at top of `Alliances.razor` — accept/decline with `POST /api/alliances/{id}/accept-invite` and `decline-invite`
- Add Wars section in `AllianceDetail.razor` — shows each active war with status badge, opponent name, date, and Propose/Accept Peace button for leaders
- Add Invite Player form in leader controls (player dropdown → `POST /api/alliances/{id}/invite`)
- Add Declare War form in leader controls (alliance dropdown → `POST /api/alliances/{id}/declare-war`)

All backend endpoints pre-exist from BGE-467.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (286 tests)
- [ ] Alliance list shows "At War"/"Peaceful" badges on each row
- [ ] Pending invites section appears when player has invites; accept/decline work
- [ ] Leader can invite a player by name — invite shows in their `/api/alliances/my-invites`
- [ ] Leader can declare war on another alliance — war appears in wars section
- [ ] Propose peace button appears on active war; accept peace appears when other side proposed
- [ ] Peace flow resolves the war

Closes BGE-471