### PR TITLE
Add integration tests for API controllers

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/AssemblyInfo.cs
+++ b/src/BrowserGameEngine.FrontendServer/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BrowserGameEngine.StatefulGameServer.Test")]

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -16,7 +16,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		[AllowAnonymous]
-		[HttpGet("")]
+		[HttpGet("all")]
 		public ActionResult<AllTimePlayerListViewModel> GetAll() {
 			var achievements = globalState.GetAchievements();
 			var grouped = achievements.GroupBy(a => a.UserId);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/AlliancesControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/AlliancesControllerIntegrationTest.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	public class AlliancesControllerIntegrationTest : IntegrationTestBase {
+		public AlliancesControllerIntegrationTest(BgeWebApplicationFactory factory) : base(factory) { }
+
+		[Fact]
+		public async Task GetAll_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/alliances");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task GetAll_Authenticated_ReturnsOk() {
+			var userId = "user-alliance-list-1";
+			await CreatePlayerAsync(userId, "AllianceListPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync("/api/alliances");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vms = await DeserializeAsync<IEnumerable<AllianceViewModel>>(response);
+			Assert.NotNull(vms);
+		}
+
+		[Fact]
+		public async Task Create_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var request = new CreateAllianceRequest { AllianceName = "TestAlliance", Password = "secret" };
+			var response = await client.PostAsJsonAsync("/api/alliances", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Create_Authenticated_ReturnsAllianceId() {
+			var userId = "user-alliance-create-1";
+			await CreatePlayerAsync(userId, "AllianceCreator1");
+
+			var client = CreateClient(userId);
+			var request = new CreateAllianceRequest { AllianceName = "IntegrationAlliance1", Password = "pw123" };
+			var response = await client.PostAsJsonAsync("/api/alliances", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var allianceId = await response.Content.ReadAsStringAsync();
+			Assert.False(string.IsNullOrEmpty(allianceId.Trim('"')));
+		}
+
+		[Fact]
+		public async Task MyStatus_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/alliances/my-status");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task MyStatus_AfterCreating_ShowsLeaderMembership() {
+			var userId = "user-alliance-status-1";
+			await CreatePlayerAsync(userId, "AllianceStatusPlayer1");
+
+			var client = CreateClient(userId);
+			var request = new CreateAllianceRequest { AllianceName = "StatusAlliance1", Password = "pw" };
+			await client.PostAsJsonAsync("/api/alliances", request, JsonOptions);
+
+			var response = await client.GetAsync("/api/alliances/my-status");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<MyAllianceStatusViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.True(vm!.IsMember);
+			Assert.True(vm.IsLeader);
+		}
+
+		[Fact]
+		public async Task Leave_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.DeleteAsync("/api/alliances/leave");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task InviteAndAccept_TwoPlayers_JoinAlliance() {
+			var leaderId = "user-alliance-invite-1";
+			var memberId = "user-alliance-invite-2";
+			var leaderPlayerId = await CreatePlayerAsync(leaderId, "AllianceLeader1");
+			var memberPlayerId = await CreatePlayerAsync(memberId, "AllianceMember1");
+
+			var leaderClient = CreateClient(leaderId);
+			var memberClient = CreateClient(memberId);
+
+			// Leader creates alliance
+			var createReq = new CreateAllianceRequest { AllianceName = "InviteAlliance1", Password = "inv" };
+			var createResp = await leaderClient.PostAsJsonAsync("/api/alliances", createReq, JsonOptions);
+			Assert.Equal(HttpStatusCode.OK, createResp.StatusCode);
+			var allianceId = (await createResp.Content.ReadAsStringAsync()).Trim('"');
+
+			// Leader invites member
+			var inviteReq = new InvitePlayerRequest { TargetPlayerId = memberPlayerId };
+			var inviteResp = await leaderClient.PostAsJsonAsync($"/api/alliances/{allianceId}/invite", inviteReq, JsonOptions);
+			Assert.Equal(HttpStatusCode.OK, inviteResp.StatusCode);
+
+			// Member checks their invites
+			var invitesResp = await memberClient.GetAsync("/api/alliances/my-invites");
+			Assert.Equal(HttpStatusCode.OK, invitesResp.StatusCode);
+			var invites = await DeserializeAsync<IEnumerable<AllianceInviteViewModel>>(invitesResp);
+			Assert.NotNull(invites);
+			var inviteList = invites!.ToList();
+			Assert.Single(inviteList);
+
+			// Member accepts invite
+			var acceptReq = new AcceptInviteRequest { InviteId = inviteList[0].InviteId };
+			var acceptResp = await memberClient.PostAsJsonAsync($"/api/alliances/{allianceId}/accept-invite", acceptReq, JsonOptions);
+			Assert.Equal(HttpStatusCode.OK, acceptResp.StatusCode);
+
+			// Verify member is in the alliance
+			var statusResp = await memberClient.GetAsync("/api/alliances/my-status");
+			var statusVm = await DeserializeAsync<MyAllianceStatusViewModel>(statusResp);
+			Assert.True(statusVm!.IsMember);
+			Assert.Equal(allianceId, statusVm.AllianceId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BattleControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BattleControllerIntegrationTest.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	public class BattleControllerIntegrationTest : IntegrationTestBase {
+		public BattleControllerIntegrationTest(BgeWebApplicationFactory factory) : base(factory) { }
+
+		[Fact]
+		public async Task AttackablePlayers_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/battle/attackableplayers");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task AttackablePlayers_Authenticated_ReturnsOk() {
+			var userId = "user-battle-atk-1";
+			await CreatePlayerAsync(userId, "BattlePlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync("/api/battle/attackableplayers");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task EnemyBase_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/battle/enemybase?enemyPlayerId=nonexistent");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task EnemyBase_WithoutSendingUnits_ReturnsBadRequest() {
+			// Viewing an enemy base requires sending units first or having spy intel
+			var attackerId = "user-battle-enemybase-1";
+			var defenderId = "user-battle-enemybase-2";
+			await CreatePlayerAsync(attackerId, "EBAttacker1");
+			var defenderPlayerId = await CreatePlayerAsync(defenderId, "EBDefender1");
+
+			var client = CreateClient(attackerId);
+			var response = await client.GetAsync($"/api/battle/enemybase?enemyPlayerId={defenderPlayerId}");
+			Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task SendUnits_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.PostAsync("/api/battle/sendunits?unitId=u1&enemyPlayerId=p1", null);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Attack_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.PostAsync("/api/battle/attack?enemyPlayerId=p1", null);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Attack_NoUnitsSent_ReturnsBadRequest() {
+			var attackerId = "user-battle-nounits-1";
+			var defenderId = "user-battle-nounits-2";
+			await CreatePlayerAsync(attackerId, "NoUnitsAttacker1");
+			var defenderPlayerId = await CreatePlayerAsync(defenderId, "NoUnitsDefender1");
+
+			var client = CreateClient(attackerId);
+			// No units sent → attack fails with BadRequest
+			var response = await client.PostAsync($"/api/battle/attack?enemyPlayerId={defenderPlayerId}", null);
+			Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BgeWebApplicationFactory.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BgeWebApplicationFactory.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using BrowserGameEngine.FrontendServer;
+using Microsoft.Extensions.Configuration;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	/// <summary>
+	/// WebApplicationFactory for BGE integration tests.
+	/// Replaces hosted services, authentication, and blob storage with test doubles.
+	/// </summary>
+	public class BgeWebApplicationFactory : WebApplicationFactory<Program> {
+		protected override void ConfigureWebHost(IWebHostBuilder builder) {
+			builder.UseEnvironment("Testing");
+
+			builder.ConfigureAppConfiguration((_, config) => {
+				config.AddInMemoryCollection(new Dictionary<string, string?> {
+					["Bge:S3BucketName"] = "",
+					["GitHub:ClientId"] = "",
+					["GitHub:ClientSecret"] = "",
+					["Bge:DevAuth"] = "true",
+				});
+			});
+
+			builder.ConfigureServices(services => {
+				// Remove background hosted services to prevent tick/persistence loops
+				services.RemoveAll<IHostedService>();
+
+				// Replace Discord notification service with null implementation
+				services.RemoveAll<IGameNotificationService>();
+				services.AddSingleton<IGameNotificationService, NullGameNotificationService>();
+
+				// Replace IBlobStorage with in-memory to isolate persistence
+				services.RemoveAll<IBlobStorage>();
+				services.AddSingleton<IBlobStorage>(new InMemoryBlobStorage());
+
+				// Register the test auth handler scheme
+				services.AddAuthentication()
+					.AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, null);
+
+				// Override the default scheme AFTER all Program.cs registrations.
+				// PostConfigure runs after all Configure actions so "Test" wins over "Cookies".
+				services.PostConfigure<AuthenticationOptions>(options => {
+					options.DefaultScheme = TestAuthHandler.SchemeName;
+					options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+					options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+					options.DefaultForbidScheme = TestAuthHandler.SchemeName;
+					options.DefaultSignInScheme = TestAuthHandler.SchemeName;
+					options.DefaultSignOutScheme = TestAuthHandler.SchemeName;
+				});
+			});
+		}
+
+		/// <summary>
+		/// Creates an unauthenticated HttpClient with auto-redirect disabled so 401/302 are returned directly.
+		/// </summary>
+		public new HttpClient CreateClient() {
+			return CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+		}
+
+		/// <summary>Creates an authenticated HttpClient for the given user ID.</summary>
+		public HttpClient CreateAuthenticatedClient(string userId) {
+			var client = CreateClient();
+			client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+			return client;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/GamesControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/GamesControllerIntegrationTest.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	public class GamesControllerIntegrationTest : IntegrationTestBase {
+		public GamesControllerIntegrationTest(BgeWebApplicationFactory factory) : base(factory) { }
+
+		[Fact]
+		public async Task GetAll_Authenticated_ReturnsGameList() {
+			// GetAll only needs authentication, not an active player
+			var client = CreateClient("user-games-getall-1");
+			var response = await client.GetAsync("/api/games");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<GameListViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.NotEmpty(vm!.Games);
+		}
+
+		[Fact]
+		public async Task GetAll_Unauthenticated_ReturnsOk() {
+			// GetAll is [AllowAnonymous]
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/games");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task GetById_KnownGame_ReturnsDetail() {
+			// GetById has [AllowAnonymous]
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/games/default");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<GameDetailViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.Equal("default", vm!.GameId);
+		}
+
+		[Fact]
+		public async Task GetById_UnknownGame_Returns404() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/games/does-not-exist-xyz");
+			Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task CreateGame_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var request = new CreateGameRequest(
+				Name: "New Test Game",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddMinutes(1),
+				EndTime: DateTime.UtcNow.AddDays(7),
+				TickDuration: "00:00:10"
+			);
+			var response = await client.PostAsJsonAsync("/api/games", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task CreateGame_Authenticated_Returns201() {
+			// Creating a game requires IsValid (an active player)
+			var userId = "user-create-game-2";
+			await CreatePlayerAsync(userId, "GameCreatorPlayer");
+
+			var client = CreateClient(userId);
+			var request = new CreateGameRequest(
+				Name: "Integration Test Game Created",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddMinutes(1),
+				EndTime: DateTime.UtcNow.AddDays(7),
+				TickDuration: "00:00:10"
+			);
+			var response = await client.PostAsJsonAsync("/api/games", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+			var vm = await DeserializeAsync<GameSummaryViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.Equal("Integration Test Game Created", vm!.Name);
+		}
+
+		[Fact]
+		public async Task JoinGame_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var request = new JoinGameRequest(PlayerName: "ShouldFail");
+			var response = await client.PostAsJsonAsync("/api/games/default/join", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task JoinGame_AuthenticatedUser_JoinsNewGame() {
+			// To use the Join endpoint, user must already have a player (IsValid).
+			// 1. Create player in default game to establish IsValid.
+			var userId = "user-join-newgame-1";
+			await CreatePlayerAsync(userId, "JoinSetupPlayer");
+			var client = CreateClient(userId);
+
+			// 2. Create a new upcoming game.
+			var createReq = new CreateGameRequest(
+				Name: "Joinable Game",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddMinutes(1),
+				EndTime: DateTime.UtcNow.AddDays(7),
+				TickDuration: "00:00:10"
+			);
+			var createResp = await client.PostAsJsonAsync("/api/games", createReq, JsonOptions);
+			Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+			var newGame = await DeserializeAsync<GameSummaryViewModel>(createResp);
+
+			// 3. Join the new game (creates a second player for this user in the new game).
+			var joinReq = new JoinGameRequest(PlayerName: "JoinedPlayer");
+			var joinResp = await client.PostAsJsonAsync($"/api/games/{newGame!.GameId}/join", joinReq, JsonOptions);
+			Assert.Equal(HttpStatusCode.OK, joinResp.StatusCode);
+			var body = await joinResp.Content.ReadAsStringAsync();
+			Assert.Contains("playerId", body, StringComparison.OrdinalIgnoreCase);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestBase.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestBase.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	/// <summary>
+	/// Base class for BGE controller integration tests. All test methods within a class
+	/// share one <see cref="BgeWebApplicationFactory"/> instance (fast startup) so tests
+	/// must use unique identifiers to avoid cross-test state interference.
+	/// </summary>
+	[Collection("Integration")]
+	public abstract class IntegrationTestBase {
+		protected readonly BgeWebApplicationFactory Factory;
+
+		protected static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+		};
+
+		protected IntegrationTestBase(BgeWebApplicationFactory factory) {
+			Factory = factory;
+		}
+
+		protected HttpClient CreateClient() => Factory.CreateClient();
+
+		protected HttpClient CreateClient(string userId) => Factory.CreateAuthenticatedClient(userId);
+
+		/// <summary>
+		/// Creates a player in the default game for the given userId.
+		/// Uses POST /api/players which only requires UserId (not an existing player).
+		/// Returns the created PlayerId string.
+		/// </summary>
+		protected async Task<string> CreatePlayerAsync(string userId, string playerName) {
+			var client = CreateClient(userId);
+			var request = new CreatePlayerForUserViewModel { PlayerName = playerName };
+			var response = await client.PostAsJsonAsync("/api/players", request, JsonOptions);
+			response.EnsureSuccessStatusCode();
+			var vm = await DeserializeAsync<PlayerSummaryViewModel>(response);
+			return vm!.PlayerId;
+		}
+
+		protected async Task<T?> DeserializeAsync<T>(HttpResponseMessage response) {
+			var content = await response.Content.ReadAsStringAsync();
+			return JsonSerializer.Deserialize<T>(content, JsonOptions);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestCollection.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestCollection.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	/// <summary>
+	/// xUnit collection that shares a single <see cref="BgeWebApplicationFactory"/> instance
+	/// across all integration test classes, avoiding multiple server startups (and multiple
+	/// DotNetRuntime metric collector registrations) within the same test process.
+	/// </summary>
+	[CollectionDefinition("Integration")]
+	public class IntegrationTestCollection : ICollectionFixture<BgeWebApplicationFactory> { }
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/MarketControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/MarketControllerIntegrationTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	public class MarketControllerIntegrationTest : IntegrationTestBase {
+		public MarketControllerIntegrationTest(BgeWebApplicationFactory factory) : base(factory) { }
+
+		[Fact]
+		public async Task Get_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/market/get");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Get_Authenticated_ReturnsMarket() {
+			var userId = "user-market-get-1";
+			await CreatePlayerAsync(userId, "MarketPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync("/api/market/get");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<MarketViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.NotNull(vm!.OpenOrders);
+		}
+
+		[Fact]
+		public async Task Post_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var request = new CreateMarketOrderRequest {
+				OfferedResourceId = "minerals",
+				OfferedAmount = 100,
+				WantedResourceId = "gas",
+				WantedAmount = 50,
+			};
+			var response = await client.PostAsJsonAsync("/api/market/post", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Post_InvalidAmounts_ReturnsBadRequest() {
+			var userId = "user-market-invalid-1";
+			await CreatePlayerAsync(userId, "MarketInvalidPlayer1");
+
+			var client = CreateClient(userId);
+			var request = new CreateMarketOrderRequest {
+				OfferedResourceId = "minerals",
+				OfferedAmount = 0, // invalid
+				WantedResourceId = "gas",
+				WantedAmount = 50,
+			};
+			var response = await client.PostAsJsonAsync("/api/market/post", request, JsonOptions);
+			Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Cancel_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.DeleteAsync($"/api/market/cancel?orderId={Guid.NewGuid()}");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Accept_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.PostAsync($"/api/market/accept?orderId={Guid.NewGuid()}", null);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	public class PlayerManagementControllerIntegrationTest : IntegrationTestBase {
+		public PlayerManagementControllerIntegrationTest(BgeWebApplicationFactory factory) : base(factory) { }
+
+		[Fact]
+		public async Task GetMyPlayers_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/players");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task GetMyPlayers_NewUser_ReturnsEmptyList() {
+			var client = CreateClient("user-pm-new-1");
+			var response = await client.GetAsync("/api/players");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<PlayerListViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.Empty(vm!.Players);
+		}
+
+		[Fact]
+		public async Task GetMyPlayers_AfterJoining_ReturnsPlayer() {
+			var userId = "user-pm-joined-1";
+			await CreatePlayerAsync(userId, "PMTestPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync("/api/players");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<PlayerListViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.Single(vm!.Players);
+			Assert.Equal("PMTestPlayer1", vm.Players[0].PlayerName);
+		}
+
+		[Fact]
+		public async Task GenerateApiKey_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.PostAsync("/api/players/some-player-id/apikey", null);
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task GenerateApiKey_ForOwnPlayer_ReturnsToken() {
+			var userId = "user-pm-apikey-1";
+			var playerId = await CreatePlayerAsync(userId, "APIKeyPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.PostAsync($"/api/players/{playerId}/apikey", null);
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var vm = await DeserializeAsync<ApiKeyViewModel>(response);
+			Assert.NotNull(vm);
+			Assert.False(string.IsNullOrEmpty(vm!.ApiKey));
+		}
+
+		[Fact]
+		public async Task DeletePlayer_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.DeleteAsync("/api/players/some-player-id");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task DeletePlayer_ActivePlayer_ReturnsConflict() {
+			// When a user has only one player, it becomes the active player.
+			// Deleting the active player returns 409 Conflict.
+			var userId = "user-pm-delete-1";
+			await CreatePlayerAsync(userId, "DeleteTestPlayer1");
+
+			var client = CreateClient(userId);
+			var listResp = await client.GetAsync("/api/players");
+			var vm = await DeserializeAsync<PlayerListViewModel>(listResp);
+			var playerId = vm!.Players[0].PlayerId;
+
+			var response = await client.DeleteAsync($"/api/players/{playerId}");
+			Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/TestAuthHandler.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/TestAuthHandler.cs
@@ -1,0 +1,41 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
+	/// <summary>
+	/// Authentication handler for integration tests. Reads X-Test-UserId header and
+	/// creates a synthetic ClaimsPrincipal — no GitHub OAuth needed.
+	/// </summary>
+	public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions> {
+		public const string SchemeName = "Test";
+		public const string UserIdHeader = "X-Test-UserId";
+
+		public TestAuthHandler(
+			IOptionsMonitor<AuthenticationSchemeOptions> options,
+			ILoggerFactory logger,
+			UrlEncoder encoder)
+			: base(options, logger, encoder) { }
+
+		protected override Task<AuthenticateResult> HandleAuthenticateAsync() {
+			if (!Request.Headers.TryGetValue(UserIdHeader, out var userIdValues)
+				|| string.IsNullOrWhiteSpace(userIdValues.ToString())) {
+				return Task.FromResult(AuthenticateResult.NoResult());
+			}
+
+			var userId = userIdValues.ToString();
+			var claims = new[] {
+				new Claim(ClaimTypes.NameIdentifier, userId),
+				new Claim(ClaimTypes.Name, userId),
+				new Claim("urn:github:login", userId),
+			};
+			var identity = new ClaimsIdentity(claims, SchemeName);
+			var principal = new System.Security.Claims.ClaimsPrincipal(identity);
+			var ticket = new AuthenticationTicket(principal, SchemeName);
+			return Task.FromResult(AuthenticateResult.Success(ticket));
+		}
+	}
+}

--- a/src/ReactClient/src/pages/PlayersList.tsx
+++ b/src/ReactClient/src/pages/PlayersList.tsx
@@ -6,7 +6,7 @@ import type { AllTimePlayerListViewModel } from '@/api/types'
 export function PlayersList() {
   const { data, isLoading } = useQuery<AllTimePlayerListViewModel>({
     queryKey: ['players-list'],
-    queryFn: () => apiClient.get<AllTimePlayerListViewModel>('/api/players').then((r) => r.data),
+    queryFn: () => apiClient.get<AllTimePlayerListViewModel>('/api/players/all').then((r) => r.data),
     refetchInterval: 30_000,
   })
 


### PR DESCRIPTION
## Summary
- Add 36 integration tests across 5 controllers (Games, PlayerManagement, Battle, Market, Alliances) using `WebApplicationFactory` with test auth handler and in-memory blob storage
- Fix ambiguous route conflict between `PlayerManagementController` and `PlayersController` — both mapped `GET /api/players`. Moved `PlayersController.GetAll` to `/api/players/all` and updated `PlayersList.tsx`
- Add `AssemblyInfo.cs` with `InternalsVisibleTo` for the test project to access `InMemoryBlobStorage`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (332 total: 296 unit + 36 integration)
- [x] All integration tests cover auth (401 for unauthenticated), happy path, and error cases

Closes BGE-561