### PR TITLE
Fix MarketController ambiguous route (BGE-569)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
@@ -49,7 +49,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return viewModel;
 		}
 
-		[HttpPost]
+		[HttpPost("post")]
 		public ActionResult Post([FromBody] CreateMarketOrderRequest request) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 
@@ -74,7 +74,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
-		[HttpPost]
+		[HttpPost("accept")]
 		public ActionResult Accept([FromQuery] Guid orderId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 
@@ -91,7 +91,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 		}
 
-		[HttpDelete]
+		[HttpDelete("cancel")]
 		public ActionResult Cancel([FromQuery] Guid orderId) {
 			if (!currentUserContext.IsValid) return Unauthorized();
 

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -37,7 +37,7 @@ export function Market({ gameId }: MarketProps) {
         wantedResourceId: wantResourceId,
         wantedAmount: wantAmount,
       }
-      return apiClient.post('/api/market', request)
+      return apiClient.post('/api/market/post', request)
     },
     onSuccess: () => {
       setPostError(null)


### PR DESCRIPTION
## Summary
- Fix `AmbiguousMatchException` on `POST /api/market` by adding explicit route templates (`post`, `accept`, `cancel`) to MarketController actions
- Update React client to call `/api/market/post` instead of `/api/market`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (296/296)
- [ ] Verify market page works in browser: create trade offer, accept, cancel

Closes BGE-569