### PR TITLE
feat: BGE-522 React social pages — Chat, Messages, Rankings, Profiles

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -12,6 +12,11 @@ import { SpyReports } from '@/pages/SpyReports'
 import { Diplomacy } from '@/pages/Diplomacy'
 import { EnemyBase } from '@/pages/EnemyBase'
 import { SelectEnemy } from '@/pages/SelectEnemy'
+import { Chat } from '@/pages/Chat'
+import { Messages } from '@/pages/Messages'
+import { PlayerRanking } from '@/pages/PlayerRanking'
+import { PlayerProfile } from '@/pages/PlayerProfile'
+import { InGamePlayerProfile } from '@/pages/InGamePlayerProfile'
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -72,6 +77,26 @@ function SelectEnemyPage() {
   if (!gameId) return null
   return <SelectEnemy gameId={gameId} />
 }
+function ChatPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Chat gameId={gameId} />
+}
+function MessagesPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Messages gameId={gameId} />
+}
+function PlayerRankingPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <PlayerRanking gameId={gameId} />
+}
+function InGamePlayerProfilePage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <InGamePlayerProfile gameId={gameId} />
+}
 
 const router = createBrowserRouter([
   {
@@ -91,9 +116,9 @@ const router = createBrowserRouter([
           { path: 'research', element: <ResearchPage /> },
           { path: 'upgrades', element: <ResearchPage /> },
           { path: 'market', element: <MarketPage /> },
-          { path: 'chat', element: <TodoPage name="Chat" /> },
-          { path: 'messages', element: <TodoPage name="Messages" /> },
-          { path: 'ranking', element: <TodoPage name="Player Ranking" /> },
+          { path: 'chat', element: <ChatPage /> },
+          { path: 'messages', element: <MessagesPage /> },
+          { path: 'ranking', element: <PlayerRankingPage /> },
           { path: 'alliances', element: <TodoPage name="Alliances" /> },
           { path: 'allianceranking', element: <TodoPage name="Alliance Ranking" /> },
           { path: 'diplomacy', element: <DiplomacyPage /> },
@@ -101,7 +126,7 @@ const router = createBrowserRouter([
           { path: 'spy', element: <SpyReportsPage /> },
           { path: 'selectenemy/:unitId', element: <SelectEnemyPage /> },
           { path: 'unitdefinitions', element: <TodoPage name="Unit Definitions" /> },
-          { path: 'player/:playerId', element: <TodoPage name="Player Profile" /> },
+          { path: 'player/:playerId', element: <InGamePlayerProfilePage /> },
           { path: 'enemybase/:enemyPlayerId', element: <EnemyBasePage /> },
           { path: 'join', element: <TodoPage name="Join Game" /> },
           { path: 'summary', element: <TodoPage name="Game Summary" /> },
@@ -119,7 +144,7 @@ const router = createBrowserRouter([
 
       { path: '/createplayer', element: <TodoPage name="Create Player" /> },
       { path: '/lobby', element: <TodoPage name="Game Lobby" /> },
-      { path: '/profile', element: <TodoPage name="Player Profile" /> },
+      { path: '/profile', element: <PlayerProfile /> },
       { path: '/profile/:userId', element: <TodoPage name="Public Profile" /> },
       { path: '/players', element: <TodoPage name="Players" /> },
       { path: '/alliances/:allianceId', element: <TodoPage name="Alliance Detail" /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -309,9 +309,16 @@ export interface InGamePlayerProfileViewModel {
   playerId: string
   playerName: string
   score: number
-  protectionTicksRemaining: number
+  rank: number
+  totalPlayers: number
+  allianceId: string | null
+  allianceName: string | null
+  allianceRole: string | null
+  techsResearched: number
   isOnline: boolean
   lastOnline: string | null
+  isAgent: boolean
+  protectionTicksRemaining: number
 }
 
 // Rankings

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -291,10 +291,18 @@ export interface PlayerProfileViewModel {
 }
 
 export interface PublicPlayerViewModel {
-  playerId: string
-  playerName: string
+  playerId: string | null
+  playerName: string | null
   score: number
+  protectionTicksRemaining: number
+  userId: string | null
+  userDisplayName: string | null
+  isAgent: boolean
+  lastOnline: string | null
   isOnline: boolean
+  approxMinerals: number | null
+  approxGas: number | null
+  approxHomeUnitCount: number | null
 }
 
 export interface InGamePlayerProfileViewModel {
@@ -511,40 +519,39 @@ export interface SelectEnemyViewModel {
 // Chat
 
 export interface ChatMessageViewModel {
-  id: string
-  playerName: string
-  playerId: string
-  message: string
+  messageId: string
+  authorPlayerId: string
+  authorName: string
+  body: string
   createdAt: string
 }
 
-export interface ChatViewModel {
+export interface ChatMessagesViewModel {
   messages: ChatMessageViewModel[]
 }
 
 export interface PostChatMessageRequest {
-  message: string
+  body: string
 }
 
 // Messages
 
 export interface MessageViewModel {
-  id: string
-  senderId: string
+  messageId: string
+  senderId: string | null
   senderName: string
   recipientId: string
-  recipientName: string
   subject: string
   body: string
   isRead: boolean
   sentAt: string
 }
 
-export interface MessageListViewModel {
+export interface MessageInboxViewModel {
   messages: MessageViewModel[]
 }
 
-export interface SendMessageRequest {
+export interface SendMessageViewModel {
   recipientId: string
   subject: string
   body: string

--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect, useRef } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { SendIcon } from 'lucide-react'
+import apiClient from '@/api/client'
+import type { ChatMessagesViewModel, PostChatMessageRequest } from '@/api/types'
+import { cn } from '@/lib/utils'
+
+interface ChatProps {
+  gameId: string
+}
+
+export function Chat({ gameId }: ChatProps) {
+  const queryClient = useQueryClient()
+  const [body, setBody] = useState('')
+  const [lastMessageId, setLastMessageId] = useState<string | null>(null)
+  const [allMessages, setAllMessages] = useState<ChatMessagesViewModel['messages']>([])
+  const [error, setError] = useState<string | null>(null)
+  const chatEndRef = useRef<HTMLDivElement>(null)
+
+  // Initial load
+  useEffect(() => {
+    apiClient.get<ChatMessagesViewModel>('/api/chat').then((r) => {
+      setAllMessages(r.data.messages)
+      const msgs = r.data.messages
+      if (msgs.length > 0) setLastMessageId(msgs[msgs.length - 1].messageId)
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameId])
+
+  // Poll for new messages
+  useQuery({
+    queryKey: ['chat-poll', gameId, lastMessageId],
+    queryFn: async () => {
+      const url = lastMessageId ? `/api/chat?after=${lastMessageId}` : '/api/chat'
+      const r = await apiClient.get<ChatMessagesViewModel>(url)
+      if (r.data.messages.length > 0) {
+        setAllMessages((prev) => [...prev, ...r.data.messages])
+        const last = r.data.messages[r.data.messages.length - 1]
+        setLastMessageId(last.messageId)
+      }
+      return r.data
+    },
+    refetchInterval: 5_000,
+    enabled: allMessages.length > 0,
+  })
+
+  // Scroll to bottom on new messages
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [allMessages])
+
+  const send = useMutation({
+    mutationFn: (req: PostChatMessageRequest) =>
+      apiClient.post('/api/chat', req),
+    onSuccess: async () => {
+      setBody('')
+      const r = await apiClient.get<ChatMessagesViewModel>(
+        lastMessageId ? `/api/chat?after=${lastMessageId}` : '/api/chat'
+      )
+      if (r.data.messages.length > 0) {
+        setAllMessages((prev) => [...prev, ...r.data.messages])
+        const last = r.data.messages[r.data.messages.length - 1]
+        setLastMessageId(last.messageId)
+      }
+    },
+    onError: async (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to send'
+      setError(msg)
+    },
+  })
+
+  function handleSend() {
+    if (!body.trim()) return
+    setError(null)
+    send.mutate({ body: body.trim() })
+  }
+
+  return (
+    <div className="max-w-2xl space-y-3">
+      <h1 className="text-xl font-bold">Game Chat</h1>
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Send box */}
+      <div className="flex gap-2">
+        <input
+          className={cn(
+            'flex-1 rounded-md border bg-input px-3 py-2 text-sm',
+            'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+          )}
+          placeholder="Type a message…"
+          maxLength={500}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend() } }}
+        />
+        <button
+          onClick={handleSend}
+          disabled={!body.trim() || send.isPending}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground',
+            'hover:bg-primary/90 disabled:opacity-50 transition-colors'
+          )}
+        >
+          <SendIcon className="h-4 w-4" />
+          Send
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground">{body.length} / 500</p>
+
+      {/* Chat window */}
+      <div className="h-[420px] overflow-y-auto rounded-lg border bg-card p-2 space-y-1.5">
+        {allMessages.length === 0 ? (
+          <p className="text-center text-muted-foreground text-sm mt-8">No messages yet. Start the conversation!</p>
+        ) : (
+          allMessages.map((msg) => (
+            <div key={msg.messageId} className="rounded-md border-l-2 border-primary/60 bg-secondary/30 px-3 py-2">
+              <div className="flex justify-between text-xs mb-0.5">
+                <span className="font-semibold text-primary">{msg.authorName}</span>
+                <span className="text-muted-foreground">
+                  {new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                </span>
+              </div>
+              <p className="text-sm">{msg.body}</p>
+            </div>
+          ))
+        )}
+        <div ref={chatEndRef} />
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -41,7 +41,7 @@ export function Chat({ gameId }: ChatProps) {
       return r.data
     },
     refetchInterval: 5_000,
-    enabled: allMessages.length > 0,
+    enabled: true,
   })
 
   // Scroll to bottom on new messages

--- a/src/ReactClient/src/pages/InGamePlayerProfile.tsx
+++ b/src/ReactClient/src/pages/InGamePlayerProfile.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams, Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { InGamePlayerProfileViewModel } from '@/api/types'
+import { relativeTime } from '@/lib/utils'
+
+interface InGamePlayerProfileProps {
+  gameId: string
+}
+
+export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
+  const { playerId } = useParams<{ playerId: string }>()
+
+  const { data: player, isLoading } = useQuery({
+    queryKey: ['ingame-player', gameId, playerId],
+    queryFn: () =>
+      apiClient
+        .get<InGamePlayerProfileViewModel>(`/api/playerranking/${encodeURIComponent(playerId ?? '')}`)
+        .then((r) => r.data),
+    enabled: !!playerId,
+  })
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>
+  if (!player) return <p className="text-destructive text-sm">Player not found.</p>
+
+  return (
+    <div className="max-w-md space-y-4">
+      <div className="flex items-center gap-2">
+        <Link to={`/games/${gameId}/ranking`} className="text-sm text-muted-foreground hover:text-foreground">
+          ← Ranking
+        </Link>
+      </div>
+
+      <div className="rounded-lg border bg-card p-6 space-y-4">
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <div className="h-14 w-14 rounded-full bg-secondary flex items-center justify-center text-xl border border-primary/40">
+            {player.playerName?.[0]?.toUpperCase() ?? '?'}
+          </div>
+          <div>
+            <div className="font-bold text-lg">{player.playerName}</div>
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <span
+                className={`h-2 w-2 rounded-full ${player.isOnline ? 'bg-green-400' : 'bg-muted-foreground'}`}
+              />
+              {player.isOnline
+                ? 'Online now'
+                : player.lastOnline
+                  ? `Last seen ${relativeTime(player.lastOnline)}`
+                  : 'Offline'}
+            </div>
+          </div>
+        </div>
+
+        {/* Stats grid */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded border bg-secondary/20 p-3">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Score</div>
+            <div className="text-2xl font-bold">{Math.floor(player.score).toLocaleString()}</div>
+          </div>
+          {player.protectionTicksRemaining > 0 && (
+            <div className="rounded border border-yellow-700/50 bg-yellow-900/20 p-3">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Protection</div>
+              <div className="text-lg font-semibold text-yellow-400">🛡 {player.protectionTicksRemaining} ticks</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/InGamePlayerProfile.tsx
+++ b/src/ReactClient/src/pages/InGamePlayerProfile.tsx
@@ -58,13 +58,39 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
             <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Score</div>
             <div className="text-2xl font-bold">{Math.floor(player.score).toLocaleString()}</div>
           </div>
+          <div className="rounded border bg-secondary/20 p-3">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Rank</div>
+            <div className="text-2xl font-bold">{player.rank} <span className="text-sm text-muted-foreground font-normal">/ {player.totalPlayers}</span></div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Techs Researched</div>
+            <div className="text-2xl font-bold">{player.techsResearched}</div>
+          </div>
           {player.protectionTicksRemaining > 0 && (
             <div className="rounded border border-yellow-700/50 bg-yellow-900/20 p-3">
               <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Protection</div>
-              <div className="text-lg font-semibold text-yellow-400">🛡 {player.protectionTicksRemaining} ticks</div>
+              <div className="text-lg font-semibold text-yellow-400">{player.protectionTicksRemaining} ticks</div>
             </div>
           )}
         </div>
+
+        {/* Alliance */}
+        {player.allianceName && (
+          <div className="rounded border bg-secondary/20 p-3">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Alliance</div>
+            <div className="font-semibold">{player.allianceName}</div>
+            {player.allianceRole && (
+              <div className="text-sm text-muted-foreground capitalize">{player.allianceRole}</div>
+            )}
+          </div>
+        )}
+
+        {/* Agent badge */}
+        {player.isAgent && (
+          <div className="inline-block rounded-full border border-blue-700/50 bg-blue-900/20 px-3 py-1 text-xs text-blue-400 font-medium">
+            AI Agent
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/ReactClient/src/pages/Messages.tsx
+++ b/src/ReactClient/src/pages/Messages.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { PenSquareIcon, InboxIcon, SendIcon, ReplyIcon } from 'lucide-react'
+import apiClient from '@/api/client'
+import type { MessageInboxViewModel, MessageViewModel, SendMessageViewModel, PublicPlayerViewModel } from '@/api/types'
+import { relativeTime } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+
+interface MessagesProps {
+  gameId: string
+}
+
+function ComposeForm({
+  players,
+  onSent,
+  replyTo,
+}: {
+  players: PublicPlayerViewModel[]
+  onSent: () => void
+  replyTo?: MessageViewModel
+}) {
+  const [recipientId, setRecipientId] = useState(replyTo?.senderId ?? '')
+  const [subject, setSubject] = useState(replyTo ? `Re: ${replyTo.subject}` : '')
+  const [body, setBody] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const send = useMutation({
+    mutationFn: (req: SendMessageViewModel) =>
+      apiClient.post('/api/messages/send', req),
+    onSuccess: () => {
+      setBody('')
+      setSubject('')
+      onSent()
+    },
+    onError: async (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to send'
+      setError(msg)
+    },
+  })
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="rounded border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+      <div>
+        <label className="text-xs text-muted-foreground mb-1 block">Recipient</label>
+        <select
+          className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+          value={recipientId}
+          onChange={(e) => setRecipientId(e.target.value)}
+        >
+          <option value="">— select player —</option>
+          {players.map((p) => (
+            <option key={p.playerId} value={p.playerId ?? ''}>
+              {p.playerName}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-xs text-muted-foreground mb-1 block">Subject</label>
+        <input
+          className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          maxLength={100}
+        />
+      </div>
+      <div>
+        <label className="text-xs text-muted-foreground mb-1 block">Message</label>
+        <textarea
+          className="w-full rounded border bg-input px-2 py-1.5 text-sm min-h-[80px]"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          maxLength={2000}
+        />
+      </div>
+      <button
+        onClick={() => send.mutate({ recipientId, subject, body })}
+        disabled={!recipientId || !subject.trim() || !body.trim() || send.isPending}
+        className="flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+      >
+        <SendIcon className="h-4 w-4" />
+        {send.isPending ? 'Sending…' : 'Send'}
+      </button>
+    </div>
+  )
+}
+
+export function Messages({ gameId }: MessagesProps) {
+  const queryClient = useQueryClient()
+  const [tab, setTab] = useState<'inbox' | 'sent'>('inbox')
+  const [selected, setSelected] = useState<MessageViewModel | null>(null)
+  const [composing, setComposing] = useState(false)
+
+  const { data: inbox } = useQuery({
+    queryKey: ['messages-inbox', gameId],
+    queryFn: () =>
+      apiClient.get<MessageInboxViewModel>('/api/messages/inbox').then((r) => r.data),
+  })
+
+  const { data: sent } = useQuery({
+    queryKey: ['messages-sent', gameId],
+    queryFn: () =>
+      apiClient.get<MessageInboxViewModel>('/api/messages/sent').then((r) => r.data),
+  })
+
+  const { data: players = [] } = useQuery({
+    queryKey: ['players-list'],
+    queryFn: () =>
+      apiClient.get<PublicPlayerViewModel[]>('/api/playerranking').then((r) => r.data),
+  })
+
+  const markRead = useMutation({
+    mutationFn: (id: string) => apiClient.post(`/api/messages/${id}/read`, {}),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['messages-inbox'] }),
+  })
+
+  function openMessage(msg: MessageViewModel) {
+    setSelected(msg)
+    setComposing(false)
+    if (!msg.isRead) markRead.mutate(msg.messageId)
+  }
+
+  const messages = tab === 'inbox' ? inbox?.messages ?? [] : sent?.messages ?? []
+  const unread = inbox?.messages.filter((m) => !m.isRead).length ?? 0
+
+  return (
+    <div className="max-w-3xl">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold">Messages</h1>
+        <button
+          onClick={() => { setComposing(true); setSelected(null) }}
+          className="flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <PenSquareIcon className="h-4 w-4" />
+          Compose
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-4">
+        {/* List pane */}
+        <div className="rounded-lg border overflow-hidden">
+          <div className="flex border-b">
+            <button
+              onClick={() => setTab('inbox')}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-sm',
+                tab === 'inbox' ? 'bg-secondary text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <InboxIcon className="h-3.5 w-3.5" />
+              Inbox
+              {unread > 0 && (
+                <span className="ml-1 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+                  {unread}
+                </span>
+              )}
+            </button>
+            <button
+              onClick={() => setTab('sent')}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-1.5 py-2 text-sm',
+                tab === 'sent' ? 'bg-secondary text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <SendIcon className="h-3.5 w-3.5" />
+              Sent
+            </button>
+          </div>
+
+          <ul className="divide-y max-h-[420px] overflow-y-auto">
+            {messages.length === 0 ? (
+              <li className="px-3 py-4 text-center text-sm text-muted-foreground">Empty</li>
+            ) : (
+              messages.map((msg) => (
+                <li key={msg.messageId}>
+                  <button
+                    onClick={() => openMessage(msg)}
+                    className={cn(
+                      'w-full text-left px-3 py-2.5 text-sm hover:bg-secondary/60 transition-colors',
+                      selected?.messageId === msg.messageId && 'bg-secondary',
+                      tab === 'inbox' && !msg.isRead && 'font-semibold'
+                    )}
+                  >
+                    <div className="truncate">{tab === 'inbox' ? msg.senderName : msg.recipientId}</div>
+                    <div className="truncate text-xs text-muted-foreground">{msg.subject}</div>
+                    <div className="text-[10px] text-muted-foreground mt-0.5">{relativeTime(msg.sentAt)}</div>
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+
+        {/* Detail / compose pane */}
+        <div className="rounded-lg border p-4 min-h-[200px]">
+          {composing ? (
+            <>
+              <h3 className="font-semibold text-sm mb-3">New Message</h3>
+              <ComposeForm
+                players={players}
+                onSent={() => {
+                  setComposing(false)
+                  queryClient.invalidateQueries({ queryKey: ['messages-sent'] })
+                }}
+              />
+            </>
+          ) : selected ? (
+            <div className="space-y-3">
+              <div>
+                <div className="flex justify-between items-start">
+                  <h3 className="font-semibold">{selected.subject}</h3>
+                  <span className="text-xs text-muted-foreground">{relativeTime(selected.sentAt)}</span>
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  From: <span className="text-foreground">{selected.senderName}</span>
+                </p>
+              </div>
+              <p className="text-sm whitespace-pre-wrap">{selected.body}</p>
+              {tab === 'inbox' && (
+                <button
+                  onClick={() => { setComposing(true) }}
+                  className="flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  <ReplyIcon className="h-3.5 w-3.5" />
+                  Reply
+                </button>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center mt-8">Select a message to read it.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -1,0 +1,59 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { ProfileViewModel } from '@/api/types'
+import { cn } from '@/lib/utils'
+
+export function PlayerProfile() {
+  const queryClient = useQueryClient()
+
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ['profile'],
+    queryFn: () => apiClient.get<ProfileViewModel>('/api/profile').then((r) => r.data),
+  })
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>
+  if (!profile) return <p className="text-destructive text-sm">Failed to load profile.</p>
+
+  return (
+    <div className="max-w-lg space-y-4">
+      <h1 className="text-xl font-bold">Profile</h1>
+
+      <div className="rounded-lg border bg-card p-6 space-y-4">
+        {/* Avatar + name */}
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 rounded-full bg-secondary flex items-center justify-center text-2xl border-2 border-primary/50">
+            {profile.userName?.[0]?.toUpperCase() ?? '?'}
+          </div>
+          <div>
+            <div className="font-bold text-lg">{profile.userName}</div>
+            {profile.isAdmin && (
+              <span className="text-xs rounded bg-yellow-900/60 text-yellow-300 px-1.5 py-0.5">Admin</span>
+            )}
+          </div>
+        </div>
+
+        {/* Current game info */}
+        {profile.currentGameId ? (
+          <div className="rounded border bg-secondary/20 px-4 py-3 text-sm space-y-1">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide">Active game</div>
+            <div className="font-medium">
+              Playing as <strong>{profile.currentPlayerName}</strong>
+            </div>
+            <Link
+              to={`/games/${profile.currentGameId}/base`}
+              className="text-primary text-xs hover:underline"
+            >
+              Go to game →
+            </Link>
+          </div>
+        ) : (
+          <div className="rounded border border-dashed px-4 py-3 text-sm text-muted-foreground">
+            Not currently in a game.{' '}
+            <Link to="/lobby" className="text-primary hover:underline">Browse games</Link>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { PublicPlayerViewModel } from '@/api/types'
+import { cn } from '@/lib/utils'
+
+interface PlayerRankingProps {
+  gameId: string
+}
+
+type Filter = 'all' | 'human' | 'agent'
+
+export function PlayerRanking({ gameId }: PlayerRankingProps) {
+  const [filter, setFilter] = useState<Filter>('all')
+
+  const { data: players, isLoading } = useQuery({
+    queryKey: ['ranking', gameId],
+    queryFn: () =>
+      apiClient.get<PublicPlayerViewModel[]>('/api/playerranking').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const filtered = (players ?? []).filter((p) => {
+    if (filter === 'human') return !p.isAgent
+    if (filter === 'agent') return p.isAgent
+    return true
+  })
+
+  const filterBtn = (f: Filter, label: string) => (
+    <button
+      key={f}
+      onClick={() => setFilter(f)}
+      className={cn(
+        'rounded px-3 py-1 text-sm',
+        filter === f
+          ? 'bg-primary text-primary-foreground'
+          : 'border hover:bg-secondary text-muted-foreground'
+      )}
+    >
+      {label}
+    </button>
+  )
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <h1 className="text-xl font-bold">Player Ranking</h1>
+
+      <div className="flex gap-2">
+        {filterBtn('all', 'All')}
+        {filterBtn('human', 'Human')}
+        {filterBtn('agent', 'Agent')}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
+                <th className="px-4 py-2 text-left w-10">#</th>
+                <th className="px-4 py-2 text-left">Player</th>
+                <th className="px-4 py-2 text-right">Score</th>
+                <th className="px-4 py-2 text-right hidden sm:table-cell">Minerals</th>
+                <th className="px-4 py-2 text-right hidden sm:table-cell">Gas</th>
+                <th className="px-4 py-2 text-right hidden md:table-cell">Units</th>
+                <th className="px-4 py-2 text-center hidden md:table-cell">Type</th>
+                <th className="px-4 py-2 text-center">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {filtered.map((p, i) => (
+                <tr key={p.playerId} className="hover:bg-secondary/20 transition-colors">
+                  <td className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
+                  <td className="px-4 py-2">
+                    <Link
+                      to={`/games/${gameId}/player/${p.playerId}`}
+                      className="hover:text-primary transition-colors font-medium"
+                    >
+                      {p.playerName}
+                    </Link>
+                    {p.protectionTicksRemaining > 0 && (
+                      <span className="ml-1.5 text-[10px] text-yellow-400" title="Under protection">🛡</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono">{Math.floor(p.score).toLocaleString()}</td>
+                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                    {p.approxMinerals != null ? Math.floor(p.approxMinerals).toLocaleString() : <span className="text-muted-foreground italic">?</span>}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                    {p.approxGas != null ? Math.floor(p.approxGas).toLocaleString() : <span className="text-muted-foreground italic">?</span>}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono hidden md:table-cell">
+                    {p.approxHomeUnitCount ?? <span className="text-muted-foreground italic">?</span>}
+                  </td>
+                  <td className="px-4 py-2 text-center hidden md:table-cell">
+                    <span className={cn(
+                      'rounded px-1.5 py-0.5 text-[10px] font-medium',
+                      p.isAgent ? 'bg-purple-900/50 text-purple-300' : 'bg-blue-900/50 text-blue-300'
+                    )}>
+                      {p.isAgent ? 'AI' : 'Human'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-center">
+                    <span className={cn(
+                      'inline-block h-2 w-2 rounded-full',
+                      p.isOnline ? 'bg-green-400' : 'bg-muted-foreground'
+                    )} title={p.isOnline ? 'Online' : 'Offline'} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements all social and profile pages for the React client ([BGE-522](/BGE/issues/BGE-522)). Built on top of the app shell PR (#168).

- **`Chat.tsx`** — game chat with 5s incremental polling (`?after=` cursor), auto-scroll to bottom, Enter to send
- **`Messages.tsx`** — inbox/sent tabs, message detail panel, compose new message with player dropdown, mark-as-read on open
- **`PlayerRanking.tsx`** — ranking table with all/human/agent filter, protection indicator, links to player profiles, 30s refetch
- **`PlayerProfile.tsx`** — current user profile card; shows active game + navigation link; admin badge
- **`InGamePlayerProfile.tsx`** — in-game player card by `:playerId` route param; score, protection ticks, online status

Also corrects `api/types.ts` for chat and message types to match the actual C# ViewModels:
- `ChatMessageViewModel`: `messageId`, `authorName`, `body` (was `id`, `playerName`, `message`)
- `ChatMessagesViewModel` renamed from `ChatViewModel`  
- `PostChatMessageRequest.body` (was `message`)
- `MessageInboxViewModel` renamed from `MessageListViewModel`
- `PublicPlayerViewModel` extended with `isAgent`, `approxMinerals`, `approxGas`, `approxHomeUnitCount`, `protectionTicksRemaining`, etc.

## Test plan

- [ ] TypeScript compiles clean
- [ ] Vite production build passes
- [ ] Chat renders messages and sends on Enter / button click
- [ ] New messages appear via polling without page reload
- [ ] Messages inbox/sent tabs work; compose sends and refreshes sent
- [ ] Ranking table filters by all/human/agent
- [ ] Player profile card shows active game link
- [ ] In-game player profile shows score + online status