### PR TITLE
Fix MarketController route template breaking integration tests

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MarketController.cs
@@ -12,7 +12,7 @@ using System.Linq;
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	[ApiController]
 	[Authorize]
-	[Route("api/[controller]/{action?}/{id?}")]
+	[Route("api/[controller]")]
 	public class MarketController : ControllerBase {
 		private readonly ILogger<MarketController> logger;
 		private readonly CurrentUserContext currentUserContext;

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/MarketControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/MarketControllerIntegrationTest.cs
@@ -12,7 +12,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 		[Fact]
 		public async Task Get_Unauthenticated_Returns401() {
 			var client = CreateClient();
-			var response = await client.GetAsync("/api/market/get");
+			var response = await client.GetAsync("/api/market");
 			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 		}
 
@@ -22,7 +22,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			await CreatePlayerAsync(userId, "MarketPlayer1");
 
 			var client = CreateClient(userId);
-			var response = await client.GetAsync("/api/market/get");
+			var response = await client.GetAsync("/api/market");
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 			var vm = await DeserializeAsync<MarketViewModel>(response);
 			Assert.NotNull(vm);


### PR DESCRIPTION
## Summary
- The `{action?}` optional token in the MarketController route template captured all URL segments (e.g. `/post`, `/cancel`, `/accept`), routing them to the `Get` action and returning `405 MethodNotAllowed` for non-GET requests
- Removed `{action?}/{id?}` from the controller route since all actions have explicit route templates via `[HttpPost("post")]` etc.
- Updated test GET URLs from `/api/market/get` to `/api/market` to match the actual route

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (332/332, including all 6 MarketControllerIntegrationTest cases)
- [x] No route changes for React client — `/api/market`, `/api/market/post`, `/api/market/accept`, `/api/market/cancel` all continue to work

This fixes pre-existing test failures on master that were blocking PRs #183, #184.