### PR TITLE
feat: merge Tech Tree and Upgrades into single Research section

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Research.razor
@@ -119,6 +119,12 @@
 
 	.tech-node-btn:hover { opacity: 0.85; }
 
+	.tech-section-divider {
+		border: none;
+		border-top: 1px solid #374151;
+		margin: 0.5rem 0 1.5rem;
+	}
+
 	@@keyframes tech-pulse {
 		0%, 100% { box-shadow: 0 0 4px var(--race-color); }
 		50%       { box-shadow: 0 0 12px var(--race-color); }
@@ -152,11 +158,9 @@
 			<span class="error">@lastError</span>
 		}
 
-		@if (upgradesModel != null) {
-			<h3>Upgrades</h3>
+		<div class="tech-tree race-@(upgradesModel?.PlayerType.ToLowerInvariant() ?? techTreeModel?.PlayerType.ToLowerInvariant() ?? "")">
 
-			<div class="tech-tree race-@upgradesModel.PlayerType.ToLowerInvariant()">
-
+			@if (upgradesModel != null) {
 				<div class="tech-row">
 					<div class="tech-row-label">Attack</div>
 					@for (int lvl = 1; lvl <= upgradesModel.MaxUpgradeLevel; lvl++) {
@@ -212,14 +216,12 @@
 						}
 					}
 				</div>
+			}
 
-			</div>
-		}
-
-		@if (techTreeModel != null) {
-			<h3>Tech Tree</h3>
-
-			<div class="tech-tree race-@techTreeModel.PlayerType.ToLowerInvariant()">
+			@if (techTreeModel != null) {
+				@if (upgradesModel != null) {
+					<hr class="tech-section-divider" />
+				}
 
 				@foreach (var tier in new[] { 1, 2, 3 }) {
 					var tierNodes = techTreeModel.Nodes.Where(n => n.Tier == tier).ToList();
@@ -256,9 +258,9 @@
 						}
 					</div>
 				}
+			}
 
-			</div>
-		}
+		</div>
 	}
 </div>
 


### PR DESCRIPTION
## Summary
- Removes the redundant `<h3>Upgrades</h3>` and `<h3>Tech Tree</h3>` sub-headings from `Research.razor`
- Merges both sections into a single `.tech-tree` container: Attack/Defense upgrade rows first, then a thin divider, then Tier 1/2/3 tech tree rows
- No logic changes — same API calls, same visual components, just unified layout

Closes [BGE-528](/BGE/issues/BGE-528)

## Test plan
- [ ] Navigate to `/games/{id}/research` — page loads with single unified tree, no duplicate headings
- [ ] Attack/Defense upgrade rows appear above the divider; Tier rows appear below
- [ ] `/upgrades` route still works (alias kept)
- [ ] Build passes: `dotnet build`