### PR TITLE
feat: BGE-523 React pages — Spies, SpyReports, Diplomacy, EnemyBase, SelectEnemy

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -3,6 +3,11 @@ import { Base } from '@/pages/Base'
 import { Units } from '@/pages/Units'
 import { Research } from '@/pages/Research'
 import { Market } from '@/pages/Market'
+import { Spies } from '@/pages/Spies'
+import { SpyReports } from '@/pages/SpyReports'
+import { Diplomacy } from '@/pages/Diplomacy'
+import { EnemyBase } from '@/pages/EnemyBase'
+import { SelectEnemy } from '@/pages/SelectEnemy'
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -49,6 +54,36 @@ function MarketPage() {
   return <Market gameId={gameId} />
 }
 
+function SpiesPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Spies gameId={gameId} />
+}
+
+function SpyReportsPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <SpyReports gameId={gameId} />
+}
+
+function DiplomacyPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Diplomacy gameId={gameId} />
+}
+
+function EnemyBasePage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <EnemyBase gameId={gameId} />
+}
+
+function SelectEnemyPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <SelectEnemy gameId={gameId} />
+}
+
 const router = createBrowserRouter([
   {
     path: '/',
@@ -72,13 +107,13 @@ const router = createBrowserRouter([
       { path: 'ranking', element: <TodoPage name="Player Ranking" /> },
       { path: 'alliances', element: <TodoPage name="Alliances" /> },
       { path: 'allianceranking', element: <TodoPage name="Alliance Ranking" /> },
-      { path: 'diplomacy', element: <TodoPage name="Diplomacy" /> },
-      { path: 'spies', element: <TodoPage name="Spies" /> },
-      { path: 'spy', element: <TodoPage name="Spy Reports" /> },
-      { path: 'selectenemy/:unitId', element: <TodoPage name="Select Enemy" /> },
+      { path: 'diplomacy', element: <DiplomacyPage /> },
+      { path: 'spies', element: <SpiesPage /> },
+      { path: 'spy', element: <SpyReportsPage /> },
+      { path: 'selectenemy/:unitId', element: <SelectEnemyPage /> },
       { path: 'unitdefinitions', element: <TodoPage name="Unit Definitions" /> },
       { path: 'player/:playerId', element: <TodoPage name="Player Profile" /> },
-      { path: 'enemybase/:enemyPlayerId', element: <TodoPage name="Enemy Base" /> },
+      { path: 'enemybase/:enemyPlayerId', element: <EnemyBasePage /> },
       { path: 'join', element: <TodoPage name="Join Game" /> },
       { path: 'summary', element: <TodoPage name="Game Summary" /> },
       { path: 'results', element: <TodoPage name="Game Results" /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -369,14 +369,58 @@ export interface AllianceRankingViewModel {
 
 // Diplomacy
 
-export interface DiplomacyEntryViewModel {
-  playerId: string
-  playerName: string
-  relationshipStatus: string
+export type DiplomacyProposalType = 'Nap' | 'ResourceAgreement'
+
+export interface DiplomacyProposalViewModel {
+  proposalId: string
+  type: DiplomacyProposalType
+  proposerPlayerId: string
+  proposerPlayerName: string
+  targetPlayerId: string
+  targetPlayerName: string
+  durationTicks: number
+  mineralsPerTick: number
+  gasPerTick: number
+  proposedAt: string
 }
 
-export interface DiplomacyViewModel {
-  entries: DiplomacyEntryViewModel[]
+export interface ActiveNapViewModel {
+  napId: string
+  partnerPlayerId: string
+  partnerPlayerName: string
+  ticksRemaining: number
+}
+
+export interface ActiveResourceAgreementViewModel {
+  agreementId: string
+  partnerPlayerId: string
+  partnerPlayerName: string
+  mineralsPerTick: number
+  gasPerTick: number
+  ticksRemaining: number
+}
+
+export interface DiplomacyStatusViewModel {
+  pendingIncoming: DiplomacyProposalViewModel[]
+  pendingSent: DiplomacyProposalViewModel[]
+  activeNaps: ActiveNapViewModel[]
+  activeResourceAgreements: ActiveResourceAgreementViewModel[]
+}
+
+export interface ProposeNapRequest {
+  targetPlayerId: string
+  durationTicks: number
+}
+
+export interface ProposeResourceAgreementRequest {
+  targetPlayerId: string
+  durationTicks: number
+  mineralsPerTick: number
+  gasPerTick: number
+}
+
+export interface RespondToProposalRequest {
+  accept: boolean
 }
 
 // Spy
@@ -384,7 +428,8 @@ export interface DiplomacyViewModel {
 export interface SpyPlayerEntryViewModel {
   playerId: string
   playerName: string
-  spyCount: number
+  score: number
+  cooldownExpiresAt: string | null
 }
 
 export interface SpyMissionViewModel {
@@ -398,23 +443,27 @@ export interface SpyMissionViewModel {
   result: string | null
 }
 
+export interface UnitEstimateViewModel {
+  unitDefId: string
+  unitTypeName: string
+  approximateCount: number
+}
+
 export interface SpyReportViewModel {
-  id: string
-  sourceMissionId: string
   targetPlayerId: string
   targetPlayerName: string
-  missionType: string
-  success: boolean
-  reportData: string
-  createdAt: string
+  approximateMinerals: number
+  approximateGas: number
+  unitEstimates: UnitEstimateViewModel[]
+  reportTime: string
+  cooldownExpiresAt: string
 }
 
 export interface SpyAttemptViewModel {
   id: string
-  attackerPlayerName: string
-  missionType: string
-  success: boolean
-  createdAt: string
+  attackerName: string
+  actionType: string
+  timestamp: string
 }
 
 export interface SendSpyMissionRequest {
@@ -429,26 +478,34 @@ export interface SendSpyMissionResponse {
 
 // Enemy Base / Battle
 
-export interface EnemyBaseViewModel {
-  playerId: string
-  playerName: string
-  score: number
-  units: UnitViewModel[]
-  assets: AssetViewModel[]
+export interface UnitLossViewModel {
+  unitName: string
+  count: number
 }
 
-export interface SelectEnemyEntryViewModel {
-  playerId: string
-  playerName: string
-  score: number
-  protectionTicksRemaining: number
+export interface BattleResultViewModel {
+  attackerId: string | null
+  attackerName: string | null
+  defenderId: string | null
+  defenderName: string | null
+  outcome: string | null
+  totalAttackerStrengthBefore: number
+  totalDefenderStrengthBefore: number
+  unitsLostByAttacker: UnitLossViewModel[]
+  unitsLostByDefender: UnitLossViewModel[]
+  resourcesPillaged: Record<string, number>
+  landTransferred: number
+  workersCaptured: number
+}
+
+export interface EnemyBaseViewModel {
+  playerAttackingUnits: UnitsViewModel
+  enemyDefendingUnits: UnitsViewModel
+  spyCostLabel: string
 }
 
 export interface SelectEnemyViewModel {
-  unitId: string
-  unitName: string
-  unitCount: number
-  players: SelectEnemyEntryViewModel[]
+  attackablePlayers: PublicPlayerViewModel[]
 }
 
 // Chat

--- a/src/ReactClient/src/pages/Diplomacy.tsx
+++ b/src/ReactClient/src/pages/Diplomacy.tsx
@@ -1,0 +1,367 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type {
+  DiplomacyStatusViewModel,
+  DiplomacyProposalViewModel,
+  PublicPlayerViewModel,
+  ProposeNapRequest,
+  ProposeResourceAgreementRequest,
+  RespondToProposalRequest,
+} from '@/api/types'
+
+interface DiplomacyProps {
+  gameId: string
+}
+
+function proposalTypeLabel(type: string): string {
+  switch (type) {
+    case 'Nap': return 'Non-Aggression Pact'
+    case 'ResourceAgreement': return 'Resource Agreement'
+    default: return type
+  }
+}
+
+function proposalTerms(p: DiplomacyProposalViewModel): string {
+  if (p.type === 'ResourceAgreement') {
+    return `${p.mineralsPerTick} minerals + ${p.gasPerTick} gas/tick`
+  }
+  return '—'
+}
+
+export function Diplomacy({ gameId }: DiplomacyProps) {
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [proposeMode, setProposeMode] = useState<'nap' | 'resource' | null>(null)
+  const [selectedTargetId, setSelectedTargetId] = useState('')
+  const [durationTicks, setDurationTicks] = useState(100)
+  const [mineralsPerTick, setMineralsPerTick] = useState(0)
+  const [gasPerTick, setGasPerTick] = useState(0)
+
+  const { data: status, refetch: refetchStatus } = useQuery<DiplomacyStatusViewModel>({
+    queryKey: ['diplomacy', gameId],
+    queryFn: () => apiClient.get('/api/diplomacy/status').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  const { data: players } = useQuery<PublicPlayerViewModel[]>({
+    queryKey: ['playerranking', gameId],
+    queryFn: () => apiClient.get('/api/playerranking').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const respondMutation = useMutation({
+    mutationFn: ({ proposalId, accept }: { proposalId: string; accept: boolean }) => {
+      const body: RespondToProposalRequest = { accept }
+      return apiClient.post(`/api/diplomacy/proposals/${proposalId}/respond`, body)
+    },
+    onSuccess: (_, { accept }) => {
+      setSuccess(accept ? 'Proposal accepted.' : 'Proposal declined.')
+      void refetchStatus()
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Request failed')
+    },
+  })
+
+  const proposeMutation = useMutation({
+    mutationFn: () => {
+      if (proposeMode === 'nap') {
+        const body: ProposeNapRequest = { targetPlayerId: selectedTargetId, durationTicks }
+        return apiClient.post('/api/diplomacy/propose/nap', body)
+      } else {
+        const body: ProposeResourceAgreementRequest = {
+          targetPlayerId: selectedTargetId,
+          durationTicks,
+          mineralsPerTick,
+          gasPerTick,
+        }
+        return apiClient.post('/api/diplomacy/propose/resource-agreement', body)
+      }
+    },
+    onSuccess: () => {
+      setSuccess('Proposal sent.')
+      setProposeMode(null)
+      setSelectedTargetId('')
+      void refetchStatus()
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Proposal failed')
+    },
+  })
+
+  const invalidateAll = () => void queryClient.invalidateQueries({ queryKey: ['diplomacy', gameId] })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Diplomacy</h1>
+
+      {error && <div className="text-destructive text-sm">{error}</div>}
+      {success && <div className="text-green-400 text-sm">{success}</div>}
+
+      {/* Incoming proposals */}
+      {(status?.pendingIncoming.length ?? 0) > 0 && (
+        <div className="rounded-lg border border-yellow-700 bg-yellow-900/10">
+          <div className="border-b border-yellow-700 bg-yellow-900/20 px-4 py-3">
+            <strong className="text-sm text-yellow-200">
+              Incoming Proposals ({status!.pendingIncoming.length})
+            </strong>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-yellow-700/50">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">From</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {status!.pendingIncoming.map((p) => (
+                  <tr key={p.proposalId} className="border-b border-border">
+                    <td className="py-2 px-3 font-medium">{p.proposerPlayerName}</td>
+                    <td className="py-2 px-3">{proposalTypeLabel(p.type)}</td>
+                    <td className="py-2 px-3 text-muted-foreground">{proposalTerms(p)}</td>
+                    <td className="py-2 px-3">{p.durationTicks} ticks</td>
+                    <td className="py-2 px-3">
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => {
+                            setError(null); setSuccess(null)
+                            respondMutation.mutate({ proposalId: p.proposalId, accept: true })
+                            invalidateAll()
+                          }}
+                          className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+                        >
+                          Accept
+                        </button>
+                        <button
+                          onClick={() => {
+                            setError(null); setSuccess(null)
+                            respondMutation.mutate({ proposalId: p.proposalId, accept: false })
+                            invalidateAll()
+                          }}
+                          className="rounded border border-destructive px-2 py-0.5 text-xs text-destructive hover:bg-destructive/10"
+                        >
+                          Decline
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Active NAPs */}
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <strong className="text-sm">Active Non-Aggression Pacts</strong>
+        </div>
+        {!status || status.activeNaps.length === 0 ? (
+          <div className="p-4 text-muted-foreground text-sm">No active NAPs.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
+                </tr>
+              </thead>
+              <tbody>
+                {status.activeNaps.map((nap) => (
+                  <tr key={nap.napId} className="border-b border-border">
+                    <td className="py-2 px-3">{nap.partnerPlayerName}</td>
+                    <td className="py-2 px-3">{nap.ticksRemaining}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Active Resource Agreements */}
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <strong className="text-sm">Active Resource Agreements</strong>
+        </div>
+        {!status || status.activeResourceAgreements.length === 0 ? (
+          <div className="p-4 text-muted-foreground text-sm">No active resource agreements.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Minerals/tick</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Gas/tick</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
+                </tr>
+              </thead>
+              <tbody>
+                {status.activeResourceAgreements.map((a) => (
+                  <tr key={a.agreementId} className="border-b border-border">
+                    <td className="py-2 px-3">{a.partnerPlayerName}</td>
+                    <td className="py-2 px-3">{a.mineralsPerTick}</td>
+                    <td className="py-2 px-3">{a.gasPerTick}</td>
+                    <td className="py-2 px-3">{a.ticksRemaining}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Sent proposals */}
+      {(status?.pendingSent.length ?? 0) > 0 && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Sent Proposals (awaiting response)</strong>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">To</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Proposed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {status!.pendingSent.map((p) => (
+                  <tr key={p.proposalId} className="border-b border-border">
+                    <td className="py-2 px-3">{p.targetPlayerName}</td>
+                    <td className="py-2 px-3">{proposalTypeLabel(p.type)}</td>
+                    <td className="py-2 px-3 text-muted-foreground">{proposalTerms(p)}</td>
+                    <td className="py-2 px-3">{p.durationTicks} ticks</td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {new Date(p.proposedAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Propose Agreement */}
+      <div className="rounded-lg border bg-card">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <strong className="text-sm">Propose Agreement</strong>
+          <div className="flex gap-2">
+            <button
+              onClick={() => { setProposeMode('nap'); setError(null); setSuccess(null) }}
+              className={`rounded px-3 py-1 text-xs ${proposeMode === 'nap' ? 'bg-primary text-primary-foreground' : 'border border-primary text-primary'}`}
+            >
+              Non-Aggression Pact
+            </button>
+            <button
+              onClick={() => { setProposeMode('resource'); setError(null); setSuccess(null) }}
+              className={`rounded px-3 py-1 text-xs ${proposeMode === 'resource' ? 'bg-primary text-primary-foreground' : 'border border-primary text-primary'}`}
+            >
+              Resource Agreement
+            </button>
+          </div>
+        </div>
+
+        {proposeMode && (
+          <div className="p-5 space-y-4">
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Target Player</label>
+              {players ? (
+                <select
+                  value={selectedTargetId}
+                  onChange={(e) => setSelectedTargetId(e.target.value)}
+                  className="w-full max-w-xs rounded border bg-input px-2 py-1.5 text-sm"
+                >
+                  <option value="">— Select a player —</option>
+                  {players.map((p) => (
+                    <option key={p.playerId} value={p.playerId}>
+                      {p.playerName}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  value={selectedTargetId}
+                  onChange={(e) => setSelectedTargetId(e.target.value)}
+                  placeholder="Player ID"
+                  className="rounded border bg-input px-2 py-1.5 text-sm"
+                />
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Duration (ticks)</label>
+              <select
+                value={durationTicks}
+                onChange={(e) => setDurationTicks(Number(e.target.value))}
+                className="rounded border bg-input px-2 py-1.5 text-sm"
+              >
+                <option value={50}>50 ticks (short)</option>
+                <option value={100}>100 ticks (medium)</option>
+                <option value={200}>200 ticks (long)</option>
+              </select>
+            </div>
+
+            {proposeMode === 'resource' && (
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm text-muted-foreground mb-1">Minerals / tick</label>
+                  <input
+                    type="number"
+                    min={0}
+                    value={mineralsPerTick}
+                    onChange={(e) => setMineralsPerTick(Number(e.target.value))}
+                    className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-muted-foreground mb-1">Gas / tick</label>
+                  <input
+                    type="number"
+                    min={0}
+                    value={gasPerTick}
+                    onChange={(e) => setGasPerTick(Number(e.target.value))}
+                    className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+                  />
+                </div>
+                <p className="col-span-2 text-xs text-muted-foreground">
+                  Resources are transferred each tick for the agreement duration.
+                </p>
+              </div>
+            )}
+
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => proposeMutation.mutate()}
+                disabled={!selectedTargetId || proposeMutation.isPending}
+                className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                {proposeMutation.isPending ? 'Sending…' : 'Send Proposal'}
+              </button>
+              <button
+                onClick={() => setProposeMode(null)}
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/EnemyBase.tsx
+++ b/src/ReactClient/src/pages/EnemyBase.tsx
@@ -1,0 +1,351 @@
+import { useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type { EnemyBaseViewModel, BattleResultViewModel, SpyReportViewModel } from '@/api/types'
+
+interface EnemyBaseProps {
+  gameId: string
+}
+
+export function EnemyBase({ gameId }: EnemyBaseProps) {
+  const { enemyPlayerId } = useParams<{ enemyPlayerId: string }>()
+  const [lastError, setLastError] = useState<string | null>(null)
+  const [battleResult, setBattleResult] = useState<BattleResultViewModel | null>(null)
+  const [spyReport, setSpyReport] = useState<SpyReportViewModel | null>(null)
+
+  const { data: model } = useQuery<EnemyBaseViewModel>({
+    queryKey: ['enemybase', gameId, enemyPlayerId],
+    queryFn: () =>
+      apiClient
+        .get(`/api/battle/enemybase?enemyPlayerId=${encodeURIComponent(enemyPlayerId ?? '')}`)
+        .then((r) => r.data),
+    refetchInterval: 10_000,
+    enabled: !!enemyPlayerId,
+  })
+
+  const attackMutation = useMutation({
+    mutationFn: () =>
+      apiClient
+        .post(`/api/battle/attack?enemyPlayerId=${encodeURIComponent(enemyPlayerId ?? '')}`, null)
+        .then((r) => r.data as BattleResultViewModel),
+    onSuccess: (result) => {
+      setLastError(null)
+      setBattleResult(result)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Attack failed')
+    },
+  })
+
+  const spyMutation = useMutation({
+    mutationFn: () =>
+      apiClient
+        .post(`/api/spy/execute?targetPlayerId=${encodeURIComponent(enemyPlayerId ?? '')}`, null)
+        .then((r) => r.data as SpyReportViewModel),
+    onSuccess: (report) => {
+      setLastError(null)
+      setSpyReport(report)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Spy failed')
+    },
+  })
+
+  if (!model) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Attack</h1>
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Attack</h1>
+
+      <Link
+        to={`/games/${gameId}/units`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        ← Request Reinforcements
+      </Link>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={() => attackMutation.mutate()}
+          disabled={attackMutation.isPending}
+          className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          Attack
+        </button>
+        <button
+          onClick={() => spyMutation.mutate()}
+          disabled={spyMutation.isPending}
+          className="rounded bg-secondary px-4 py-1.5 text-sm text-secondary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {spyMutation.isPending ? 'Spying…' : `Send Spy (${model.spyCostLabel})`}
+        </button>
+      </div>
+
+      {lastError && <div className="text-destructive text-sm">{lastError}</div>}
+
+      {/* Spy Report */}
+      {spyReport && (
+        <details open className="rounded-lg border bg-card p-4">
+          <summary className="cursor-pointer font-semibold text-sm">
+            Spy Report — {spyReport.targetPlayerName}{' '}
+            <span className="text-muted-foreground font-normal">
+              ({new Date(spyReport.reportTime).toLocaleTimeString()})
+            </span>
+          </summary>
+          <div className="mt-3 space-y-2 text-sm">
+            <p>
+              <strong>Approximate Resources:</strong> ~{Math.round(spyReport.approximateMinerals)}{' '}
+              minerals, ~{Math.round(spyReport.approximateGas)} gas
+            </p>
+            {spyReport.unitEstimates.length > 0 ? (
+              <table className="w-full text-sm">
+                <thead className="border-b">
+                  <tr>
+                    <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                    <th className="py-1 text-left font-medium text-muted-foreground">~Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {spyReport.unitEstimates
+                    .slice()
+                    .sort((a, b) => b.approximateCount - a.approximateCount)
+                    .map((u) => (
+                      <tr key={u.unitDefId} className="border-b border-border">
+                        <td className="py-1">{u.unitTypeName}</td>
+                        <td className="py-1">~{u.approximateCount}</td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className="text-muted-foreground">No units detected at base.</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Next spy available: {new Date(spyReport.cooldownExpiresAt).toLocaleTimeString()}
+            </p>
+          </div>
+        </details>
+      )}
+
+      {/* Battle Result */}
+      {battleResult ? (
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold">Battle Result</h2>
+          <p
+            className={`text-2xl font-bold ${
+              battleResult.outcome === 'AttackerWon'
+                ? 'text-green-400'
+                : battleResult.outcome === 'DefenderWon'
+                  ? 'text-red-400'
+                  : 'text-yellow-400'
+            }`}
+          >
+            {battleResult.outcome === 'AttackerWon'
+              ? 'Victory!'
+              : battleResult.outcome === 'DefenderWon'
+                ? 'Defeat'
+                : 'Draw'}
+          </p>
+          <p className="text-sm">
+            {battleResult.attackerId ? (
+              <Link
+                to={`/games/${gameId}/player/${battleResult.attackerId}`}
+                className="font-bold hover:underline"
+              >
+                {battleResult.attackerName}
+              </Link>
+            ) : (
+              <strong>{battleResult.attackerName}</strong>
+            )}{' '}
+            vs{' '}
+            {battleResult.defenderId ? (
+              <Link
+                to={`/games/${gameId}/player/${battleResult.defenderId}`}
+                className="font-bold hover:underline"
+              >
+                {battleResult.defenderName}
+              </Link>
+            ) : (
+              <strong>{battleResult.defenderName}</strong>
+            )}
+          </p>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <strong>Attacker strength:</strong> {battleResult.totalAttackerStrengthBefore}
+            </div>
+            <div>
+              <strong>Defender strength:</strong> {battleResult.totalDefenderStrengthBefore}
+            </div>
+          </div>
+
+          {(battleResult.landTransferred > 0 ||
+            battleResult.workersCaptured > 0 ||
+            Object.keys(battleResult.resourcesPillaged).length > 0) && (
+            <div>
+              <h4 className="font-semibold text-sm mb-2">Spoils of War</h4>
+              {battleResult.landTransferred > 0 && (
+                <span className="rounded bg-green-800/50 px-2 py-0.5 text-xs text-green-300 mr-2">
+                  +{battleResult.landTransferred} land captured
+                </span>
+              )}
+              {battleResult.workersCaptured > 0 && (
+                <span className="rounded bg-green-800/50 px-2 py-0.5 text-xs text-green-300 mr-2">
+                  +{battleResult.workersCaptured} workers captured
+                </span>
+              )}
+              {Object.entries(battleResult.resourcesPillaged).map(([res, amt]) => (
+                <span
+                  key={res}
+                  className="rounded bg-yellow-800/50 px-2 py-0.5 text-xs text-yellow-200 mr-2"
+                >
+                  +{amt} {res} pillaged
+                </span>
+              ))}
+            </div>
+          )}
+
+          <details className="rounded-lg border bg-card p-4">
+            <summary className="cursor-pointer font-semibold text-sm">Unit Losses</summary>
+            <div className="grid grid-cols-2 gap-4 mt-3">
+              <div>
+                <h5 className="font-medium text-sm mb-2">Your losses ({battleResult.attackerName})</h5>
+                {battleResult.unitsLostByAttacker.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">No losses</p>
+                ) : (
+                  <table className="w-full text-xs">
+                    <thead className="border-b">
+                      <tr>
+                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th className="py-1 text-left font-medium text-muted-foreground">Lost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {battleResult.unitsLostByAttacker
+                        .slice()
+                        .sort((a, b) => b.count - a.count)
+                        .map((l, i) => (
+                          <tr key={i} className="border-b border-border">
+                            <td className="py-1">{l.unitName}</td>
+                            <td className="py-1">{l.count}</td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+              <div>
+                <h5 className="font-medium text-sm mb-2">Enemy losses ({battleResult.defenderName})</h5>
+                {battleResult.unitsLostByDefender.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">No losses</p>
+                ) : (
+                  <table className="w-full text-xs">
+                    <thead className="border-b">
+                      <tr>
+                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th className="py-1 text-left font-medium text-muted-foreground">Lost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {battleResult.unitsLostByDefender
+                        .slice()
+                        .sort((a, b) => b.count - a.count)
+                        .map((l, i) => (
+                          <tr key={i} className="border-b border-border">
+                            <td className="py-1">{l.unitName}</td>
+                            <td className="py-1">{l.count}</td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </div>
+          </details>
+        </div>
+      ) : (
+        <>
+          {/* Your Troops */}
+          <div className="rounded-lg border bg-card overflow-hidden">
+            <div className="border-b px-4 py-3 bg-secondary/30">
+              <strong className="text-sm">Your Troops</strong>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b">
+                  <tr>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {model.playerAttackingUnits.units
+                    .slice()
+                    .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name))
+                    .map((u) => (
+                      <tr key={u.unitId} className="border-b border-border">
+                        <td className="py-2 px-3">{u.definition.name}</td>
+                        <td className="py-2 px-3 tabular-nums">{u.count.toLocaleString()}</td>
+                        <td className="py-2 px-3 text-xs text-muted-foreground">
+                          ⚔️{u.definition.attack} 🛡️{u.definition.defense}
+                        </td>
+                        <td className="py-2 px-3 text-xs text-muted-foreground">
+                          {u.positionPlayerId ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Enemy Troops */}
+          <div className="rounded-lg border bg-card overflow-hidden">
+            <div className="border-b px-4 py-3 bg-secondary/30">
+              <strong className="text-sm">Enemy Troops</strong>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b">
+                  <tr>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {model.enemyDefendingUnits.units
+                    .slice()
+                    .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name))
+                    .map((u) => (
+                      <tr key={u.unitId} className="border-b border-border">
+                        <td className="py-2 px-3">{u.definition.name}</td>
+                        <td className="py-2 px-3 tabular-nums">{u.count.toLocaleString()}</td>
+                        <td className="py-2 px-3 text-xs text-muted-foreground">
+                          ⚔️{u.definition.attack} 🛡️{u.definition.defense}
+                        </td>
+                        <td className="py-2 px-3 text-xs text-muted-foreground">
+                          {u.positionPlayerId ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/SelectEnemy.tsx
+++ b/src/ReactClient/src/pages/SelectEnemy.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { useNavigate, useParams, Link } from 'react-router'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type { SelectEnemyViewModel, SpyReportViewModel } from '@/api/types'
+
+interface SelectEnemyProps {
+  gameId: string
+}
+
+export function SelectEnemy({ gameId }: SelectEnemyProps) {
+  const { unitId } = useParams<{ unitId: string }>()
+  const navigate = useNavigate()
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  const [spyReport, setSpyReport] = useState<SpyReportViewModel | null>(null)
+
+  const { data: model } = useQuery<SelectEnemyViewModel>({
+    queryKey: ['attackableplayers', gameId],
+    queryFn: () => apiClient.get<SelectEnemyViewModel>('/api/battle/attackableplayers').then((r) => r.data),
+  })
+
+  useEffect(() => {
+    if (model?.attackablePlayers && model.attackablePlayers.length > 0 && !selectedPlayerId) {
+      setSelectedPlayerId(model.attackablePlayers[0].playerId)
+    }
+  }, [model, selectedPlayerId])
+
+  const sendTroopsMutation = useMutation({
+    mutationFn: () =>
+      apiClient.post(
+        `/api/battle/sendunits?unitId=${unitId}&enemyPlayerId=${encodeURIComponent(selectedPlayerId)}`,
+        ''
+      ),
+    onSuccess: () => {
+      void navigate(`/games/${gameId}/enemybase/${encodeURIComponent(selectedPlayerId)}`)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Send failed')
+    },
+  })
+
+  const spyMutation = useMutation({
+    mutationFn: () =>
+      apiClient
+        .post(`/api/spy/execute?targetPlayerId=${encodeURIComponent(selectedPlayerId)}`, null)
+        .then((r) => r.data as SpyReportViewModel),
+    onSuccess: (report) => {
+      setError(null)
+      setSpyReport(report)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Spy failed')
+    },
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Select Enemy</h1>
+
+      {error && <div className="text-destructive text-sm">{error}</div>}
+
+      {!model ? (
+        <div className="text-muted-foreground">Loading...</div>
+      ) : (
+        <>
+          <div className="space-y-4 max-w-sm">
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Target player</label>
+              <select
+                value={selectedPlayerId}
+                onChange={(e) => { setSelectedPlayerId(e.target.value); setSpyReport(null) }}
+                className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+              >
+                {model.attackablePlayers.map((p) => (
+                  <option key={p.playerId} value={p.playerId}>
+                    {p.playerName} ({Math.round(p.score)})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => sendTroopsMutation.mutate()}
+                disabled={!selectedPlayerId || sendTroopsMutation.isPending}
+                className="rounded bg-destructive px-4 py-1.5 text-sm text-destructive-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                Send Troops
+              </button>
+              <button
+                onClick={() => spyMutation.mutate()}
+                disabled={!selectedPlayerId || spyMutation.isPending}
+                className="rounded bg-secondary px-4 py-1.5 text-sm text-secondary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                {spyMutation.isPending ? 'Spying…' : 'Send Spy (50 minerals)'}
+              </button>
+            </div>
+          </div>
+
+          {/* Spy Report inline */}
+          {spyReport && (
+            <details open className="rounded-lg border bg-card p-4 max-w-md">
+              <summary className="cursor-pointer font-semibold text-sm">
+                Spy Report — {spyReport.targetPlayerName}{' '}
+                <span className="text-muted-foreground font-normal">
+                  ({new Date(spyReport.reportTime).toLocaleTimeString()})
+                </span>
+              </summary>
+              <div className="mt-3 space-y-2 text-sm">
+                <p>
+                  <strong>Approximate Resources:</strong> ~{Math.round(spyReport.approximateMinerals)}{' '}
+                  minerals, ~{Math.round(spyReport.approximateGas)} gas
+                </p>
+                {spyReport.unitEstimates.length > 0 ? (
+                  <table className="w-full text-xs">
+                    <thead className="border-b">
+                      <tr>
+                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th className="py-1 text-left font-medium text-muted-foreground">~Count</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {spyReport.unitEstimates
+                        .slice()
+                        .sort((a, b) => b.approximateCount - a.approximateCount)
+                        .map((u) => (
+                          <tr key={u.unitDefId} className="border-b border-border">
+                            <td className="py-1">{u.unitTypeName}</td>
+                            <td className="py-1">~{u.approximateCount}</td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </table>
+                ) : (
+                  <p className="text-muted-foreground">No units detected at base.</p>
+                )}
+              </div>
+            </details>
+          )}
+
+          <Link
+            to={`/games/${gameId}/units`}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Cancel Attack
+          </Link>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Spies.tsx
+++ b/src/ReactClient/src/pages/Spies.tsx
@@ -1,0 +1,310 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type {
+  SpyPlayerEntryViewModel,
+  SpyMissionViewModel,
+  SendSpyMissionRequest,
+  SendSpyMissionResponse,
+} from '@/api/types'
+
+interface SpiesProps {
+  gameId: string
+}
+
+const MISSION_TYPES = [
+  {
+    id: 'intelligence',
+    label: 'Gather Intelligence',
+    desc: 'Reveal approximate resources and unit counts',
+  },
+  {
+    id: 'sabotage',
+    label: 'Sabotage',
+    desc: 'Destroy a portion of target resources',
+  },
+  {
+    id: 'steal_resources',
+    label: 'Steal Resources',
+    desc: 'Transfer a portion of target minerals/gas to you',
+  },
+]
+
+function missionTypeLabel(type: string): string {
+  return MISSION_TYPES.find((m) => m.id === type)?.label ?? type
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'in_transit': return 'In Transit'
+    case 'completed': return 'Completed'
+    case 'intercepted': return 'Intercepted'
+    default: return status
+  }
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'in_transit': return 'bg-yellow-700/50 text-yellow-200'
+    case 'completed': return 'bg-green-800/50 text-green-300'
+    case 'intercepted': return 'bg-red-800/50 text-red-300'
+    default: return 'bg-secondary text-secondary-foreground'
+  }
+}
+
+interface SpyMissionDetailModalProps {
+  mission: SpyMissionViewModel
+  onClose: () => void
+}
+
+function SpyMissionDetailModal({ mission, onClose }: SpyMissionDetailModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="rounded-lg border bg-card p-6 w-full max-w-md shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-semibold">Mission Details</h3>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground text-xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+        <div className="space-y-2 text-sm">
+          <div>
+            <span className="text-muted-foreground">Target:</span>{' '}
+            <span className="font-medium">{mission.targetPlayerName}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Mission:</span>{' '}
+            <span>{missionTypeLabel(mission.missionType)}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Status:</span>{' '}
+            <span className={`rounded px-1.5 py-0.5 text-xs ${statusColor(mission.status)}`}>
+              {statusLabel(mission.status)}
+            </span>
+          </div>
+          {mission.resolvedAt && (
+            <div>
+              <span className="text-muted-foreground">Resolved:</span>{' '}
+              <span>{new Date(mission.resolvedAt).toLocaleString()}</span>
+            </div>
+          )}
+          {mission.result && (
+            <div className="mt-3 rounded border bg-secondary p-3">
+              <div className="text-muted-foreground text-xs mb-1 font-medium uppercase tracking-wide">
+                Result
+              </div>
+              <pre className="text-xs whitespace-pre-wrap">{mission.result}</pre>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={onClose}
+          className="mt-4 rounded bg-secondary px-4 py-1.5 text-sm text-secondary-foreground hover:opacity-90"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function Spies({ gameId }: SpiesProps) {
+  const queryClient = useQueryClient()
+  const [selectedPlayerId, setSelectedPlayerId] = useState('')
+  const [selectedMissionType, setSelectedMissionType] = useState('intelligence')
+  const [sendError, setSendError] = useState<string | null>(null)
+  const [sendSuccess, setSendSuccess] = useState<string | null>(null)
+  const [detailMission, setDetailMission] = useState<SpyMissionViewModel | null>(null)
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  const { data: players } = useQuery<SpyPlayerEntryViewModel[]>({
+    queryKey: ['spyplayers', gameId],
+    queryFn: () =>
+      apiClient
+        .get<SpyPlayerEntryViewModel[]>('/api/spy/players')
+        .then((r) => r.data)
+        .catch((err: unknown) => {
+          if (axios.isAxiosError(err)) setPageError(err.message)
+          return []
+        }),
+    refetchInterval: 30_000,
+  })
+
+  const { data: missions, refetch: refetchMissions } = useQuery<SpyMissionViewModel[]>({
+    queryKey: ['spymissions', gameId],
+    queryFn: () => apiClient.get('/api/spy/missions').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const sendMutation = useMutation({
+    mutationFn: () => {
+      const request: SendSpyMissionRequest = {
+        targetPlayerId: selectedPlayerId,
+        missionType: selectedMissionType,
+      }
+      return apiClient.post<SendSpyMissionResponse>('/api/spy/send', request).then((r) => r.data)
+    },
+    onSuccess: (data) => {
+      setSendError(null)
+      const resolveTime = data.estimatedResolveAt
+        ? new Date(data.estimatedResolveAt).toLocaleTimeString()
+        : ''
+      setSendSuccess(`Spy dispatched! Estimated resolution: ${resolveTime}`)
+      setSelectedPlayerId('')
+      void refetchMissions()
+      void queryClient.invalidateQueries({ queryKey: ['spyplayers', gameId] })
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setSendError((err.response?.data as string) ?? 'Send failed')
+    },
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Intelligence Operations</h1>
+
+      {pageError && <div className="text-destructive text-sm">{pageError}</div>}
+
+      {detailMission && (
+        <SpyMissionDetailModal
+          mission={detailMission}
+          onClose={() => setDetailMission(null)}
+        />
+      )}
+
+      {/* Send Spy card */}
+      <div className="rounded-lg border bg-card p-5">
+        <h2 className="font-semibold mb-4">Send Spy</h2>
+        {!players ? (
+          <div className="text-muted-foreground text-sm">Loading players...</div>
+        ) : players.length === 0 ? (
+          <div className="text-muted-foreground text-sm">No other players to target.</div>
+        ) : (
+          <>
+            <div className="mb-4">
+              <label className="block text-sm text-muted-foreground mb-1">Target Player</label>
+              <select
+                value={selectedPlayerId}
+                onChange={(e) => setSelectedPlayerId(e.target.value)}
+                className="w-full max-w-xs rounded border bg-input px-2 py-1.5 text-sm"
+              >
+                <option value="">— select target —</option>
+                {players.map((p) => (
+                  <option key={p.playerId} value={p.playerId}>
+                    {p.playerName} ({Math.round(p.score)} pts)
+                    {p.cooldownExpiresAt && new Date(p.cooldownExpiresAt) > new Date()
+                      ? ' [cooldown]'
+                      : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="mb-4 space-y-2">
+              <div className="text-sm text-muted-foreground mb-1">Mission Type</div>
+              {MISSION_TYPES.map((mt) => (
+                <label key={mt.id} className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="missionType"
+                    value={mt.id}
+                    checked={selectedMissionType === mt.id}
+                    onChange={() => setSelectedMissionType(mt.id)}
+                    className="mt-0.5"
+                  />
+                  <div>
+                    <span className="font-medium text-sm">{mt.label}</span>
+                    <span className="text-muted-foreground text-sm"> — {mt.desc}</span>
+                  </div>
+                </label>
+              ))}
+            </div>
+
+            <p className="text-xs text-muted-foreground mb-3">
+              Mission cost: 50 minerals · Risk of interception increases with target counter-intelligence
+            </p>
+
+            {sendError && <div className="text-destructive text-sm mb-2">{sendError}</div>}
+            {sendSuccess && <div className="text-green-400 text-sm mb-2">{sendSuccess}</div>}
+
+            <button
+              onClick={() => sendMutation.mutate()}
+              disabled={!selectedPlayerId || sendMutation.isPending}
+              className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {sendMutation.isPending ? 'Sending…' : 'Send Spy'}
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Active Missions */}
+      <div className="rounded-lg border bg-card">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <strong className="text-sm">Active Missions</strong>
+          <button
+            onClick={() => void refetchMissions()}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Refresh
+          </button>
+        </div>
+        {!missions ? (
+          <div className="p-4 text-muted-foreground text-sm">Loading...</div>
+        ) : missions.length === 0 ? (
+          <div className="p-4 text-muted-foreground text-sm">No active missions.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Target</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Mission</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Launched</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Resolved</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {missions.map((m) => (
+                  <tr key={m.id} className="border-b border-border">
+                    <td className="py-2 px-3">{m.targetPlayerName}</td>
+                    <td className="py-2 px-3">{missionTypeLabel(m.missionType)}</td>
+                    <td className="py-2 px-3">
+                      <span className={`rounded px-1.5 py-0.5 text-xs ${statusColor(m.status)}`}>
+                        {statusLabel(m.status)}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {new Date(m.createdAt).toLocaleString('en', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {m.resolvedAt
+                        ? new Date(m.resolvedAt).toLocaleString('en', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+                        : '—'}
+                    </td>
+                    <td className="py-2 px-3">
+                      {m.result && (
+                        <button
+                          onClick={() => setDetailMission(m)}
+                          className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary-foreground hover:opacity-90"
+                        >
+                          Details
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/SpyReports.tsx
+++ b/src/ReactClient/src/pages/SpyReports.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { SpyAttemptViewModel } from '@/api/types'
+
+interface SpyReportsProps {
+  gameId: string
+}
+
+export function SpyReports({ gameId }: SpyReportsProps) {
+  const { data: attempts, isLoading } = useQuery<SpyAttemptViewModel[]>({
+    queryKey: ['spyattempts', gameId],
+    queryFn: () => apiClient.get('/api/spy/attempts').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Incoming Intel</h1>
+      <p className="text-sm text-muted-foreground">
+        Detected spy attempts against you. Requires Counter-Intelligence tech to detect spies.
+      </p>
+
+      {isLoading ? (
+        <div className="text-muted-foreground">Loading...</div>
+      ) : !attempts || attempts.length === 0 ? (
+        <div className="rounded-lg border bg-card p-6 text-center text-muted-foreground text-sm">
+          No detected spy attempts. Upgrade Counter-Intelligence in the Tech Tree to improve detection.
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Attacker</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Operation Type</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Detected At</th>
+                </tr>
+              </thead>
+              <tbody>
+                {attempts.map((a) => (
+                  <tr key={a.id} className="border-b border-border">
+                    <td className="py-2 px-3 font-medium">{a.attackerName}</td>
+                    <td className="py-2 px-3">
+                      <span className="rounded bg-yellow-700/50 px-1.5 py-0.5 text-xs text-yellow-200">
+                        {a.actionType}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {new Date(a.timestamp ?? a.id).toLocaleString('en', {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Implements 5 combat & spy pages for the React client
- Stacked on top of [PR #162](https://github.com/discostu105/bge/pull/162) (BGE-521 scaffold + core pages)
- Corrects TypeScript type definitions for spy/battle/diplomacy viewmodels

## Pages implemented

| Page | Route | API |
|------|-------|-----|
| **Spies** | `/games/:gameId/spies` | `api/spy/players`, `api/spy/missions`, `api/spy/send` |
| **SpyReports** | `/games/:gameId/spy` | `api/spy/attempts` |
| **Diplomacy** | `/games/:gameId/diplomacy` | `api/diplomacy/status`, proposals endpoints |
| **EnemyBase** | `/games/:gameId/enemybase/:enemyPlayerId` | `api/battle/enemybase`, `api/battle/attack` |
| **SelectEnemy** | `/games/:gameId/selectenemy/:unitId` | `api/battle/attackableplayers`, `api/battle/sendunits` |

## Details

- Spies page: mission type radio (intelligence/sabotage/steal), target player selector, active missions table with status badges, detail modal for resolved missions
- Diplomacy: incoming proposals (accept/decline), active NAPs, resource agreements, propose new agreement form
- EnemyBase: full battle flow — unit tables, attack button, battle result with spoils + unit losses, spy preview
- SelectEnemy: player picker, send troops → navigates to EnemyBase, inline spy report
- Fixed: `SpyPlayerEntryViewModel`, `SpyReportViewModel`, `EnemyBaseViewModel`, `BattleResultViewModel` types corrected to match actual C# ViewModels

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` — 292/292 passed  
- [x] `npm run build` — clean build, no TypeScript errors

Closes BGE-523