### PR TITLE
fix: BGE-534/535/536/537 — spy missions, alliance name/route, ranking highlight

### DIFF
--- a/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/AllianceDetail.razor
@@ -1,4 +1,5 @@
 @page "/alliances/{AllianceId}"
+@page "/games/{GameId}/alliances/{AllianceId}"
 @using BrowserGameEngine.Shared
 @inject HttpClient Http
 @implements IDisposable
@@ -158,6 +159,7 @@
 
 @code {
     [Parameter] public required string AllianceId { get; set; }
+    [Parameter] public string? GameId { get; set; }
 
     private AllianceDetailViewModel? detail;
     private MyAllianceStatusViewModel? myStatus;

--- a/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Alliances.razor
@@ -51,7 +51,7 @@
         <div class="card-header">Create Alliance</div>
         <div class="card-body">
             <div class="mb-2">
-                <input class="form-control" placeholder="Alliance name" @bind="createName" />
+                <input class="form-control" placeholder="Alliance name" @bind="createName" @bind:event="oninput" />
             </div>
             <div class="mb-2">
                 <input class="form-control" type="password" placeholder="Password" @bind="createPassword" />

--- a/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/PlayerRanking.razor
@@ -47,7 +47,7 @@
                 </thead>
                 <tbody>
                     @foreach (var (rank, item) in group.players) {
-                    <tr>
+                    <tr class="@(item.IsCurrentPlayer ? "table-primary fw-bold" : "")">
                         <td><strong>#@rank</strong></td>
                         <td>
                             @if (GameId != null && item.PlayerId != null) {

--- a/src/BrowserGameEngine.BlazorClient/Pages/Spy.razor
+++ b/src/BrowserGameEngine.BlazorClient/Pages/Spy.razor
@@ -14,6 +14,14 @@
         </button>
     </li>
     <li class="nav-item">
+        <button class="nav-link @(activeTab == "missions" ? "active" : "")" @onclick='() => SwitchToMissions()'>
+            Active Missions
+            @if (missions != null && missions.Any(m => m.Status == "Pending")) {
+                <span class="badge bg-info ms-1">@missions.Count(m => m.Status == "Pending")</span>
+            }
+        </button>
+    </li>
+    <li class="nav-item">
         <button class="nav-link @(activeTab == "incoming" ? "active" : "")" @onclick='() => activeTab = "incoming"'>
             Incoming Intel
             @if (intelAttempts != null && intelAttempts.Length > 0) {
@@ -28,7 +36,9 @@
 }
 
 @if (activeTab == "outgoing") {
-    <p class="text-muted">Gather intelligence on other players. Each mission costs 50 minerals with a 30-minute cooldown per target.</p>
+    <div class="mb-3">
+        <p class="text-muted">Select a mission type and send your spy. Costs: Intelligence 50🪨, Steal Resources 75🪨, Sabotage 100🪨</p>
+    </div>
 
     @if (players == null) {
         <p><em>Loading...</em></p>
@@ -40,6 +50,7 @@
                 <tr>
                     <th>Player</th>
                     <th>Score</th>
+                    <th>Mission Type</th>
                     <th></th>
                 </tr>
             </thead>
@@ -49,6 +60,16 @@
                         <td>@player.PlayerName</td>
                         <td>@((int)player.Score)</td>
                         <td>
+                            <select class="form-select form-select-sm"
+                                    style="width:auto"
+                                    @bind="missionTypes[player.PlayerId]"
+                                    disabled="@(player.CooldownExpiresAt.HasValue)">
+                                <option value="Intelligence">Intelligence (50🪨)</option>
+                                <option value="StealResources">Steal Resources (75🪨)</option>
+                                <option value="Sabotage">Sabotage (100🪨)</option>
+                            </select>
+                        </td>
+                        <td>
                             @if (player.CooldownExpiresAt.HasValue) {
                                 var remaining = player.CooldownExpiresAt.Value - DateTime.UtcNow;
                                 var display = remaining > TimeSpan.Zero ? remaining.ToString(@"mm\:ss") : "0:00";
@@ -56,46 +77,66 @@
                                     <span class="oi oi-eye" aria-hidden="true"></span> @display
                                 </button>
                             } else {
-                                <button class="btn btn-secondary btn-sm"
-                                        @onclick="() => SendSpy(player.PlayerId)"
+                                <button class="btn btn-primary btn-sm"
+                                        @onclick="() => SendMission(player.PlayerId)"
                                         disabled="@(spyLoadings.TryGetValue(player.PlayerId, out var loading) && loading)">
                                     @if (spyLoadings.TryGetValue(player.PlayerId, out var isLoading) && isLoading) {
-                                        <span>Spying...</span>
+                                        <span>Sending...</span>
                                     } else {
-                                        <span><span class="oi oi-eye" aria-hidden="true"></span> Spy</span>
+                                        <span><span class="oi oi-eye" aria-hidden="true"></span> Send</span>
                                     }
                                 </button>
                             }
                             @if (spyErrors.TryGetValue(player.PlayerId, out var err) && err != null) {
                                 <span class="text-danger ms-2 small">@err</span>
                             }
+                            @if (spySuccess.TryGetValue(player.PlayerId, out var msg) && msg != null) {
+                                <span class="text-success ms-2 small">@msg</span>
+                            }
                         </td>
                     </tr>
-                    @if (spyReports.TryGetValue(player.PlayerId, out var report)) {
-                        <tr>
-                            <td colspan="3">
-                                <details open class="mt-1 mb-2">
-                                    <summary><strong>Spy Report — @report.TargetPlayerName</strong> <small class="text-muted">(@report.ReportTime.ToLocalTime().ToString("HH:mm:ss"))</small></summary>
-                                    <div class="mt-2">
-                                        <p><strong>Approximate Resources:</strong> ~@((int)report.ApproximateMinerals) minerals, ~@((int)report.ApproximateGas) gas</p>
-                                        @if (report.UnitEstimates.Any()) {
-                                            <table class="table table-sm">
-                                                <thead><tr><th>Unit</th><th>~Count</th></tr></thead>
-                                                <tbody>
-                                                    @foreach (var u in report.UnitEstimates.OrderByDescending(x => x.ApproximateCount)) {
-                                                        <tr><td>@u.UnitTypeName</td><td>~@u.ApproximateCount</td></tr>
-                                                    }
-                                                </tbody>
-                                            </table>
-                                        } else {
-                                            <p class="text-muted">No units detected at base.</p>
-                                        }
-                                        <p class="text-muted"><small>Next spy available: @report.CooldownExpiresAt.ToLocalTime()</small></p>
-                                    </div>
-                                </details>
-                            </td>
-                        </tr>
-                    }
+                }
+            </tbody>
+        </table>
+    }
+}
+
+@if (activeTab == "missions") {
+    <p class="text-muted">Outgoing spy missions dispatched from your base.</p>
+    <button class="btn btn-sm btn-outline-secondary mb-3" @onclick="LoadMissions">Refresh</button>
+
+    @if (missions == null) {
+        <p><em>Loading...</em></p>
+    } else if (missions.Count == 0) {
+        <p class="text-muted">No missions dispatched yet.</p>
+    } else {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Target</th>
+                    <th>Mission Type</th>
+                    <th>Status</th>
+                    <th>Sent</th>
+                    <th>Result</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var m in missions.OrderByDescending(x => x.CreatedAt)) {
+                    <tr>
+                        <td>@m.TargetPlayerName</td>
+                        <td><span class="badge bg-secondary">@m.MissionType</span></td>
+                        <td>
+                            @if (m.Status == "Pending") {
+                                <span class="badge bg-warning text-dark">In Progress</span>
+                            } else if (m.Status == "Success") {
+                                <span class="badge bg-success">Success</span>
+                            } else {
+                                <span class="badge bg-danger">@m.Status</span>
+                            }
+                        </td>
+                        <td>@m.CreatedAt.ToLocalTime().ToString("MMM d, HH:mm")</td>
+                        <td>@(m.Result ?? "—")</td>
+                    </tr>
                 }
             </tbody>
         </table>
@@ -138,9 +179,11 @@
     private string activeTab = "outgoing";
     private SpyPlayerEntryViewModel[]? players;
     private SpyAttemptViewModel[]? intelAttempts;
-    private readonly Dictionary<string, SpyReportViewModel> spyReports = new();
+    private List<SpyMissionViewModel>? missions;
     private readonly Dictionary<string, bool> spyLoadings = new();
     private readonly Dictionary<string, string?> spyErrors = new();
+    private readonly Dictionary<string, string?> spySuccess = new();
+    private readonly Dictionary<string, string> missionTypes = new();
     private string? pageError;
 
     protected override async Task OnInitializedAsync() {
@@ -150,6 +193,13 @@
     private async Task LoadPlayers() {
         try {
             players = await Http.GetFromJsonAsync<SpyPlayerEntryViewModel[]>("api/spy/players");
+            if (players != null) {
+                foreach (var p in players) {
+                    if (!missionTypes.ContainsKey(p.PlayerId)) {
+                        missionTypes[p.PlayerId] = "Intelligence";
+                    }
+                }
+            }
         } catch (Exception ex) {
             pageError = ex.Message;
             players = Array.Empty<SpyPlayerEntryViewModel>();
@@ -164,25 +214,40 @@
         }
     }
 
-    private async Task SendSpy(string targetPlayerId) {
+    private async Task LoadMissions() {
+        try {
+            missions = await Http.GetFromJsonAsync<List<SpyMissionViewModel>>("api/spy/missions") ?? new();
+        } catch {
+            missions = new();
+        }
+    }
+
+    private async Task SwitchToMissions() {
+        activeTab = "missions";
+        if (missions == null) {
+            await LoadMissions();
+        }
+    }
+
+    private async Task SendMission(string targetPlayerId) {
         spyLoadings[targetPlayerId] = true;
-        spyReports.Remove(targetPlayerId);
         spyErrors.Remove(targetPlayerId);
+        spySuccess.Remove(targetPlayerId);
         StateHasChanged();
 
-        var response = await Http.PostAsync($"api/spy/execute?targetPlayerId={Uri.EscapeDataString(targetPlayerId)}", null);
+        var missionType = missionTypes.TryGetValue(targetPlayerId, out var mt) ? mt : "Intelligence";
+        var response = await Http.PostAsJsonAsync("api/spy/send", new SendSpyMissionRequest {
+            TargetPlayerId = targetPlayerId,
+            MissionType = missionType
+        });
         spyLoadings[targetPlayerId] = false;
 
         if (response.IsSuccessStatusCode) {
-            var report = await response.Content.ReadFromJsonAsync<SpyReportViewModel>();
-            if (report != null) {
-                spyReports[targetPlayerId] = report;
-                // Update the player entry cooldown so button immediately reflects new state
-                var player = players?.FirstOrDefault(p => p.PlayerId == targetPlayerId);
-                if (player != null) {
-                    player.CooldownExpiresAt = report.CooldownExpiresAt;
-                }
+            var result = await response.Content.ReadFromJsonAsync<SendSpyMissionResponse>();
+            if (result != null) {
+                spySuccess[targetPlayerId] = $"Mission dispatched. ETA: {result.EstimatedResolveAt.ToLocalTime():HH:mm}";
             }
+            missions = null; // invalidate missions cache so next switch refreshes
         } else {
             spyErrors[targetPlayerId] = await response.Content.ReadAsStringAsync();
         }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -52,7 +52,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return playerRepository.GetAll().Select(p => {
 				bool isOwnPlayer = currentUserContext.PlayerId != null && p.PlayerId == currentUserContext.PlayerId;
 				SpyResult? intel = isOwnPlayer ? null : fogOfWarRepository.GetValidIntel(currentUserContext.PlayerId!, p.PlayerId);
-				return p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository, intel, isOwnPlayer);
+				var vm = p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository, intel, isOwnPlayer);
+				return vm with { IsCurrentPlayer = isOwnPlayer };
 			});
 		}
 

--- a/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PublicPlayerViewModel.cs
@@ -18,5 +18,6 @@ namespace BrowserGameEngine.Shared {
 		public decimal? ApproxMinerals { get; set; }
 		public decimal? ApproxGas { get; set; }
 		public int? ApproxHomeUnitCount { get; set; }
+		public bool IsCurrentPlayer { get; set; }
 	}
 }


### PR DESCRIPTION
## Summary
- **BGE-534**: Spy page now has a mission type selector (Intelligence / Steal Resources / Sabotage) per player row and an Active Missions tab; uses `api/spy/send` (async dispatch) instead of the intelligence-only `api/spy/execute`
- **BGE-535**: Alliance name input uses `@bind:event="oninput"` so `createName` is captured on each keystroke — prevents empty name when Create is clicked without blurring the field first
- **BGE-536**: `AllianceDetail.razor` adds `@page "/games/{GameId}/alliances/{AllianceId}"` route; links from the game-scoped Alliances page now resolve correctly instead of 404
- **BGE-537**: `PublicPlayerViewModel` gains `IsCurrentPlayer` flag; `PlayerRankingController.Get()` sets it for the authenticated user's player; `PlayerRanking.razor` highlights that row with `table-primary fw-bold`

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (296 tests)
- [ ] Spy page: each player row has a mission type dropdown; clicking Send dispatches the selected type and shows ETA; Active Missions tab lists dispatched missions
- [ ] Alliances: create an alliance — name is correctly sent and displayed
- [ ] Alliance detail: navigate to `/games/{id}/alliances/{allianceId}` — page loads correctly
- [ ] Ranking page `/ranking`: logged-in player row is highlighted in blue/bold

Closes BGE-534
Closes BGE-535
Closes BGE-536
Closes BGE-537