### PR TITLE
feat: BGE-599 full accessibility pass

### DIFF
--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -287,10 +287,10 @@ export function AllianceDetail() {
 					<table className="w-full text-sm">
 						<thead className="border-b">
 							<tr>
-								<th className="py-2 px-3 text-left font-medium text-muted-foreground">Player</th>
-								<th className="py-2 px-3 text-left font-medium text-muted-foreground">Votes</th>
-								<th className="py-2 px-3 text-left font-medium text-muted-foreground">Joined</th>
-								{isLeader && <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>}
+								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Player</th>
+								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Votes</th>
+								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Joined</th>
+								{isLeader && <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>}
 							</tr>
 						</thead>
 						<tbody>
@@ -362,6 +362,7 @@ export function AllianceDetail() {
 					<div className="p-4 flex flex-wrap gap-2">
 						<button
 							onClick={() => { setShowInvite(!showInvite); setShowDeclareWar(false); setEditPassword(false) }}
+							aria-pressed={showInvite}
 							className={cn(
 								'rounded px-3 py-1.5 text-xs flex items-center gap-1',
 								showInvite ? 'bg-primary text-primary-foreground' : 'border border-primary text-primary'
@@ -372,6 +373,7 @@ export function AllianceDetail() {
 						</button>
 						<button
 							onClick={() => { setShowDeclareWar(!showDeclareWar); setShowInvite(false); setEditPassword(false) }}
+							aria-pressed={showDeclareWar}
 							className={cn(
 								'rounded px-3 py-1.5 text-xs flex items-center gap-1',
 								showDeclareWar ? 'bg-danger text-white' : 'border border-danger text-danger-foreground'
@@ -382,6 +384,7 @@ export function AllianceDetail() {
 						</button>
 						<button
 							onClick={() => { setEditPassword(!editPassword); setShowInvite(false); setShowDeclareWar(false) }}
+							aria-pressed={editPassword}
 							className={cn(
 								'rounded px-3 py-1.5 text-xs',
 								editPassword ? 'bg-secondary text-secondary-foreground' : 'border text-muted-foreground hover:text-foreground'

--- a/src/ReactClient/src/pages/Alliances.tsx
+++ b/src/ReactClient/src/pages/Alliances.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
 import { ShieldIcon, SwordsIcon, UsersIcon } from 'lucide-react'
@@ -284,11 +284,11 @@ export function Alliances({ gameId }: AlliancesProps) {
 						<table className="w-full text-sm">
 							<thead className="border-b">
 								<tr>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Members</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Founded</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Members</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Founded</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
 								</tr>
 							</thead>
 							<tbody>
@@ -344,53 +344,97 @@ export function Alliances({ gameId }: AlliancesProps) {
 
 			{/* Join Alliance Modal */}
 			{joinAllianceId && (
-				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-					<div className="w-full max-w-sm rounded-lg border bg-card p-6 shadow-xl space-y-4">
-						<div className="flex items-center justify-between">
-							<strong className="text-sm">Join Alliance</strong>
-							<button
-								onClick={() => setJoinAllianceId(null)}
-								className="text-muted-foreground hover:text-foreground text-lg"
-							>
-								×
-							</button>
-						</div>
-						<p className="text-sm text-muted-foreground">
-							Enter the alliance password to request membership.
-						</p>
-						<div>
-							<label className="block text-sm text-muted-foreground mb-1">Password</label>
-							<input
-								type="password"
-								value={joinPassword}
-								onChange={(e) => setJoinPassword(e.target.value)}
-								placeholder="Alliance password"
-								className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-								onKeyDown={(e) => {
-									if (e.key === 'Enter' && joinPassword.trim()) {
-										joinMutation.mutate({ allianceId: joinAllianceId, password: joinPassword })
-									}
-								}}
-							/>
-						</div>
-						<div className="flex gap-2">
-							<button
-								onClick={() => joinMutation.mutate({ allianceId: joinAllianceId, password: joinPassword })}
-								disabled={!joinPassword.trim() || joinMutation.isPending}
-								className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
-							>
-								{joinMutation.isPending ? 'Joining…' : 'Join'}
-							</button>
-							<button
-								onClick={() => setJoinAllianceId(null)}
-								className="text-sm text-muted-foreground hover:text-foreground"
-							>
-								Cancel
-							</button>
-						</div>
-					</div>
-				</div>
+				<JoinAllianceModal
+					joinAllianceId={joinAllianceId}
+					joinPassword={joinPassword}
+					setJoinPassword={setJoinPassword}
+					joinMutation={joinMutation}
+					onClose={() => setJoinAllianceId(null)}
+				/>
 			)}
+		</div>
+	)
+}
+
+function JoinAllianceModal({
+	joinAllianceId,
+	joinPassword,
+	setJoinPassword,
+	joinMutation,
+	onClose,
+}: {
+	joinAllianceId: string
+	joinPassword: string
+	setJoinPassword: (v: string) => void
+	joinMutation: { mutate: (v: { allianceId: string; password: string }) => void; isPending: boolean }
+	onClose: () => void
+}) {
+	const dialogRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose()
+		}
+		document.addEventListener('keydown', handleKeyDown)
+		dialogRef.current?.focus()
+		return () => document.removeEventListener('keydown', handleKeyDown)
+	}, [onClose])
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="join-alliance-title"
+				tabIndex={-1}
+				className="w-full max-w-sm rounded-lg border bg-card p-6 shadow-xl space-y-4"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div className="flex items-center justify-between">
+					<strong id="join-alliance-title" className="text-sm">Join Alliance</strong>
+					<button
+						onClick={onClose}
+						aria-label="Close dialog"
+						className="text-muted-foreground hover:text-foreground text-lg"
+					>
+						×
+					</button>
+				</div>
+				<p className="text-sm text-muted-foreground">
+					Enter the alliance password to request membership.
+				</p>
+				<div>
+					<label className="block text-sm text-muted-foreground mb-1">Password</label>
+					<input
+						type="password"
+						value={joinPassword}
+						onChange={(e) => setJoinPassword(e.target.value)}
+						placeholder="Alliance password"
+						className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' && joinPassword.trim()) {
+								joinMutation.mutate({ allianceId: joinAllianceId, password: joinPassword })
+							}
+						}}
+					/>
+				</div>
+				<div className="flex gap-2">
+					<button
+						onClick={() => joinMutation.mutate({ allianceId: joinAllianceId, password: joinPassword })}
+						disabled={!joinPassword.trim() || joinMutation.isPending}
+						className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+					>
+						{joinMutation.isPending ? 'Joining…' : 'Join'}
+					</button>
+					<button
+						onClick={onClose}
+						className="text-sm text-muted-foreground hover:text-foreground"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/src/ReactClient/src/pages/Diplomacy.tsx
+++ b/src/ReactClient/src/pages/Diplomacy.tsx
@@ -118,11 +118,11 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
             <table className="w-full text-sm">
               <thead className="border-b border-warning/30">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">From</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">From</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
                 </tr>
               </thead>
               <tbody>
@@ -176,8 +176,8 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
                 </tr>
               </thead>
               <tbody>
@@ -205,10 +205,10 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Minerals/tick</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Gas/tick</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Partner</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Minerals/tick</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Gas/tick</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Ticks Remaining</th>
                 </tr>
               </thead>
               <tbody>
@@ -236,11 +236,11 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">To</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Proposed</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">To</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Terms</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Duration</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Proposed</th>
                 </tr>
               </thead>
               <tbody>
@@ -268,12 +268,14 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
           <div className="flex gap-2">
             <button
               onClick={() => { setProposeMode('nap'); setError(null); setSuccess(null) }}
+              aria-pressed={proposeMode === 'nap'}
               className={`rounded px-3 py-1 text-xs ${proposeMode === 'nap' ? 'bg-primary text-primary-foreground' : 'border border-primary text-primary'}`}
             >
               Non-Aggression Pact
             </button>
             <button
               onClick={() => { setProposeMode('resource'); setError(null); setSuccess(null) }}
+              aria-pressed={proposeMode === 'resource'}
               className={`rounded px-3 py-1 text-xs ${proposeMode === 'resource' ? 'bg-primary text-primary-foreground' : 'border border-primary text-primary'}`}
             >
               Resource Agreement

--- a/src/ReactClient/src/pages/EnemyBase.tsx
+++ b/src/ReactClient/src/pages/EnemyBase.tsx
@@ -107,8 +107,8 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
               <table className="w-full text-sm">
                 <thead className="border-b">
                   <tr>
-                    <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
-                    <th className="py-1 text-left font-medium text-muted-foreground">~Count</th>
+                    <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                    <th scope="col" className="py-1 text-left font-medium text-muted-foreground">~Count</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -221,8 +221,8 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
                   <table className="w-full text-xs">
                     <thead className="border-b">
                       <tr>
-                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
-                        <th className="py-1 text-left font-medium text-muted-foreground">Lost</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Lost</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -247,8 +247,8 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
                   <table className="w-full text-xs">
                     <thead className="border-b">
                       <tr>
-                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
-                        <th className="py-1 text-left font-medium text-muted-foreground">Lost</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Lost</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -279,10 +279,10 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
               <table className="w-full text-sm">
                 <thead className="border-b">
                   <tr>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -315,10 +315,10 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
               <table className="w-full text-sm">
                 <thead className="border-b">
                   <tr>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                    <th className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Count</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                    <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Position</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/ReactClient/src/pages/GameLobby.tsx
+++ b/src/ReactClient/src/pages/GameLobby.tsx
@@ -60,11 +60,11 @@ export function GameLobby() {
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="py-2 pr-4">Game</th>
-                <th className="py-2 pr-4">Status</th>
-                <th className="py-2 pr-4">Players</th>
-                <th className="py-2 pr-4">Start Time</th>
-                <th className="py-2" />
+                <th scope="col" className="py-2 pr-4">Game</th>
+                <th scope="col" className="py-2 pr-4">Status</th>
+                <th scope="col" className="py-2 pr-4">Players</th>
+                <th scope="col" className="py-2 pr-4">Start Time</th>
+                <th scope="col" className="py-2" />
               </tr>
             </thead>
             <tbody>

--- a/src/ReactClient/src/pages/GameResults.tsx
+++ b/src/ReactClient/src/pages/GameResults.tsx
@@ -92,9 +92,9 @@ export function GameResults() {
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="py-2 pr-4">Rank</th>
-                <th className="py-2 pr-4">Player</th>
-                <th className="py-2">Score</th>
+                <th scope="col" className="py-2 pr-4">Rank</th>
+                <th scope="col" className="py-2 pr-4">Player</th>
+                <th scope="col" className="py-2">Score</th>
               </tr>
             </thead>
             <tbody>

--- a/src/ReactClient/src/pages/GameSummary.tsx
+++ b/src/ReactClient/src/pages/GameSummary.tsx
@@ -58,9 +58,9 @@ export function GameSummary() {
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="py-2 pr-4">Rank</th>
-                <th className="py-2 pr-4">Player</th>
-                <th className="py-2">Score</th>
+                <th scope="col" className="py-2 pr-4">Rank</th>
+                <th scope="col" className="py-2 pr-4">Player</th>
+                <th scope="col" className="py-2">Score</th>
               </tr>
             </thead>
             <tbody>

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -182,11 +182,11 @@ export function Market({ gameId }: MarketProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
                 </tr>
               </thead>
               <tbody>
@@ -236,12 +236,12 @@ export function Market({ gameId }: MarketProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Seller</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Seller</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
                 </tr>
               </thead>
               <tbody>

--- a/src/ReactClient/src/pages/PlayerHistory.tsx
+++ b/src/ReactClient/src/pages/PlayerHistory.tsx
@@ -68,13 +68,13 @@ export function PlayerHistory() {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-border bg-muted/40">
-              <th className="px-3 py-2 text-left font-medium"></th>
-              <th className="px-3 py-2 text-left font-medium">Game</th>
-              <th className="px-3 py-2 text-left font-medium">Ended</th>
-              <th className="px-3 py-2 text-left font-medium hidden sm:table-cell">Duration</th>
-              <th className="px-3 py-2 text-left font-medium">Rank</th>
-              <th className="px-3 py-2 text-right font-medium">Score</th>
-              <th className="px-3 py-2 text-right font-medium hidden sm:table-cell">Players</th>
+              <th scope="col" className="px-3 py-2 text-left font-medium"></th>
+              <th scope="col" className="px-3 py-2 text-left font-medium">Game</th>
+              <th scope="col" className="px-3 py-2 text-left font-medium">Ended</th>
+              <th scope="col" className="px-3 py-2 text-left font-medium hidden sm:table-cell">Duration</th>
+              <th scope="col" className="px-3 py-2 text-left font-medium">Rank</th>
+              <th scope="col" className="px-3 py-2 text-right font-medium">Score</th>
+              <th scope="col" className="px-3 py-2 text-right font-medium hidden sm:table-cell">Players</th>
             </tr>
           </thead>
           <tbody>

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -34,6 +34,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
     <button
       key={f}
       onClick={() => setFilter(f)}
+      aria-pressed={filter === f}
       className={cn(
         'rounded px-3 py-1 text-sm',
         filter === f
@@ -64,14 +65,14 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
-                <th className="px-4 py-2 text-left w-10">#</th>
-                <th className="px-4 py-2 text-left">Player</th>
-                <th className="px-4 py-2 text-right">Score</th>
-                <th className="px-4 py-2 text-right hidden sm:table-cell">Minerals</th>
-                <th className="px-4 py-2 text-right hidden sm:table-cell">Gas</th>
-                <th className="px-4 py-2 text-right hidden md:table-cell">Units</th>
-                <th className="px-4 py-2 text-center hidden md:table-cell">Type</th>
-                <th className="px-4 py-2 text-center">Status</th>
+                <th scope="col" className="px-4 py-2 text-left w-10">#</th>
+                <th scope="col" className="px-4 py-2 text-left">Player</th>
+                <th scope="col" className="px-4 py-2 text-right">Score</th>
+                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Minerals</th>
+                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Gas</th>
+                <th scope="col" className="px-4 py-2 text-right hidden md:table-cell">Units</th>
+                <th scope="col" className="px-4 py-2 text-center hidden md:table-cell">Type</th>
+                <th scope="col" className="px-4 py-2 text-center">Status</th>
               </tr>
             </thead>
             <tbody className="divide-y">

--- a/src/ReactClient/src/pages/PlayersList.tsx
+++ b/src/ReactClient/src/pages/PlayersList.tsx
@@ -29,12 +29,12 @@ export function PlayersList() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
-                <th className="px-4 py-2 text-left w-10">#</th>
-                <th className="px-4 py-2 text-left">Player</th>
-                <th className="px-4 py-2 text-right">Score</th>
-                <th className="px-4 py-2 text-right hidden sm:table-cell">Games</th>
-                <th className="px-4 py-2 text-right hidden sm:table-cell">Wins</th>
-                <th className="px-4 py-2 text-right hidden md:table-cell">Best Rank</th>
+                <th scope="col" className="px-4 py-2 text-left w-10">#</th>
+                <th scope="col" className="px-4 py-2 text-left">Player</th>
+                <th scope="col" className="px-4 py-2 text-right">Score</th>
+                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Games</th>
+                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Wins</th>
+                <th scope="col" className="px-4 py-2 text-right hidden md:table-cell">Best Rank</th>
               </tr>
             </thead>
             <tbody className="divide-y">

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -80,11 +80,11 @@ export function PublicProfile() {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Result</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Score</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Ended</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Result</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Score</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Ended</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/ReactClient/src/pages/SelectEnemy.tsx
+++ b/src/ReactClient/src/pages/SelectEnemy.tsx
@@ -121,8 +121,8 @@ export function SelectEnemy({ gameId }: SelectEnemyProps) {
                   <table className="w-full text-xs">
                     <thead className="border-b">
                       <tr>
-                        <th className="py-1 text-left font-medium text-muted-foreground">Unit</th>
-                        <th className="py-1 text-left font-medium text-muted-foreground">~Count</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">Unit</th>
+                        <th scope="col" className="py-1 text-left font-medium text-muted-foreground">~Count</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/src/ReactClient/src/pages/Spies.tsx
+++ b/src/ReactClient/src/pages/Spies.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
@@ -60,13 +60,33 @@ interface SpyMissionDetailModalProps {
 }
 
 function SpyMissionDetailModal({ mission, onClose }: SpyMissionDetailModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    dialogRef.current?.focus()
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="rounded-lg border bg-card p-6 w-full max-w-md shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="spy-mission-title"
+        tabIndex={-1}
+        className="rounded-lg border bg-card p-6 w-full max-w-md shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between mb-4">
-          <h3 className="font-semibold">Mission Details</h3>
+          <h3 id="spy-mission-title" className="font-semibold">Mission Details</h3>
           <button
             onClick={onClose}
+            aria-label="Close dialog"
             className="text-muted-foreground hover:text-foreground text-xl leading-none"
           >
             ×
@@ -263,12 +283,12 @@ export function Spies({ gameId }: SpiesProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Target</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Mission</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Launched</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Resolved</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Target</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Mission</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Launched</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Resolved</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
                 </tr>
               </thead>
               <tbody>

--- a/src/ReactClient/src/pages/SpyReports.tsx
+++ b/src/ReactClient/src/pages/SpyReports.tsx
@@ -36,9 +36,9 @@ export function SpyReports({ gameId }: SpyReportsProps) {
             <table className="w-full text-sm">
               <thead className="border-b">
                 <tr>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Attacker</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Operation Type</th>
-                  <th className="py-2 px-3 text-left font-medium text-muted-foreground">Detected At</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Attacker</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Operation Type</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Detected At</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -225,11 +225,11 @@ export function Units({ gameId }: UnitsProps) {
                 <table className="w-full text-sm">
                   <thead className="border-b">
                     <tr>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
-                      <th className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Location</th>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
+                      <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Location</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -268,10 +268,10 @@ export function Units({ gameId }: UnitsProps) {
                 <table className="w-full text-sm">
                   <thead className="border-b">
                     <tr>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
-                      <th className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                      <th className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
+                      <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/src/ReactClient/src/pages/admin/AdminGames.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGames.tsx
@@ -230,12 +230,12 @@ export function AdminGames() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border bg-muted/40">
-                <th className="px-3 py-2 text-left font-medium">Name</th>
-                <th className="px-3 py-2 text-left font-medium">Status</th>
-                <th className="px-3 py-2 text-right font-medium">Players</th>
-                <th className="px-3 py-2 text-left font-medium hidden md:table-cell">Start</th>
-                <th className="px-3 py-2 text-left font-medium hidden md:table-cell">End</th>
-                <th className="px-3 py-2 text-right font-medium">Actions</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Name</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Status</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Players</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium hidden md:table-cell">Start</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium hidden md:table-cell">End</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary

- Add `scope="col"` to all table `<th>` elements across 19 pages for screen reader compatibility
- Add `aria-pressed` to filter/toggle buttons in PlayerRanking, Diplomacy, and AllianceDetail
- Add proper dialog accessibility (`role="dialog"`, `aria-modal`, `aria-labelledby`, Escape key close, backdrop click close) to Spies mission detail and Alliances join modals
- Add ARIA tab roles (`role="tab"`, `aria-selected`, `role="tabpanel"`) to Messages inbox/sent tabs

## Test plan
- [ ] Verify tables are announced correctly by screen readers (VoiceOver/NVDA)
- [ ] Verify filter buttons announce pressed state
- [ ] Verify modals can be closed with Escape key
- [ ] Verify clicking backdrop closes modals
- [ ] Verify tab navigation in Messages announces selected state
- [ ] Visual regression check — no layout changes expected