### PR TITLE
feat: BGE-525 React pages — Games, Lobby, JoinGame, Summary, Results, CreatePlayer, UnitDefinitions

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -8,6 +8,14 @@ import { SpyReports } from '@/pages/SpyReports'
 import { Diplomacy } from '@/pages/Diplomacy'
 import { EnemyBase } from '@/pages/EnemyBase'
 import { SelectEnemy } from '@/pages/SelectEnemy'
+import { Index } from '@/pages/Index'
+import { Games } from '@/pages/Games'
+import { GameLobby } from '@/pages/GameLobby'
+import { JoinGame } from '@/pages/JoinGame'
+import { GameSummary } from '@/pages/GameSummary'
+import { GameResults } from '@/pages/GameResults'
+import { CreatePlayer } from '@/pages/CreatePlayer'
+import { UnitDefinitions } from '@/pages/UnitDefinitions'
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -87,11 +95,11 @@ function SelectEnemyPage() {
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <TodoPage name="Index" />,
+    element: <Index />,
   },
   {
     path: '/games',
-    element: <TodoPage name="Games" />,
+    element: <Games />,
   },
   {
     path: '/games/:gameId',
@@ -111,21 +119,21 @@ const router = createBrowserRouter([
       { path: 'spies', element: <SpiesPage /> },
       { path: 'spy', element: <SpyReportsPage /> },
       { path: 'selectenemy/:unitId', element: <SelectEnemyPage /> },
-      { path: 'unitdefinitions', element: <TodoPage name="Unit Definitions" /> },
+      { path: 'unitdefinitions', element: <UnitDefinitions /> },
       { path: 'player/:playerId', element: <TodoPage name="Player Profile" /> },
       { path: 'enemybase/:enemyPlayerId', element: <EnemyBasePage /> },
-      { path: 'join', element: <TodoPage name="Join Game" /> },
-      { path: 'summary', element: <TodoPage name="Game Summary" /> },
-      { path: 'results', element: <TodoPage name="Game Results" /> },
+      { path: 'join', element: <JoinGame /> },
+      { path: 'summary', element: <GameSummary /> },
+      { path: 'results', element: <GameResults /> },
     ],
   },
   {
     path: '/createplayer',
-    element: <TodoPage name="Create Player" />,
+    element: <CreatePlayer />,
   },
   {
     path: '/lobby',
-    element: <TodoPage name="Game Lobby" />,
+    element: <GameLobby />,
   },
   {
     path: '/profile',

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -230,6 +230,7 @@ export interface GameSummaryViewModel {
   winnerName: string | null
   discordWebhookUrl: string | null
   isPlayerEnrolled: boolean
+  victoryConditionType: string | null
 }
 
 export interface GameListViewModel {
@@ -260,6 +261,8 @@ export interface GameResultsViewModel {
   endTime: string
   standings: GameResultEntryViewModel[]
   currentPlayerId: string | null
+  victoryConditionType: string | null
+  victoryConditionLabel: string | null
 }
 
 export interface JoinGameRequest {

--- a/src/ReactClient/src/pages/CreatePlayer.tsx
+++ b/src/ReactClient/src/pages/CreatePlayer.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+import apiClient from '@/api/client'
+import type { CreatePlayerRequest } from '@/api/types'
+
+export function CreatePlayer() {
+  const navigate = useNavigate()
+  const [playerName, setPlayerName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreatePlayerRequest) =>
+      apiClient.post('/api/playerprofile/create', req),
+    onSuccess: () => {
+      void navigate('/games?welcome=1')
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to create player.'
+      setError(String(msg))
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!playerName.trim()) {
+      setError('Please enter a commander name.')
+      return
+    }
+    setError(null)
+    createMutation.mutate({ playerName: playerName.trim(), playerType: '' })
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-[80vh] px-4">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-card p-8 space-y-6">
+        <div className="text-center space-y-2">
+          <div className="flex justify-center">
+            <svg className="w-11 h-11 fill-blue-400" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M7.97 16L5 19.03A2 2 0 0 1 2 17.56V17l2.5-9.5A5 5 0 0 1 9.37 4h5.26a5 5 0 0 1 4.87 3.5L22 17v.56a2 2 0 0 1-3 1.47L16.03 16H7.97zM6 10h2v2h2v-2h2V8h-2V6h-2v2H6v2zm10 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm2-3a1 1 0 1 0 0-2 1 1 0 0 0 0 2z" />
+            </svg>
+          </div>
+          <h1 className="text-xl font-bold">Welcome to BGE</h1>
+          <p className="text-muted-foreground text-sm">Choose your commander name to begin</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded border border-red-700 bg-red-900/20 p-2 text-sm text-red-400">{error}</div>
+          )}
+
+          <div className="space-y-1">
+            <label htmlFor="playerName" className="text-sm font-medium">
+              Commander name
+            </label>
+            <input
+              id="playerName"
+              type="text"
+              className="w-full rounded border border-border bg-background px-3 py-2 text-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={playerName}
+              onChange={(e) => setPlayerName(e.target.value)}
+              placeholder="Enter your name"
+              maxLength={32}
+              autoFocus
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full py-2.5 rounded bg-blue-600 text-white text-sm font-semibold hover:bg-blue-500 disabled:opacity-50 transition-colors"
+            disabled={createMutation.isPending}
+          >
+            {createMutation.isPending ? 'Entering game...' : 'Enter the game'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/GameLobby.tsx
+++ b/src/ReactClient/src/pages/GameLobby.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
+
+function statusBadge(status: string): { css: string; label: string } {
+  switch (status.toLowerCase()) {
+    case 'upcoming': return { css: 'bg-yellow-500 text-black', label: 'Upcoming' }
+    case 'active': return { css: 'bg-green-700 text-white', label: 'Active' }
+    case 'finished': return { css: 'bg-gray-500 text-white', label: 'Finished' }
+    default: return { css: 'bg-gray-300 text-black', label: status }
+  }
+}
+
+export function GameLobby() {
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const { data, isLoading } = useQuery<GameListViewModel>({
+    queryKey: ['games'],
+    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const joinMutation = useMutation({
+    mutationFn: (game: GameSummaryViewModel) =>
+      apiClient.post(`/api/games/${game.gameId}/join`, {}),
+    onSuccess: (_, game) => {
+      setError(null)
+      setSuccess(`You have joined "${game.name}"!`)
+      void queryClient.invalidateQueries({ queryKey: ['games'] })
+    },
+    onError: async (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to join.'
+      setError(String(msg))
+    },
+  })
+
+  const games = data?.games ?? []
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Game Lobby</h1>
+
+      {success && <div className="rounded border border-green-700 bg-green-900/20 p-3 text-sm">{success}</div>}
+      {error && <div className="rounded border border-red-700 bg-red-900/20 p-3 text-sm text-red-400">{error}</div>}
+
+      {isLoading && <p className="text-muted-foreground text-sm">Loading...</p>}
+
+      {!isLoading && games.length === 0 && (
+        <p className="text-muted-foreground text-sm">No games available.</p>
+      )}
+
+      {games.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-2 pr-4">Game</th>
+                <th className="py-2 pr-4">Status</th>
+                <th className="py-2 pr-4">Players</th>
+                <th className="py-2 pr-4">Start Time</th>
+                <th className="py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {games.map((game) => {
+                const badge = statusBadge(game.status)
+                return (
+                  <tr key={game.gameId} className="border-b border-border hover:bg-muted/30">
+                    <td className="py-2 pr-4 font-medium">{game.name}</td>
+                    <td className="py-2 pr-4">
+                      <span className={`text-xs font-bold px-2 py-0.5 rounded ${badge.css}`}>{badge.label}</span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      {game.playerCount} / {game.maxPlayers}
+                    </td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {game.startTime
+                        ? new Date(game.startTime).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
+                        : 'TBD'}
+                    </td>
+                    <td className="py-2">
+                      {game.canJoin && (
+                        <button
+                          className="text-xs px-2 py-1 rounded bg-blue-700 text-white hover:bg-blue-600"
+                          onClick={() => joinMutation.mutate(game)}
+                          disabled={joinMutation.isPending}
+                        >
+                          Join
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/GameResults.tsx
+++ b/src/ReactClient/src/pages/GameResults.tsx
@@ -1,0 +1,156 @@
+import { useParams } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { GameResultsViewModel } from '@/api/types'
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const days = Math.floor(totalSec / 86400)
+  const hours = Math.floor((totalSec % 86400) / 3600)
+  const mins = Math.floor((totalSec % 3600) / 60)
+  if (days >= 1) return `${days}d ${hours}h`
+  if (hours >= 1) return `${hours}h ${mins}m`
+  return `${mins}m`
+}
+
+function vcEmoji(type: string | null | undefined): string {
+  switch (type) {
+    case 'EconomicThreshold': return '💰'
+    case 'TimeExpired': return '⏰'
+    case 'AdminFinalized': return '🛑'
+    default: return '🏁'
+  }
+}
+
+function vcBadgeCss(type: string | null | undefined): string {
+  switch (type) {
+    case 'EconomicThreshold': return 'bg-yellow-500 text-black'
+    case 'TimeExpired': return 'bg-gray-500 text-white'
+    case 'AdminFinalized': return 'bg-red-700 text-white'
+    default: return 'bg-gray-500 text-white'
+  }
+}
+
+function vcText(type: string | null | undefined): string {
+  switch (type) {
+    case 'EconomicThreshold': return 'CONQUERED'
+    case 'TimeExpired': return 'TIME EXPIRED'
+    case 'AdminFinalized': return 'ADMIN ENDED'
+    default: return 'FINISHED'
+  }
+}
+
+export function GameResults() {
+  const { gameId } = useParams<{ gameId: string }>()
+
+  const { data: model, error, isLoading } = useQuery<GameResultsViewModel>({
+    queryKey: ['game-results', gameId],
+    queryFn: () => apiClient.get(`/api/games/${gameId}/results`).then((r) => r.data),
+    enabled: !!gameId,
+  })
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading...</p>
+  if (error) return <div className="rounded border border-red-700 bg-red-900/20 p-3 text-sm text-red-400">{String(error)}</div>
+  if (!model) return null
+
+  const end = new Date(model.actualEndTime ?? model.endTime)
+  const start = new Date(model.startTime)
+  const duration = formatDuration(end.getTime() - start.getTime())
+
+  const [first, second, third] = [model.standings[0], model.standings[1], model.standings[2]]
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">{model.name} — Results</h1>
+
+      {model.victoryConditionType && (
+        <div className="flex items-center gap-2">
+          <span className="text-2xl">{vcEmoji(model.victoryConditionType)}</span>
+          <span className={`text-sm font-bold px-3 py-1 rounded ${vcBadgeCss(model.victoryConditionType)}`}>
+            {vcText(model.victoryConditionType)}
+          </span>
+          {model.victoryConditionLabel && (
+            <span className="text-muted-foreground text-sm">— {model.victoryConditionLabel}</span>
+          )}
+        </div>
+      )}
+
+      <p className="text-muted-foreground text-sm">
+        {start.toLocaleDateString()} {start.toLocaleTimeString()} — {end.toLocaleDateString()} {end.toLocaleTimeString()}
+        &nbsp;·&nbsp; Duration: {duration}
+      </p>
+
+      {model.standings.length === 0 && (
+        <p className="text-muted-foreground text-sm">No standings recorded for this game.</p>
+      )}
+
+      {model.standings.length >= 1 && (
+        <>
+          {/* Podium */}
+          <div className="flex items-end justify-center gap-4 flex-wrap">
+            {second && (
+              <div className="rounded-lg border border-gray-600 text-center p-4 w-36">
+                <div className="text-2xl">🥈</div>
+                <div className="font-bold text-sm">{second.playerName}</div>
+                <div className="text-muted-foreground text-xs">{second.score.toLocaleString()}</div>
+              </div>
+            )}
+            {first && (
+              <div className="rounded-lg border border-yellow-600 text-center p-4 w-40">
+                <div className="text-3xl">🏆</div>
+                <div className="font-bold">{first.playerName}</div>
+                <div className="text-muted-foreground text-sm">{first.score.toLocaleString()}</div>
+                <span className="text-xs px-2 py-0.5 rounded bg-yellow-500 text-black mt-1 inline-block">Winner</span>
+              </div>
+            )}
+            {third && (
+              <div className="rounded-lg border border-gray-600 text-center p-4 w-36">
+                <div className="text-2xl">🥉</div>
+                <div className="font-bold text-sm">{third.playerName}</div>
+                <div className="text-muted-foreground text-xs">{third.score.toLocaleString()}</div>
+              </div>
+            )}
+          </div>
+
+          {/* Full standings table */}
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-2 pr-4">Rank</th>
+                <th className="py-2 pr-4">Player</th>
+                <th className="py-2">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {model.standings.map((entry) => {
+                const isMe = entry.playerId === model.currentPlayerId
+                return (
+                  <tr
+                    key={entry.playerId}
+                    className={`border-b border-border ${
+                      isMe ? 'bg-blue-900/30 font-semibold' : entry.isWinner ? 'bg-yellow-900/20' : ''
+                    }`}
+                  >
+                    <td className="py-2 pr-4">
+                      {entry.isWinner ? `🏆 #${entry.rank}` : `#${entry.rank}`}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {entry.playerName}
+                      {isMe && (
+                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-blue-700 text-white">You</span>
+                      )}
+                      {!isMe && entry.isWinner && (
+                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-yellow-500 text-black">Winner</span>
+                      )}
+                    </td>
+                    <td className="py-2">{entry.score.toLocaleString()}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/GameSummary.tsx
+++ b/src/ReactClient/src/pages/GameSummary.tsx
@@ -1,0 +1,109 @@
+import { useParams } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { GameResultsViewModel } from '@/api/types'
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const days = Math.floor(totalSec / 86400)
+  const hours = Math.floor((totalSec % 86400) / 3600)
+  const mins = Math.floor((totalSec % 3600) / 60)
+  if (days >= 1) return `${days}d ${hours}h`
+  if (hours >= 1) return `${hours}h ${mins}m`
+  return `${mins}m`
+}
+
+export function GameSummary() {
+  const { gameId } = useParams<{ gameId: string }>()
+
+  const { data: model, error, isLoading } = useQuery<GameResultsViewModel>({
+    queryKey: ['game-results', gameId],
+    queryFn: () => apiClient.get(`/api/games/${gameId}/results`).then((r) => r.data),
+    enabled: !!gameId,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground text-sm">
+        <span className="animate-spin">⟳</span> Loading game summary...
+      </div>
+    )
+  }
+
+  if (error || !model) {
+    return (
+      <div className="rounded border border-yellow-700 bg-yellow-900/20 p-4 space-y-2 text-sm">
+        <p className="font-medium">⚠️ No summary available for this game.</p>
+        {error && <p className="text-muted-foreground">{String(error)}</p>}
+        <a href="/games" className="text-blue-400 hover:underline">← Back to Games List</a>
+      </div>
+    )
+  }
+
+  const end = new Date(model.actualEndTime ?? model.endTime)
+  const start = new Date(model.startTime)
+  const duration = formatDuration(end.getTime() - start.getTime())
+  const winner = model.standings.find((s) => s.isWinner)
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">🏆 Game Over: {model.name}</h1>
+      <p className="text-muted-foreground text-sm">
+        Ended {end.toLocaleDateString()} {end.toLocaleTimeString()} · Duration: {duration}
+      </p>
+
+      {winner && (
+        <div className="flex items-center gap-4 rounded-lg border border-yellow-700 bg-yellow-900/20 p-4">
+          <span className="text-4xl">🏆</span>
+          <div>
+            <div className="font-bold text-lg">{winner.playerName} wins!</div>
+            <div className="text-muted-foreground text-sm">Final Score: {winner.score.toLocaleString()}</div>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Final Standings</h2>
+        {model.standings.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No standings recorded for this game.</p>
+        ) : (
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-2 pr-4">Rank</th>
+                <th className="py-2 pr-4">Player</th>
+                <th className="py-2">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {model.standings.map((entry) => (
+                <tr
+                  key={entry.playerId}
+                  className={`border-b border-border ${entry.isWinner ? 'bg-yellow-900/20 font-semibold' : ''}`}
+                >
+                  <td className="py-2 pr-4">
+                    {entry.isWinner ? '🏆 1' : `#${entry.rank}`}
+                  </td>
+                  <td className="py-2 pr-4">{entry.playerName}</td>
+                  <td className="py-2">{entry.score.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="flex gap-3 flex-wrap">
+        <a href="/games" className="text-sm px-4 py-2 rounded bg-green-700 text-white hover:bg-green-600">
+          🎮 Join Next Game
+        </a>
+        <a href="/games" className="text-sm px-4 py-2 rounded border border-border hover:bg-muted">
+          ← Back to Games List
+        </a>
+        <a href={`/games/${gameId}/results`} className="text-sm px-4 py-2 rounded border border-border hover:bg-muted">
+          Detailed Results
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Games.tsx
+++ b/src/ReactClient/src/pages/Games.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useSearchParams } from 'react-router'
+import apiClient from '@/api/client'
+import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
+
+function vcBadge(type: string | null | undefined): { css: string; text: string } {
+  switch (type) {
+    case 'EconomicThreshold': return { css: 'bg-yellow-500 text-black', text: 'CONQUERED' }
+    case 'TimeExpired': return { css: 'bg-gray-500 text-white', text: 'TIME EXPIRED' }
+    case 'AdminFinalized': return { css: 'bg-red-600 text-white', text: 'ADMIN ENDED' }
+    default: return { css: 'bg-gray-500 text-white', text: 'FINISHED' }
+  }
+}
+
+function GameCard({ game, onJoin }: { game: GameSummaryViewModel; onJoin: (game: GameSummaryViewModel) => void }) {
+  const formatDate = (d: string | null | undefined) =>
+    d ? new Date(d).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' }) : 'TBD'
+
+  if (game.status === 'Active') {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+        <div className="flex justify-between items-start">
+          <h3 className="font-semibold">{game.name}</h3>
+          <span className="text-xs font-bold px-2 py-0.5 rounded bg-green-700 text-white">LIVE</span>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          <div>Players: {game.playerCount}{game.maxPlayers > 0 ? ` / ${game.maxPlayers}` : ''}</div>
+          <div>Ends: {formatDate(game.endTime)}</div>
+        </div>
+        <div className="flex gap-2 mt-auto flex-wrap">
+          {game.canJoin && (
+            <button
+              className="text-sm px-3 py-1 rounded bg-green-700 text-white hover:bg-green-600"
+              onClick={() => onJoin(game)}
+            >
+              Join
+            </button>
+          )}
+          {game.isPlayerEnrolled && (
+            <a
+              href={`/games/${game.gameId}/base`}
+              className="text-sm px-3 py-1 rounded bg-blue-700 text-white hover:bg-blue-600"
+            >
+              Play Now
+            </a>
+          )}
+          <a
+            href={`/games/${game.gameId}/ranking`}
+            className="text-sm px-3 py-1 rounded border border-border hover:bg-muted"
+          >
+            Spectate
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  if (game.status === 'Upcoming') {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+        <div className="flex justify-between items-start">
+          <h3 className="font-semibold">{game.name}</h3>
+          <span className="text-xs font-bold px-2 py-0.5 rounded bg-yellow-500 text-black">UPCOMING</span>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          <div>Players: {game.playerCount}{game.maxPlayers > 0 ? ` / ${game.maxPlayers}` : ''}</div>
+          <div>Starts: {formatDate(game.startTime)}</div>
+        </div>
+        <div className="mt-auto">
+          {game.canJoin ? (
+            <button
+              className="text-sm px-3 py-1 rounded bg-green-700 text-white hover:bg-green-600"
+              onClick={() => onJoin(game)}
+            >
+              Register Now
+            </button>
+          ) : game.maxPlayers > 0 && game.playerCount >= game.maxPlayers ? (
+            <span className="text-xs px-2 py-0.5 rounded bg-red-700 text-white">Full</span>
+          ) : (
+            <span className="text-xs px-2 py-0.5 rounded bg-gray-600 text-white">Registered</span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // Finished
+  const badge = vcBadge(game.victoryConditionType)
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+      <div className="flex justify-between items-start">
+        <h3 className="font-semibold">{game.name}</h3>
+        <span className={`text-xs font-bold px-2 py-0.5 rounded ${badge.css}`}>{badge.text}</span>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        {game.winnerName && game.victoryConditionType === 'EconomicThreshold' && (
+          <div>🏅 Conqueror: <strong>{game.winnerName}</strong></div>
+        )}
+        {game.winnerName && game.victoryConditionType !== 'EconomicThreshold' && (
+          <div>Winner: <strong>{game.winnerName}</strong></div>
+        )}
+        <div>Ended: {formatDate(game.endTime)}</div>
+      </div>
+      <div className="mt-auto">
+        <a
+          href={`/games/${game.gameId}/results`}
+          className="text-sm px-3 py-1 rounded border border-border hover:bg-muted"
+        >
+          View Results
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export function Games() {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const isNewPlayer = searchParams.get('welcome') === '1'
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [showAllFinished, setShowAllFinished] = useState(false)
+
+  const { data } = useQuery<GameListViewModel>({
+    queryKey: ['games'],
+    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const joinMutation = useMutation({
+    mutationFn: (game: GameSummaryViewModel) =>
+      apiClient.post(`/api/games/${game.gameId}/players`, {}),
+    onSuccess: (_, game) => {
+      setError(null)
+      setSuccess(`You have joined "${game.name}"!`)
+      void queryClient.invalidateQueries({ queryKey: ['games'] })
+      void navigate(`/games/${game.gameId}/base`)
+    },
+    onError: async (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to join game.'
+      setError(String(msg))
+    },
+  })
+
+  const games = data?.games ?? []
+  const active = games.filter((g) => g.status === 'Active')
+  const upcoming = games.filter((g) => g.status === 'Upcoming')
+  const finished = games.filter((g) => g.status === 'Finished')
+  const visibleFinished = showAllFinished || finished.length <= 5 ? finished : finished.slice(0, 5)
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Season Schedule</h1>
+
+      {isNewPlayer && (
+        <div className="rounded-lg border border-green-700 bg-green-900/20 p-4 text-sm">
+          <strong>Welcome to BGE!</strong> Your commander is ready.{' '}
+          <span className="text-muted-foreground">
+            Join an active game below, or register for an upcoming season.
+          </span>
+        </div>
+      )}
+
+      {success && <div className="rounded-lg border border-green-700 bg-green-900/20 p-3 text-sm">{success}</div>}
+      {error && <div className="rounded-lg border border-red-700 bg-red-900/20 p-3 text-sm text-red-400">{error}</div>}
+
+      {!data && (
+        <div className="text-muted-foreground text-sm">Loading...</div>
+      )}
+
+      {data && (
+        <>
+          <section>
+            <h2 className="text-lg font-semibold mb-3">Active</h2>
+            {active.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No games are currently running.
+                {upcoming.length === 0 && ' New seasons are started by the game administrator. Check back soon.'}
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {active.map((g) => (
+                  <GameCard key={g.gameId} game={g} onJoin={(game) => joinMutation.mutate(game)} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3">Upcoming</h2>
+            {upcoming.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No upcoming games are scheduled yet. New seasons are announced here — check back soon.
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {upcoming.map((g) => (
+                  <GameCard key={g.gameId} game={g} onJoin={(game) => joinMutation.mutate(game)} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          {finished.length > 0 && (
+            <section>
+              <div className="flex items-center gap-3 mb-3">
+                <h2 className="text-lg font-semibold">Finished</h2>
+                {finished.length > 5 && (
+                  <button
+                    className="text-sm text-blue-400 hover:underline"
+                    onClick={() => setShowAllFinished((v) => !v)}
+                  >
+                    {showAllFinished ? '▲ Collapse' : `▼ Show all (${finished.length})`}
+                  </button>
+                )}
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {visibleFinished.map((g) => (
+                  <GameCard key={g.gameId} game={g} onJoin={(game) => joinMutation.mutate(game)} />
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Index.tsx
+++ b/src/ReactClient/src/pages/Index.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { ProfileViewModel } from '@/api/types'
+
+export function Index() {
+  const navigate = useNavigate()
+
+  const { data: profile, isLoading } = useQuery<ProfileViewModel>({
+    queryKey: ['profile'],
+    queryFn: () => apiClient.get('/api/profile').then((r) => r.data),
+  })
+
+  useEffect(() => {
+    if (!profile) return
+    if (profile.currentGameId) {
+      void navigate(`/games/${profile.currentGameId}/base`, { replace: true })
+    } else {
+      void navigate('/games', { replace: true })
+    }
+  }, [profile, navigate])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-64">
+        <div className="text-muted-foreground text-sm">Loading...</div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/ReactClient/src/pages/JoinGame.tsx
+++ b/src/ReactClient/src/pages/JoinGame.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { GameDetailViewModel, JoinGameRequest } from '@/api/types'
+
+function statusBadge(status: string): string {
+  switch (status) {
+    case 'Active': return 'bg-green-700 text-white'
+    case 'Upcoming': return 'bg-yellow-500 text-black'
+    case 'Finished': return 'bg-gray-500 text-white'
+    default: return 'bg-gray-300 text-black'
+  }
+}
+
+export function JoinGame() {
+  const { gameId } = useParams<{ gameId: string }>()
+  const navigate = useNavigate()
+  const [playerName, setPlayerName] = useState('')
+  const [joinError, setJoinError] = useState<string | null>(null)
+  const [alreadyJoined, setAlreadyJoined] = useState(false)
+
+  const { data: game, error: loadError, isLoading } = useQuery<GameDetailViewModel>({
+    queryKey: ['game', gameId],
+    queryFn: () => apiClient.get(`/api/games/${gameId}`).then((r) => r.data),
+    enabled: !!gameId,
+  })
+
+  const joinMutation = useMutation({
+    mutationFn: (req: JoinGameRequest) =>
+      apiClient.post(`/api/games/${gameId}/join`, req),
+    onSuccess: () => {
+      void navigate(`/games/${gameId}/base`)
+    },
+    onError: async (err: unknown) => {
+      const status = (err as { response?: { status?: number; data?: string } })?.response?.status
+      if (status === 409) {
+        setAlreadyJoined(true)
+      } else {
+        const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to join.'
+        setJoinError(String(msg))
+      }
+    },
+  })
+
+  function handleJoin() {
+    if (!playerName.trim()) {
+      setJoinError('Please enter a commander name.')
+      return
+    }
+    setJoinError(null)
+    joinMutation.mutate({ playerName: playerName.trim() })
+  }
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading...</p>
+
+  if (loadError || !game) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded border border-red-700 bg-red-900/20 p-3 text-sm text-red-400">Game not found.</div>
+        <a href="/games" className="text-sm text-blue-400 hover:underline">← Back to Games</a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Join Game</h1>
+
+      <div className="flex items-center gap-2">
+        <strong>{game.name}</strong>
+        <span className={`text-xs font-bold px-2 py-0.5 rounded ${statusBadge(game.status)}`}>{game.status}</span>
+      </div>
+
+      {alreadyJoined ? (
+        <div className="space-y-3">
+          <div className="rounded border border-blue-700 bg-blue-900/20 p-3 text-sm">You have already joined this game.</div>
+          <a href={`/games/${gameId}/base`} className="inline-block text-sm px-4 py-2 rounded bg-blue-700 text-white hover:bg-blue-600">
+            Play
+          </a>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border bg-card p-4 max-w-sm space-y-4">
+          <h2 className="font-semibold">Choose your commander</h2>
+
+          {joinError && (
+            <div className="rounded border border-red-700 bg-red-900/20 p-2 text-sm text-red-400">{joinError}</div>
+          )}
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Commander Name</label>
+            <input
+              type="text"
+              className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+              value={playerName}
+              onChange={(e) => setPlayerName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+              placeholder="Enter your name"
+              maxLength={32}
+            />
+          </div>
+
+          <button
+            className="w-full py-2 rounded bg-blue-700 text-white text-sm font-medium hover:bg-blue-600 disabled:opacity-50"
+            onClick={handleJoin}
+            disabled={joinMutation.isPending}
+          >
+            {joinMutation.isPending ? 'Joining...' : 'Join Game'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/UnitDefinitions.tsx
+++ b/src/ReactClient/src/pages/UnitDefinitions.tsx
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { UnitDefinitionViewModel } from '@/api/types'
+
+export function UnitDefinitions() {
+  const { data: units, isLoading, error } = useQuery<UnitDefinitionViewModel[]>({
+    queryKey: ['unit-definitions'],
+    queryFn: () => apiClient.get('/api/unitdefinitions').then((r) => r.data),
+  })
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading...</p>
+  if (error) return <div className="text-sm text-red-400">Failed to load unit definitions.</div>
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Unit Definitions</h1>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-border text-left text-muted-foreground">
+              <th className="py-2 pr-4">ID</th>
+              <th className="py-2 pr-4">Name</th>
+              <th className="py-2 pr-4">Attack</th>
+              <th className="py-2 pr-4">Defense</th>
+              <th className="py-2 pr-4">HP</th>
+              <th className="py-2 pr-4">Speed</th>
+              <th className="py-2">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(units ?? []).map((unit) => (
+              <tr key={unit.id} className="border-b border-border hover:bg-muted/30">
+                <td className="py-2 pr-4 text-muted-foreground font-mono text-xs">{unit.id}</td>
+                <td className="py-2 pr-4 font-medium">{unit.name}</td>
+                <td className="py-2 pr-4">{unit.attack}</td>
+                <td className="py-2 pr-4">{unit.defense}</td>
+                <td className="py-2 pr-4">{unit.hitpoints}</td>
+                <td className="py-2 pr-4">{unit.speed}</td>
+                <td className="py-2 text-muted-foreground text-xs">
+                  {Object.entries(unit.cost.cost)
+                    .map(([k, v]) => `${v} ${k}`)
+                    .join(', ')}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `Index.tsx` — redirects to active game (`/games/:id/base`) or `/games` based on `ProfileViewModel.currentGameId`
- `Games.tsx` — season schedule with Active/Upcoming/Finished sections; join/play/spectate actions; contextual VC badges (CONQUERED, TIME EXPIRED, ADMIN ENDED)
- `GameLobby.tsx` — table view of games with join button (uses `api/games`)
- `JoinGame.tsx` — commander name form; handles already-joined (409 → redirect to /base)
- `GameSummary.tsx` — game-over screen with winner highlight and standings table
- `GameResults.tsx` — detailed results with podium display, VC badge, current player highlighted
- `CreatePlayer.tsx` — commander creation form posting to `api/playerprofile/create`
- `UnitDefinitions.tsx` — unit stat reference table
- `App.tsx` — all 8 new pages wired in, replacing TodoPage stubs
- `types.ts` — `victoryConditionType` added to `GameSummaryViewModel`; `victoryConditionType` + `victoryConditionLabel` added to `GameResultsViewModel`

## Test plan
- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] `dotnet test` passes (296 passed)
- [ ] Navigate to `/` — should redirect based on active game
- [ ] Navigate to `/games` — season schedule renders correctly
- [ ] Navigate to `/games/:id/join` — commander name form works
- [ ] Navigate to `/games/:id/results` — podium and standings render
- [ ] Navigate to `/createplayer` — form submits and redirects to `/games?welcome=1`
- [ ] Navigate to `/games/:id/unitdefinitions` — unit table renders

Closes BGE-525