### PR TITLE
fix: sort ranking by score and highlight current player (BGE-571)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -54,7 +54,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				SpyResult? intel = isOwnPlayer ? null : fogOfWarRepository.GetValidIntel(currentUserContext.PlayerId!, p.PlayerId);
 				var vm = p.ToPublicPlayerViewModel(scoreRepository, userRepository, onlineStatusRepository, intel, isOwnPlayer);
 				return vm with { IsCurrentPlayer = isOwnPlayer };
-			});
+			}).OrderByDescending(p => p.Score);
 		}
 
 		/// <summary>Returns the current game's leaderboard ranked by score.</summary>

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -306,6 +306,7 @@ export interface PublicPlayerViewModel {
   approxMinerals: number | null
   approxGas: number | null
   approxHomeUnitCount: number | null
+  isCurrentPlayer: boolean
 }
 
 export interface InGamePlayerProfileViewModel {

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -21,7 +21,8 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
     refetchInterval: 30_000,
   })
 
-  const filtered = (players ?? []).filter((p) => {
+  const sorted = [...(players ?? [])].sort((a, b) => b.score - a.score)
+  const filtered = sorted.filter((p) => {
     if (filter === 'human') return !p.isAgent
     if (filter === 'agent') return p.isAgent
     return true
@@ -71,14 +72,23 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
             </thead>
             <tbody className="divide-y">
               {filtered.map((p, i) => (
-                <tr key={p.playerId} className="hover:bg-secondary/20 transition-colors">
+                <tr key={p.playerId} className={cn(
+                  'transition-colors',
+                  p.isCurrentPlayer
+                    ? 'bg-primary/10 border-l-2 border-l-primary font-semibold'
+                    : 'hover:bg-secondary/20'
+                )}>
                   <td className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
                   <td className="px-4 py-2">
                     <Link
                       to={`/games/${gameId}/player/${p.playerId}`}
-                      className="hover:text-primary transition-colors font-medium"
+                      className={cn(
+                        'hover:text-primary transition-colors font-medium',
+                        p.isCurrentPlayer && 'text-primary'
+                      )}
                     >
                       {p.playerName}
+                      {p.isCurrentPlayer && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(you)</span>}
                     </Link>
                     {p.protectionTicksRemaining > 0 && (
                       <span className="ml-1.5 text-[10px] text-yellow-400" title="Under protection">🛡</span>


### PR DESCRIPTION
## Summary
- **Sort by score**: Added `OrderByDescending(p => p.Score)` to `PlayerRankingController.Get()` so the API returns players ranked highest-first. Also added client-side sort as a safety net.
- **Highlight current player**: The logged-in player's row now has an accent background, primary-colored left border, and a "(you)" label next to their name.
- Added `isCurrentPlayer` to the TypeScript `PublicPlayerViewModel` type (already returned by the API).

## Test plan
- [x] `dotnet build --configuration Release` — passes
- [x] `dotnet test` — all 296 tests pass
- [x] TypeScript type check — passes
- [ ] Manual: log in, navigate to ranking page, verify players sorted by score descending
- [ ] Manual: verify your own row is visually highlighted with accent background and "(you)" label