### PR TITLE
feat: add all-time players list page (BGE-550)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -15,6 +15,30 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.globalState = globalState;
 		}
 
+		[AllowAnonymous]
+		[HttpGet("")]
+		public ActionResult<AllTimePlayerListViewModel> GetAll() {
+			var achievements = globalState.GetAchievements();
+			var grouped = achievements.GroupBy(a => a.UserId);
+
+			var players = grouped.Select(g => {
+				var list = g.ToList();
+				var displayName = globalState.GetUserDisplayName(g.Key) ?? list.First().PlayerName;
+				return new AllTimePlayerEntryViewModel(
+					UserId: g.Key,
+					DisplayName: displayName,
+					TotalGames: list.Count,
+					TotalWins: list.Count(a => a.FinalRank == 1),
+					BestRank: list.Min(a => a.FinalRank),
+					TotalScore: list.Sum(a => a.FinalScore)
+				);
+			})
+			.OrderByDescending(p => p.TotalScore)
+			.ToArray();
+
+			return Ok(new AllTimePlayerListViewModel(players));
+		}
+
 		/// <summary>
 		/// Public achievements for any user, identified by their OAuth user ID.
 		/// Returns empty list when the user has no achievements.

--- a/src/BrowserGameEngine.Shared/AllTimePlayerListViewModel.cs
+++ b/src/BrowserGameEngine.Shared/AllTimePlayerListViewModel.cs
@@ -1,0 +1,14 @@
+namespace BrowserGameEngine.Shared {
+	public record AllTimePlayerEntryViewModel(
+		string UserId,
+		string DisplayName,
+		int TotalGames,
+		int TotalWins,
+		int BestRank,
+		decimal TotalScore
+	);
+
+	public record AllTimePlayerListViewModel(
+		AllTimePlayerEntryViewModel[] Players
+	);
+}

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -30,6 +30,7 @@ import { AllianceDetail } from '@/pages/AllianceDetail'
 import { Achievements } from '@/pages/Achievements'
 import { PlayerHistory } from '@/pages/PlayerHistory'
 import { AdminGames } from '@/pages/admin/AdminGames'
+import { PlayersList } from '@/pages/PlayersList'
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -164,7 +165,7 @@ const router = createBrowserRouter([
       { path: '/lobby', element: <GameLobby /> },
       { path: '/profile', element: <PlayerProfile /> },
       { path: '/profile/:userId', element: <TodoPage name="Public Profile" /> },
-      { path: '/players', element: <TodoPage name="Players" /> },
+      { path: '/players', element: <PlayersList /> },
       { path: '/alliances/:allianceId', element: <AllianceDetail /> },
       { path: '/achievements', element: <Achievements /> },
       { path: '/history', element: <PlayerHistory /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -700,6 +700,21 @@ export interface UpdateGameRequest {
   discordWebhookUrl: string | null
 }
 
+// Player List (all-time)
+
+export interface AllTimePlayerEntryViewModel {
+  userId: string
+  displayName: string
+  totalGames: number
+  totalWins: number
+  bestRank: number
+  totalScore: number
+}
+
+export interface AllTimePlayerListViewModel {
+  players: AllTimePlayerEntryViewModel[]
+}
+
 // Create Player
 
 export interface CreatePlayerRequest {

--- a/src/ReactClient/src/pages/PlayersList.tsx
+++ b/src/ReactClient/src/pages/PlayersList.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { AllTimePlayerListViewModel } from '@/api/types'
+
+export function PlayersList() {
+  const { data, isLoading } = useQuery<AllTimePlayerListViewModel>({
+    queryKey: ['players-list'],
+    queryFn: () => apiClient.get<AllTimePlayerListViewModel>('/api/players').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const players = data?.players ?? []
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <h1 className="text-xl font-bold">All-Time Players</h1>
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">Loading...</p>
+      ) : players.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No players yet.</p>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
+                <th className="px-4 py-2 text-left w-10">#</th>
+                <th className="px-4 py-2 text-left">Player</th>
+                <th className="px-4 py-2 text-right">Score</th>
+                <th className="px-4 py-2 text-right hidden sm:table-cell">Games</th>
+                <th className="px-4 py-2 text-right hidden sm:table-cell">Wins</th>
+                <th className="px-4 py-2 text-right hidden md:table-cell">Best Rank</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {players.map((p, i) => (
+                <tr key={p.userId} className="hover:bg-secondary/20 transition-colors">
+                  <td className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
+                  <td className="px-4 py-2">
+                    <Link
+                      to={`/profile/${p.userId}`}
+                      className="hover:text-primary transition-colors font-medium"
+                    >
+                      {p.displayName}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono">
+                    {Math.floor(p.totalScore).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                    {p.totalGames}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                    {p.totalWins}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono hidden md:table-cell">
+                    {p.bestRank}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/players` endpoint aggregating cross-game stats from achievements (public, AllowAnonymous)
- Add `AllTimePlayerListViewModel` / `AllTimePlayerEntryViewModel` records in Shared
- Add `PlayersList.tsx` React page with responsive table (rank, name, score, games, wins, best rank)
- Wire `/players` route in `App.tsx`, replacing the TodoPage stub

## Test plan

- [x] `dotnet build` passes
- [x] All 296 existing tests pass
- [ ] Manual: visit `/players` — verify table renders with player data
- [ ] Manual: verify responsive column hiding on mobile viewport
- [ ] Manual: verify player name links to `/profile/{userId}`