### PR TITLE
feat: BGE-581 — add Alliance Chat as third Messages tab

### DIFF
--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -9,7 +9,7 @@ interface ChatProps {
   gameId: string
 }
 
-export function Chat({ gameId }: ChatProps) {
+export function ChatPanel({ gameId }: ChatProps) {
   const [body, setBody] = useState('')
   const [lastMessageId, setLastMessageId] = useState<string | null>(null)
   const [allMessages, setAllMessages] = useState<ChatMessagesViewModel['messages']>([])
@@ -74,9 +74,7 @@ export function Chat({ gameId }: ChatProps) {
   }
 
   return (
-    <div className="max-w-2xl space-y-3">
-      <h1 className="text-xl font-bold">Game Chat</h1>
-
+    <div className="space-y-3">
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
@@ -129,6 +127,15 @@ export function Chat({ gameId }: ChatProps) {
         )}
         <div ref={chatEndRef} />
       </div>
+    </div>
+  )
+}
+
+export function Chat({ gameId }: ChatProps) {
+  return (
+    <div className="max-w-2xl space-y-3">
+      <h1 className="text-xl font-bold">Game Chat</h1>
+      <ChatPanel gameId={gameId} />
     </div>
   )
 }

--- a/src/ReactClient/src/pages/Messages.tsx
+++ b/src/ReactClient/src/pages/Messages.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { PenSquareIcon, InboxIcon, SendIcon, ReplyIcon } from 'lucide-react'
+import { PenSquareIcon, InboxIcon, SendIcon, ReplyIcon, MessageSquareIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { MessageInboxViewModel, MessageViewModel, MessageThreadViewModel, SendMessageViewModel, PublicPlayerViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
+import { ChatPanel } from '@/pages/Chat'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
@@ -94,7 +95,7 @@ function ComposeForm({
 
 export function Messages({ gameId }: MessagesProps) {
   const queryClient = useQueryClient()
-  const [tab, setTab] = useState<'inbox' | 'sent'>('inbox')
+  const [tab, setTab] = useState<'inbox' | 'sent' | 'chat'>('inbox')
   const [selected, setSelected] = useState<MessageViewModel | null>(null)
   const [composing, setComposing] = useState(false)
 
@@ -157,46 +158,62 @@ export function Messages({ gameId }: MessagesProps) {
     <div className="max-w-3xl">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-bold">Messages</h1>
+        {tab !== 'chat' && (
+          <button
+            onClick={() => { setComposing(true); setSelected(null) }}
+            className="flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <PenSquareIcon className="h-4 w-4" />
+            Compose
+          </button>
+        )}
+      </div>
+
+      {/* Top-level tabs */}
+      <div className="flex border-b mb-4">
         <button
-          onClick={() => { setComposing(true); setSelected(null) }}
-          className="flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          onClick={() => setTab('inbox')}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-2 text-sm border-b-2 -mb-px transition-colors',
+            tab === 'inbox' ? 'border-primary text-foreground font-medium' : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
         >
-          <PenSquareIcon className="h-4 w-4" />
-          Compose
+          <InboxIcon className="h-3.5 w-3.5" />
+          Inbox
+          {unread > 0 && (
+            <span className="ml-1 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+              {unread}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => setTab('sent')}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-2 text-sm border-b-2 -mb-px transition-colors',
+            tab === 'sent' ? 'border-primary text-foreground font-medium' : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <SendIcon className="h-3.5 w-3.5" />
+          Sent
+        </button>
+        <button
+          onClick={() => { setTab('chat'); setComposing(false); setSelected(null) }}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-2 text-sm border-b-2 -mb-px transition-colors',
+            tab === 'chat' ? 'border-primary text-foreground font-medium' : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <MessageSquareIcon className="h-3.5 w-3.5" />
+          Alliance Chat
         </button>
       </div>
 
+      {tab === 'chat' ? (
+        <ChatPanel gameId={gameId} />
+      ) : (
       <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-4">
         {/* List pane */}
         <div className="rounded-lg border overflow-hidden">
-          <div className="flex border-b">
-            <button
-              onClick={() => setTab('inbox')}
-              className={cn(
-                'flex-1 flex items-center justify-center gap-1.5 py-2 text-sm',
-                tab === 'inbox' ? 'bg-secondary text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <InboxIcon className="h-3.5 w-3.5" />
-              Inbox
-              {unread > 0 && (
-                <span className="ml-1 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
-                  {unread}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => setTab('sent')}
-              className={cn(
-                'flex-1 flex items-center justify-center gap-1.5 py-2 text-sm',
-                tab === 'sent' ? 'bg-secondary text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <SendIcon className="h-3.5 w-3.5" />
-              Sent
-            </button>
-          </div>
-
           <ul className="divide-y max-h-[420px] overflow-y-auto">
             {messages.length === 0 ? (
               <li className="px-3 py-4 text-center text-sm text-muted-foreground">Empty</li>
@@ -286,6 +303,7 @@ export function Messages({ gameId }: MessagesProps) {
           )}
         </div>
       </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds Alliance Chat as a third tab (Inbox / Sent / Alliance Chat) in `Messages.tsx`
- Extracts a `ChatPanel` component from `Chat.tsx` (chat logic without the page header/wrapper) so it can be embedded in the Messages tab layout
- Tabs use a top-level underline style for clear visual consistency
- Compose button is hidden when the Chat tab is active (not applicable to chat)
- The standalone `/chat` route continues to work unchanged — `Chat` now wraps `ChatPanel`

## Notes

- This PR modifies `Messages.tsx` and `Chat.tsx`. BGE-580 also modifies `Messages.tsx` (adds PageLoader/ApiError); a rebase may be needed when merging if both land close together.

## Test plan

- [ ] Navigate to Messages page; confirm Inbox / Sent / Alliance Chat tabs are visible
- [ ] Alliance Chat tab shows the chat UI with message history and send input
- [ ] Inbox and Sent tabs continue to work as before
- [ ] Compose button visible on Inbox/Sent, hidden on Chat tab
- [ ] `/chat` route still opens the standalone chat page
- [ ] Build passes: `tsc -b && vite build` (React), `dotnet build` (.NET)

Closes BGE-581