### PR TITLE
test: BGE-512 xUnit tests for victory conditions

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameFinalizationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameFinalizationTest.cs
@@ -1,3 +1,4 @@
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
@@ -100,6 +101,16 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
 			Assert.Equal(GameStatus.Active, gameRecord.Status);
 			Assert.Empty(game.GlobalState.GetAchievements());
+		}
+
+		[Fact]
+		public void CalculateTick_WhenEndTimeReached_SetsVictoryConditionTypeToTimeExpired() {
+			var (game, _, module) = Setup(endTime: DateTime.UtcNow.AddHours(-1));
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single(g => g.GameId.Id == TestGameId);
+			Assert.Equal(VictoryConditionTypes.TimeExpired, gameRecord.VictoryConditionType);
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
@@ -1,0 +1,97 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Linq;
+using Xunit;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class VictoryConditionModuleTest {
+		private const string TestGameId = "default";
+		private const decimal LowThreshold = 500m;   // players start with res1=1000, so above threshold
+		private const decimal HighThreshold = 9999m;  // players start with res1=1000, so below threshold
+
+		private static (TestGame game, GameRegistryNs.GameRegistry registry, VictoryConditionModule module) Setup(
+			decimal threshold = LowThreshold, int playerCount = 1) {
+			var game = new TestGame(playerCount);
+
+			var record = new GameRecordImmutable(
+				new GameId(TestGameId), "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddHours(-2), DateTime.UtcNow.AddHours(1), TimeSpan.FromSeconds(30));
+			game.GlobalState.AddGame(record);
+
+			var registry = new GameRegistryNs.GameRegistry(game.GlobalState);
+			var instance = new GameRegistryNs.GameInstance(record, game.World, game.GameDef);
+			registry.Register(instance);
+
+			var storage = new InMemoryBlobStorage();
+			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
+			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
+			var userRepositoryWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+			var lifecycleEngine = new GameRegistryNs.GameLifecycleEngine(
+				registry,
+				game.GlobalState,
+				persistenceService,
+				globalPersistenceService,
+				new GameRegistryNs.NullGameNotificationService(),
+				new InMemoryPlayerNotificationService(),
+				userRepositoryWrite,
+				TimeProvider.System,
+				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
+			);
+
+			var module = new VictoryConditionModule(game.Accessor, game.GlobalState, game.GameDef, lifecycleEngine);
+			module.SetProperty("type", VictoryConditionTypes.EconomicThreshold);
+			module.SetProperty("threshold", threshold.ToString());
+
+			return (game, registry, module);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenScoreAtOrAboveThreshold_FinalizesGameWithEconomicThreshold() {
+			var (game, _, module) = Setup(threshold: LowThreshold);
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Finished, gameRecord.Status);
+			Assert.Equal(VictoryConditionTypes.EconomicThreshold, gameRecord.VictoryConditionType);
+		}
+
+		[Fact]
+		public void CalculateTick_WhenScoreBelowThreshold_DoesNotFinalizeGame() {
+			var (game, _, module) = Setup(threshold: HighThreshold);
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Active, gameRecord.Status);
+			Assert.Null(gameRecord.VictoryConditionType);
+		}
+
+		[Fact]
+		public void CalculateTick_AfterGameFinalized_SecondCallIsNoOp() {
+			var (game, _, module) = Setup(threshold: LowThreshold, playerCount: 2);
+			var player2 = new PlayerId("player1");
+
+			// First call finalizes the game
+			module.CalculateTick(game.Player1);
+			var recordAfterFirst = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Finished, recordAfterFirst.Status);
+
+			// Second call for a different player must be a no-op
+			module.CalculateTick(player2);
+
+			var recordAfterSecond = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Finished, recordAfterSecond.Status);
+			Assert.Equal(VictoryConditionTypes.EconomicThreshold, recordAfterSecond.VictoryConditionType);
+			// VictoryConditionType must not have been overwritten to a different value
+			Assert.Equal(recordAfterFirst.VictoryConditionType, recordAfterSecond.VictoryConditionType);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `VictoryConditionModuleTest` with 3 tests covering the new `VictoryConditionModule`:
  - Score at/above threshold finalizes game with `VictoryConditionType = "EconomicThreshold"`
  - Score below threshold leaves game Active
  - Double-finalization guard: second `CalculateTick` after game is Finished is a no-op
- Adds 1 test to `GameFinalizationTest`: time-expired finalization stamps `VictoryConditionType = "TimeExpired"`

All 296 tests pass.

## Smoke test (manual)
To verify end-to-end in dev:
1. In `StarcraftOnlineGameDefFactory.cs`, temporarily lower the EconomicThreshold to e.g. `"threshold": "100"`.
2. Start the game and accumulate minerals past 100.
3. After the next tick, the game should transition to Finished.
4. Check the results page — `VictoryConditionLabel` should show "Economic victory — score threshold reached".

Closes BGE-512.