### PR TITLE
fix: BGE-570 — rename 'spies' route to 'operations'

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -67,7 +67,7 @@ function MarketPage() {
   if (!gameId) return null
   return <Market gameId={gameId} />
 }
-function SpiesPage() {
+function OperationsPage() {
   const { gameId } = useParams<{ gameId: string }>()
   if (!gameId) return null
   return <Spies gameId={gameId} />
@@ -142,7 +142,7 @@ const router = createBrowserRouter([
           { path: 'alliances', element: <AlliancesPage /> },
           { path: 'allianceranking', element: <TodoPage name="Alliance Ranking" /> },
           { path: 'diplomacy', element: <DiplomacyPage /> },
-          { path: 'spies', element: <SpiesPage /> },
+          { path: 'operations', element: <OperationsPage /> },
           { path: 'spy', element: <SpyReportsPage /> },
           { path: 'selectenemy/:unitId', element: <SelectEnemyPage /> },
           { path: 'unitdefinitions', element: <UnitDefinitions /> },
@@ -160,7 +160,7 @@ const router = createBrowserRouter([
       { path: '/research', element: <BareRouteRedirect path="research" /> },
       { path: '/market', element: <BareRouteRedirect path="market" /> },
       { path: '/spy', element: <BareRouteRedirect path="spy" /> },
-      { path: '/spies', element: <BareRouteRedirect path="spies" /> },
+      { path: '/operations', element: <BareRouteRedirect path="operations" /> },
 
       { path: '/createplayer', element: <CreatePlayer /> },
       { path: '/lobby', element: <GameLobby /> },

--- a/src/ReactClient/src/components/NavMenu.tsx
+++ b/src/ReactClient/src/components/NavMenu.tsx
@@ -73,7 +73,7 @@ export function NavMenu() {
         <NavItem to={g('research')} icon={FlaskConicalIcon} label="Research" />
         <NavItem to={g('market')} icon={ShoppingCartIcon} label="Market" />
         <NavItem to={g('spy')} icon={EyeIcon} label="Spy" />
-        <NavItem to={g('spies')} icon={CrosshairIcon} label="Operations" />
+        <NavItem to={g('operations')} icon={CrosshairIcon} label="Operations" />
 
         <SectionLabel>Info</SectionLabel>
         <NavItem to={g('unitdefinitions')} icon={BookOpenIcon} label="Unit Types" />


### PR DESCRIPTION
## Summary

- Renamed the in-game route from `spies` to `operations` so the URL matches the sidebar nav label
- Updated the `NavMenu` link, `App.tsx` route definition, and bare route redirect
- Navigating to `/games/:gameId/operations` now correctly renders the Intelligence Operations page

## Test plan

- [ ] Click "Operations" in the in-game sidebar → page loads without error
- [ ] Navigate directly to `/games/:gameId/operations` → page renders correctly
- [ ] Verify "Spy" link still works at `/games/:gameId/spy`