### PR TITLE
feat: BGE-511 victory conditions — EconomicThreshold module + VictoryConditionType tracking

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Games/Results.razor
@@ -14,6 +14,13 @@
 } else if (model != null) {
 	<h1>@model.Name — Results</h1>
 
+	@if (model.VictoryConditionLabel != null) {
+		<div class="alert alert-success d-inline-flex align-items-center gap-2 py-2 px-3 mb-3">
+			<span class="fs-5">🏆</span>
+			<span>@model.VictoryConditionLabel</span>
+		</div>
+	}
+
 	<p class="text-muted">
 		@{
 			var end = model.ActualEndTime ?? model.EndTime;

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -100,7 +100,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				PlayerCount: playerCount,
 				WinnerId: record.WinnerId?.Id,
 				ActualEndTime: record.ActualEndTime,
-				DiscordWebhookUrl: record.DiscordWebhookUrl
+				DiscordWebhookUrl: record.DiscordWebhookUrl,
+				VictoryConditionType: record.VictoryConditionType,
+				VictoryConditionLabel: GetVictoryConditionLabel(record.VictoryConditionType)
 			));
 		}
 
@@ -207,7 +209,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				PlayerCount: GetPlayerCount(updated),
 				WinnerId: updated.WinnerId?.Id,
 				ActualEndTime: updated.ActualEndTime,
-				DiscordWebhookUrl: updated.DiscordWebhookUrl
+				DiscordWebhookUrl: updated.DiscordWebhookUrl,
+				VictoryConditionType: updated.VictoryConditionType,
+				VictoryConditionLabel: GetVictoryConditionLabel(updated.VictoryConditionType)
 			));
 		}
 
@@ -263,7 +267,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (record.Status != GameStatus.Active)
 				return BadRequest($"Game is not active (current status: {record.Status}).");
 
-			await gameLifecycleEngine.FinalizeGameEarlyAsync(record, timeProvider.GetUtcNow().UtcDateTime);
+			await gameLifecycleEngine.FinalizeGameEarlyAsync(record, timeProvider.GetUtcNow().UtcDateTime, BrowserGameEngine.GameDefinition.VictoryConditionTypes.AdminFinalized);
 			logger.LogInformation("Game {GameId} manually finalized by {UserId}", gameId, currentUserContext.UserId);
 			return Ok();
 		}
@@ -308,7 +312,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				ActualEndTime: record.ActualEndTime,
 				EndTime: record.EndTime,
 				Standings: standings,
-				CurrentPlayerId: currentPlayerId
+				CurrentPlayerId: currentPlayerId,
+				VictoryConditionType: record.VictoryConditionType,
+				VictoryConditionLabel: GetVictoryConditionLabel(record.VictoryConditionType)
 			));
 		}
 
@@ -337,7 +343,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				WinnerId: record.WinnerId?.Id,
 				WinnerName: winnerName,
 				DiscordWebhookUrl: record.DiscordWebhookUrl,
-				IsPlayerEnrolled: isPlayerEnrolled
+				IsPlayerEnrolled: isPlayerEnrolled,
+				VictoryConditionType: record.VictoryConditionType
 			);
 		}
 
@@ -345,5 +352,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var instance = gameRegistry.TryGetInstance(record.GameId);
 			return instance?.PlayerCount ?? 0;
 		}
+
+		private static string? GetVictoryConditionLabel(string? victoryConditionType) => victoryConditionType switch {
+			BrowserGameEngine.GameDefinition.VictoryConditionTypes.EconomicThreshold => "Economic victory — score threshold reached",
+			BrowserGameEngine.GameDefinition.VictoryConditionTypes.TimeExpired => "Time expired",
+			BrowserGameEngine.GameDefinition.VictoryConditionTypes.AdminFinalized => "Admin finalized",
+			_ => null
+		};
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Services/DiscordWebhookNotificationService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/DiscordWebhookNotificationService.cs
@@ -24,12 +24,13 @@ namespace BrowserGameEngine.FrontendServer.Services {
 				color: 0x57F287);
 		}
 
-		public async Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount) {
+		public async Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount, string? victoryConditionLabel = null) {
 			if (string.IsNullOrEmpty(record.DiscordWebhookUrl)) return;
 			var winner = winnerName != null ? $"Winner: **{winnerName}**" : "No winner";
+			var conditionLine = victoryConditionLabel != null ? $"\nVictory: {victoryConditionLabel}" : string.Empty;
 			await PostEmbedAsync(record.DiscordWebhookUrl,
 				title: $"Game Over: {record.Name}",
-				description: $"{winner}\n\nhttps://ageofagents.net/games/{record.GameId.Id}/results",
+				description: $"{winner}{conditionLine}\n\nhttps://ageofagents.net/games/{record.GameId.Id}/results",
 				color: 0xED4245);
 		}
 

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -41,7 +41,17 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 					new GameTickModuleDef("techresearch:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("buildqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("spymission:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
+					new GameTickModuleDef("victorycondition:1", new Dictionary<string, string> {
+						{ "type", "EconomicThreshold" },
+						{ "threshold", "500000" }
+					}.ToFrozenDictionary()),
 					new GameTickModuleDef("gamefinalization:1", new Dictionary<string, string> { }.ToFrozenDictionary())
+				},
+
+				VictoryConditions = new List<VictoryConditionDef> {
+					new VictoryConditionDef(VictoryConditionTypes.EconomicThreshold, new Dictionary<string, string> {
+						{ "threshold", "500000" }
+					})
 				},
 
 				Assets = new List<AssetDef> {

--- a/src/BrowserGameEngine.GameDefinition/GameDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/GameDef.cs
@@ -12,6 +12,7 @@ namespace BrowserGameEngine.GameDefinition {
 		public ResourceDefId ScoreResource { get; init; } = null!; // player ranking is based on this resource
 		public IEnumerable<GameTickModuleDef> GameTickModules { get; init; } = new List<GameTickModuleDef>();
 		public IEnumerable<TechNodeDef> TechNodes { get; init; } = new List<TechNodeDef>();
+		public IReadOnlyList<VictoryConditionDef> VictoryConditions { get; init; } = [];
 		public TimeSpan TickDuration { get; init; } = TimeSpan.FromMinutes(20);
 
 	}

--- a/src/BrowserGameEngine.GameDefinition/VictoryConditionDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/VictoryConditionDef.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameDefinition {
+	public record VictoryConditionDef(
+		string Type,
+		IReadOnlyDictionary<string, string> Properties
+	);
+}

--- a/src/BrowserGameEngine.GameDefinition/VictoryConditionTypes.cs
+++ b/src/BrowserGameEngine.GameDefinition/VictoryConditionTypes.cs
@@ -1,0 +1,7 @@
+namespace BrowserGameEngine.GameDefinition {
+	public static class VictoryConditionTypes {
+		public const string TimeExpired = "TimeExpired";
+		public const string EconomicThreshold = "EconomicThreshold";
+		public const string AdminFinalized = "AdminFinalized";
+	}
+}

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -15,6 +15,7 @@ namespace BrowserGameEngine.GameModel {
 		TimeSpan TickDuration,
 		PlayerId? WinnerId = null,
 		DateTime? ActualEndTime = null,
+		string? VictoryConditionType = null,
 		string? CreatedByUserId = null,
 		string? DiscordWebhookUrl = null
 	);

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -15,7 +15,8 @@ namespace BrowserGameEngine.Shared {
 		string? WinnerId = null,
 		string? WinnerName = null,
 		string? DiscordWebhookUrl = null,
-		bool IsPlayerEnrolled = false
+		bool IsPlayerEnrolled = false,
+		string? VictoryConditionType = null
 	);
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -12,7 +12,9 @@ namespace BrowserGameEngine.Shared {
 		int PlayerCount,
 		string? WinnerId,
 		DateTime? ActualEndTime,
-		string? DiscordWebhookUrl = null
+		string? DiscordWebhookUrl = null,
+		string? VictoryConditionType = null,
+		string? VictoryConditionLabel = null
 	);
 
 	public record CreateGameRequest(
@@ -45,7 +47,9 @@ namespace BrowserGameEngine.Shared {
 		DateTime? ActualEndTime,
 		DateTime EndTime,
 		List<GameResultEntryViewModel> Standings,
-		string? CurrentPlayerId = null
+		string? CurrentPlayerId = null,
+		string? VictoryConditionType = null,
+		string? VictoryConditionLabel = null
 	);
 
 	/// <summary>A game the current user is actively playing in, with their player info.</summary>

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -1,3 +1,4 @@
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -98,16 +99,16 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				.ToList();
 
 			foreach (var record in toFinalize) {
-				await FinalizeGameAsync(record, utcNow);
+				await FinalizeGameAsync(record, utcNow, VictoryConditionTypes.TimeExpired);
 			}
 			return toFinalize.Count > 0;
 		}
 
-		public Task FinalizeGameEarlyAsync(GameRecordImmutable record, DateTime utcNow) {
-			return FinalizeGameAsync(record, utcNow);
+		public Task FinalizeGameEarlyAsync(GameRecordImmutable record, DateTime utcNow, string victoryConditionType = VictoryConditionTypes.AdminFinalized) {
+			return FinalizeGameAsync(record, utcNow, victoryConditionType);
 		}
 
-		private async Task FinalizeGameAsync(GameRecordImmutable record, DateTime utcNow) {
+		private async Task FinalizeGameAsync(GameRecordImmutable record, DateTime utcNow, string victoryConditionType = VictoryConditionTypes.TimeExpired) {
 			if (!_finalizingGames.TryAdd(record.GameId.Id, true)) {
 				logger.LogWarning("Game {GameId} is already being finalized — skipping duplicate finalization", record.GameId.Id);
 				return;
@@ -115,7 +116,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			var instance = gameRegistry.TryGetInstance(record.GameId);
 			if (instance == null) {
 				// Instance already gone; update the record only
-				globalState.UpdateGame(record, record with { Status = GameStatus.Finished, ActualEndTime = utcNow });
+				globalState.UpdateGame(record, record with { Status = GameStatus.Finished, ActualEndTime = utcNow, VictoryConditionType = victoryConditionType });
 				logger.LogWarning("Finalizing game {GameId}: no in-memory instance found, updated record only", record.GameId.Id);
 				return;
 			}
@@ -153,7 +154,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			var updated = record with {
 				Status = GameStatus.Finished,
 				ActualEndTime = utcNow,
-				WinnerId = winnerId
+				WinnerId = winnerId,
+				VictoryConditionType = victoryConditionType
 			};
 			globalState.UpdateGame(record, updated);
 
@@ -173,8 +175,16 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			logger.LogInformation("Game {GameId} finalized. Winner: {WinnerId}, Players: {PlayerCount}",
 				record.GameId.Id, winnerId?.Id ?? "(none)", rankings.Count);
 
-			await notificationService.NotifyGameFinishedAsync(updated, winnerId, winnerName, rankings.Count);
+			var victoryLabel = GetVictoryConditionLabel(victoryConditionType);
+			await notificationService.NotifyGameFinishedAsync(updated, winnerId, winnerName, rankings.Count, victoryLabel);
 		}
+
+		private static string? GetVictoryConditionLabel(string victoryConditionType) => victoryConditionType switch {
+			VictoryConditionTypes.EconomicThreshold => "Economic victory — score threshold reached",
+			VictoryConditionTypes.TimeExpired => "Time expired",
+			VictoryConditionTypes.AdminFinalized => "Admin finalized",
+			_ => null
+		};
 
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/IGameNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/IGameNotificationService.cs
@@ -4,6 +4,6 @@ using System.Threading.Tasks;
 namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 	public interface IGameNotificationService {
 		Task NotifyGameStartedAsync(GameRecordImmutable record, int playerCount);
-		Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount);
+		Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount, string? victoryConditionLabel = null);
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/NullGameNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/NullGameNotificationService.cs
@@ -4,6 +4,6 @@ using System.Threading.Tasks;
 namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 	public class NullGameNotificationService : IGameNotificationService {
 		public Task NotifyGameStartedAsync(GameRecordImmutable record, int playerCount) => Task.CompletedTask;
-		public Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount) => Task.CompletedTask;
+		public Task NotifyGameFinishedAsync(GameRecordImmutable record, PlayerId? winnerId, string? winnerName, int playerCount, string? victoryConditionLabel = null) => Task.CompletedTask;
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -76,6 +76,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, TechResearchTimerModule>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
 			services.AddSingleton<IGameTickModule, SpyMissionModule>();
+			services.AddSingleton<IGameTickModule, VictoryConditionModule>();
 			services.AddSingleton<IGameTickModule, GameFinalizationModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/GameFinalizationModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/GameFinalizationModule.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using System;
@@ -72,7 +73,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 			var updatedRecord = gameRecord with {
 				Status = GameStatus.Finished,
 				WinnerId = winnerId,
-				ActualEndTime = finishedAt
+				ActualEndTime = finishedAt,
+				VictoryConditionType = VictoryConditionTypes.TimeExpired
 			};
 			globalState.UpdateGame(gameRecord, updatedRecord);
 			gameRegistry.Remove(gameId);

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/VictoryConditionModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/VictoryConditionModule.cs
@@ -1,0 +1,67 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class VictoryConditionModule : IGameTickModule {
+		public string Name => "victorycondition:1";
+
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private readonly GlobalState globalState;
+		private readonly GameDef gameDef;
+		private readonly GameLifecycleEngine gameLifecycleEngine;
+		private readonly object _checkLock = new();
+
+		private string _type = VictoryConditionTypes.EconomicThreshold;
+		private decimal _threshold = 500_000;
+
+		public VictoryConditionModule(
+			IWorldStateAccessor worldStateAccessor,
+			GlobalState globalState,
+			GameDef gameDef,
+			GameLifecycleEngine gameLifecycleEngine) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.globalState = globalState;
+			this.gameDef = gameDef;
+			this.gameLifecycleEngine = gameLifecycleEngine;
+		}
+
+		public void SetProperty(string name, string value) {
+			if (name == "type") _type = value;
+			else if (name == "threshold" && decimal.TryParse(value, out var t)) _threshold = t;
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			if (_type != VictoryConditionTypes.EconomicThreshold) return;
+
+			var score = GetScore(playerId);
+			if (score < _threshold) return;
+
+			var gameId = worldStateAccessor.WorldState.GameId;
+			var gameRecord = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);
+			if (gameRecord == null || gameRecord.Status != GameStatus.Active) return;
+
+			lock (_checkLock) {
+				// Re-check inside lock to avoid double-finalization
+				gameRecord = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);
+				if (gameRecord == null || gameRecord.Status != GameStatus.Active) return;
+
+				// Fire-and-forget; exceptions are logged inside FinalizeGameEarlyAsync
+				_ = gameLifecycleEngine.FinalizeGameEarlyAsync(gameRecord, DateTime.UtcNow, VictoryConditionTypes.EconomicThreshold);
+			}
+		}
+
+		private decimal GetScore(PlayerId playerId) {
+			if (worldStateAccessor.WorldState.Players.TryGetValue(playerId, out var player)) {
+				if (player.State.Resources.TryGetValue(gameDef.ScoreResource, out var score)) {
+					return score;
+				}
+			}
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `VictoryConditionTypes` constants (`TimeExpired`, `EconomicThreshold`, `AdminFinalized`) and `VictoryConditionDef` record to `GameDefinition`
- Add `VictoryConditionType` field to `GameRecordImmutable` (null for old games, set on finalization)
- Update `GameLifecycleEngine.FinalizeGameEarlyAsync` to accept and stamp `victoryConditionType`; update `GameFinalizationModule` to also stamp `TimeExpired`
- Add `VictoryConditionModule` tick module: when any player's score reaches the configured EconomicThreshold, triggers early game finalization with `EconomicThreshold` victory type
- Register module in DI before `GameFinalizationModule`; wire `victorycondition:1` with threshold=500000 into SCO `StarcraftOnlineGameDefFactory`; add `VictoryConditions` list to `GameDef`
- Add `VictoryConditionType`/`VictoryConditionLabel` to `GameDetailViewModel`, `GameResultsViewModel`, `GameSummaryViewModel`; map in `GamesController`
- Pass `victoryConditionLabel` through `IGameNotificationService.NotifyGameFinishedAsync` to Discord webhook
- Display `VictoryConditionLabel` banner near top of `Results.razor` when non-null

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (292 tests)
- [ ] Verify economic threshold victory fires when a player's score hits 500,000 land
- [ ] Verify `VictoryConditionType` is stored and returned in game results endpoint
- [ ] Verify Results page shows victory condition banner for finished games
- [ ] Verify Discord notification includes victory condition line when set

Closes BGE-511