### PR TITLE
feat: BGE-610 structured logging, request timing, and ECS container health check

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -388,6 +388,14 @@ resource "aws_ecs_task_definition" "app" {
         "awslogs-stream-prefix" = "ecs"
       }
     }
+
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 60
+    }
   }])
 }
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -14,6 +14,7 @@ using Mvc.Client.Extensions;
 
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	public class AuthenticationController : Controller {
+		private readonly ILogger<AuthenticationController> logger;
 		private readonly IOptions<BgeOptions> options;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly PlayerRepository playerRepository;
@@ -27,6 +28,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, UserRepositoryWrite userRepositoryWrite
 			) {
+			this.logger = logger;
 			this.options = options;
 			this.currentUserContext = currentUserContext;
 			this.playerRepository = playerRepository;
@@ -47,6 +49,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (string.IsNullOrWhiteSpace(provider)) return BadRequest();
 			if (!await HttpContext.IsProviderSupportedAsync(provider)) return BadRequest();
 
+			logger.LogInformation("Auth: login initiated provider={Provider}", provider);
+
 			// Redirect back to the original page after login, or home if none/external.
 			var redirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/";
 
@@ -59,6 +63,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[HttpGet("~/signout")]
 		[HttpPost("~/signout")]
 		public new IActionResult SignOut() {
+			var githubId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value ?? "unknown";
+			logger.LogInformation("Auth: user signed out githubId={GithubId}", githubId);
 			// Instruct the cookies middleware to delete the local cookie created
 			// when the user agent is redirected from the external identity provider
 			// after a successful authentication flow (e.g Google or Facebook).

--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -18,7 +18,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 	[Authorize]
 	[Route("api/[controller]/{action?}")]
 	public class BattleController : ControllerBase {
-		private readonly ILogger<PlayerRankingController> logger;
+		private readonly ILogger<BattleController> logger;
 		private readonly GameDef gameDef;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly ScoreRepository scoreRepository;
@@ -30,7 +30,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly OnlineStatusRepository onlineStatusRepository;
 		private readonly SpyRepositoryWrite spyRepositoryWrite;
 
-		public BattleController(ILogger<PlayerRankingController> logger
+		public BattleController(ILogger<BattleController> logger
 				, GameDef gameDef
 				, CurrentUserContext currentUserContext
 				, ScoreRepository scoreRepository
@@ -132,6 +132,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			bool attackerWon = !result.BtlResult.DefendingUnitsSurvived.Any() && result.BtlResult.AttackingUnitsSurvived.Any();
 			bool draw = !result.BtlResult.AttackingUnitsSurvived.Any() && !result.BtlResult.DefendingUnitsSurvived.Any();
 			string outcome = attackerWon ? "AttackerWon" : draw ? "Draw" : "DefenderWon";
+
+			logger.LogInformation(
+				"Battle: attacker={AttackerName} defender={DefenderName} outcome={Outcome} attackerStrength={AttackerStrength} defenderStrength={DefenderStrength} landTransferred={LandTransferred}",
+				attacker.Name, defender.Name, outcome,
+				result.BtlResult.TotalAttackerStrengthBefore, result.BtlResult.TotalDefenderStrengthBefore,
+				result.BtlResult.LandTransferred);
 
 			return new BattleResultViewModel {
 				AttackerId = result.Attacker.Id,

--- a/src/BrowserGameEngine.FrontendServer/Middleware/RequestDurationMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/RequestDurationMiddleware.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace BrowserGameEngine.FrontendServer.Middleware;
+
+public class RequestDurationMiddleware
+{
+	private readonly RequestDelegate _next;
+	private readonly ILogger<RequestDurationMiddleware> _logger;
+
+	public RequestDurationMiddleware(RequestDelegate next, ILogger<RequestDurationMiddleware> logger)
+	{
+		_next = next;
+		_logger = logger;
+	}
+
+	public async Task InvokeAsync(HttpContext context)
+	{
+		var sw = Stopwatch.StartNew();
+		await _next(context);
+		sw.Stop();
+
+		// Only log API requests; skip health, metrics, static files
+		var path = context.Request.Path.Value ?? "";
+		if (path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase)) {
+			_logger.LogInformation("HTTP {Method} {Path} responded {StatusCode} in {ElapsedMs}ms",
+				context.Request.Method,
+				path,
+				context.Response.StatusCode,
+				sw.ElapsedMilliseconds);
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -23,12 +23,15 @@ using Serilog.Events;
 using System.Linq;
 using System.Threading.RateLimiting;
 
+var isProduction = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Production";
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Information()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
     .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
     .Enrich.FromLogContext()
-    .WriteTo.Console()
+    .WriteTo.Console(isProduction
+        ? new Serilog.Formatting.Json.JsonFormatter()
+        : new Serilog.Formatting.Display.MessageTemplateTextFormatter("[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
     .CreateLogger();
 
 var builder = WebApplication.CreateBuilder(args);
@@ -183,6 +186,7 @@ IDisposable collector = DotNetRuntimeStatsBuilder
     .StartCollecting();
 
 app.UseAuthentication();
+app.UseMiddleware<RequestDurationMiddleware>();
 app.UseMiddleware<BearerTokenMiddleware>();
 app.UseRateLimiter();
 app.UseMiddleware<CurrentUserMiddleware>();

--- a/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
@@ -31,10 +31,12 @@ namespace BrowserGameEngine.FrontendServer {
 			if (Interlocked.CompareExchange(ref isactive, 1, 0) != 0) return;
 			try {
 				var count = Interlocked.Increment(ref executionCount);
-				logger.LogInformation("GameTickTimer #{Count}", count);
+				var sw = System.Diagnostics.Stopwatch.StartNew();
 				foreach (var instance in gameRegistry.GetAllInstances()) {
 					instance.TickEngine?.CheckAllTicks();
 				}
+				sw.Stop();
+				logger.LogInformation("GameTick #{Count} completed in {ElapsedMs}ms", count, sw.ElapsedMilliseconds);
 			} finally {
 				Interlocked.Exchange(ref isactive, 0);
 			}


### PR DESCRIPTION
## Summary

- **JSON structured logging**: Serilog switches to `JsonFormatter` in Production so CloudWatch Logs Insights can parse fields like `ElapsedMs`, `Outcome`, etc.
- **Request duration middleware**: Logs `HTTP {Method} {Path} {StatusCode} {ElapsedMs}ms` for all `/api/*` requests
- **Game tick timing**: `GameTickTimerService` now logs tick duration instead of just a counter
- **Battle outcome logging**: `BattleController.Attack` logs attacker/defender names, outcome, strength, and land transferred
- **Auth event logging**: Login initiated and signout events logged with provider/githubId
- **ECS container health check**: Added `healthCheck` block to task definition (`curl /health`, 30s interval, 60s startPeriod) so ECS itself can restart unhealthy containers independent of the ALB
- **Bug fix**: `BattleController` logger was typed as `ILogger<PlayerRankingController>` — corrected to `ILogger<BattleController>`

**Note (Terraform):** The container health check change requires `terraform apply` to take effect. The ALB health check at `/health` already existed; this adds the ECS-level container check.

## Test plan

- [ ] Build passes (`dotnet build --configuration Release`)  
- [ ] In dev mode, logs appear as human-readable text; set `ASPNETCORE_ENVIRONMENT=Production` locally to verify JSON output
- [ ] Hit `/api/*` endpoints and confirm request duration log entries
- [ ] After deploy to ECS, check `/ecs/bge` log group in CloudWatch — entries should be valid JSON
- [ ] Run `terraform plan` in `infra/` to review the ECS task definition diff before applying