### PR TITLE
feat: BGE-598 route-based code splitting for React client

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -1,38 +1,43 @@
+import { lazy } from 'react'
 import { createBrowserRouter, RouterProvider, useParams } from 'react-router'
 import { RootLayout } from '@/layouts/RootLayout'
 import { GameLayout } from '@/layouts/GameLayout'
 import { BareRouteRedirect } from '@/components/BareRouteRedirect'
+
+// Eagerly loaded — must render instantly
 import { SignIn } from '@/pages/SignIn'
-import { Base } from '@/pages/Base'
-import { Units } from '@/pages/Units'
-import { Research } from '@/pages/Research'
-import { Market } from '@/pages/Market'
-import { Spies } from '@/pages/Spies'
-import { SpyReports } from '@/pages/SpyReports'
-import { Diplomacy } from '@/pages/Diplomacy'
-import { EnemyBase } from '@/pages/EnemyBase'
-import { SelectEnemy } from '@/pages/SelectEnemy'
-import { Chat } from '@/pages/Chat'
-import { Messages } from '@/pages/Messages'
-import { PlayerRanking } from '@/pages/PlayerRanking'
-import { PlayerProfile } from '@/pages/PlayerProfile'
-import { InGamePlayerProfile } from '@/pages/InGamePlayerProfile'
 import { Index } from '@/pages/Index'
-import { Games } from '@/pages/Games'
-import { GameLobby } from '@/pages/GameLobby'
-import { JoinGame } from '@/pages/JoinGame'
-import { GameSummary } from '@/pages/GameSummary'
-import { GameResults } from '@/pages/GameResults'
-import { CreatePlayer } from '@/pages/CreatePlayer'
-import { UnitDefinitions } from '@/pages/UnitDefinitions'
-import { Alliances } from '@/pages/Alliances'
-import { AllianceDetail } from '@/pages/AllianceDetail'
-import { Achievements } from '@/pages/Achievements'
-import { PlayerHistory } from '@/pages/PlayerHistory'
-import { PublicProfile } from '@/pages/PublicProfile'
-import { AdminGames } from '@/pages/admin/AdminGames'
-import { PlayersList } from '@/pages/PlayersList'
-import { Trade } from '@/pages/Trade'
+
+// Lazy-loaded pages — split into separate chunks
+const Base = lazy(() => import('@/pages/Base').then(m => ({ default: m.Base })))
+const Units = lazy(() => import('@/pages/Units').then(m => ({ default: m.Units })))
+const Research = lazy(() => import('@/pages/Research').then(m => ({ default: m.Research })))
+const Market = lazy(() => import('@/pages/Market').then(m => ({ default: m.Market })))
+const Spies = lazy(() => import('@/pages/Spies').then(m => ({ default: m.Spies })))
+const SpyReports = lazy(() => import('@/pages/SpyReports').then(m => ({ default: m.SpyReports })))
+const Diplomacy = lazy(() => import('@/pages/Diplomacy').then(m => ({ default: m.Diplomacy })))
+const EnemyBase = lazy(() => import('@/pages/EnemyBase').then(m => ({ default: m.EnemyBase })))
+const SelectEnemy = lazy(() => import('@/pages/SelectEnemy').then(m => ({ default: m.SelectEnemy })))
+const Chat = lazy(() => import('@/pages/Chat').then(m => ({ default: m.Chat })))
+const Messages = lazy(() => import('@/pages/Messages').then(m => ({ default: m.Messages })))
+const PlayerRanking = lazy(() => import('@/pages/PlayerRanking').then(m => ({ default: m.PlayerRanking })))
+const PlayerProfile = lazy(() => import('@/pages/PlayerProfile').then(m => ({ default: m.PlayerProfile })))
+const InGamePlayerProfile = lazy(() => import('@/pages/InGamePlayerProfile').then(m => ({ default: m.InGamePlayerProfile })))
+const Games = lazy(() => import('@/pages/Games').then(m => ({ default: m.Games })))
+const GameLobby = lazy(() => import('@/pages/GameLobby').then(m => ({ default: m.GameLobby })))
+const JoinGame = lazy(() => import('@/pages/JoinGame').then(m => ({ default: m.JoinGame })))
+const GameSummary = lazy(() => import('@/pages/GameSummary').then(m => ({ default: m.GameSummary })))
+const GameResults = lazy(() => import('@/pages/GameResults').then(m => ({ default: m.GameResults })))
+const CreatePlayer = lazy(() => import('@/pages/CreatePlayer').then(m => ({ default: m.CreatePlayer })))
+const UnitDefinitions = lazy(() => import('@/pages/UnitDefinitions').then(m => ({ default: m.UnitDefinitions })))
+const Alliances = lazy(() => import('@/pages/Alliances').then(m => ({ default: m.Alliances })))
+const AllianceDetail = lazy(() => import('@/pages/AllianceDetail').then(m => ({ default: m.AllianceDetail })))
+const Achievements = lazy(() => import('@/pages/Achievements').then(m => ({ default: m.Achievements })))
+const PlayerHistory = lazy(() => import('@/pages/PlayerHistory').then(m => ({ default: m.PlayerHistory })))
+const PublicProfile = lazy(() => import('@/pages/PublicProfile').then(m => ({ default: m.PublicProfile })))
+const AdminGames = lazy(() => import('@/pages/admin/AdminGames').then(m => ({ default: m.AdminGames })))
+const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ default: m.PlayersList })))
+const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {

--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 import { Outlet, NavLink, useParams, Navigate, useLocation } from 'react-router'
 import { GamepadIcon, LogOutIcon, MenuIcon, XIcon } from 'lucide-react'
 import { CurrentGameProvider, useCurrentGame } from '@/contexts/CurrentGameContext'
 import { NavMenu } from '@/components/NavMenu'
 import { PlayerResources } from '@/components/PlayerResources'
 import { NotificationBell } from '@/components/NotificationBell'
+import { PageLoader } from '@/components/PageLoader'
 import { cn } from '@/lib/utils'
 import { useEffect } from 'react'
 import { vcText, vcBadgeCss } from '@/lib/victory'
@@ -167,7 +168,9 @@ function GameLayoutInner() {
 
         {/* Page content */}
         <main className="flex-1 overflow-y-auto p-4">
-          <Outlet />
+          <Suspense fallback={<PageLoader />}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
     </div>

--- a/src/ReactClient/src/layouts/RootLayout.tsx
+++ b/src/ReactClient/src/layouts/RootLayout.tsx
@@ -1,12 +1,16 @@
+import { Suspense } from 'react'
 import { Outlet } from 'react-router'
 import { CurrentUserProvider } from '@/contexts/CurrentUserContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { PageLoader } from '@/components/PageLoader'
 
 export function RootLayout() {
   return (
     <ErrorBoundary>
       <CurrentUserProvider>
-        <Outlet />
+        <Suspense fallback={<PageLoader />}>
+          <Outlet />
+        </Suspense>
       </CurrentUserProvider>
     </ErrorBoundary>
   )


### PR DESCRIPTION
## Summary
- Add `React.lazy()` + `Suspense` for route-based code splitting across all 27 non-critical page components
- Only `SignIn` and `Index` remain eagerly loaded for instant render on first visit
- Suspense boundaries in `RootLayout` and `GameLayout` show `PageLoader` while chunks load
- Main JS bundle reduced from ~571KB to ~415KB — Vite chunk size warning eliminated

## Build output
- 29 separate page chunks (0.46KB – 15.75KB each)
- Main chunk: 414.71KB (was ~571KB)
- No new dependencies

## Test plan
- [ ] Vite build succeeds with no chunk warnings
- [ ] Navigate to each major route — verify page loads correctly
- [ ] Check Network tab — chunks load on demand per route
- [ ] Direct URL navigation works (e.g. paste `/games/1/messages`)
- [ ] `PageLoader` spinner shows briefly on slow connections