### PR TITLE
feat: BGE-579 add EconomicThreshold victory progress bar to game dashboard

### DIFF
--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -337,6 +337,14 @@ export interface PlayerRankingViewModel {
   entries: PlayerRankingEntryViewModel[]
 }
 
+export interface LeaderboardEntryViewModel {
+  rank: number
+  playerId: string
+  playerName: string
+  score: number
+  isCurrentPlayer: boolean
+}
+
 // Alliance
 
 export interface AllianceMemberViewModel {

--- a/src/ReactClient/src/components/VictoryProgressBar.tsx
+++ b/src/ReactClient/src/components/VictoryProgressBar.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { PlayerProfileViewModel, LeaderboardEntryViewModel } from '@/api/types'
+
+const ECONOMIC_THRESHOLD = 500_000
+
+interface VictoryProgressBarProps {
+	gameId: string
+}
+
+export function VictoryProgressBar({ gameId }: VictoryProgressBarProps) {
+	const { data: profile } = useQuery<PlayerProfileViewModel>({
+		queryKey: ['playerprofile', gameId],
+		queryFn: () => apiClient.get('/api/playerprofile').then((r) => r.data),
+		refetchInterval: 30_000,
+	})
+
+	const { data: leaderboard } = useQuery<LeaderboardEntryViewModel[]>({
+		queryKey: ['leaderboard', gameId],
+		queryFn: () => apiClient.get(`/api/games/${gameId}/leaderboard`).then((r) => r.data),
+		refetchInterval: 30_000,
+	})
+
+	const playerScore = profile?.score ?? 0
+	const leaderScore = leaderboard?.[0]?.score ?? 0
+	const progressPercent = Math.min(100, Math.round((playerScore / ECONOMIC_THRESHOLD) * 100))
+
+	return (
+		<div className="rounded-lg border bg-card p-4">
+			<div className="flex items-baseline justify-between mb-1">
+				<span className="text-sm font-semibold">Economic Victory Progress</span>
+				<span className="text-xs text-muted-foreground">
+					Target: {ECONOMIC_THRESHOLD.toLocaleString()}
+				</span>
+			</div>
+			<div className="h-3 w-full rounded-full bg-secondary overflow-hidden">
+				<div
+					className="h-full rounded-full bg-yellow-500 transition-all"
+					style={{ width: `${progressPercent}%` }}
+					role="progressbar"
+					aria-valuenow={progressPercent}
+					aria-valuemin={0}
+					aria-valuemax={100}
+				/>
+			</div>
+			<div className="flex justify-between mt-1">
+				<span className="text-xs text-muted-foreground">
+					You: {Math.floor(playerScore).toLocaleString()}
+				</span>
+				{leaderScore > playerScore && (
+					<span className="text-xs text-muted-foreground">
+						Leader: {Math.floor(leaderScore).toLocaleString()}
+					</span>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -14,6 +14,7 @@ import { BuildQueue } from '@/components/BuildQueue'
 import { BuildUnitsForm } from '@/components/BuildUnitsForm'
 import { WorkerAssignment } from '@/components/WorkerAssignment'
 import { CostBadge } from '@/components/CostBadge'
+import { VictoryProgressBar } from '@/components/VictoryProgressBar'
 import { relativeTime } from '@/lib/utils'
 
 interface BaseProps {
@@ -200,6 +201,10 @@ export function Base({ gameId }: BaseProps) {
           </a>
           .
         </div>
+      )}
+
+      {!isFinished && gameDetail?.gameDefType === 'sco' && (
+        <VictoryProgressBar gameId={gameId} />
       )}
 
       <WorkerAssignment gameId={gameId} />


### PR DESCRIPTION
## Summary

- Add `VictoryProgressBar` React component showing progress toward the 500k score threshold
- Displays player's current score and leader score (when the current player is behind)
- Fetches player score from `/api/playerprofile`, leader score from `/api/games/{gameId}/leaderboard`
- Renders on the Base page only for active SCO games (EconomicThreshold victory condition)
- Adds `LeaderboardEntryViewModel` to `types.ts`

This ports `_VictoryProgressBar.razor` from PR #160 to React, and wires the live data that the Blazor skeleton left as a TODO.

Closes BGE-579 / parent: BGE-576

## Test plan
- [ ] `dotnet build` passes
- [ ] Open an active SCO game's Base page → progress bar renders with your current score
- [ ] If trailing the leader, the leader's score is shown on the right
- [ ] If you are the leader (or tied), only your score is shown
- [ ] Non-SCO games or finished games do not show the progress bar