### PR TITLE
Fix Messages: recipient name in Sent tab + Reply pre-fill

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MessagesController.cs
@@ -142,11 +142,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var senderName = message.SenderId != null && playerRepository.Exists(message.SenderId)
 				? playerRepository.Get(message.SenderId).Name
 				: null;
+			var recipientName = playerRepository.Exists(message.RecipientId)
+				? playerRepository.Get(message.RecipientId).Name
+				: "Unknown";
 			return new MessageViewModel {
 				MessageId = message.Id.ToString(),
 				SenderId = message.SenderId?.Id,
 				SenderName = senderName ?? "System",
 				RecipientId = message.RecipientId.Id,
+				RecipientName = recipientName,
 				Subject = message.Subject,
 				Body = message.Body,
 				IsRead = message.IsRead,

--- a/src/BrowserGameEngine.Shared/MessageViewModels.cs
+++ b/src/BrowserGameEngine.Shared/MessageViewModels.cs
@@ -7,6 +7,7 @@ namespace BrowserGameEngine.Shared {
 		public string? SenderId { get; set; }
 		public string SenderName { get; set; } = "";
 		public string RecipientId { get; set; } = "";
+		public string RecipientName { get; set; } = "";
 		public string Subject { get; set; } = "";
 		public string Body { get; set; } = "";
 		public bool IsRead { get; set; }

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -551,6 +551,7 @@ export interface MessageViewModel {
   senderId: string | null
   senderName: string
   recipientId: string
+  recipientName: string
   subject: string
   body: string
   isRead: boolean

--- a/src/ReactClient/src/pages/Messages.tsx
+++ b/src/ReactClient/src/pages/Messages.tsx
@@ -186,7 +186,7 @@ export function Messages({ gameId }: MessagesProps) {
                       tab === 'inbox' && !msg.isRead && 'font-semibold'
                     )}
                   >
-                    <div className="truncate">{tab === 'inbox' ? msg.senderName : msg.recipientId}</div>
+                    <div className="truncate">{tab === 'inbox' ? msg.senderName : msg.recipientName}</div>
                     <div className="truncate text-xs text-muted-foreground">{msg.subject}</div>
                     <div className="text-[10px] text-muted-foreground mt-0.5">{relativeTime(msg.sentAt)}</div>
                   </button>
@@ -200,11 +200,13 @@ export function Messages({ gameId }: MessagesProps) {
         <div className="rounded-lg border p-4 min-h-[200px]">
           {composing ? (
             <>
-              <h3 className="font-semibold text-sm mb-3">New Message</h3>
+              <h3 className="font-semibold text-sm mb-3">{selected ? 'Reply' : 'New Message'}</h3>
               <ComposeForm
                 players={players}
+                replyTo={selected ?? undefined}
                 onSent={() => {
                   setComposing(false)
+                  setSelected(null)
                   queryClient.invalidateQueries({ queryKey: ['messages-sent'] })
                 }}
               />


### PR DESCRIPTION
## Summary
- Add `RecipientName` to `MessageViewModel` and resolve it from `PlayerRepository` in `MessagesController.ToViewModel()` — fixes Sent tab showing raw UUID (BGE-553)
- Pass `replyTo={selected}` to `ComposeForm` when replying — fixes Reply button opening blank form (BGE-554)
- Update TypeScript `MessageViewModel` type with new `recipientName` field

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (296 tests)
- [ ] Verify Sent tab shows player names instead of UUIDs
- [ ] Verify Reply button pre-fills recipient and "Re: subject"

Closes BGE-553, Closes BGE-554