### PR TITLE
feat: BGE-524 React pages — Alliances, AllianceDetail, AllianceRanking

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -8,6 +8,9 @@ import { SpyReports } from '@/pages/SpyReports'
 import { Diplomacy } from '@/pages/Diplomacy'
 import { EnemyBase } from '@/pages/EnemyBase'
 import { SelectEnemy } from '@/pages/SelectEnemy'
+import { Alliances } from '@/pages/Alliances'
+import { AllianceDetail } from '@/pages/AllianceDetail'
+import { AllianceRanking } from '@/pages/AllianceRanking'
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -84,6 +87,24 @@ function SelectEnemyPage() {
   return <SelectEnemy gameId={gameId} />
 }
 
+function AlliancesPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Alliances gameId={gameId} />
+}
+
+function AllianceRankingPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <AllianceRanking gameId={gameId} />
+}
+
+function AllianceDetailPage() {
+  const { allianceId } = useParams<{ allianceId: string }>()
+  if (!allianceId) return null
+  return <AllianceDetail allianceId={allianceId} />
+}
+
 const router = createBrowserRouter([
   {
     path: '/',
@@ -105,8 +126,8 @@ const router = createBrowserRouter([
       { path: 'chat', element: <TodoPage name="Chat" /> },
       { path: 'messages', element: <TodoPage name="Messages" /> },
       { path: 'ranking', element: <TodoPage name="Player Ranking" /> },
-      { path: 'alliances', element: <TodoPage name="Alliances" /> },
-      { path: 'allianceranking', element: <TodoPage name="Alliance Ranking" /> },
+      { path: 'alliances', element: <AlliancesPage /> },
+      { path: 'allianceranking', element: <AllianceRankingPage /> },
       { path: 'diplomacy', element: <DiplomacyPage /> },
       { path: 'spies', element: <SpiesPage /> },
       { path: 'spy', element: <SpyReportsPage /> },
@@ -141,7 +162,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/alliances/:allianceId',
-    element: <TodoPage name="Alliance Detail" />,
+    element: <AllianceDetailPage />,
   },
   {
     path: '/achievements',

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -336,6 +336,7 @@ export interface AllianceViewModel {
   message: string | null
   memberCount: number
   created: string
+  isAtWar: boolean
 }
 
 export interface AllianceDetailViewModel {
@@ -355,16 +356,81 @@ export interface MyAllianceStatusViewModel {
   isLeader: boolean
 }
 
-export interface AllianceRankingEntryViewModel {
-  rank: number
+export interface AllianceRankingViewModel {
   allianceId: string
-  allianceName: string
+  name: string
   memberCount: number
-  totalScore: number
+  totalLand: number
+  avgLand: number
+  score: number
 }
 
-export interface AllianceRankingViewModel {
-  entries: AllianceRankingEntryViewModel[]
+export interface AllianceInviteViewModel {
+  inviteId: string
+  allianceId: string
+  allianceName: string
+  inviterPlayerName: string
+  expiresAt: string
+}
+
+export interface AllianceWarViewModel {
+  warId: string
+  attackerAllianceId: string
+  attackerAllianceName: string
+  defenderAllianceId: string
+  defenderAllianceName: string
+  status: string
+  declaredAt: string
+  proposerAllianceId: string | null
+}
+
+export interface AllianceChatPostViewModel {
+  postId: string
+  authorPlayerId: string
+  authorName: string
+  body: string
+  createdAt: string
+}
+
+export interface CreateAllianceRequest {
+  allianceName: string
+  password: string
+}
+
+export interface JoinAllianceRequest {
+  password: string
+}
+
+export interface VoteLeaderRequest {
+  voteePlayerId: string
+}
+
+export interface SetAlliancePasswordRequest {
+  newPassword: string
+}
+
+export interface SetAllianceMessageRequest {
+  message: string
+}
+
+export interface PostAllianceChatRequest {
+  body: string
+}
+
+export interface InvitePlayerRequest {
+  targetPlayerId: string
+}
+
+export interface DeclareWarRequest {
+  targetAllianceId: string
+}
+
+export interface AcceptInviteRequest {
+  inviteId: string
+}
+
+export interface PeaceRequest {
+  warId: string
 }
 
 // Diplomacy

--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -1,0 +1,508 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type {
+  AllianceDetailViewModel,
+  MyAllianceStatusViewModel,
+  AllianceChatPostViewModel,
+  AllianceWarViewModel,
+  AllianceViewModel,
+  PublicPlayerViewModel,
+  VoteLeaderRequest,
+  SetAllianceMessageRequest,
+  SetAlliancePasswordRequest,
+  PostAllianceChatRequest,
+  InvitePlayerRequest,
+  DeclareWarRequest,
+  PeaceRequest,
+} from '@/api/types'
+
+interface AllianceDetailProps {
+  allianceId: string
+}
+
+export function AllianceDetail({ allianceId }: AllianceDetailProps) {
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [newMessage, setNewMessage] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [newChatBody, setNewChatBody] = useState('')
+  const [invitePlayerId, setInvitePlayerId] = useState('')
+  const [inviteResult, setInviteResult] = useState<string | null>(null)
+  const [warTargetAllianceId, setWarTargetAllianceId] = useState('')
+  const [warResult, setWarResult] = useState<string | null>(null)
+
+  const invalidateDetail = () => {
+    void queryClient.invalidateQueries({ queryKey: ['alliance-detail', allianceId] })
+    void queryClient.invalidateQueries({ queryKey: ['alliance-status', allianceId] })
+    void queryClient.invalidateQueries({ queryKey: ['alliance-chat', allianceId] })
+    void queryClient.invalidateQueries({ queryKey: ['alliance-wars', allianceId] })
+  }
+
+  const { data: detail } = useQuery<AllianceDetailViewModel>({
+    queryKey: ['alliance-detail', allianceId],
+    queryFn: () => apiClient.get(`/api/alliances/${allianceId}`).then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  const { data: myStatus } = useQuery<MyAllianceStatusViewModel>({
+    queryKey: ['alliance-status', allianceId],
+    queryFn: () => apiClient.get('/api/alliances/my-status').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  const { data: chatPosts } = useQuery<AllianceChatPostViewModel[]>({
+    queryKey: ['alliance-chat', allianceId],
+    queryFn: () =>
+      apiClient.get(`/api/alliances/${allianceId}/posts`).then((r) => r.data),
+    enabled: myStatus?.isMember === true && myStatus.isPending === false,
+    refetchInterval: 10_000,
+  })
+
+  const { data: wars, refetch: refetchWars } = useQuery<AllianceWarViewModel[]>({
+    queryKey: ['alliance-wars', allianceId],
+    queryFn: () =>
+      apiClient
+        .get<AllianceWarViewModel[]>(`/api/alliances/${allianceId}/wars`)
+        .then((r) => r.data)
+        .catch(() => []),
+    refetchInterval: 15_000,
+  })
+
+  const { data: allPlayers } = useQuery<PublicPlayerViewModel[]>({
+    queryKey: ['playerranking'],
+    queryFn: () =>
+      apiClient
+        .get<PublicPlayerViewModel[]>('/api/playerranking')
+        .then((r) => r.data)
+        .catch(() => []),
+    enabled: myStatus?.isLeader === true && myStatus.isPending === false,
+    refetchInterval: 60_000,
+  })
+
+  const { data: allAlliances } = useQuery<AllianceViewModel[]>({
+    queryKey: ['alliances-list'],
+    queryFn: () =>
+      apiClient
+        .get<AllianceViewModel[]>('/api/alliances')
+        .then((r) => r.data)
+        .catch(() => []),
+    enabled: myStatus?.isLeader === true && myStatus.isPending === false,
+    refetchInterval: 60_000,
+  })
+
+  const withError = (err: unknown) => {
+    if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Request failed')
+  }
+
+  const acceptMember = useMutation({
+    mutationFn: (playerId: string) =>
+      apiClient.post(`/api/alliances/${allianceId}/members/${playerId}/accept`, ''),
+    onSuccess: () => { setError(null); invalidateDetail() },
+    onError: withError,
+  })
+
+  const rejectMember = useMutation({
+    mutationFn: (playerId: string) =>
+      apiClient.post(`/api/alliances/${allianceId}/members/${playerId}/reject`, ''),
+    onSuccess: () => { setError(null); invalidateDetail() },
+    onError: withError,
+  })
+
+  const kickMember = useMutation({
+    mutationFn: (playerId: string) =>
+      apiClient.delete(`/api/alliances/${allianceId}/members/${playerId}`),
+    onSuccess: () => { setError(null); invalidateDetail() },
+    onError: withError,
+  })
+
+  const voteMutation = useMutation({
+    mutationFn: (req: VoteLeaderRequest) =>
+      apiClient.post(`/api/alliances/${allianceId}/leader-vote`, req),
+    onSuccess: () => { setError(null); invalidateDetail() },
+    onError: withError,
+  })
+
+  const messageMutation = useMutation({
+    mutationFn: (req: SetAllianceMessageRequest) =>
+      apiClient.patch(`/api/alliances/${allianceId}/message`, req),
+    onSuccess: () => { setError(null); setNewMessage(''); invalidateDetail() },
+    onError: withError,
+  })
+
+  const passwordMutation = useMutation({
+    mutationFn: (req: SetAlliancePasswordRequest) =>
+      apiClient.patch(`/api/alliances/${allianceId}/password`, req),
+    onSuccess: () => { setError(null); setNewPassword('') },
+    onError: withError,
+  })
+
+  const chatMutation = useMutation({
+    mutationFn: (req: PostAllianceChatRequest) =>
+      apiClient.post(`/api/alliances/${allianceId}/posts`, req),
+    onSuccess: () => {
+      setError(null)
+      setNewChatBody('')
+      void queryClient.invalidateQueries({ queryKey: ['alliance-chat', allianceId] })
+    },
+    onError: withError,
+  })
+
+  const inviteMutation = useMutation({
+    mutationFn: (req: InvitePlayerRequest) =>
+      apiClient.post(`/api/alliances/${allianceId}/invite`, req),
+    onSuccess: () => {
+      setInviteResult('Invite sent.')
+      setInvitePlayerId('')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setInviteResult(`Error: ${(err.response?.data as string) ?? 'failed'}`)
+    },
+  })
+
+  const declareWarMutation = useMutation({
+    mutationFn: (req: DeclareWarRequest) =>
+      apiClient.post(`/api/alliances/${allianceId}/declare-war`, req),
+    onSuccess: () => {
+      setWarResult('War declared.')
+      setWarTargetAllianceId('')
+      void refetchWars()
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setWarResult(`Error: ${(err.response?.data as string) ?? 'failed'}`)
+    },
+  })
+
+  const peaceMutation = useMutation({
+    mutationFn: (req: PeaceRequest) =>
+      apiClient.post(`/api/alliances/wars/${req.warId}/peace`, req),
+    onSuccess: () => { setError(null); void refetchWars() },
+    onError: withError,
+  })
+
+  const isLeader = myStatus?.isMember && myStatus.isLeader && !myStatus.isPending
+  const isActiveMember = myStatus?.isMember && !myStatus.isPending
+
+  if (!detail || !myStatus) {
+    return <div className="text-muted-foreground text-sm">Loading...</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Alliance: {detail.name}</h1>
+
+      {error && <div className="text-destructive text-sm">{error}</div>}
+
+      {detail.message && (
+        <div className="rounded-lg border border-blue-700 bg-blue-900/10 px-4 py-3 text-sm text-blue-200">
+          {detail.message}
+        </div>
+      )}
+
+      <p className="text-sm text-muted-foreground">
+        Founded: {new Date(detail.created).toLocaleDateString()}
+      </p>
+
+      {/* Members table */}
+      <div className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <strong className="text-sm">Members</strong>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b">
+              <tr>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Votes</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {detail.members.map((m) => (
+                <tr key={m.playerId} className="border-b border-border">
+                  <td className="py-2 px-3">
+                    {m.playerName} {m.isLeader ? '★' : ''}
+                  </td>
+                  <td className="py-2 px-3 text-muted-foreground">
+                    {m.isPending ? 'Pending' : 'Member'}
+                  </td>
+                  <td className="py-2 px-3">{m.voteCount}</td>
+                  <td className="py-2 px-3">
+                    <div className="flex gap-2">
+                      {isLeader && m.isPending && (
+                        <>
+                          <button
+                            onClick={() => acceptMember.mutate(m.playerId)}
+                            className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+                          >
+                            Accept
+                          </button>
+                          <button
+                            onClick={() => rejectMember.mutate(m.playerId)}
+                            className="rounded bg-destructive px-2 py-0.5 text-xs text-destructive-foreground hover:opacity-90"
+                          >
+                            Reject
+                          </button>
+                        </>
+                      )}
+                      {isLeader && !m.isPending && !m.isLeader && (
+                        <button
+                          onClick={() => kickMember.mutate(m.playerId)}
+                          className="rounded border border-yellow-600 px-2 py-0.5 text-xs text-yellow-400 hover:bg-yellow-600/10"
+                        >
+                          Kick
+                        </button>
+                      )}
+                      {isActiveMember && !m.isPending && m.playerId !== myStatus.allianceId && (
+                        <button
+                          onClick={() => voteMutation.mutate({ voteePlayerId: m.playerId })}
+                          className="rounded border border-primary px-2 py-0.5 text-xs text-primary hover:bg-primary/10"
+                        >
+                          Vote Leader
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Leader Controls */}
+      {isLeader && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Leader Controls</strong>
+          </div>
+          <div className="p-4 space-y-4">
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Alliance Message</label>
+              <div className="flex gap-2">
+                <input
+                  className="flex-1 max-w-sm rounded border bg-input px-2 py-1.5 text-sm"
+                  placeholder="Set message..."
+                  value={newMessage}
+                  onChange={(e) => setNewMessage(e.target.value)}
+                />
+                <button
+                  onClick={() => messageMutation.mutate({ message: newMessage })}
+                  disabled={messageMutation.isPending}
+                  className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Change Password</label>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  className="flex-1 max-w-sm rounded border bg-input px-2 py-1.5 text-sm"
+                  placeholder="New password..."
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+                <button
+                  onClick={() => passwordMutation.mutate({ newPassword })}
+                  disabled={passwordMutation.isPending}
+                  className="rounded bg-secondary px-3 py-1.5 text-xs text-secondary-foreground hover:opacity-90 disabled:opacity-50"
+                >
+                  Change
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Invite Player</label>
+              <div className="flex gap-2">
+                <select
+                  value={invitePlayerId}
+                  onChange={(e) => setInvitePlayerId(e.target.value)}
+                  className="flex-1 max-w-xs rounded border bg-input px-2 py-1.5 text-sm"
+                >
+                  <option value="">— Select a player —</option>
+                  {(allPlayers ?? []).map((p) => (
+                    <option key={p.playerId} value={p.playerId}>
+                      {p.playerName}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => {
+                    setInviteResult(null)
+                    if (invitePlayerId) inviteMutation.mutate({ targetPlayerId: invitePlayerId })
+                  }}
+                  disabled={!invitePlayerId || inviteMutation.isPending}
+                  className="rounded border border-green-600 px-3 py-1.5 text-xs text-green-400 hover:bg-green-600/10 disabled:opacity-50"
+                >
+                  Invite
+                </button>
+              </div>
+              {inviteResult && (
+                <div
+                  className={`text-xs mt-1 ${inviteResult.startsWith('Error') ? 'text-destructive' : 'text-green-400'}`}
+                >
+                  {inviteResult}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm text-muted-foreground mb-1">Declare War</label>
+              <div className="flex gap-2">
+                <select
+                  value={warTargetAllianceId}
+                  onChange={(e) => setWarTargetAllianceId(e.target.value)}
+                  className="flex-1 max-w-xs rounded border bg-input px-2 py-1.5 text-sm"
+                >
+                  <option value="">— Select an alliance —</option>
+                  {(allAlliances ?? [])
+                    .filter((a) => a.allianceId !== allianceId)
+                    .map((a) => (
+                      <option key={a.allianceId} value={a.allianceId}>
+                        {a.name}
+                      </option>
+                    ))}
+                </select>
+                <button
+                  onClick={() => {
+                    setWarResult(null)
+                    if (warTargetAllianceId)
+                      declareWarMutation.mutate({ targetAllianceId: warTargetAllianceId })
+                  }}
+                  disabled={!warTargetAllianceId || declareWarMutation.isPending}
+                  className="rounded border border-destructive px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  Declare War
+                </button>
+              </div>
+              {warResult && (
+                <div
+                  className={`text-xs mt-1 ${warResult.startsWith('Error') ? 'text-destructive' : 'text-green-400'}`}
+                >
+                  {warResult}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Wars */}
+      {(wars?.length ?? 0) > 0 && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Wars</strong>
+          </div>
+          <div className="p-3 space-y-2">
+            {wars!.map((war) => {
+              const opponent =
+                war.attackerAllianceId === allianceId
+                  ? war.defenderAllianceName
+                  : war.attackerAllianceName
+              const peaceOfferedToUs =
+                war.status === 'PeaceProposed' && war.proposerAllianceId !== allianceId
+              return (
+                <div
+                  key={war.warId}
+                  className="flex items-center justify-between rounded border px-3 py-2"
+                >
+                  <div className="text-sm">
+                    <span
+                      className={`rounded px-1.5 py-0.5 text-xs mr-2 ${
+                        war.status === 'PeaceProposed'
+                          ? 'bg-yellow-700/50 text-yellow-200'
+                          : 'bg-red-800/60 text-red-200'
+                      }`}
+                    >
+                      {war.status}
+                    </span>
+                    vs <strong>{opponent}</strong>
+                    <span className="text-muted-foreground ml-2 text-xs">
+                      since {new Date(war.declaredAt).toLocaleDateString()}
+                    </span>
+                    {peaceOfferedToUs && (
+                      <span className="ml-2 rounded bg-blue-700/50 px-1.5 py-0.5 text-xs text-blue-200">
+                        Peace offered to us
+                      </span>
+                    )}
+                  </div>
+                  {isLeader && (
+                    <button
+                      onClick={() => peaceMutation.mutate({ warId: war.warId })}
+                      disabled={peaceMutation.isPending}
+                      className="rounded border border-yellow-600 px-2 py-0.5 text-xs text-yellow-400 hover:bg-yellow-600/10 disabled:opacity-50"
+                    >
+                      {peaceOfferedToUs ? 'Accept Peace' : 'Propose Peace'}
+                    </button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Chat */}
+      {isActiveMember && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Alliance Chat</strong>
+          </div>
+          <div className="p-4 space-y-3">
+            <div className="flex gap-2">
+              <input
+                className="flex-1 rounded border bg-input px-2 py-1.5 text-sm"
+                placeholder="Write a message..."
+                value={newChatBody}
+                onChange={(e) => setNewChatBody(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newChatBody.trim())
+                    chatMutation.mutate({ body: newChatBody })
+                }}
+              />
+              <button
+                onClick={() => {
+                  if (newChatBody.trim()) chatMutation.mutate({ body: newChatBody })
+                }}
+                disabled={!newChatBody.trim() || chatMutation.isPending}
+                className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                Send
+              </button>
+            </div>
+          </div>
+          {!chatPosts ? (
+            <div className="px-4 pb-4 text-muted-foreground text-sm">Loading chat...</div>
+          ) : chatPosts.length === 0 ? (
+            <div className="px-4 pb-4 text-muted-foreground text-sm">
+              No messages yet. Be the first to post!
+            </div>
+          ) : (
+            <div className="divide-y">
+              {chatPosts.map((post) => (
+                <div key={post.postId} className="px-4 py-3">
+                  <div className="flex items-center justify-between mb-1">
+                    <strong className="text-sm">{post.authorName}</strong>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(post.createdAt).toLocaleString()}
+                    </span>
+                  </div>
+                  <p className="text-sm">{post.body}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/AllianceRanking.tsx
+++ b/src/ReactClient/src/pages/AllianceRanking.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { AllianceRankingViewModel } from '@/api/types'
+
+interface AllianceRankingProps {
+  gameId: string
+}
+
+export function AllianceRanking({ gameId }: AllianceRankingProps) {
+  const { data: ranking } = useQuery<AllianceRankingViewModel[]>({
+    queryKey: ['allianceranking', gameId],
+    queryFn: () => apiClient.get('/api/allianceranking').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Alliance Ranking</h1>
+
+      {!ranking ? (
+        <div className="text-muted-foreground text-sm">Loading...</div>
+      ) : ranking.length === 0 ? (
+        <div className="text-muted-foreground text-sm">
+          No alliances with 2 or more members yet.
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b">
+              <tr>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">#</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Members</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Total Land</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Avg Land</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ranking.map((item, i) => (
+                <tr key={item.allianceId} className="border-b border-border">
+                  <td className="py-2 px-3 text-muted-foreground">{i + 1}</td>
+                  <td className="py-2 px-3 font-medium">
+                    <a
+                      href={`/alliances/${item.allianceId}`}
+                      className="text-primary hover:underline"
+                    >
+                      {item.name}
+                    </a>
+                  </td>
+                  <td className="py-2 px-3">{item.memberCount}</td>
+                  <td className="py-2 px-3">{item.totalLand.toLocaleString()}</td>
+                  <td className="py-2 px-3">{item.avgLand.toLocaleString()}</td>
+                  <td className="py-2 px-3">{item.score.toFixed(1)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Alliances.tsx
+++ b/src/ReactClient/src/pages/Alliances.tsx
@@ -1,0 +1,323 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import type {
+  AllianceViewModel,
+  MyAllianceStatusViewModel,
+  AllianceInviteViewModel,
+  CreateAllianceRequest,
+  JoinAllianceRequest,
+  AcceptInviteRequest,
+} from '@/api/types'
+
+interface AlliancesProps {
+  gameId: string
+}
+
+export function Alliances({ gameId }: AlliancesProps) {
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [createName, setCreateName] = useState('')
+  const [createPassword, setCreatePassword] = useState('')
+  const [joiningAlliance, setJoiningAlliance] = useState<AllianceViewModel | null>(null)
+  const [joinPassword, setJoinPassword] = useState('')
+
+  const { data: alliances } = useQuery<AllianceViewModel[]>({
+    queryKey: ['alliances', gameId],
+    queryFn: () => apiClient.get('/api/alliances').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  const { data: myStatus } = useQuery<MyAllianceStatusViewModel>({
+    queryKey: ['alliances-status', gameId],
+    queryFn: () => apiClient.get('/api/alliances/my-status').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  const { data: myInvites } = useQuery<AllianceInviteViewModel[]>({
+    queryKey: ['alliances-invites', gameId],
+    queryFn: () =>
+      apiClient
+        .get<AllianceInviteViewModel[]>('/api/alliances/my-invites')
+        .then((r) => r.data)
+        .catch(() => []),
+    refetchInterval: 10_000,
+  })
+
+  const invalidateAll = () => {
+    void queryClient.invalidateQueries({ queryKey: ['alliances', gameId] })
+    void queryClient.invalidateQueries({ queryKey: ['alliances-status', gameId] })
+    void queryClient.invalidateQueries({ queryKey: ['alliances-invites', gameId] })
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreateAllianceRequest) => apiClient.post('/api/alliances', req),
+    onSuccess: () => {
+      setError(null)
+      setCreateName('')
+      setCreatePassword('')
+      invalidateAll()
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Create failed')
+    },
+  })
+
+  const joinMutation = useMutation({
+    mutationFn: ({ allianceId, req }: { allianceId: string; req: JoinAllianceRequest }) =>
+      apiClient.post(`/api/alliances/${allianceId}/join`, req),
+    onSuccess: () => {
+      setError(null)
+      setJoiningAlliance(null)
+      setJoinPassword('')
+      invalidateAll()
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Join failed')
+    },
+  })
+
+  const leaveMutation = useMutation({
+    mutationFn: () => apiClient.delete('/api/alliances/leave'),
+    onSuccess: () => { setError(null); invalidateAll() },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Leave failed')
+    },
+  })
+
+  const acceptInviteMutation = useMutation({
+    mutationFn: ({ allianceId, req }: { allianceId: string; req: AcceptInviteRequest }) =>
+      apiClient.post(`/api/alliances/${allianceId}/accept-invite`, req),
+    onSuccess: () => { setError(null); invalidateAll() },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Accept failed')
+    },
+  })
+
+  const declineInviteMutation = useMutation({
+    mutationFn: ({ allianceId, req }: { allianceId: string; req: AcceptInviteRequest }) =>
+      apiClient.post(`/api/alliances/${allianceId}/decline-invite`, req),
+    onSuccess: () => { setError(null); invalidateAll() },
+    onError: () => {},
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Alliances</h1>
+
+      {myStatus?.isMember && (
+        <div
+          className={`rounded-lg border px-4 py-3 text-sm flex items-center justify-between ${
+            myStatus.isPending
+              ? 'border-yellow-700 bg-yellow-900/10 text-yellow-200'
+              : 'border-green-700 bg-green-900/10 text-green-200'
+          }`}
+        >
+          {myStatus.isPending ? (
+            <span>
+              Your request to join <strong>{myStatus.allianceName}</strong> is pending leader
+              approval.
+            </span>
+          ) : (
+            <span>
+              You are a member of{' '}
+              <strong>
+                <a href={`/alliances/${myStatus.allianceId}`} className="underline">
+                  {myStatus.allianceName}
+                </a>
+              </strong>
+              {myStatus.isLeader ? ' (Leader)' : ''}.
+            </span>
+          )}
+          <button
+            onClick={() => leaveMutation.mutate()}
+            disabled={leaveMutation.isPending}
+            className="rounded bg-destructive px-3 py-1 text-xs text-destructive-foreground hover:opacity-90 ml-4"
+          >
+            Leave
+          </button>
+        </div>
+      )}
+
+      {error && <div className="text-destructive text-sm">{error}</div>}
+
+      {(myInvites?.length ?? 0) > 0 && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Pending Invites</strong>
+          </div>
+          <div className="p-3 space-y-2">
+            {myInvites!.map((invite) => (
+              <div
+                key={invite.inviteId}
+                className="flex items-center justify-between rounded border px-3 py-2"
+              >
+                <div className="text-sm">
+                  <strong>{invite.allianceName}</strong>
+                  <span className="text-muted-foreground ml-2">
+                    invited by {invite.inviterPlayerName}
+                  </span>
+                  <span className="text-muted-foreground ml-2 text-xs">
+                    expires {new Date(invite.expiresAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() =>
+                      acceptInviteMutation.mutate({
+                        allianceId: invite.allianceId,
+                        req: { inviteId: invite.inviteId },
+                      })
+                    }
+                    className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+                  >
+                    Accept
+                  </button>
+                  <button
+                    onClick={() =>
+                      declineInviteMutation.mutate({
+                        allianceId: invite.allianceId,
+                        req: { inviteId: invite.inviteId },
+                      })
+                    }
+                    className="rounded border border-destructive px-2 py-0.5 text-xs text-destructive hover:bg-destructive/10"
+                  >
+                    Decline
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {myStatus && !myStatus.isMember && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Create Alliance</strong>
+          </div>
+          <div className="p-4 space-y-3">
+            <input
+              className="w-full max-w-sm rounded border bg-input px-2 py-1.5 text-sm"
+              placeholder="Alliance name"
+              value={createName}
+              onChange={(e) => setCreateName(e.target.value)}
+            />
+            <input
+              type="password"
+              className="w-full max-w-sm rounded border bg-input px-2 py-1.5 text-sm"
+              placeholder="Password"
+              value={createPassword}
+              onChange={(e) => setCreatePassword(e.target.value)}
+            />
+            <button
+              onClick={() =>
+                createMutation.mutate({ allianceName: createName, password: createPassword })
+              }
+              disabled={!createName || createMutation.isPending}
+              className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!alliances ? (
+        <div className="text-muted-foreground text-sm">Loading...</div>
+      ) : (
+        <div className="rounded-lg border bg-card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b">
+              <tr>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Members</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground">Created</th>
+                <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {alliances.map((a) => (
+                <tr key={a.allianceId} className="border-b border-border">
+                  <td className="py-2 px-3 font-medium">
+                    <a href={`/alliances/${a.allianceId}`} className="text-primary hover:underline">
+                      {a.name}
+                    </a>
+                  </td>
+                  <td className="py-2 px-3">{a.memberCount}</td>
+                  <td className="py-2 px-3">
+                    {a.isAtWar ? (
+                      <span className="rounded bg-red-800/60 px-1.5 py-0.5 text-xs text-red-200">
+                        At War
+                      </span>
+                    ) : (
+                      <span className="rounded bg-green-800/60 px-1.5 py-0.5 text-xs text-green-200">
+                        Peaceful
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-xs text-muted-foreground">
+                    {new Date(a.created).toLocaleDateString()}
+                  </td>
+                  <td className="py-2 px-3">
+                    {myStatus && !myStatus.isMember && (
+                      <button
+                        onClick={() => {
+                          setJoiningAlliance(a)
+                          setJoinPassword('')
+                          setError(null)
+                        }}
+                        className="rounded border border-primary px-2 py-0.5 text-xs text-primary hover:bg-primary/10"
+                      >
+                        Join
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {joiningAlliance && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Join {joiningAlliance.name}</strong>
+          </div>
+          <div className="p-4 space-y-3">
+            <input
+              type="password"
+              className="w-full max-w-sm rounded border bg-input px-2 py-1.5 text-sm"
+              placeholder="Password"
+              value={joinPassword}
+              onChange={(e) => setJoinPassword(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() =>
+                  joinMutation.mutate({
+                    allianceId: joiningAlliance.allianceId,
+                    req: { password: joinPassword },
+                  })
+                }
+                disabled={joinMutation.isPending}
+                className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                {joinMutation.isPending ? 'Joining…' : 'Join'}
+              </button>
+              <button
+                onClick={() => setJoiningAlliance(null)}
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `Alliances.tsx` — list all alliances, create/join/leave, accept/decline invitations
- `AllianceDetail.tsx` — member list, leader controls (message all, change password, invite player, declare war, propose/accept peace), wars panel, alliance chat
- `AllianceRanking.tsx` — alliance leaderboard with totalLand, avgLand, memberCount
- Routes added in `App.tsx` for /alliances, /alliances/:id, /alliance-ranking
- `types.ts` extended with alliance-related ViewModel types

Stacked on [BGE-523](/BGE/issues/BGE-523) (PR #165) — will auto-update base to master after BGE-523 merges.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (296 passed)
- [ ] Manual: navigate to /alliances (list + create), join alliance, /alliances/:id (detail + leader actions), /alliance-ranking

Closes BGE-524