### PR TITLE
feat: BGE-629 admin dashboard with player moderation and game management

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -38,6 +38,8 @@ public class AdminController : ControllerBase
 	private readonly IBlobStorage storage;
 	private readonly IActionLogger actionLogger;
 	private readonly GameDef gameDef;
+	private readonly ScoreRepository scoreRepository;
+	private readonly MarketRepository marketRepository;
 
 	public AdminController(
 		ILogger<AdminController> logger,
@@ -54,7 +56,9 @@ public class AdminController : ControllerBase
 		GameStateJsonSerializer serializer,
 		IBlobStorage storage,
 		IActionLogger actionLogger,
-		GameDef gameDef
+		GameDef gameDef,
+		ScoreRepository scoreRepository,
+		MarketRepository marketRepository
 	)
 	{
 		this.logger = logger;
@@ -72,6 +76,8 @@ public class AdminController : ControllerBase
 		this.storage = storage;
 		this.actionLogger = actionLogger;
 		this.gameDef = gameDef;
+		this.scoreRepository = scoreRepository;
+		this.marketRepository = marketRepository;
 	}
 
 	// ── Existing cheat endpoints ──────────────────────────────────────────────
@@ -253,9 +259,125 @@ public class AdminController : ControllerBase
 		if (!options.Value.DevAuth) return NotFound();
 		return Ok(actionLogger.GetRecentEntries());
 	}
+
+	// ── Player Moderation ─────────────────────────────────────────────────────
+
+	[HttpGet("players/{playerId}")]
+	public ActionResult GetPlayerDetail(string playerId)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var pid = PlayerIdFactory.Create(playerId);
+		if (!playerRepository.Exists(pid)) return NotFound($"Player '{playerId}' not found.");
+		var player = playerRepository.Get(pid);
+		var resources = new Dictionary<string, decimal>();
+		foreach (var resDef in gameDef.Resources) {
+			resources[resDef.Id.Id] = resourceRepository.GetAmount(pid, resDef.Id);
+		}
+		return Ok(new {
+			playerId = player.PlayerId.Id,
+			name = player.Name,
+			playerType = player.PlayerType.Id,
+			created = player.Created,
+			lastOnline = player.LastOnline,
+			isBanned = player.IsBanned,
+			allianceId = player.AllianceId?.Id,
+			score = scoreRepository.GetScore(pid),
+			resources,
+			unitCount = player.State.Units.Count,
+			assetCount = player.State.Assets.Count,
+			currentTick = player.State.CurrentGameTick.Tick,
+			protectionTicksRemaining = player.State.ProtectionTicksRemaining,
+			mineralWorkers = player.State.MineralWorkers,
+			gasWorkers = player.State.GasWorkers,
+		});
+	}
+
+	[HttpGet("players-detail")]
+	public ActionResult GetPlayersDetail()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var players = playerRepository.GetAll().Select(p => new {
+			playerId = p.PlayerId.Id,
+			name = p.Name,
+			playerType = p.PlayerType.Id,
+			created = p.Created,
+			lastOnline = p.LastOnline,
+			isBanned = p.IsBanned,
+			allianceId = p.AllianceId?.Id,
+			score = scoreRepository.GetScore(p.PlayerId),
+			unitCount = p.State.Units.Count,
+			assetCount = p.State.Assets.Count,
+		}).OrderByDescending(p => p.score);
+		return Ok(players);
+	}
+
+	[HttpPost("ban-player")]
+	public ActionResult BanPlayer([FromBody] BanPlayerRequest request)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var playerId = PlayerIdFactory.Create(request.PlayerId);
+		if (!playerRepository.Exists(playerId)) return NotFound($"Player '{request.PlayerId}' not found.");
+		playerRepositoryWrite.BanPlayer(playerId);
+		logger.LogWarning("Player {PlayerId} banned via admin endpoint", request.PlayerId);
+		return Ok(new { playerId = request.PlayerId, isBanned = true });
+	}
+
+	[HttpPost("unban-player")]
+	public ActionResult UnbanPlayer([FromBody] UnbanPlayerRequest request)
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var playerId = PlayerIdFactory.Create(request.PlayerId);
+		if (!playerRepository.Exists(playerId)) return NotFound($"Player '{request.PlayerId}' not found.");
+		playerRepositoryWrite.UnbanPlayer(playerId);
+		logger.LogInformation("Player {PlayerId} unbanned via admin endpoint", request.PlayerId);
+		return Ok(new { playerId = request.PlayerId, isBanned = false });
+	}
+
+	// ── Live Stats ────────────────────────────────────────────────────────────
+
+	[HttpGet("live-stats")]
+	public ActionResult GetLiveStats()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var players = playerRepository.GetAll().ToList();
+		var totalResources = new Dictionary<string, decimal>();
+		foreach (var resDef in gameDef.Resources) {
+			totalResources[resDef.Id.Id] = players.Sum(p => p.State.Resources.TryGetValue(resDef.Id, out var val) ? val : 0);
+		}
+		var openOrders = marketRepository.GetOpenOrders();
+		var recentlyOnline = players.Count(p => p.LastOnline.HasValue && p.LastOnline.Value > DateTime.UtcNow.AddMinutes(-15));
+		var snapshot = worldState.ToImmutable();
+		return Ok(new {
+			totalPlayers = players.Count,
+			activePlayers = recentlyOnline,
+			bannedPlayers = players.Count(p => p.IsBanned),
+			totalResources,
+			openMarketOrders = openOrders.Count,
+			currentTick = snapshot.GameTickState.CurrentGameTick.Tick,
+			isPaused = gameTickEngine.IsPaused,
+			effectiveTickDurationSeconds = gameTickEngine.EffectiveTickDuration.TotalSeconds,
+		});
+	}
+
+	// ── Tick Status ───────────────────────────────────────────────────────────
+
+	[HttpGet("tick-status")]
+	public ActionResult GetTickStatus()
+	{
+		if (!options.Value.DevAuth) return NotFound();
+		var snapshot = worldState.ToImmutable();
+		return Ok(new {
+			currentTick = snapshot.GameTickState.CurrentGameTick.Tick,
+			isPaused = gameTickEngine.IsPaused,
+			effectiveTickDurationSeconds = gameTickEngine.EffectiveTickDuration.TotalSeconds,
+			defaultTickDurationSeconds = gameDef.TickDuration.TotalSeconds,
+		});
+	}
 }
 
 public record SetResourcesRequest(string PlayerId, string ResourceDefId, decimal Amount);
 public record GrantBuildingRequest(string PlayerId, string AssetDefId);
 public record GrantUnitsRequest(string PlayerId, string UnitDefId, int Count);
 public record ResetPlayerRequest(string PlayerId);
+public record BanPlayerRequest(string PlayerId);
+public record UnbanPlayerRequest(string PlayerId);

--- a/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
@@ -13,6 +13,7 @@ namespace BrowserGameEngine.GameModel {
 		string? UserId = null,
 		string? ApiKeyHash = null,
 		DateTime? LastOnline = null,
-		AllianceId? AllianceId = null
+		AllianceId? AllianceId = null,
+		bool IsBanned = false
 	);
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PlayerRepositoryTest.cs
@@ -1,4 +1,5 @@
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Linq;
 using Xunit;
@@ -153,6 +154,43 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			// player2 score = 1000, which is >= 1500 * 0.5 = 750
 
 			Assert.Null(game.PlayerRepository.GetIneligibilityReason(player1, player2));
+		}
+
+		[Fact]
+		public void BanPlayer_SetsIsBannedTrue() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+
+			game.PlayerRepositoryWrite.BanPlayer(playerId);
+
+			var player = game.PlayerRepository.Get(playerId);
+			Assert.True(player.IsBanned);
+		}
+
+		[Fact]
+		public void UnbanPlayer_SetsIsBannedFalse() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+
+			game.PlayerRepositoryWrite.BanPlayer(playerId);
+			game.PlayerRepositoryWrite.UnbanPlayer(playerId);
+
+			var player = game.PlayerRepository.Get(playerId);
+			Assert.False(player.IsBanned);
+		}
+
+		[Fact]
+		public void BanPlayer_IsBannedSurvivesSerialization() {
+			var game = new TestGame(playerCount: 1);
+			var playerId = PlayerIdFactory.Create("player0");
+
+			game.PlayerRepositoryWrite.BanPlayer(playerId);
+
+			// Round-trip through immutable/mutable
+			var immutable = game.World.ToImmutable();
+			var game2 = new TestGame(immutable);
+			var player = game2.PlayerRepository.Get(playerId);
+			Assert.True(player.IsBanned);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
@@ -15,6 +15,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public string? ApiKeyHash { get; set; }
 		public DateTime? LastOnline { get; set; }
 		public AllianceId? AllianceId { get; set; }
+		public bool IsBanned { get; set; }
 	}
 
 	internal static class PlayerExtensions {
@@ -28,7 +29,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UserId: player.UserId,
 				ApiKeyHash: player.ApiKeyHash,
 				LastOnline: player.LastOnline,
-				AllianceId: player.AllianceId
+				AllianceId: player.AllianceId,
+				IsBanned: player.IsBanned
 			);
 		}
 
@@ -42,7 +44,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				UserId = playerImmutable.UserId,
 				ApiKeyHash = playerImmutable.ApiKeyHash,
 				LastOnline = playerImmutable.LastOnline,
-				AllianceId = playerImmutable.AllianceId
+				AllianceId = playerImmutable.AllianceId,
+				IsBanned = playerImmutable.IsBanned
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -118,6 +118,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		public void BanPlayer(PlayerId playerId) {
+			lock (_lock) {
+				world.GetPlayer(playerId).IsBanned = true;
+			}
+		}
+
+		public void UnbanPlayer(PlayerId playerId) {
+			lock (_lock) {
+				world.GetPlayer(playerId).IsBanned = false;
+			}
+		}
+
 		public void DeletePlayer(PlayerId playerId) {
 			lock (_lock) {
 				if (!world.PlayerExists(playerId)) return;

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -36,6 +36,9 @@ const Achievements = lazy(() => import('@/pages/Achievements').then(m => ({ defa
 const PlayerHistory = lazy(() => import('@/pages/PlayerHistory').then(m => ({ default: m.PlayerHistory })))
 const PublicProfile = lazy(() => import('@/pages/PublicProfile').then(m => ({ default: m.PublicProfile })))
 const AdminGames = lazy(() => import('@/pages/admin/AdminGames').then(m => ({ default: m.AdminGames })))
+const AdminPlayers = lazy(() => import('@/pages/admin/AdminPlayers').then(m => ({ default: m.AdminPlayers })))
+const AdminTickControl = lazy(() => import('@/pages/admin/AdminTickControl').then(m => ({ default: m.AdminTickControl })))
+const AdminStats = lazy(() => import('@/pages/admin/AdminStats').then(m => ({ default: m.AdminStats })))
 const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ default: m.PlayersList })))
 const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
 
@@ -184,6 +187,9 @@ const router = createBrowserRouter([
       { path: '/achievements', element: <Achievements /> },
       { path: '/history', element: <PlayerHistory /> },
       { path: '/admin/games', element: <AdminGames /> },
+      { path: '/admin/players', element: <AdminPlayers /> },
+      { path: '/admin/ticks', element: <AdminTickControl /> },
+      { path: '/admin/stats', element: <AdminStats /> },
     ],
   },
 ])

--- a/src/ReactClient/src/pages/admin/AdminGames.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGames.tsx
@@ -5,6 +5,7 @@ import apiClient from '@/api/client'
 import type { GameListViewModel, GameSummaryViewModel, CreateGameRequest, UpdateGameRequest } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
 
 interface EditState {
   gameId: string
@@ -156,6 +157,7 @@ export function AdminGames() {
 
   return (
     <div className="p-6 max-w-4xl mx-auto">
+      <AdminNav />
       <h1 className="text-2xl font-bold mb-6">Game Admin</h1>
 
       {/* Create Game */}

--- a/src/ReactClient/src/pages/admin/AdminNav.tsx
+++ b/src/ReactClient/src/pages/admin/AdminNav.tsx
@@ -1,0 +1,29 @@
+import { useLocation } from 'react-router'
+
+const links = [
+  { path: '/admin/games', label: 'Games' },
+  { path: '/admin/players', label: 'Players' },
+  { path: '/admin/ticks', label: 'Tick Control' },
+  { path: '/admin/stats', label: 'Live Stats' },
+]
+
+export function AdminNav() {
+  const location = useLocation()
+  return (
+    <nav className="flex gap-1 mb-6 border-b border-border pb-2">
+      {links.map(({ path, label }) => (
+        <a
+          key={path}
+          href={path}
+          className={`px-3 py-1.5 rounded text-sm ${
+            location.pathname === path
+              ? 'bg-primary text-primary-foreground'
+              : 'hover:bg-muted text-muted-foreground'
+          }`}
+        >
+          {label}
+        </a>
+      ))}
+    </nav>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminPlayers.tsx
+++ b/src/ReactClient/src/pages/admin/AdminPlayers.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface AdminPlayerEntry {
+  playerId: string
+  name: string
+  playerType: string
+  created: string
+  lastOnline: string | null
+  isBanned: boolean
+  allianceId: string | null
+  score: number
+  unitCount: number
+  assetCount: number
+}
+
+interface AdminPlayerDetail extends AdminPlayerEntry {
+  resources: Record<string, number>
+  currentTick: number
+  protectionTicksRemaining: number
+  mineralWorkers: number
+  gasWorkers: number
+}
+
+export function AdminPlayers() {
+  const queryClient = useQueryClient()
+  const [selectedPlayer, setSelectedPlayer] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const { data: players, isLoading, error, refetch } = useQuery<AdminPlayerEntry[]>({
+    queryKey: ['admin-players'],
+    queryFn: () => apiClient.get('/api/admin/players-detail').then((r) => r.data),
+  })
+
+  const { data: detail } = useQuery<AdminPlayerDetail>({
+    queryKey: ['admin-player-detail', selectedPlayer],
+    queryFn: () => apiClient.get(`/api/admin/players/${selectedPlayer}`).then((r) => r.data),
+    enabled: !!selectedPlayer,
+  })
+
+  const banMutation = useMutation({
+    mutationFn: (playerId: string) => apiClient.post('/api/admin/ban-player', { playerId }),
+    onSuccess: () => {
+      setActionError(null)
+      queryClient.invalidateQueries({ queryKey: ['admin-players'] })
+      queryClient.invalidateQueries({ queryKey: ['admin-player-detail'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Ban failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  const unbanMutation = useMutation({
+    mutationFn: (playerId: string) => apiClient.post('/api/admin/unban-player', { playerId }),
+    onSuccess: () => {
+      setActionError(null)
+      queryClient.invalidateQueries({ queryKey: ['admin-players'] })
+      queryClient.invalidateQueries({ queryKey: ['admin-player-detail'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Unban failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  const resetMutation = useMutation({
+    mutationFn: (playerId: string) => apiClient.post('/api/admin/reset-player', { playerId }),
+    onSuccess: () => {
+      setActionError(null)
+      queryClient.invalidateQueries({ queryKey: ['admin-players'] })
+      queryClient.invalidateQueries({ queryKey: ['admin-player-detail'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Reset failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Player Moderation</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Player Moderation</h1>
+        <ApiError message="Failed to load players." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-6">Player Moderation</h1>
+
+      {actionError && (
+        <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">
+          {actionError}
+        </div>
+      )}
+
+      {isLoading ? (
+        <PageLoader message="Loading players..." />
+      ) : !players || players.length === 0 ? (
+        <p className="text-muted-foreground">No players found.</p>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th scope="col" className="px-3 py-2 text-left font-medium">Name</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Type</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Score</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium hidden md:table-cell">Units</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium hidden md:table-cell">Last Online</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Status</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {players.map((player) => (
+                <>
+                  <tr key={player.playerId} className="border-b border-border/50">
+                    <td className="px-3 py-2 font-medium">{player.name}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{player.playerType}</td>
+                    <td className="px-3 py-2 text-right">{player.score}</td>
+                    <td className="px-3 py-2 text-right text-muted-foreground hidden md:table-cell">{player.unitCount}</td>
+                    <td className="px-3 py-2 text-muted-foreground hidden md:table-cell">
+                      {player.lastOnline ? new Date(player.lastOnline).toLocaleString() : 'Never'}
+                    </td>
+                    <td className="px-3 py-2">
+                      {player.isBanned ? (
+                        <span className="text-xs px-2 py-0.5 rounded font-bold bg-destructive text-destructive-foreground">
+                          Banned
+                        </span>
+                      ) : (
+                        <span className="text-xs px-2 py-0.5 rounded font-bold bg-success text-success-foreground">
+                          Active
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => setSelectedPlayer(selectedPlayer === player.playerId ? null : player.playerId)}
+                          className="px-2 py-1 rounded border border-border text-xs hover:bg-muted"
+                        >
+                          {selectedPlayer === player.playerId ? 'Hide' : 'Details'}
+                        </button>
+                        {player.isBanned ? (
+                          <button
+                            onClick={() => unbanMutation.mutate(player.playerId)}
+                            disabled={unbanMutation.isPending}
+                            className="px-2 py-1 rounded bg-success text-success-foreground text-xs hover:bg-success/90 disabled:opacity-50"
+                          >
+                            Unban
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => banMutation.mutate(player.playerId)}
+                            disabled={banMutation.isPending}
+                            className="px-2 py-1 rounded bg-destructive text-destructive-foreground text-xs hover:bg-destructive/90 disabled:opacity-50"
+                          >
+                            Ban
+                          </button>
+                        )}
+                        <button
+                          onClick={() => {
+                            if (window.confirm(`Reset player "${player.name}" to initial state?`)) {
+                              resetMutation.mutate(player.playerId)
+                            }
+                          }}
+                          disabled={resetMutation.isPending}
+                          className="px-2 py-1 rounded border border-destructive text-destructive text-xs hover:bg-destructive/10 disabled:opacity-50"
+                        >
+                          Reset
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  {selectedPlayer === player.playerId && detail && (
+                    <tr key={`${player.playerId}-detail`} className="border-b border-border/50 bg-muted/20">
+                      <td colSpan={7} className="px-4 py-4">
+                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                          <div>
+                            <div className="text-xs text-muted-foreground">Player ID</div>
+                            <div className="font-mono text-xs">{detail.playerId}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Created</div>
+                            <div>{new Date(detail.created).toLocaleString()}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Alliance</div>
+                            <div>{detail.allianceId ?? 'None'}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Current Tick</div>
+                            <div>{detail.currentTick}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Protection Ticks</div>
+                            <div>{detail.protectionTicksRemaining}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Workers (M/G)</div>
+                            <div>{detail.mineralWorkers} / {detail.gasWorkers}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Assets</div>
+                            <div>{detail.assetCount}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">Units</div>
+                            <div>{detail.unitCount}</div>
+                          </div>
+                        </div>
+                        {detail.resources && Object.keys(detail.resources).length > 0 && (
+                          <div className="mt-3">
+                            <div className="text-xs text-muted-foreground mb-1">Resources</div>
+                            <div className="flex gap-4 flex-wrap">
+                              {Object.entries(detail.resources).map(([key, val]) => (
+                                <div key={key} className="text-sm">
+                                  <span className="font-medium">{key}:</span>{' '}
+                                  <span className="text-muted-foreground">{Number(val).toLocaleString()}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminStats.tsx
+++ b/src/ReactClient/src/pages/admin/AdminStats.tsx
@@ -1,0 +1,121 @@
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface LiveStats {
+  totalPlayers: number
+  activePlayers: number
+  bannedPlayers: number
+  totalResources: Record<string, number>
+  openMarketOrders: number
+  currentTick: number
+  isPaused: boolean
+  effectiveTickDurationSeconds: number
+}
+
+export function AdminStats() {
+  const { data: stats, isLoading, error, refetch } = useQuery<LiveStats>({
+    queryKey: ['admin-live-stats'],
+    queryFn: () => apiClient.get('/api/admin/live-stats').then((r) => r.data),
+    refetchInterval: 10000,
+  })
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Live Stats</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Live Stats</h1>
+        <ApiError message="Failed to load live stats." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-6">Live Stats</h1>
+
+      {isLoading || !stats ? (
+        <PageLoader message="Loading stats..." />
+      ) : (
+        <div className="space-y-6">
+          {/* Player Stats */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Players</h2>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.totalPlayers}</div>
+                <div className="text-xs text-muted-foreground">Total</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-success-foreground">{stats.activePlayers}</div>
+                <div className="text-xs text-muted-foreground">Active (15m)</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-destructive">{stats.bannedPlayers}</div>
+                <div className="text-xs text-muted-foreground">Banned</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Tick Info */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Tick Engine</h2>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.currentTick}</div>
+                <div className="text-xs text-muted-foreground">Current Tick</div>
+              </div>
+              <div className="text-center">
+                <div className={`text-3xl font-bold ${stats.isPaused ? 'text-warning' : 'text-success-foreground'}`}>
+                  {stats.isPaused ? 'Paused' : 'Running'}
+                </div>
+                <div className="text-xs text-muted-foreground">Status</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.effectiveTickDurationSeconds}s</div>
+                <div className="text-xs text-muted-foreground">Tick Duration</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Economy */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Economy</h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {Object.entries(stats.totalResources).map(([key, val]) => (
+                <div key={key} className="text-center">
+                  <div className="text-2xl font-bold">{Number(val).toLocaleString()}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{key}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Market */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Market</h2>
+            <div className="grid grid-cols-1 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.openMarketOrders}</div>
+                <div className="text-xs text-muted-foreground">Open Market Orders</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminTickControl.tsx
+++ b/src/ReactClient/src/pages/admin/AdminTickControl.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface TickStatus {
+  currentTick: number
+  isPaused: boolean
+  effectiveTickDurationSeconds: number
+  defaultTickDurationSeconds: number
+}
+
+export function AdminTickControl() {
+  const queryClient = useQueryClient()
+  const [tickCount, setTickCount] = useState(1)
+  const [tickDuration, setTickDuration] = useState('')
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
+
+  const { data: status, isLoading, error, refetch } = useQuery<TickStatus>({
+    queryKey: ['admin-tick-status'],
+    queryFn: () => apiClient.get('/api/admin/tick-status').then((r) => r.data),
+    refetchInterval: 5000,
+  })
+
+  const pauseMutation = useMutation({
+    mutationFn: () => apiClient.post('/api/admin/pause-ticks'),
+    onSuccess: () => {
+      setActionError(null)
+      setActionSuccess('Ticks paused.')
+      queryClient.invalidateQueries({ queryKey: ['admin-tick-status'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Pause failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  const resumeMutation = useMutation({
+    mutationFn: () => apiClient.post('/api/admin/resume-ticks'),
+    onSuccess: () => {
+      setActionError(null)
+      setActionSuccess('Ticks resumed.')
+      queryClient.invalidateQueries({ queryKey: ['admin-tick-status'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Resume failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  const forceTickMutation = useMutation({
+    mutationFn: (count: number) => apiClient.post(`/api/admin/force-tick?count=${count}`),
+    onSuccess: (_, count) => {
+      setActionError(null)
+      setActionSuccess(`Forced ${count} tick(s).`)
+      queryClient.invalidateQueries({ queryKey: ['admin-tick-status'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Force tick failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  const setDurationMutation = useMutation({
+    mutationFn: (seconds: number) => apiClient.post(`/api/admin/set-tick-duration?seconds=${seconds}`),
+    onSuccess: (_, seconds) => {
+      setActionError(null)
+      setActionSuccess(`Tick duration set to ${seconds}s.`)
+      setTickDuration('')
+      queryClient.invalidateQueries({ queryKey: ['admin-tick-status'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Set duration failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Game Tick Control</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Game Tick Control</h1>
+        <ApiError message="Failed to load tick status." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-6">Game Tick Control</h1>
+
+      {actionError && (
+        <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">
+          {actionError}
+        </div>
+      )}
+      {actionSuccess && (
+        <div className="rounded border border-success/50 bg-success/10 p-3 text-success-foreground text-sm mb-4">
+          {actionSuccess}
+        </div>
+      )}
+
+      {isLoading || !status ? (
+        <PageLoader message="Loading tick status..." />
+      ) : (
+        <div className="space-y-6">
+          {/* Status */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Current Status</h2>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <div className="text-xs text-muted-foreground">Current Tick</div>
+                <div className="text-lg font-bold">{status.currentTick}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Status</div>
+                <div className="text-lg font-bold">
+                  {status.isPaused ? (
+                    <span className="text-warning">Paused</span>
+                  ) : (
+                    <span className="text-success-foreground">Running</span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Tick Duration</div>
+                <div>{status.effectiveTickDurationSeconds}s</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Default Duration</div>
+                <div>{status.defaultTickDurationSeconds}s</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Pause / Resume */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Tick Engine</h2>
+            <div className="flex gap-2">
+              <button
+                onClick={() => pauseMutation.mutate()}
+                disabled={pauseMutation.isPending || status.isPaused}
+                className="px-4 py-2 rounded bg-warning text-warning-foreground text-sm hover:bg-warning/90 disabled:opacity-50"
+              >
+                Pause
+              </button>
+              <button
+                onClick={() => resumeMutation.mutate()}
+                disabled={resumeMutation.isPending || !status.isPaused}
+                className="px-4 py-2 rounded bg-success text-success-foreground text-sm hover:bg-success/90 disabled:opacity-50"
+              >
+                Resume
+              </button>
+            </div>
+          </div>
+
+          {/* Force Tick */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Force Tick</h2>
+            <div className="flex items-end gap-2">
+              <div>
+                <label className="block text-xs font-medium mb-1">Tick Count</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={1000}
+                  value={tickCount}
+                  onChange={(e) => setTickCount(Math.max(1, Math.min(1000, parseInt(e.target.value) || 1)))}
+                  className="w-24 rounded border border-input bg-background px-3 py-2 text-sm"
+                />
+              </div>
+              <button
+                onClick={() => forceTickMutation.mutate(tickCount)}
+                disabled={forceTickMutation.isPending}
+                className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+              >
+                {forceTickMutation.isPending ? 'Running...' : 'Force Tick'}
+              </button>
+            </div>
+          </div>
+
+          {/* Set Tick Duration */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Override Tick Duration</h2>
+            <div className="flex items-end gap-2">
+              <div>
+                <label className="block text-xs font-medium mb-1">Seconds (1-86400)</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={86400}
+                  placeholder={String(status.effectiveTickDurationSeconds)}
+                  value={tickDuration}
+                  onChange={(e) => setTickDuration(e.target.value)}
+                  className="w-32 rounded border border-input bg-background px-3 py-2 text-sm"
+                />
+              </div>
+              <button
+                onClick={() => {
+                  const secs = parseInt(tickDuration)
+                  if (secs >= 1 && secs <= 86400) setDurationMutation.mutate(secs)
+                }}
+                disabled={setDurationMutation.isPending || !tickDuration}
+                className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+              >
+                Set Duration
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Player moderation**: View detailed player info (resources, units, assets, workers), ban/unban players, reset player state — all via new admin UI
- **Game tick control**: Pause/resume tick engine, force ticks, override tick duration — dedicated admin page with live status
- **Live stats dashboard**: Active players (15m window), total economy resources, open market orders, tick engine status — auto-refreshing every 10s
- **Admin navigation**: Shared nav bar linking Games, Players, Tick Control, and Live Stats admin pages
- **IsBanned model field**: Added to Player/PlayerImmutable with serialization round-trip support

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (350 tests, 3 new ban/unban tests)
- [x] React client builds (`npm run build`)
- [ ] Manual: Navigate to `/admin/players` — verify player list with ban/unban/reset actions
- [ ] Manual: Navigate to `/admin/ticks` — verify pause/resume/force tick/set duration
- [ ] Manual: Navigate to `/admin/stats` — verify live stats auto-refresh
- [ ] Manual: Admin nav links work across all admin pages

Closes BGE-629