### PR TITLE
feat: BGE-549 Player Profile pages (my profile + public)

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -29,6 +29,7 @@ import { Alliances } from '@/pages/Alliances'
 import { AllianceDetail } from '@/pages/AllianceDetail'
 import { Achievements } from '@/pages/Achievements'
 import { PlayerHistory } from '@/pages/PlayerHistory'
+import { PublicProfile } from '@/pages/PublicProfile'
 import { AdminGames } from '@/pages/admin/AdminGames'
 import { PlayersList } from '@/pages/PlayersList'
 
@@ -164,7 +165,7 @@ const router = createBrowserRouter([
       { path: '/createplayer', element: <CreatePlayer /> },
       { path: '/lobby', element: <GameLobby /> },
       { path: '/profile', element: <PlayerProfile /> },
-      { path: '/profile/:userId', element: <TodoPage name="Public Profile" /> },
+      { path: '/profile/:userId', element: <PublicProfile /> },
       { path: '/players', element: <PlayersList /> },
       { path: '/alliances/:allianceId', element: <AllianceDetail /> },
       { path: '/achievements', element: <Achievements /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -769,10 +769,40 @@ export interface UserPreferencesViewModel {
 // Profile
 
 export interface ProfileViewModel {
-  userId: string
-  userName: string
+  playerName: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  score: number
+  land: number
+  minerals: number
+  gas: number
+  armySize: number
+  rank: number
+  totalPlayers: number
+  gamesPlayed: number
+  wins: number
+  bestRank: number
   currentGameId: string | null
-  currentPlayerId: string | null
-  currentPlayerName: string | null
-  isAdmin: boolean
+}
+
+// Public cross-game stats
+
+export interface PlayerCrossGameEntry {
+  gameId: string
+  gameName: string
+  gameStatus: string
+  gameEndTime: string
+  finalRank: number
+  finalScore: number
+  isWinner: boolean
+}
+
+export interface PlayerCrossGameStatsViewModel {
+  userId: string
+  playerName: string | null
+  totalGames: number
+  totalWins: number
+  bestRank: number
+  totalScore: number
+  games: PlayerCrossGameEntry[]
 }

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -1,12 +1,10 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
+import { TrophyIcon, SwordsIcon, StarIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { ProfileViewModel } from '@/api/types'
-import { cn } from '@/lib/utils'
 
 export function PlayerProfile() {
-  const queryClient = useQueryClient()
-
   const { data: profile, isLoading } = useQuery({
     queryKey: ['profile'],
     queryFn: () => apiClient.get<ProfileViewModel>('/api/profile').then((r) => r.data),
@@ -15,45 +13,117 @@ export function PlayerProfile() {
   if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>
   if (!profile) return <p className="text-destructive text-sm">Failed to load profile.</p>
 
-  return (
-    <div className="max-w-lg space-y-4">
-      <h1 className="text-xl font-bold">Profile</h1>
+  const displayName = profile.displayName ?? profile.playerName ?? 'Unknown'
 
-      <div className="rounded-lg border bg-card p-6 space-y-4">
+  return (
+    <div className="max-w-lg space-y-5">
+      <h1 className="text-xl font-bold">My Profile</h1>
+
+      <div className="rounded-lg border bg-card p-6 space-y-5">
         {/* Avatar + name */}
         <div className="flex items-center gap-4">
-          <div className="h-16 w-16 rounded-full bg-secondary flex items-center justify-center text-2xl border-2 border-primary/50">
-            {profile.userName?.[0]?.toUpperCase() ?? '?'}
-          </div>
+          {profile.avatarUrl ? (
+            <img
+              src={profile.avatarUrl}
+              alt={displayName}
+              className="h-16 w-16 rounded-full border-2 border-primary/50"
+            />
+          ) : (
+            <div className="h-16 w-16 rounded-full bg-secondary flex items-center justify-center text-2xl border-2 border-primary/50">
+              {displayName[0]?.toUpperCase() ?? '?'}
+            </div>
+          )}
           <div>
-            <div className="font-bold text-lg">{profile.userName}</div>
-            {profile.isAdmin && (
-              <span className="text-xs rounded bg-yellow-900/60 text-yellow-300 px-1.5 py-0.5">Admin</span>
+            <div className="font-bold text-lg">{displayName}</div>
+            {profile.playerName && profile.displayName && profile.playerName !== profile.displayName && (
+              <div className="text-sm text-muted-foreground">Playing as {profile.playerName}</div>
             )}
           </div>
         </div>
 
-        {/* Current game info */}
+        {/* Current game stats */}
         {profile.currentGameId ? (
-          <div className="rounded border bg-secondary/20 px-4 py-3 text-sm space-y-1">
-            <div className="text-xs text-muted-foreground uppercase tracking-wide">Active game</div>
-            <div className="font-medium">
-              Playing as <strong>{profile.currentPlayerName}</strong>
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded border bg-secondary/20 p-3">
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Score</div>
+                <div className="text-2xl font-bold">{Math.floor(profile.score).toLocaleString()}</div>
+              </div>
+              <div className="rounded border bg-secondary/20 p-3">
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Rank</div>
+                <div className="text-2xl font-bold">
+                  {profile.rank}
+                  <span className="text-sm text-muted-foreground font-normal"> / {profile.totalPlayers}</span>
+                </div>
+              </div>
             </div>
+
+            <div className="grid grid-cols-3 gap-3">
+              <div className="rounded border bg-secondary/20 p-3">
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Land</div>
+                <div className="text-lg font-semibold">{Math.floor(profile.land).toLocaleString()}</div>
+              </div>
+              <div className="rounded border bg-secondary/20 p-3">
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Minerals</div>
+                <div className="text-lg font-semibold">{Math.floor(profile.minerals).toLocaleString()}</div>
+              </div>
+              <div className="rounded border bg-secondary/20 p-3">
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Gas</div>
+                <div className="text-lg font-semibold">{Math.floor(profile.gas).toLocaleString()}</div>
+              </div>
+            </div>
+
+            <div className="rounded border bg-secondary/20 p-3 flex items-center gap-2">
+              <SwordsIcon className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Army Size:</span>
+              <span className="font-semibold">{profile.armySize.toLocaleString()}</span>
+            </div>
+
             <Link
               to={`/games/${profile.currentGameId}/base`}
-              className="text-primary text-xs hover:underline"
+              className="block rounded bg-primary px-4 py-2 text-center text-sm text-primary-foreground hover:opacity-90"
             >
-              Go to game →
+              Go to Game →
             </Link>
-          </div>
+          </>
         ) : (
           <div className="rounded border border-dashed px-4 py-3 text-sm text-muted-foreground">
             Not currently in a game.{' '}
-            <Link to="/lobby" className="text-primary hover:underline">Browse games</Link>
+            <Link to="/games" className="text-primary hover:underline">Browse games</Link>
           </div>
         )}
       </div>
+
+      {/* Career stats */}
+      {profile.gamesPlayed > 0 && (
+        <div className="rounded-lg border bg-card p-5 space-y-3">
+          <strong className="text-sm flex items-center gap-1.5">
+            <TrophyIcon className="h-4 w-4 text-primary" />
+            Career Stats
+          </strong>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Games</div>
+              <div className="text-xl font-bold">{profile.gamesPlayed}</div>
+            </div>
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Wins</div>
+              <div className="text-xl font-bold text-green-400">{profile.wins}</div>
+            </div>
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Best Rank</div>
+              <div className="text-xl font-bold">
+                {profile.bestRank > 0 ? (
+                  <span className="flex items-center justify-center gap-1">
+                    {profile.bestRank === 1 && <StarIcon className="h-4 w-4 text-amber-400" />}
+                    #{profile.bestRank}
+                  </span>
+                ) : '—'}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'react-router'
+import { UserIcon, TrophyIcon, StarIcon } from 'lucide-react'
+import apiClient from '@/api/client'
+import type { PlayerCrossGameStatsViewModel } from '@/api/types'
+import { relativeTime } from '@/lib/utils'
+
+export function PublicProfile() {
+  const { userId } = useParams<{ userId: string }>()
+
+  const { data: stats, isLoading, error } = useQuery<PlayerCrossGameStatsViewModel>({
+    queryKey: ['public-profile', userId],
+    queryFn: () =>
+      apiClient.get(`/api/players/${encodeURIComponent(userId ?? '')}/profile`).then((r) => r.data),
+    enabled: !!userId,
+  })
+
+  if (isLoading) return <p className="text-muted-foreground text-sm p-4">Loading profile…</p>
+  if (error || !stats) {
+    return (
+      <div className="max-w-lg p-4">
+        <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+          <UserIcon className="h-10 w-10 mx-auto mb-2 opacity-40" />
+          <p className="text-sm">Player not found or no game history yet.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-lg space-y-5">
+      <h1 className="text-xl font-bold flex items-center gap-2">
+        <UserIcon className="h-5 w-5 text-primary" />
+        {stats.playerName ?? 'Unknown Player'}
+      </h1>
+
+      {/* Summary stats */}
+      <div className="rounded-lg border bg-card p-5 space-y-3">
+        <strong className="text-sm flex items-center gap-1.5">
+          <TrophyIcon className="h-4 w-4 text-primary" />
+          Career Stats
+        </strong>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Games</div>
+            <div className="text-xl font-bold">{stats.totalGames}</div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Wins</div>
+            <div className="text-xl font-bold text-green-400">{stats.totalWins}</div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Best Rank</div>
+            <div className="text-xl font-bold">
+              {stats.bestRank > 0 ? (
+                <span className="flex items-center justify-center gap-1">
+                  {stats.bestRank === 1 && <StarIcon className="h-4 w-4 text-amber-400" />}
+                  #{stats.bestRank}
+                </span>
+              ) : '—'}
+            </div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Total Score</div>
+            <div className="text-xl font-bold">{Math.floor(stats.totalScore).toLocaleString()}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Game History */}
+      {stats.games.length > 0 && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Game History</strong>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Result</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Score</th>
+                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ended</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.games.map((g) => (
+                  <tr key={g.gameId} className="border-b border-border">
+                    <td className="py-2 px-3 font-medium">{g.gameName}</td>
+                    <td className="py-2 px-3">
+                      {g.isWinner ? (
+                        <span className="inline-flex items-center gap-1 rounded bg-green-700/30 px-2 py-0.5 text-xs text-green-300">
+                          <StarIcon className="h-3 w-3" />
+                          Winner
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">{g.gameStatus}</span>
+                      )}
+                    </td>
+                    <td className="py-2 px-3">#{g.finalRank}</td>
+                    <td className="py-2 px-3">{Math.floor(g.finalScore).toLocaleString()}</td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {relativeTime(g.gameEndTime)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **My Profile** (`/profile`): enhanced with full game stats — score, rank, land, minerals, gas, army size, career stats (games played, wins, best rank), GitHub avatar support
- **Public Profile** (`/profile/:userId`): new page showing cross-game stats and game history table using `GET /api/players/{userId}/profile`
- Fixed `ProfileViewModel` TypeScript type to match the C# backend (was completely out of sync — old type had `userName`, `isAdmin` etc. which don't exist on the API)
- Added `PlayerCrossGameStatsViewModel` and `PlayerCrossGameEntry` TS types

## Test plan
- [ ] Navigate to `/profile` and verify full stats display (score, rank, resources, army, career)
- [ ] Verify GitHub avatar renders if user has GitHub login
- [ ] Navigate to `/profile/:userId` for a user with game history — verify stats and game table
- [ ] Navigate to `/profile/:userId` for a non-existent user — verify graceful "not found" message
- [ ] Verify Index page redirect still works (uses `currentGameId` from `ProfileViewModel`)
- [ ] Verify bare route redirects still work (`/base` → `/games/:id/base`)