### PR TITLE
feat: BGE-562 — Playwright E2E test framework for React client

### DIFF
--- a/src/ReactClient/.gitignore
+++ b/src/ReactClient/.gitignore
@@ -3,3 +3,8 @@ dist/
 .env
 .env.local
 *.tsbuildinfo
+
+# Playwright
+playwright-report/
+test-results/
+e2e/.auth/

--- a/src/ReactClient/e2e/global-setup.ts
+++ b/src/ReactClient/e2e/global-setup.ts
@@ -1,0 +1,31 @@
+import { chromium } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Global setup: authenticates as the shared E2E test user via dev auth
+ * (POST /signindev) and saves cookie state so tests skip the login flow.
+ *
+ * Requires: docker-compose up (Bge__DevAuth=true).
+ */
+export default async function globalSetup() {
+	const authDir = path.join(__dirname, '.auth')
+	if (!fs.existsSync(authDir)) {
+		fs.mkdirSync(authDir, { recursive: true })
+	}
+
+	const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+	const browser = await chromium.launch()
+	const context = await browser.newContext()
+	const page = await context.newPage()
+
+	// Use dev auth to sign in — no UI form required; POST directly to the endpoint.
+	// Bge__DevAuth=true is set in docker-compose so this endpoint is active.
+	await page.request.post(`${baseURL}/signindev`, {
+		form: { playerid: 'e2e-test-admin', returnUrl: '/' },
+	})
+
+	// Save auth cookies so all tests share the session
+	await context.storageState({ path: path.join(authDir, 'state.json') })
+	await browser.close()
+}

--- a/src/ReactClient/e2e/tests/01-signin.spec.ts
+++ b/src/ReactClient/e2e/tests/01-signin.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, request } from '@playwright/test'
+
+/**
+ * Sign-in flow tests.
+ *
+ * The production build does not include the dev-login UI form
+ * (VITE_DEV_AUTH is not set at build time), so these tests verify:
+ *   1. The sign-in page renders correctly (GitHub OAuth button visible).
+ *   2. Dev auth via POST /signindev creates a session and redirects to the app.
+ */
+test.describe('Sign-in page', () => {
+	test.use({ storageState: { cookies: [], origins: [] } }) // run unauthenticated
+
+	test('sign-in page renders with GitHub login button', async ({ page }) => {
+		await page.goto('/signin')
+		await expect(page.getByRole('heading', { name: 'Age of Agents' })).toBeVisible()
+		await expect(page.getByText('Sign in to continue')).toBeVisible()
+		await expect(page.getByRole('button', { name: /sign in with github/i })).toBeVisible()
+	})
+
+	test('unauthenticated access to protected route redirects to sign-in', async ({ page }) => {
+		await page.goto('/games')
+		// The app redirects unauthenticated users to /signin
+		await expect(page).toHaveURL(/\/signin/)
+	})
+
+	test('dev auth POST authenticates and redirects to home', async ({ page, baseURL }) => {
+		const uniqueId = `e2e-signin-${Date.now()}`
+		const base = baseURL ?? 'http://localhost:8080'
+
+		// POST to /signindev — same form action the React SignIn component uses in dev builds
+		await page.request.post(`${base}/signindev`, {
+			form: { playerid: uniqueId, returnUrl: '/' },
+		})
+
+		// Navigate — should now land on the app (not redirect to /signin)
+		await page.goto('/')
+		await expect(page).not.toHaveURL(/\/signin/)
+	})
+})

--- a/src/ReactClient/e2e/tests/01-signin.spec.ts
+++ b/src/ReactClient/e2e/tests/01-signin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, request } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 /**
  * Sign-in flow tests.

--- a/src/ReactClient/e2e/tests/02-games.spec.ts
+++ b/src/ReactClient/e2e/tests/02-games.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Game management tests: listing and creating games.
+ * Authenticated as e2e-test-admin (set up in global-setup.ts).
+ */
+test.describe('Games list', () => {
+	test('games page renders with season schedule', async ({ page }) => {
+		await page.goto('/games')
+		await expect(page.getByRole('heading', { name: 'Season Schedule' })).toBeVisible()
+		// At least the Active and Upcoming sections are present
+		await expect(page.getByRole('heading', { name: 'Active' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Upcoming' })).toBeVisible()
+	})
+})
+
+test.describe('Create game', () => {
+	test('admin can create a game via the admin page', async ({ page }) => {
+		await page.goto('/admin/games')
+		await expect(page.getByRole('heading', { name: 'Game Admin' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Create Game' })).toBeVisible()
+
+		const gameName = `E2E Test Game ${Date.now()}`
+
+		// Fill in the create form
+		await page.getByPlaceholder('Game name').fill(gameName)
+		// Leave tick duration and times at their defaults (pre-filled by the UI)
+
+		// Submit
+		await page.getByRole('button', { name: 'Create Game' }).click()
+
+		// Success message appears
+		await expect(page.getByText(`Game '${gameName}' created.`)).toBeVisible()
+
+		// The new game should appear in the admin games table
+		await expect(page.getByRole('cell', { name: gameName })).toBeVisible()
+	})
+})

--- a/src/ReactClient/e2e/tests/03-gameplay.spec.ts
+++ b/src/ReactClient/e2e/tests/03-gameplay.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Core gameplay tests: join a game, create a player, navigate in-game pages.
+ *
+ * Strategy: create an active game via API (faster than UI), then join it and
+ * navigate the in-game pages to verify they render without errors.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+/** Create an active (already-started) game via the REST API and return its gameId. */
+async function createActiveGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const startTime = new Date(now.getTime() - 60_000).toISOString() // started 1 min ago
+	const endTime = new Date(now.getTime() + 7 * 24 * 3600_000).toISOString() // ends in 7 days
+
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Gameplay Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime,
+			endTime,
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	return game.gameId
+}
+
+test.describe('Join game and navigate in-game pages', () => {
+	let gameId: string
+
+	test.beforeAll(async ({ browser }) => {
+		// Create an active game once for all tests in this describe block
+		const context = await browser.newContext({
+			storageState: 'e2e/.auth/state.json',
+		})
+		const page = await context.newPage()
+		gameId = await createActiveGame(page)
+		await context.close()
+	})
+
+	test('join a game and land on base page', async ({ page }) => {
+		await page.goto('/games')
+		await expect(page.getByRole('heading', { name: 'Season Schedule' })).toBeVisible()
+
+		// The game we created should be listed as Active
+		await page.waitForFunction(() => {
+			return document.querySelector('body')?.textContent?.includes('LIVE')
+		}, { timeout: 10_000 })
+
+		// Click "Play Now" or "Join" for our game
+		// Prefer "Play Now" if already enrolled, otherwise "Join"
+		const gameCard = page.locator('.rounded-lg').filter({ hasText: 'LIVE' }).first()
+		const playNow = gameCard.getByRole('link', { name: 'Play Now' })
+		const joinBtn = gameCard.getByRole('button', { name: 'Join' })
+
+		if (await playNow.isVisible()) {
+			await playNow.click()
+		} else {
+			await joinBtn.click()
+		}
+
+		// Should land on base page inside the game
+		await expect(page).toHaveURL(/\/games\/[^/]+\/base/, { timeout: 10_000 })
+		await expect(page.getByRole('heading', { name: /base/i })).toBeVisible()
+	})
+
+	test('base page renders without errors', async ({ page }) => {
+		await page.goto(`/games/${gameId}/base`)
+		await expect(page.getByRole('heading', { name: /base/i })).toBeVisible()
+		// No error boundary / crash message
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+
+	test('units page renders without errors', async ({ page }) => {
+		await page.goto(`/games/${gameId}/units`)
+		await expect(page.locator('h1')).toBeVisible()
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+
+	test('research page renders without errors', async ({ page }) => {
+		await page.goto(`/games/${gameId}/research`)
+		await expect(page.locator('h1')).toBeVisible()
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+
+	test('market page renders without errors', async ({ page }) => {
+		await page.goto(`/games/${gameId}/market`)
+		await expect(page.locator('h1')).toBeVisible()
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+})
+
+test.describe('Create player', () => {
+	test('create player page renders and form is functional', async ({ page }) => {
+		// Sign in as a fresh user who has no player profile yet
+		const freshUserId = `e2e-newuser-${Date.now()}`
+		await page.request.post(`${baseURL}/signindev`, {
+			form: { playerid: freshUserId, returnUrl: '/' },
+		})
+
+		await page.goto('/createplayer')
+		await expect(page.getByRole('heading', { name: 'Welcome to BGE' })).toBeVisible()
+		await expect(page.getByLabel('Commander name')).toBeVisible()
+
+		// Fill and submit
+		await page.getByLabel('Commander name').fill(`Commander ${freshUserId.slice(-8)}`)
+		await page.getByRole('button', { name: 'Enter the game' }).click()
+
+		// After creating player, redirected to games with welcome message
+		await expect(page).toHaveURL(/\/games\?welcome=1/, { timeout: 10_000 })
+		await expect(page.getByText('Welcome to BGE!')).toBeVisible()
+	})
+})

--- a/src/ReactClient/e2e/tests/04-chat.spec.ts
+++ b/src/ReactClient/e2e/tests/04-chat.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Chat tests: send a message in game chat and verify it appears.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createAndJoinGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Chat Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+
+	// Join the game
+	const joinRes = await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, {
+		data: {},
+	})
+	// 200 or 409 (already enrolled) are both fine
+	expect([200, 201, 204, 409]).toContain(joinRes.status())
+
+	return game.gameId
+}
+
+test.describe('Game chat', () => {
+	test('send a message and verify it appears in the chat window', async ({ page }) => {
+		const gameId = await createAndJoinGame(page)
+
+		await page.goto(`/games/${gameId}/chat`)
+		await expect(page.getByRole('heading', { name: 'Game Chat' })).toBeVisible()
+
+		const message = `Hello E2E test ${Date.now()}`
+
+		// Type the message
+		await page.getByPlaceholder('Type a message…').fill(message)
+
+		// Send via button click
+		await page.getByRole('button', { name: 'Send' }).click()
+
+		// Message should appear in the chat window
+		await expect(page.getByText(message)).toBeVisible({ timeout: 10_000 })
+	})
+
+	test('send a message via Enter key and verify it appears', async ({ page }) => {
+		const gameId = await createAndJoinGame(page)
+
+		await page.goto(`/games/${gameId}/chat`)
+		await expect(page.getByRole('heading', { name: 'Game Chat' })).toBeVisible()
+
+		const message = `Enter key test ${Date.now()}`
+
+		await page.getByPlaceholder('Type a message…').fill(message)
+		await page.getByPlaceholder('Type a message…').press('Enter')
+
+		await expect(page.getByText(message)).toBeVisible({ timeout: 10_000 })
+	})
+})

--- a/src/ReactClient/package-lock.json
+++ b/src/ReactClient/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.0.0",
         "@types/node": "^25.5.2",
         "@types/react": "^19.0.2",
@@ -1062,6 +1063,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4661,6 +4678,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/src/ReactClient/package.json
+++ b/src/ReactClient/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
@@ -29,6 +32,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^25.5.2",
     "@types/react": "^19.0.2",

--- a/src/ReactClient/playwright.config.ts
+++ b/src/ReactClient/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * E2E test configuration for BGE React client.
+ * Tests run against the local docker-compose stack (http://localhost:8080).
+ *
+ * Prerequisites:
+ *   docker-compose up   (starts the full BGE stack with DevAuth enabled)
+ *
+ * Run tests:
+ *   npm run test:e2e
+ */
+export default defineConfig({
+	testDir: './e2e/tests',
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: process.env.CI ? 'github' : 'list',
+	globalSetup: './e2e/global-setup.ts',
+	use: {
+		baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+		trace: 'on-first-retry',
+		storageState: 'e2e/.auth/state.json',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+})


### PR DESCRIPTION
## Summary

- Initializes Playwright (`@playwright/test`) in `src/ReactClient/e2e/`
- `playwright.config.ts` targets the local docker-compose stack (`http://localhost:8080`, configurable via `E2E_BASE_URL`)
- Global setup authenticates via `POST /signindev` (dev auth mode) and saves cookie state — all tests run pre-authenticated
- 13 tests across 4 files covering all required flows:
  - **01-signin**: sign-in page renders, unauthenticated redirect, dev auth POST flow
  - **02-games**: games list renders, create a game via admin page
  - **03-gameplay**: join a game, create player, navigate Base / Units / Research / Market pages
  - **04-chat**: send a message via button click and via Enter key; verify it appears

## How to run

```bash
# Start the stack
docker-compose up

# In another terminal
cd src/ReactClient
npm run test:e2e          # headless
npm run test:e2e:ui       # interactive Playwright UI
npm run test:e2e:report   # open last HTML report
```

## Test plan

- [ ] `docker-compose up` builds and starts cleanly
- [ ] `npm run test:e2e` runs all 13 tests green against the running stack
- [ ] Auth state (cookie) is persisted via `e2e/.auth/state.json` (gitignored)
- [ ] `e2e/.auth/`, `playwright-report/`, `test-results/` are all gitignored

Closes BGE-562