### PR TITLE
feat: BGE-597 replace hardcoded colors with theme variables

### DIFF
--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -208,7 +208,7 @@ export function AllianceDetail() {
 			</div>
 
 			{error && <div className="text-destructive text-sm">{error}</div>}
-			{success && <div className="text-green-400 text-sm">{success}</div>}
+			{success && <div className="text-success-foreground text-sm">{success}</div>}
 
 			{/* Alliance Message */}
 			<div className="rounded-lg border bg-card p-4">
@@ -297,7 +297,7 @@ export function AllianceDetail() {
 							{confirmedMembers.map((m) => (
 								<tr key={m.playerId} className="border-b border-border">
 									<td className="py-2 px-3 font-medium flex items-center gap-1.5">
-										{m.isLeader && <CrownIcon className="h-3.5 w-3.5 text-amber-400" />}
+										{m.isLeader && <CrownIcon className="h-3.5 w-3.5 text-warning-foreground" />}
 										{m.playerName}
 									</td>
 									<td className="py-2 px-3">{m.voteCount}</td>
@@ -323,20 +323,20 @@ export function AllianceDetail() {
 
 			{/* Pending Members (leader only) */}
 			{isLeader && pendingMembers.length > 0 && (
-				<div className="rounded-lg border border-yellow-700 bg-yellow-900/10">
-					<div className="border-b border-yellow-700 bg-yellow-900/20 px-4 py-3">
-						<strong className="text-sm text-yellow-200">
+				<div className="rounded-lg border border-warning/50 bg-warning/10">
+					<div className="border-b border-warning/50 bg-warning/20 px-4 py-3">
+						<strong className="text-sm text-warning-foreground">
 							Pending Members ({pendingMembers.length})
 						</strong>
 					</div>
-					<div className="divide-y divide-yellow-700/30">
+					<div className="divide-y divide-warning/30">
 						{pendingMembers.map((m) => (
 							<div key={m.playerId} className="flex items-center justify-between px-4 py-2">
 								<span className="font-medium text-sm">{m.playerName}</span>
 								<div className="flex gap-2">
 									<button
 										onClick={() => { setError(null); acceptMemberMut.mutate(m.playerId) }}
-										className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+										className="rounded bg-success px-2 py-0.5 text-xs text-white hover:opacity-90"
 									>
 										Accept
 									</button>
@@ -374,7 +374,7 @@ export function AllianceDetail() {
 							onClick={() => { setShowDeclareWar(!showDeclareWar); setShowInvite(false); setEditPassword(false) }}
 							className={cn(
 								'rounded px-3 py-1.5 text-xs flex items-center gap-1',
-								showDeclareWar ? 'bg-red-600 text-white' : 'border border-red-600 text-red-400'
+								showDeclareWar ? 'bg-danger text-white' : 'border border-danger text-danger-foreground'
 							)}
 						>
 							<SwordsIcon className="h-3.5 w-3.5" />
@@ -448,7 +448,7 @@ export function AllianceDetail() {
 									if (warTargetId) { setError(null); declareWarMut.mutate(warTargetId) }
 								}}
 								disabled={!warTargetId || declareWarMut.isPending}
-								className="rounded bg-red-600 px-4 py-1.5 text-sm text-white hover:opacity-90 disabled:opacity-50"
+								className="rounded bg-danger px-4 py-1.5 text-sm text-white hover:opacity-90 disabled:opacity-50"
 							>
 								{declareWarMut.isPending ? 'Declaring…' : 'Declare War'}
 							</button>
@@ -481,14 +481,14 @@ export function AllianceDetail() {
 
 			{/* Wars */}
 			{(wars?.length ?? 0) > 0 && (
-				<div className="rounded-lg border border-red-700/50 bg-red-900/10">
-					<div className="border-b border-red-700/50 bg-red-900/20 px-4 py-3">
-						<strong className="text-sm text-red-200 flex items-center gap-1.5">
+				<div className="rounded-lg border border-danger/50 bg-danger/10">
+					<div className="border-b border-danger/50 bg-danger/20 px-4 py-3">
+						<strong className="text-sm text-danger-foreground flex items-center gap-1.5">
 							<SwordsIcon className="h-4 w-4" />
 							Active Wars ({wars!.length})
 						</strong>
 					</div>
-					<div className="divide-y divide-red-700/30">
+					<div className="divide-y divide-danger/30">
 						{wars!.map((w) => {
 							const isAttacker = w.attackerAllianceId === allianceId
 							const opponent = isAttacker ? w.defenderAllianceName : w.attackerAllianceName
@@ -500,7 +500,7 @@ export function AllianceDetail() {
 											declared {relativeTime(w.declaredAt)}
 										</span>
 										{w.status === 'PeaceProposed' && (
-											<span className="ml-2 rounded bg-yellow-700/30 px-2 py-0.5 text-xs text-yellow-300">
+											<span className="ml-2 rounded bg-warning/30 px-2 py-0.5 text-xs text-warning-foreground">
 												Peace Proposed
 											</span>
 										)}
@@ -509,7 +509,7 @@ export function AllianceDetail() {
 										<button
 											onClick={() => { setError(null); peaceMut.mutate(w.warId) }}
 											disabled={peaceMut.isPending}
-											className="rounded border border-green-600 px-2 py-0.5 text-xs text-green-400 hover:bg-green-600/10"
+											className="rounded border border-success px-2 py-0.5 text-xs text-success-foreground hover:bg-success/10"
 										>
 											Propose Peace
 										</button>
@@ -518,7 +518,7 @@ export function AllianceDetail() {
 										<button
 											onClick={() => { setError(null); peaceMut.mutate(w.warId) }}
 											disabled={peaceMut.isPending}
-											className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+											className="rounded bg-success px-2 py-0.5 text-xs text-white hover:opacity-90"
 										>
 											Accept Peace
 										</button>

--- a/src/ReactClient/src/pages/Alliances.tsx
+++ b/src/ReactClient/src/pages/Alliances.tsx
@@ -138,7 +138,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 			</div>
 
 			{error && <div className="text-destructive text-sm">{error}</div>}
-			{success && <div className="text-green-400 text-sm">{success}</div>}
+			{success && <div className="text-success-foreground text-sm">{success}</div>}
 
 			{alliancesLoading && <PageLoader message="Loading alliances..." />}
 			{alliancesError && !alliances && <ApiError message="Failed to load alliances." onRetry={() => void refetchAlliances()} />}
@@ -156,12 +156,12 @@ export function Alliances({ gameId }: AlliancesProps) {
 								{myStatus.allianceName}
 							</Link>
 							{myStatus.isPending && (
-								<span className="ml-2 rounded bg-yellow-700/30 px-2 py-0.5 text-xs text-yellow-300">
+								<span className="ml-2 rounded bg-warning/30 px-2 py-0.5 text-xs text-warning-foreground">
 									Pending Approval
 								</span>
 							)}
 							{myStatus.isLeader && (
-								<span className="ml-2 rounded bg-amber-700/30 px-2 py-0.5 text-xs text-amber-300">
+								<span className="ml-2 rounded bg-warning/30 px-2 py-0.5 text-xs text-warning-foreground">
 									Leader
 								</span>
 							)}
@@ -179,13 +179,13 @@ export function Alliances({ gameId }: AlliancesProps) {
 
 			{/* Pending Invites */}
 			{(invites?.length ?? 0) > 0 && !inAlliance && (
-				<div className="rounded-lg border border-yellow-700 bg-yellow-900/10">
-					<div className="border-b border-yellow-700 bg-yellow-900/20 px-4 py-3">
-						<strong className="text-sm text-yellow-200">
+				<div className="rounded-lg border border-warning/50 bg-warning/10">
+					<div className="border-b border-warning/50 bg-warning/20 px-4 py-3">
+						<strong className="text-sm text-warning-foreground">
 							Pending Invites ({invites!.length})
 						</strong>
 					</div>
-					<div className="divide-y divide-yellow-700/30">
+					<div className="divide-y divide-warning/30">
 						{invites!.map((inv) => (
 							<div key={inv.inviteId} className="flex items-center justify-between px-4 py-3">
 								<div>
@@ -203,7 +203,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 											setError(null); setSuccess(null)
 											acceptInviteMutation.mutate({ allianceId: inv.allianceId, inviteId: inv.inviteId })
 										}}
-										className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+										className="rounded bg-success px-2 py-0.5 text-xs text-white hover:opacity-90"
 									>
 										Accept
 									</button>
@@ -311,7 +311,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 										</td>
 										<td className="py-2 px-3">
 											{a.isAtWar && (
-												<span className="inline-flex items-center gap-1 rounded bg-red-700/30 px-2 py-0.5 text-xs text-red-300">
+												<span className="inline-flex items-center gap-1 rounded bg-danger/30 px-2 py-0.5 text-xs text-danger-foreground">
 													<SwordsIcon className="h-3 w-3" />
 													At War
 												</span>

--- a/src/ReactClient/src/pages/Diplomacy.tsx
+++ b/src/ReactClient/src/pages/Diplomacy.tsx
@@ -101,22 +101,22 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
       <h1 className="text-2xl font-bold">Diplomacy</h1>
 
       {error && <div className="text-destructive text-sm">{error}</div>}
-      {success && <div className="text-green-400 text-sm">{success}</div>}
+      {success && <div className="text-success-foreground text-sm">{success}</div>}
 
       {statusLoading && <PageLoader message="Loading diplomacy..." />}
       {statusError && !status && <ApiError message="Failed to load diplomacy status." onRetry={() => void refetchStatus()} />}
 
       {/* Incoming proposals */}
       {(status?.pendingIncoming.length ?? 0) > 0 && (
-        <div className="rounded-lg border border-yellow-700 bg-yellow-900/10">
-          <div className="border-b border-yellow-700 bg-yellow-900/20 px-4 py-3">
-            <strong className="text-sm text-yellow-200">
+        <div className="rounded-lg border border-warning/50 bg-warning/10">
+          <div className="border-b border-warning/50 bg-warning/20 px-4 py-3">
+            <strong className="text-sm text-warning-foreground">
               Incoming Proposals ({status!.pendingIncoming.length})
             </strong>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="border-b border-yellow-700/50">
+              <thead className="border-b border-warning/30">
                 <tr>
                   <th className="py-2 px-3 text-left font-medium text-muted-foreground">From</th>
                   <th className="py-2 px-3 text-left font-medium text-muted-foreground">Type</th>
@@ -140,7 +140,7 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
                             respondMutation.mutate({ proposalId: p.proposalId, accept: true })
                             invalidateAll()
                           }}
-                          className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90"
+                          className="rounded bg-success px-2 py-0.5 text-xs text-white hover:opacity-90"
                         >
                           Accept
                         </button>

--- a/src/ReactClient/src/pages/EnemyBase.tsx
+++ b/src/ReactClient/src/pages/EnemyBase.tsx
@@ -140,10 +140,10 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
           <p
             className={`text-2xl font-bold ${
               battleResult.outcome === 'AttackerWon'
-                ? 'text-green-400'
+                ? 'text-success-foreground'
                 : battleResult.outcome === 'DefenderWon'
-                  ? 'text-red-400'
-                  : 'text-yellow-400'
+                  ? 'text-danger-foreground'
+                  : 'text-warning-foreground'
             }`}
           >
             {battleResult.outcome === 'AttackerWon'
@@ -190,19 +190,19 @@ export function EnemyBase({ gameId }: EnemyBaseProps) {
             <div>
               <h4 className="font-semibold text-sm mb-2">Spoils of War</h4>
               {battleResult.landTransferred > 0 && (
-                <span className="rounded bg-green-800/50 px-2 py-0.5 text-xs text-green-300 mr-2">
+                <span className="rounded bg-success/50 px-2 py-0.5 text-xs text-success-foreground mr-2">
                   +{battleResult.landTransferred} land captured
                 </span>
               )}
               {battleResult.workersCaptured > 0 && (
-                <span className="rounded bg-green-800/50 px-2 py-0.5 text-xs text-green-300 mr-2">
+                <span className="rounded bg-success/50 px-2 py-0.5 text-xs text-success-foreground mr-2">
                   +{battleResult.workersCaptured} workers captured
                 </span>
               )}
               {Object.entries(battleResult.resourcesPillaged).map(([res, amt]) => (
                 <span
                   key={res}
-                  className="rounded bg-yellow-800/50 px-2 py-0.5 text-xs text-yellow-200 mr-2"
+                  className="rounded bg-warning/50 px-2 py-0.5 text-xs text-warning-foreground mr-2"
                 >
                   +{amt} {res} pillaged
                 </span>

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -191,7 +191,7 @@ export function Market({ gameId }: MarketProps) {
               </thead>
               <tbody>
                 {myOrders.map((order) => (
-                  <tr key={order.orderId} className="border-b border-border bg-blue-900/10">
+                  <tr key={order.orderId} className="border-b border-border bg-info/10">
                     <td className="py-2 px-3">
                       {order.offeredAmount} {order.offeredResourceName}
                     </td>
@@ -265,7 +265,7 @@ export function Market({ gameId }: MarketProps) {
                         <button
                           onClick={() => acceptMutation.mutate(order.orderId)}
                           disabled={acceptMutation.isPending}
-                          className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90 disabled:opacity-50"
+                          className="rounded bg-success px-2 py-0.5 text-xs text-white hover:opacity-90 disabled:opacity-50"
                         >
                           Accept
                         </button>

--- a/src/ReactClient/src/pages/PlayerHistory.tsx
+++ b/src/ReactClient/src/pages/PlayerHistory.tsx
@@ -17,9 +17,9 @@ function formatDuration(startIso: string, endIso: string): string {
 }
 
 function rankBadgeClass(rank: number, players: number): string {
-  if (rank === 1) return 'bg-yellow-500 text-black'
-  if (rank === 2) return 'bg-gray-400 text-black'
-  if (rank === 3) return 'bg-amber-700 text-white'
+  if (rank === 1) return 'bg-warning text-black'
+  if (rank === 2) return 'bg-muted-foreground text-black'
+  if (rank === 3) return 'bg-warning/60 text-white'
   if (rank > players / 2) return 'bg-secondary text-secondary-foreground opacity-60'
   return 'bg-secondary text-secondary-foreground'
 }
@@ -53,7 +53,7 @@ export function PlayerHistory() {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
         {[
           { label: 'Games Played', value: data.totalGames, color: '' },
-          { label: 'Wins', value: data.totalWins, color: 'text-yellow-400' },
+          { label: 'Wins', value: data.totalWins, color: 'text-warning-foreground' },
           { label: 'Best Rank', value: `#${data.bestRank}`, color: '' },
           { label: 'Total Score', value: Number(data.totalScore).toLocaleString(), color: '' },
         ].map(({ label, value, color }) => (

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -95,7 +95,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                       {p.isCurrentPlayer && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(you)</span>}
                     </Link>
                     {p.protectionTicksRemaining > 0 && (
-                      <span className="ml-1.5 text-[10px] text-yellow-400" title="Under protection">🛡</span>
+                      <span className="ml-1.5 text-[10px] text-warning-foreground" title="Under protection">🛡</span>
                     )}
                   </td>
                   <td className="px-4 py-2 text-right font-mono">{Math.floor(p.score).toLocaleString()}</td>
@@ -111,7 +111,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                   <td className="px-4 py-2 text-center hidden md:table-cell">
                     <span className={cn(
                       'rounded px-1.5 py-0.5 text-[10px] font-medium',
-                      p.isAgent ? 'bg-purple-900/50 text-purple-300' : 'bg-blue-900/50 text-blue-300'
+                      p.isAgent ? 'bg-accent text-accent-foreground' : 'bg-info/50 text-info-foreground'
                     )}>
                       {p.isAgent ? 'AI' : 'Human'}
                     </span>
@@ -119,7 +119,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                   <td className="px-4 py-2 text-center">
                     <span className={cn(
                       'inline-block h-2 w-2 rounded-full',
-                      p.isOnline ? 'bg-green-400' : 'bg-muted-foreground'
+                      p.isOnline ? 'bg-success' : 'bg-muted-foreground'
                     )} title={p.isOnline ? 'Online' : 'Offline'} />
                   </td>
                 </tr>

--- a/src/ReactClient/src/pages/Spies.tsx
+++ b/src/ReactClient/src/pages/Spies.tsx
@@ -47,9 +47,9 @@ function statusLabel(status: string): string {
 
 function statusColor(status: string): string {
   switch (status) {
-    case 'in_transit': return 'bg-yellow-700/50 text-yellow-200'
-    case 'completed': return 'bg-green-800/50 text-green-300'
-    case 'intercepted': return 'bg-red-800/50 text-red-300'
+    case 'in_transit': return 'bg-warning/50 text-warning-foreground'
+    case 'completed': return 'bg-success/50 text-success-foreground'
+    case 'intercepted': return 'bg-danger/50 text-danger-foreground'
     default: return 'bg-secondary text-secondary-foreground'
   }
 }
@@ -230,7 +230,7 @@ export function Spies({ gameId }: SpiesProps) {
             </p>
 
             {sendError && <div className="text-destructive text-sm mb-2">{sendError}</div>}
-            {sendSuccess && <div className="text-green-400 text-sm mb-2">{sendSuccess}</div>}
+            {sendSuccess && <div className="text-success-foreground text-sm mb-2">{sendSuccess}</div>}
 
             <button
               onClick={() => sendMutation.mutate()}

--- a/src/ReactClient/src/pages/SpyReports.tsx
+++ b/src/ReactClient/src/pages/SpyReports.tsx
@@ -46,7 +46,7 @@ export function SpyReports({ gameId }: SpyReportsProps) {
                   <tr key={a.id} className="border-b border-border">
                     <td className="py-2 px-3 font-medium">{a.attackerName}</td>
                     <td className="py-2 px-3">
-                      <span className="rounded bg-yellow-700/50 px-1.5 py-0.5 text-xs text-yellow-200">
+                      <span className="rounded bg-warning/50 px-1.5 py-0.5 text-xs text-warning-foreground">
                         {a.actionType}
                       </span>
                     </td>


### PR DESCRIPTION
## Summary
- Replace ~50 hardcoded Tailwind color classes across 9 secondary pages with semantic theme variables (`success`, `warning`, `danger`, `info`)
- Uses the theme colors added in PR #188
- Pages updated: SpyReports, Spies, EnemyBase, PlayerHistory, PlayerRanking, Diplomacy, Alliances, AllianceDetail, Market
- WorkerAssignment.tsx does not exist — skipped

## Color mapping
| Hardcoded | Theme variable |
|-----------|---------------|
| `bg-green-600`, `bg-green-800/50` | `bg-success`, `bg-success/50` |
| `text-green-300/400` | `text-success-foreground` |
| `bg-yellow-700/50`, `bg-yellow-900/*` | `bg-warning/*` |
| `text-yellow-200/300/400` | `text-warning-foreground` |
| `border-yellow-700` | `border-warning/50` |
| `bg-red-600`, `bg-red-700/30` | `bg-danger`, `bg-danger/30` |
| `text-red-200/300/400` | `text-danger-foreground` |
| `border-red-600/700` | `border-danger` |
| `bg-blue-900/10` | `bg-info/10` |

## Test plan
- [ ] Build succeeds (`npm run build` in ReactClient)
- [ ] Verify badge colors on Spies (in_transit/completed/intercepted)
- [ ] Verify battle outcome colors on EnemyBase
- [ ] Verify rank badges on PlayerHistory
- [ ] Verify warning sections (Diplomacy incoming proposals, Alliance pending invites/members)
- [ ] Verify accept/decline buttons across Diplomacy, Alliances, AllianceDetail
- [ ] Verify Market "my orders" highlight and accept button