### PR TITLE
Fix Diplomacy, Spy, and Players page crashes

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/DiplomacyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/DiplomacyController.cs
@@ -14,8 +14,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.currentUserContext = currentUserContext;
 		}
 
-		[HttpGet]
-		[Route("api/diplomacy/status")]
+		[HttpGet("status")]
 		[ProducesResponseType(typeof(DiplomacyStatusViewModel), StatusCodes.Status200OK)]
 		public ActionResult<DiplomacyStatusViewModel> Status() {
 			if (!currentUserContext.IsValid) return Unauthorized();

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace BrowserGameEngine.FrontendServer.Controllers {
 	[ApiController]
 	[Authorize]
-	[Route("api/players")]
+	[Route("api/player-management")]
 	public class PlayerManagementController : ControllerBase {
 		private readonly ILogger<PlayerManagementController> logger;
 		private readonly CurrentUserContext currentUserContext;

--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpyController.cs
@@ -153,8 +153,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		/// <summary>Dispatches an offensive spy mission against a target player.</summary>
-		[HttpPost]
-		[Route("api/spy/send")]
+		[HttpPost("send")]
 		[ProducesResponseType(typeof(SendSpyMissionResponse), StatusCodes.Status201Created)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -179,8 +178,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		/// <summary>Returns all outgoing spy missions for the current player, most recent first.</summary>
-		[HttpGet]
-		[Route("api/spy/missions")]
+		[HttpGet("missions")]
 		[ProducesResponseType(typeof(IEnumerable<SpyMissionViewModel>), StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<IEnumerable<SpyMissionViewModel>> Missions() {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestBase.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/IntegrationTestBase.cs
@@ -31,13 +31,13 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 
 		/// <summary>
 		/// Creates a player in the default game for the given userId.
-		/// Uses POST /api/players which only requires UserId (not an existing player).
+		/// Uses POST /api/player-management which only requires UserId (not an existing player).
 		/// Returns the created PlayerId string.
 		/// </summary>
 		protected async Task<string> CreatePlayerAsync(string userId, string playerName) {
 			var client = CreateClient(userId);
 			var request = new CreatePlayerForUserViewModel { PlayerName = playerName };
-			var response = await client.PostAsJsonAsync("/api/players", request, JsonOptions);
+			var response = await client.PostAsJsonAsync("/api/player-management", request, JsonOptions);
 			response.EnsureSuccessStatusCode();
 			var vm = await DeserializeAsync<PlayerSummaryViewModel>(response);
 			return vm!.PlayerId;

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
@@ -10,14 +10,14 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 		[Fact]
 		public async Task GetMyPlayers_Unauthenticated_Returns401() {
 			var client = CreateClient();
-			var response = await client.GetAsync("/api/players");
+			var response = await client.GetAsync("/api/player-management");
 			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 		}
 
 		[Fact]
 		public async Task GetMyPlayers_NewUser_ReturnsEmptyList() {
 			var client = CreateClient("user-pm-new-1");
-			var response = await client.GetAsync("/api/players");
+			var response = await client.GetAsync("/api/player-management");
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 			var vm = await DeserializeAsync<PlayerListViewModel>(response);
 			Assert.NotNull(vm);
@@ -30,7 +30,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			await CreatePlayerAsync(userId, "PMTestPlayer1");
 
 			var client = CreateClient(userId);
-			var response = await client.GetAsync("/api/players");
+			var response = await client.GetAsync("/api/player-management");
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 			var vm = await DeserializeAsync<PlayerListViewModel>(response);
 			Assert.NotNull(vm);
@@ -41,7 +41,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 		[Fact]
 		public async Task GenerateApiKey_Unauthenticated_Returns401() {
 			var client = CreateClient();
-			var response = await client.PostAsync("/api/players/some-player-id/apikey", null);
+			var response = await client.PostAsync("/api/player-management/some-player-id/apikey", null);
 			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 		}
 
@@ -51,7 +51,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			var playerId = await CreatePlayerAsync(userId, "APIKeyPlayer1");
 
 			var client = CreateClient(userId);
-			var response = await client.PostAsync($"/api/players/{playerId}/apikey", null);
+			var response = await client.PostAsync($"/api/player-management/{playerId}/apikey", null);
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 			var vm = await DeserializeAsync<ApiKeyViewModel>(response);
 			Assert.NotNull(vm);
@@ -61,7 +61,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 		[Fact]
 		public async Task DeletePlayer_Unauthenticated_Returns401() {
 			var client = CreateClient();
-			var response = await client.DeleteAsync("/api/players/some-player-id");
+			var response = await client.DeleteAsync("/api/player-management/some-player-id");
 			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 		}
 
@@ -73,11 +73,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			await CreatePlayerAsync(userId, "DeleteTestPlayer1");
 
 			var client = CreateClient(userId);
-			var listResp = await client.GetAsync("/api/players");
+			var listResp = await client.GetAsync("/api/player-management");
 			var vm = await DeserializeAsync<PlayerListViewModel>(listResp);
 			var playerId = vm!.Players[0].PlayerId;
 
-			var response = await client.DeleteAsync($"/api/players/{playerId}");
+			var response = await client.DeleteAsync($"/api/player-management/{playerId}");
 			Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
 		}
 	}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -707,7 +707,7 @@ export interface AchievementsViewModel {
   achievements: AchievementViewModel[]
 }
 
-// Player game-completion achievements (api/players/me/achievements)
+// Player game-completion achievements (api/player-management/me/achievements)
 
 export interface PlayerAchievementViewModel {
   achievementType: string

--- a/src/ReactClient/src/pages/Achievements.tsx
+++ b/src/ReactClient/src/pages/Achievements.tsx
@@ -8,7 +8,7 @@ import { ApiError } from '@/components/ApiError'
 export function Achievements() {
   const { data, isLoading, error, refetch } = useQuery<PlayerAchievementsViewModel>({
     queryKey: ['achievements'],
-    queryFn: () => apiClient.get('/api/players/me/achievements').then((r) => r.data),
+    queryFn: () => apiClient.get('/api/player-management/me/achievements').then((r) => r.data),
   })
 
   const formatDate = (d: string) =>

--- a/src/ReactClient/src/pages/Diplomacy.tsx
+++ b/src/ReactClient/src/pages/Diplomacy.tsx
@@ -107,7 +107,7 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
       {statusError && !status && <ApiError message="Failed to load diplomacy status." onRetry={() => void refetchStatus()} />}
 
       {/* Incoming proposals */}
-      {(status?.pendingIncoming.length ?? 0) > 0 && (
+      {(status?.pendingIncoming?.length ?? 0) > 0 && (
         <div className="rounded-lg border border-yellow-700 bg-yellow-900/10">
           <div className="border-b border-yellow-700 bg-yellow-900/20 px-4 py-3">
             <strong className="text-sm text-yellow-200">
@@ -227,7 +227,7 @@ export function Diplomacy({ gameId }: DiplomacyProps) {
       </div>
 
       {/* Sent proposals */}
-      {(status?.pendingSent.length ?? 0) > 0 && (
+      {(status?.pendingSent?.length ?? 0) > 0 && (
         <div className="rounded-lg border bg-card">
           <div className="border-b px-4 py-3">
             <strong className="text-sm">Sent Proposals (awaiting response)</strong>

--- a/src/ReactClient/src/pages/Spies.tsx
+++ b/src/ReactClient/src/pages/Spies.tsx
@@ -254,7 +254,7 @@ export function Spies({ gameId }: SpiesProps) {
             Refresh
           </button>
         </div>
-        {!missions ? (
+        {!missions || !Array.isArray(missions) ? (
           <div className="p-4 text-muted-foreground text-sm">Loading...</div>
         ) : missions.length === 0 ? (
           <div className="p-4 text-muted-foreground text-sm">No active missions.</div>


### PR DESCRIPTION
## Summary
- **BGE-606**: Fix DiplomacyController route attribute from relative `[Route("api/diplomacy/status")]` to `[HttpGet("status")]` so the endpoint is reachable. Add optional chaining on `pendingIncoming` and `pendingSent` in Diplomacy.tsx.
- **BGE-607**: Fix SpyController route attributes from relative `[Route("api/spy/missions")]`/`[Route("api/spy/send")]` to `[HttpGet("missions")]`/`[HttpPost("send")]`. Add `Array.isArray` guard in Spies.tsx.
- **BGE-608**: Move PlayerManagementController base route from `api/players` to `api/player-management` to eliminate `AmbiguousMatchException` with PlayersController on `GET /api/players/all`. Updated React client and integration tests.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (332 tests)
- [ ] Diplomacy page loads without crash
- [ ] Spy/Operations page loads without crash
- [ ] Players list page shows players

Closes BGE-606, BGE-607, BGE-608