### PR TITLE
feat: BGE-612 SignalR GameHub and real-time event publishing

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Events/SignalRGameEventPublisher.cs
+++ b/src/BrowserGameEngine.FrontendServer/Events/SignalRGameEventPublisher.cs
@@ -1,0 +1,70 @@
+using BrowserGameEngine.FrontendServer.Hubs;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Events;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BrowserGameEngine.FrontendServer.Events;
+
+/// <summary>
+/// SignalR-backed implementation of IGameEventPublisher.
+/// Sends real-time events to connected clients via the GameHub.
+/// </summary>
+public class SignalRGameEventPublisher : IGameEventPublisher
+{
+	private readonly IHubContext<GameHub> _hubContext;
+	private readonly PlayerConnectionTracker _tracker;
+	private readonly AllianceRepository _allianceRepository;
+	private readonly ILogger<SignalRGameEventPublisher> _logger;
+
+	public SignalRGameEventPublisher(
+		IHubContext<GameHub> hubContext,
+		PlayerConnectionTracker tracker,
+		AllianceRepository allianceRepository,
+		ILogger<SignalRGameEventPublisher> logger)
+	{
+		_hubContext = hubContext;
+		_tracker = tracker;
+		_allianceRepository = allianceRepository;
+		_logger = logger;
+	}
+
+	public void PublishToPlayer(PlayerId playerId, string eventType, object payload)
+	{
+		var connectionIds = _tracker.GetConnections(playerId);
+		if (connectionIds.Count == 0) return;
+
+		_hubContext.Clients.Clients(connectionIds).SendAsync(eventType, payload)
+			.ConfigureAwait(false);
+		_logger.LogDebug("Published {EventType} to player {PlayerId} ({Count} connections)",
+			eventType, playerId.Id, connectionIds.Count);
+	}
+
+	public void PublishToAlliance(AllianceId allianceId, string eventType, object payload)
+	{
+		var alliance = _allianceRepository.Get(allianceId);
+		if (alliance == null) return;
+
+		var connectionIds = new List<string>();
+		foreach (var member in alliance.Members.Where(m => !m.IsPending)) {
+			connectionIds.AddRange(_tracker.GetConnections(member.PlayerId));
+		}
+		if (connectionIds.Count == 0) return;
+
+		_hubContext.Clients.Clients(connectionIds).SendAsync(eventType, payload)
+			.ConfigureAwait(false);
+		_logger.LogDebug("Published {EventType} to alliance {AllianceId} ({Count} connections)",
+			eventType, allianceId.Id, connectionIds.Count);
+	}
+
+	public void PublishToGame(string eventType, object payload)
+	{
+		var connectionIds = _tracker.GetAllConnectionIds();
+		if (connectionIds.Count == 0) return;
+
+		_hubContext.Clients.Clients(connectionIds).SendAsync(eventType, payload)
+			.ConfigureAwait(false);
+		_logger.LogDebug("Published {EventType} to all ({Count} connections)",
+			eventType, connectionIds.Count);
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Hubs/GameHub.cs
+++ b/src/BrowserGameEngine.FrontendServer/Hubs/GameHub.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BrowserGameEngine.FrontendServer.Hubs;
+
+/// <summary>
+/// Central SignalR hub for real-time game events.
+/// Server-to-client only — all player actions go through REST controllers.
+/// </summary>
+[Authorize]
+public class GameHub : Hub
+{
+	private readonly PlayerConnectionTracker _tracker;
+	private readonly UserRepository _userRepository;
+	private readonly ILogger<GameHub> _logger;
+
+	public GameHub(
+		PlayerConnectionTracker tracker,
+		UserRepository userRepository,
+		ILogger<GameHub> logger)
+	{
+		_tracker = tracker;
+		_userRepository = userRepository;
+		_logger = logger;
+	}
+
+	public override Task OnConnectedAsync()
+	{
+		var playerId = ResolvePlayerId();
+		if (playerId != null) {
+			_tracker.Track(playerId, Context.ConnectionId);
+			_logger.LogDebug("SignalR connected: {PlayerId} -> {ConnectionId}", playerId.Id, Context.ConnectionId);
+		} else {
+			_logger.LogWarning("SignalR connection without resolvable player: {ConnectionId}", Context.ConnectionId);
+		}
+		return base.OnConnectedAsync();
+	}
+
+	public override Task OnDisconnectedAsync(Exception? exception)
+	{
+		_tracker.Untrack(Context.ConnectionId);
+		_logger.LogDebug("SignalR disconnected: {ConnectionId}", Context.ConnectionId);
+		return base.OnDisconnectedAsync(exception);
+	}
+
+	private PlayerId? ResolvePlayerId()
+	{
+		// Bearer token path: BearerTokenMiddleware stores PlayerId in HttpContext.Items
+		var httpContext = Context.GetHttpContext();
+		if (httpContext?.Items.TryGetValue("BearerPlayerId", out var bearerObj) == true
+			&& bearerObj is string bearerPlayerIdStr) {
+			return PlayerIdFactory.Create(bearerPlayerIdStr);
+		}
+
+		// Cookie/OAuth path: resolve from GitHub claims
+		var githubIdClaim = Context.User?.FindFirst(ClaimTypes.NameIdentifier);
+		if (githubIdClaim == null) return null;
+
+		var user = _userRepository.GetByGithubId(githubIdClaim.Value);
+		if (user == null) return null;
+
+		var players = _userRepository.GetPlayersForUser(user.UserId).ToList();
+		if (players.Count == 0) return null;
+
+		// Use the first player (multi-player selection not supported over SignalR)
+		return players[0].PlayerId;
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Hubs/PlayerConnectionTracker.cs
+++ b/src/BrowserGameEngine.FrontendServer/Hubs/PlayerConnectionTracker.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.FrontendServer.Hubs;
+
+/// <summary>
+/// Thread-safe singleton that maps player IDs to active SignalR connection IDs.
+/// A player may have multiple connections (multiple browser tabs).
+/// </summary>
+public class PlayerConnectionTracker
+{
+	private readonly ConcurrentDictionary<string, HashSet<string>> _playerConnections = new();
+	private readonly ConcurrentDictionary<string, string> _connectionToPlayer = new();
+
+	public void Track(PlayerId playerId, string connectionId)
+	{
+		var key = playerId.Id;
+		_connectionToPlayer[connectionId] = key;
+		_playerConnections.AddOrUpdate(
+			key,
+			_ => new HashSet<string> { connectionId },
+			(_, existing) => {
+				lock (existing) {
+					existing.Add(connectionId);
+				}
+				return existing;
+			}
+		);
+	}
+
+	public void Untrack(string connectionId)
+	{
+		if (!_connectionToPlayer.TryRemove(connectionId, out var playerId)) return;
+		if (!_playerConnections.TryGetValue(playerId, out var connections)) return;
+		lock (connections) {
+			connections.Remove(connectionId);
+			if (connections.Count == 0) {
+				_playerConnections.TryRemove(playerId, out _);
+			}
+		}
+	}
+
+	public IReadOnlyList<string> GetConnections(PlayerId playerId)
+	{
+		if (!_playerConnections.TryGetValue(playerId.Id, out var connections)) return [];
+		lock (connections) {
+			return connections.ToList();
+		}
+	}
+
+	public IReadOnlyList<string> GetAllConnectionIds()
+	{
+		return _connectionToPlayer.Keys.ToList();
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -1,8 +1,11 @@
 using Amazon.S3;
 using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Events;
+using BrowserGameEngine.FrontendServer.Hubs;
 using Microsoft.AspNetCore.DataProtection;
 using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.FrontendServer.Services;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.GameModel;
@@ -55,6 +58,9 @@ builder.Services.AddLogging();
 builder.Services.AddHealthChecks()
     .AddCheck<BlobStorageHealthCheck>("blob-storage");
 builder.Services.AddOpenApi();
+builder.Services.AddSignalR();
+builder.Services.AddSingleton<PlayerConnectionTracker>();
+builder.Services.AddSingleton<IGameEventPublisher, SignalRGameEventPublisher>();
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
@@ -210,6 +216,7 @@ app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks
 app.MapDefaultControllerRoute();
 app.MapRazorPages();
 app.MapControllers();
+app.MapHub<GameHub>("/hubs/game");
 app.MapMetrics();
 app.MapFallbackToFile("index.html", new StaticFileOptions {
 	OnPrepareResponse = ctx => {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AlliancesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AlliancesControllerTest.cs
@@ -5,6 +5,7 @@ using System;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
@@ -19,7 +20,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				game.AllianceRepository,
 				game.AllianceRepositoryWrite,
 				new AllianceChatRepository(game.Accessor),
-				new AllianceChatRepositoryWrite(game.Accessor, TimeProvider.System),
+				new AllianceChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance),
 				game.PlayerRepository,
 				NullNotificationService.Instance,
 				game.AllianceInviteRepository,

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ChatTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ChatTest.cs
@@ -1,4 +1,5 @@
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
 using System;
 using Xunit;
@@ -8,7 +9,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void PostMessage_ValidPlayer_MessageStored() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System);
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
 
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Hello world"));
 
@@ -21,7 +22,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void PostMessage_RingBuffer_KeepsLast200() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System);
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
 
 			for (int i = 0; i < 205; i++) {
 				chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, $"Message {i}"));
@@ -36,7 +37,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetMessagesAfter_ReturnsOnlyNewMessages() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System);
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
 
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "First"));
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Second"));
@@ -54,7 +55,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetMessagesAfter_EvictedId_FallsBackToFullReload() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System);
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
 
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Hello"));
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Events/GameEventPublisherIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Events/GameEventPublisherIntegrationTest.cs
@@ -1,0 +1,137 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Events {
+	/// <summary>
+	/// Records all events published through IGameEventPublisher for assertion.
+	/// </summary>
+	public class RecordingGameEventPublisher : IGameEventPublisher {
+		public List<(PlayerId PlayerId, string EventType, object Payload)> PlayerEvents { get; } = new();
+		public List<(AllianceId AllianceId, string EventType, object Payload)> AllianceEvents { get; } = new();
+		public List<(string EventType, object Payload)> GameEvents { get; } = new();
+
+		public void PublishToPlayer(PlayerId playerId, string eventType, object payload) {
+			PlayerEvents.Add((playerId, eventType, payload));
+		}
+
+		public void PublishToAlliance(AllianceId allianceId, string eventType, object payload) {
+			AllianceEvents.Add((allianceId, eventType, payload));
+		}
+
+		public void PublishToGame(string eventType, object payload) {
+			GameEvents.Add((eventType, payload));
+		}
+	}
+
+	public class GameEventPublisherIntegrationTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void NotificationService_Notify_PublishesReceiveNotification() {
+			var game = new TestGame();
+			var recorder = new RecordingGameEventPublisher();
+			var service = new NotificationService(game.Accessor, recorder);
+
+			service.Notify(Player1, GameNotificationType.AttackReceived, "Under attack!", "Details here");
+
+			Assert.Single(recorder.PlayerEvents);
+			Assert.Equal(Player1, recorder.PlayerEvents[0].PlayerId);
+			Assert.Equal(GameEventTypes.ReceiveNotification, recorder.PlayerEvents[0].EventType);
+		}
+
+		[Fact]
+		public void NotificationService_NotifyNonExistentPlayer_DoesNotPublish() {
+			var game = new TestGame();
+			var recorder = new RecordingGameEventPublisher();
+			var service = new NotificationService(game.Accessor, recorder);
+
+			service.Notify(PlayerIdFactory.Create("nonexistent"), GameNotificationType.AttackReceived, "test");
+
+			Assert.Empty(recorder.PlayerEvents);
+		}
+
+		[Fact]
+		public void ChatRepositoryWrite_PostMessage_PublishesReceiveChatMessage() {
+			var game = new TestGame();
+			var recorder = new RecordingGameEventPublisher();
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, System.TimeProvider.System, recorder);
+
+			chatRepo.PostMessage(new PostChatMessageCommand(Player1, "Hello everyone!"));
+
+			Assert.Single(recorder.GameEvents);
+			Assert.Equal(GameEventTypes.ReceiveChatMessage, recorder.GameEvents[0].EventType);
+		}
+
+		[Fact]
+		public void GameTickEngine_IncrementWorldTick_PublishesGameTickCompleted() {
+			var game = new TestGame();
+			var recorder = new RecordingGameEventPublisher();
+			var tickEngine = new GameTicks.GameTickEngine(
+				NullLogger<GameTicks.GameTickEngine>.Instance,
+				game.Accessor,
+				game.GameDef,
+				game.GameTickModuleRegistry,
+				game.PlayerRepositoryWrite,
+				System.TimeProvider.System,
+				recorder
+			);
+
+			tickEngine.IncrementWorldTick();
+
+			Assert.Single(recorder.GameEvents);
+			Assert.Equal(GameEventTypes.GameTickCompleted, recorder.GameEvents[0].EventType);
+		}
+
+		[Fact]
+		public void TradeRepositoryWrite_Accept_PublishesMarketOrderFilled() {
+			var game = new TestGame(playerCount: 2);
+			var recorder = new RecordingGameEventPublisher();
+			var tradeWriteRepo = new TradeRepositoryWrite(
+				game.Accessor, System.TimeProvider.System,
+				NullNotificationService.Instance, recorder,
+				game.ResourceRepository, game.ResourceRepositoryWrite);
+
+			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
+				FromPlayerId: Player1,
+				ToPlayerId: Player2,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50,
+				Note: null
+			));
+
+			tradeWriteRepo.Accept(new AcceptTradeOfferCommand(
+				AcceptingPlayerId: Player2,
+				OfferId: offerId
+			));
+
+			// Should have published to both players
+			var fillEvents = recorder.PlayerEvents.FindAll(e => e.EventType == GameEventTypes.MarketOrderFilled);
+			Assert.Equal(2, fillEvents.Count);
+			Assert.Contains(fillEvents, e => e.PlayerId == Player1);
+			Assert.Contains(fillEvents, e => e.PlayerId == Player2);
+		}
+
+		[Fact]
+		public void InMemoryPlayerNotificationService_Push_PublishesReceiveAlert() {
+			var recorder = new RecordingGameEventPublisher();
+			var service = new InMemoryPlayerNotificationService(recorder);
+
+			service.Push("player0", "Game started!", NotificationKind.GameEvent);
+
+			Assert.Single(recorder.PlayerEvents);
+			Assert.Equal(GameEventTypes.ReceiveAlert, recorder.PlayerEvents[0].EventType);
+			Assert.Equal(Player1, recorder.PlayerEvents[0].PlayerId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Events/PlayerConnectionTrackerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Events/PlayerConnectionTrackerTest.cs
@@ -1,0 +1,108 @@
+using BrowserGameEngine.FrontendServer.Hubs;
+using BrowserGameEngine.GameModel;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test.Events {
+	public class PlayerConnectionTrackerTest {
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		[Fact]
+		public void Track_SingleConnection_ReturnsIt() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+
+			var connections = tracker.GetConnections(Player1);
+			Assert.Single(connections);
+			Assert.Equal("conn1", connections[0]);
+		}
+
+		[Fact]
+		public void Track_MultipleConnections_ReturnsAll() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+			tracker.Track(Player1, "conn2");
+			tracker.Track(Player1, "conn3");
+
+			var connections = tracker.GetConnections(Player1);
+			Assert.Equal(3, connections.Count);
+		}
+
+		[Fact]
+		public void Untrack_RemovesConnection() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+			tracker.Track(Player1, "conn2");
+
+			tracker.Untrack("conn1");
+
+			var connections = tracker.GetConnections(Player1);
+			Assert.Single(connections);
+			Assert.Equal("conn2", connections[0]);
+		}
+
+		[Fact]
+		public void Untrack_LastConnection_CleansUpPlayer() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+
+			tracker.Untrack("conn1");
+
+			var connections = tracker.GetConnections(Player1);
+			Assert.Empty(connections);
+		}
+
+		[Fact]
+		public void Untrack_UnknownConnection_DoesNotThrow() {
+			var tracker = new PlayerConnectionTracker();
+			var ex = Record.Exception(() => tracker.Untrack("nonexistent"));
+			Assert.Null(ex);
+		}
+
+		[Fact]
+		public void GetConnections_UnknownPlayer_ReturnsEmpty() {
+			var tracker = new PlayerConnectionTracker();
+			var connections = tracker.GetConnections(Player1);
+			Assert.Empty(connections);
+		}
+
+		[Fact]
+		public void GetAllConnectionIds_ReturnsAllConnections() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+			tracker.Track(Player2, "conn2");
+			tracker.Track(Player1, "conn3");
+
+			var all = tracker.GetAllConnectionIds();
+			Assert.Equal(3, all.Count);
+		}
+
+		[Fact]
+		public void MultiplePlayers_IsolatedConnections() {
+			var tracker = new PlayerConnectionTracker();
+			tracker.Track(Player1, "conn1");
+			tracker.Track(Player2, "conn2");
+
+			Assert.Single(tracker.GetConnections(Player1));
+			Assert.Equal("conn1", tracker.GetConnections(Player1)[0]);
+			Assert.Single(tracker.GetConnections(Player2));
+			Assert.Equal("conn2", tracker.GetConnections(Player2)[0]);
+		}
+
+		[Fact]
+		public async System.Threading.Tasks.Task ConcurrentTrackUntrack_DoesNotThrow() {
+			var tracker = new PlayerConnectionTracker();
+			var tasks = new System.Threading.Tasks.Task[100];
+			for (int i = 0; i < 100; i++) {
+				int idx = i;
+				tasks[i] = System.Threading.Tasks.Task.Run(() => {
+					tracker.Track(Player1, $"conn{idx}");
+					tracker.Untrack($"conn{idx}");
+				});
+			}
+			await System.Threading.Tasks.Task.WhenAll(tasks);
+			// All connections should be cleaned up
+			Assert.Empty(tracker.GetConnections(Player1));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -94,7 +94,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				persistenceService,
 				globalPersistenceService,
 				new GameRegistryNs.NullGameNotificationService(),
-				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance),
 				userRepositoryWrite,
 				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
@@ -233,7 +233,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				persistenceService,
 				globalPersistenceService,
 				new GameRegistryNs.NullGameNotificationService(),
-				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance),
 				userRepoWrite,
 				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.Persistence;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -62,7 +63,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				persistenceService,
 				globalPersistenceService,
 				new NullGameNotificationService(),
-				new InMemoryPlayerNotificationService(),
+				new InMemoryPlayerNotificationService(NullGameEventPublisher.Instance),
 				userRepositoryWrite,
 				TimeProvider.System,
 				NullLogger<GameRegistry.GameLifecycleEngine>.Instance

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -56,7 +56,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				new PersistenceService(storage, serializer),
 				new GlobalPersistenceService(storage, globalSerializer),
 				new GameRegistryNs.NullGameNotificationService(),
-				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(),
+				new BrowserGameEngine.StatefulGameServer.Notifications.InMemoryPlayerNotificationService(BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance),
 				userRepositoryWrite,
 				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance

--- a/src/BrowserGameEngine.StatefulGameServer.Test/NotificationServiceTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/NotificationServiceTest.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using System;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void Notify_AddsNotificationToPlayer() {
 			var game = new TestGame(playerCount: 2);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack!", "You were attacked.");
 
@@ -30,7 +31,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void MarkRead_SetsReadAt() {
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.MessageReceived, "Hello");
 			var notifications = service.GetNotifications(Player1);
@@ -45,7 +46,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void MarkAllRead_MarksAllNotificationsRead() {
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack 1");
 			service.Notify(Player1, GameNotificationType.MessageReceived, "Msg 1");
@@ -61,7 +62,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetNotifications_UnreadOnly_ReturnsOnlyUnread() {
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.AttackReceived, "Attack 1");
 			service.Notify(Player1, GameNotificationType.MessageReceived, "Msg 1");
@@ -78,7 +79,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetNotifications_OrderedByCreatedAtDescending() {
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.AttackReceived, "First");
 			service.Notify(Player1, GameNotificationType.MessageReceived, "Second");
@@ -94,7 +95,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void Notify_NonExistentPlayer_DoesNotThrow() {
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 			var fakePlayerId = PlayerIdFactory.Create("nonexistent");
 
 			// Should silently do nothing
@@ -106,7 +107,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void Notifications_PersistedInPlayerStateImmutable() {
 			// Verify notifications are stored in player state (would survive serialization)
 			var game = new TestGame(playerCount: 1);
-			var service = new NotificationService(game.Accessor);
+			var service = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 
 			service.Notify(Player1, GameNotificationType.SpyAttempted, "Spy detected!");
 
@@ -121,7 +122,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void SendMessage_CreatesMessageReceivedNotification() {
 			var game = new TestGame(playerCount: 2);
 			// Use a real NotificationService (not the NullNotificationService from TestGame)
-			var notificationService = new NotificationService(game.Accessor);
+			var notificationService = new NotificationService(game.Accessor, NullGameEventPublisher.Instance);
 			var messageRepositoryWrite = new MessageRepositoryWrite(game.Accessor, TimeProvider.System, notificationService);
 
 			messageRepositoryWrite.Send(new SendMessageCommand(Player1, Player2, "Hello", "World message body"));

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -96,7 +97,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));
 			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger(), TechRepository));
 			GameTickModuleRegistry = new GameTickModuleRegistry(LoggerFactory.CreateLogger<GameTickModuleRegistry>(), services.BuildServiceProvider(), GameDef);
-			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), Accessor, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System);
+			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), Accessor, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System, NullGameEventPublisher.Instance);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TradeRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TradeRepositoryTest.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using System;
@@ -15,7 +16,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void CreateOffer_ReturnsValidOfferId() {
 			var game = new TestGame(playerCount: 2);
 			var tradeRepo = new TradeRepository(game.Accessor);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
 				FromPlayerId: Player1,
@@ -39,7 +40,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void Accept_TransfersResourcesBetweenPlayers() {
 			var game = new TestGame(playerCount: 2);
 			var tradeRepo = new TradeRepository(game.Accessor);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			var p1Res1Before = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res1"));
 			var p1Res2Before = game.ResourceRepository.GetAmount(Player1, Id.ResDef("res2"));
@@ -78,7 +79,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void Accept_FailsIfAcceptorHasInsufficientResources() {
 			var game = new TestGame(playerCount: 2);
 			var tradeRepo = new TradeRepository(game.Accessor);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
 				FromPlayerId: Player1,
@@ -104,7 +105,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void Decline_SetsStatusToDeclined() {
 			var game = new TestGame(playerCount: 2);
 			var tradeRepo = new TradeRepository(game.Accessor);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
 				FromPlayerId: Player1,
@@ -130,7 +131,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public void Cancel_ByOfferor_SetsStatusToCancelled() {
 			var game = new TestGame(playerCount: 2);
 			var tradeRepo = new TradeRepository(game.Accessor);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			var offerId = tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
 				FromPlayerId: Player1,
@@ -155,7 +156,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void TradeOffers_RoundTripThroughImmutable() {
 			var game = new TestGame(playerCount: 2);
-			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
+			var tradeWriteRepo = new TradeRepositoryWrite(game.Accessor, TimeProvider.System, NullNotificationService.Instance, NullGameEventPublisher.Instance, game.ResourceRepository, game.ResourceRepositoryWrite);
 
 			tradeWriteRepo.CreateOffer(new CreateTradeOfferCommand(
 				FromPlayerId: Player1,

--- a/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
@@ -3,6 +3,7 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
@@ -39,7 +40,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				persistenceService,
 				globalPersistenceService,
 				new GameRegistryNs.NullGameNotificationService(),
-				new InMemoryPlayerNotificationService(),
+				new InMemoryPlayerNotificationService(NullGameEventPublisher.Instance),
 				userRepositoryWrite,
 				TimeProvider.System,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance

--- a/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
@@ -1,0 +1,12 @@
+namespace BrowserGameEngine.StatefulGameServer.Events;
+
+/// <summary>Well-known SignalR event method names pushed to clients.</summary>
+public static class GameEventTypes
+{
+	public const string ReceiveNotification = "ReceiveNotification";
+	public const string ReceiveAlert = "ReceiveAlert";
+	public const string ReceiveChatMessage = "ReceiveChatMessage";
+	public const string ReceiveAllianceChatMessage = "ReceiveAllianceChatMessage";
+	public const string GameTickCompleted = "GameTickCompleted";
+	public const string MarketOrderFilled = "MarketOrderFilled";
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/IGameEventPublisher.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/IGameEventPublisher.cs
@@ -1,0 +1,14 @@
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.Events;
+
+/// <summary>
+/// Publishes real-time game events to connected clients.
+/// Implementations may use SignalR, no-op (tests), or other transports.
+/// </summary>
+public interface IGameEventPublisher
+{
+	void PublishToPlayer(PlayerId playerId, string eventType, object payload);
+	void PublishToAlliance(AllianceId allianceId, string eventType, object payload);
+	void PublishToGame(string eventType, object payload);
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/NullGameEventPublisher.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/NullGameEventPublisher.cs
@@ -1,0 +1,13 @@
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.Events;
+
+/// <summary>No-op implementation used in tests and when SignalR is not configured.</summary>
+public class NullGameEventPublisher : IGameEventPublisher
+{
+	public static readonly NullGameEventPublisher Instance = new();
+
+	public void PublishToPlayer(PlayerId playerId, string eventType, object payload) { }
+	public void PublishToAlliance(AllianceId allianceId, string eventType, object payload) { }
+	public void PublishToGame(string eventType, object payload) { }
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton(defaultInstance.WorldState);
 			services.AddSingleton(defaultInstance.GameDef);
 			services.AddSingleton(TimeProvider.System);
+			services.AddSingleton<IGameEventPublisher, NullGameEventPublisher>();
 			services.AddSingleton<GameRepository>();
 
 			services.AddSingleton<UserRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/GameTickEngine.cs
@@ -1,4 +1,5 @@
 ﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using Microsoft.Extensions.Logging;
 using System;
@@ -25,6 +26,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 		private readonly GameTickModuleRegistry gameTickModuleRegistry;
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly TimeProvider timeProvider;
+		private readonly IGameEventPublisher eventPublisher;
 
 		private readonly Lock _tickLock = new();
 		private volatile bool isPaused = false;
@@ -36,6 +38,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 				, GameTickModuleRegistry gameTickModuleRegistry
 				, PlayerRepositoryWrite playerRepositoryWrite
 				, TimeProvider timeProvider
+				, IGameEventPublisher eventPublisher
 			) {
 			this.logger = logger;
 			this.worldStateAccessor = worldStateAccessor;
@@ -43,6 +46,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 			this.gameTickModuleRegistry = gameTickModuleRegistry;
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.timeProvider = timeProvider;
+			this.eventPublisher = eventPublisher;
 		}
 
 		public void CheckAllTicks() {
@@ -124,7 +128,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks {
 					worldState.GameTickState.LastUpdate += duration;
 					logger.LogDebug("Incremented World Tick to #{CurrentTick}. LastUpdate: {LastUpdate}", worldState.GameTickState.CurrentGameTick.Tick, worldState.GameTickState.LastUpdate);
 				}
-				return worldState.GameTickState.CurrentGameTick;
+				var completedTick = worldState.GameTickState.CurrentGameTick;
+				eventPublisher.PublishToGame(GameEventTypes.GameTickCompleted, new {
+					tick = completedTick.Tick,
+					timestamp = timeProvider.GetUtcNow().UtcDateTime
+				});
+				return completedTick;
 			}
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/InMemoryPlayerNotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/InMemoryPlayerNotificationService.cs
@@ -1,3 +1,5 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Events;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -9,6 +11,11 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 
 		// Each user has a fixed-capacity ring of notifications; newest first
 		private readonly ConcurrentDictionary<string, LinkedList<PlayerNotification>> _store = new();
+		private readonly IGameEventPublisher eventPublisher;
+
+		public InMemoryPlayerNotificationService(IGameEventPublisher eventPublisher) {
+			this.eventPublisher = eventPublisher;
+		}
 
 		public void Push(string userId, string message, NotificationKind kind) {
 			var notification = new PlayerNotification(
@@ -35,6 +42,13 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 					return existing;
 				}
 			);
+
+			// userId is the PlayerId string for this service
+			eventPublisher.PublishToPlayer(PlayerIdFactory.Create(userId), GameEventTypes.ReceiveAlert, new {
+				message,
+				kind = kind.ToString(),
+				createdAt = notification.CreatedAt
+			});
 		}
 
 		public List<PlayerNotification> GetRecent(string userId, int limit = 20) {

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
@@ -1,4 +1,5 @@
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
@@ -10,9 +11,11 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
+		private readonly IGameEventPublisher eventPublisher;
 
-		public NotificationService(IWorldStateAccessor worldStateAccessor) {
+		public NotificationService(IWorldStateAccessor worldStateAccessor, IGameEventPublisher eventPublisher) {
 			this.worldStateAccessor = worldStateAccessor;
+			this.eventPublisher = eventPublisher;
 		}
 
 		public void Notify(PlayerId playerId, GameNotificationType type, string title, string? body = null) {
@@ -28,6 +31,12 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 			lock (_lock) {
 				world.GetPlayer(playerId).State.Notifications.Add(notification);
 			}
+			eventPublisher.PublishToPlayer(playerId, GameEventTypes.ReceiveNotification, new {
+				type = type.ToString(),
+				title,
+				body,
+				createdAt = notification.CreatedAt
+			});
 		}
 
 		public void MarkRead(PlayerId playerId, Guid notificationId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Threading;
@@ -10,10 +11,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
+		private readonly IGameEventPublisher eventPublisher;
 
-		public AllianceChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+		public AllianceChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider, IGameEventPublisher eventPublisher) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
+			this.eventPublisher = eventPublisher;
 		}
 
 		public AlliancePostId Post(PostAllianceChatCommand command) {
@@ -31,6 +34,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 					CreatedAt = timeProvider.GetUtcNow().UtcDateTime
 				});
 			}
+			var authorName = world.GetPlayer(command.PlayerId).Name;
+			eventPublisher.PublishToAlliance(command.AllianceId, GameEventTypes.ReceiveAllianceChatMessage, new {
+				postId = postId.Id.ToString(),
+				authorPlayerId = command.PlayerId.Id,
+				authorName,
+				body = command.Body,
+				createdAt = timeProvider.GetUtcNow().UtcDateTime
+			});
 			return postId;
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
@@ -12,11 +13,13 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 		private WorldState world => worldStateAccessor.WorldState;
 		private System.Threading.Lock ChatMessagesLock => world.ChatMessagesLock;
 		private readonly TimeProvider timeProvider;
+		private readonly IGameEventPublisher eventPublisher;
 		private const int MaxMessages = 200;
 
-		public ChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider) {
+		public ChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider, IGameEventPublisher eventPublisher) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
+			this.eventPublisher = eventPublisher;
 		}
 
 		public IList<ChatMessageImmutable> GetMessages(int count = 50) {
@@ -73,6 +76,14 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 					world.ChatMessages.RemoveAt(0);
 				}
 			}
+			var authorName = world.GetPlayer(command.AuthorPlayerId).Name;
+			eventPublisher.PublishToGame(GameEventTypes.ReceiveChatMessage, new {
+				messageId = messageId.Id,
+				authorPlayerId = command.AuthorPlayerId.Id,
+				authorName,
+				body = command.Body,
+				createdAt = timeProvider.GetUtcNow().UtcDateTime
+			});
 			return messageId;
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Trade/TradeRepositoryWrite.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using System;
@@ -11,6 +12,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
 		private readonly INotificationService notificationService;
+		private readonly IGameEventPublisher eventPublisher;
 		private readonly ResourceRepository resourceRepository;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
 
@@ -18,12 +20,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 			IWorldStateAccessor worldStateAccessor,
 			TimeProvider timeProvider,
 			INotificationService notificationService,
+			IGameEventPublisher eventPublisher,
 			ResourceRepository resourceRepository,
 			ResourceRepositoryWrite resourceRepositoryWrite
 		) {
 			this.worldStateAccessor = worldStateAccessor;
 			this.timeProvider = timeProvider;
 			this.notificationService = notificationService;
+			this.eventPublisher = eventPublisher;
 			this.resourceRepository = resourceRepository;
 			this.resourceRepositoryWrite = resourceRepositoryWrite;
 		}
@@ -87,6 +91,16 @@ namespace BrowserGameEngine.StatefulGameServer {
 				}
 
 				offer.Status = TradeOfferStatus.Accepted;
+
+				var fillPayload = new {
+					offeredResource = offer.OfferedResourceId.Id,
+					offeredAmount = offer.OfferedAmount,
+					wantedResource = offer.WantedResourceId.Id,
+					wantedAmount = offer.WantedAmount
+				};
+				eventPublisher.PublishToPlayer(offer.FromPlayerId, GameEventTypes.MarketOrderFilled, fillPayload);
+				eventPublisher.PublishToPlayer(command.AcceptingPlayerId, GameEventTypes.MarketOrderFilled, fillPayload);
+
 				return true;
 			}
 		}


### PR DESCRIPTION
## Summary
- Add SignalR `GameHub` with player-scoped connection tracking (`PlayerConnectionTracker`) mapped at `/hubs/game`
- Introduce `IGameEventPublisher` interface in StatefulGameServer, decoupling game logic from SignalR transport
- Implement `SignalRGameEventPublisher` backed by `IHubContext<GameHub>` with player, alliance, and game-wide targeting
- Wire real-time event publishing into: notifications, alerts, chat, alliance chat, game tick completion, and trade order fills
- Hub authenticates via existing cookie/bearer auth — no new auth infrastructure needed
- Add 15 new tests covering `PlayerConnectionTracker` thread safety and event publishing integration from game logic

## Architecture
Following the plan from BGE-609:
- **Server-to-client only** — all player actions still go through REST controllers
- **Graceful degradation** — REST API and polling remain unchanged; SignalR is an additive push layer
- **Single-server first** — Redis backplane documented as follow-up but not implemented

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (347 tests, 0 failures)
- [x] PlayerConnectionTracker concurrent track/untrack test
- [x] Integration tests verify events fire from NotificationService, ChatRepositoryWrite, GameTickEngine, TradeRepositoryWrite, InMemoryPlayerNotificationService
- [ ] Manual: connect SignalR client to `/hubs/game`, verify events received on chat/notification actions

Closes BGE-612