### PR TITLE
feat: BGE-639 complete Zerg race data

### DIFF
--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -186,20 +186,53 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Cost = CostHelper.Create(("minerals", 150), ("gas", 200)),
 						Attack = 0,
 						Defense = 0,
-						Hitpoints = 500, // TODO
+						Hitpoints = 500,
 						BuildTimeTicks = new GameTick(50),
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("hydraliskden") }
+					},
+					new AssetDef {
+						Id = Id.AssetDef("spire"),
+						Name = "Spire",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 200), ("gas", 150)),
+						Attack = 0,
+						Defense = 0,
+						Hitpoints = 600,
+						BuildTimeTicks = new GameTick(40),
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("spawningpool") }
 					},
 					new AssetDef {
 						Id = Id.AssetDef("greaterspire"),
 						Name = "Greater Spire",
 						PlayerTypeRestriction = Id.PlayerType("zerg"),
-						Cost = CostHelper.Create(("minerals", 200), ("gas", 150)),
+						Cost = CostHelper.Create(("minerals", 100), ("gas", 150)),
 						Attack = 0,
 						Defense = 0,
-						Hitpoints = 500, // TODO
+						Hitpoints = 800,
 						BuildTimeTicks = new GameTick(60),
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") }
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spire") }
+					},
+					new AssetDef {
+						Id = Id.AssetDef("queensnest"),
+						Name = "Queen's Nest",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 150), ("gas", 100)),
+						Attack = 0,
+						Defense = 0,
+						Hitpoints = 400,
+						BuildTimeTicks = new GameTick(30),
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spawningpool") }
+					},
+					new AssetDef {
+						Id = Id.AssetDef("defilermond"),
+						Name = "Defiler Mound",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 100), ("gas", 100)),
+						Attack = 0,
+						Defense = 0,
+						Hitpoints = 400,
+						BuildTimeTicks = new GameTick(45),
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("ultraliskcavern") }
 					},
 
 					// Protoss buildings
@@ -496,7 +529,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Defense = 26,
 						Hitpoints = 120,
 						Speed = 7,
-						Prerequisites = new List<AssetDefId> { Id.AssetDef("greaterspire") },
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spire") },
 						AttackBonuses = [1, 2, 3],
 						DefenseBonuses = [2, 4, 6]
 					},
@@ -539,6 +572,59 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") },
 						AttackBonuses = [0, 0, 0],
 						DefenseBonuses = [2, 4, 6]
+					},
+					new UnitDef {
+						Id = Id.UnitDef("sporecolony"),
+						Name = "Spore Colony",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 125)),
+						Attack = 0,
+						Defense = 18,
+						Hitpoints = 200,
+						Speed = 0,
+						IsMobile = false,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("evolutionchamber") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [2, 4, 6]
+					},
+					new UnitDef {
+						Id = Id.UnitDef("queen"),
+						Name = "Queen",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 100), ("gas", 100)),
+						Attack = 8,
+						Defense = 10,
+						Hitpoints = 120,
+						Speed = 6,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("queensnest") },
+						AttackBonuses = [1, 2, 3],
+						DefenseBonuses = [1, 2, 3]
+					},
+					new UnitDef {
+						Id = Id.UnitDef("scourge"),
+						Name = "Scourge",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 25), ("gas", 75)),
+						Attack = 40,
+						Defense = 0,
+						Hitpoints = 25,
+						Speed = 4,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("spire") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [0, 0, 0]
+					},
+					new UnitDef {
+						Id = Id.UnitDef("defiler"),
+						Name = "Defiler",
+						PlayerTypeRestriction = Id.PlayerType("zerg"),
+						Cost = CostHelper.Create(("minerals", 50), ("gas", 150)),
+						Attack = 5,
+						Defense = 15,
+						Hitpoints = 80,
+						Speed = 8,
+						Prerequisites = new List<AssetDefId> { Id.AssetDef("defilermond") },
+						AttackBonuses = [0, 0, 0],
+						DefenseBonuses = [1, 2, 3]
 					},
 
 					// Protoss units

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ZergRaceDataTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ZergRaceDataTest.cs
@@ -1,0 +1,150 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test;
+
+public class ZergRaceDataTest
+{
+	private readonly GameDef _gameDef;
+	private readonly PlayerTypeDefId _zerg = Id.PlayerType("zerg");
+
+	public ZergRaceDataTest()
+	{
+		_gameDef = new StarcraftOnlineGameDefFactory().CreateGameDef();
+	}
+
+	[Fact]
+	public void ScoGameDef_PassesValidation()
+	{
+		new GameDefVerifier().Verify(_gameDef);
+	}
+
+	[Fact]
+	public void ZergPlayerType_Exists()
+	{
+		Assert.Contains(_gameDef.PlayerTypes, pt => pt.Id == _zerg);
+	}
+
+	[Theory]
+	[InlineData("hive")]
+	[InlineData("spawningpool")]
+	[InlineData("evolutionchamber")]
+	[InlineData("hydraliskden")]
+	[InlineData("ultraliskcavern")]
+	[InlineData("spire")]
+	[InlineData("greaterspire")]
+	[InlineData("queensnest")]
+	[InlineData("defilermond")]
+	public void ZergBuilding_Exists(string buildingId)
+	{
+		var asset = _gameDef.GetAssetDef(Id.AssetDef(buildingId));
+		Assert.NotNull(asset);
+		Assert.Equal(_zerg, asset!.PlayerTypeRestriction);
+	}
+
+	[Theory]
+	[InlineData("drone")]
+	[InlineData("zergling")]
+	[InlineData("hydralisk")]
+	[InlineData("lurker")]
+	[InlineData("ultralisk")]
+	[InlineData("mutalisk")]
+	[InlineData("guardian")]
+	[InlineData("devourer")]
+	[InlineData("sunkencolony")]
+	[InlineData("sporecolony")]
+	[InlineData("queen")]
+	[InlineData("scourge")]
+	[InlineData("defiler")]
+	public void ZergUnit_Exists(string unitId)
+	{
+		var unit = _gameDef.GetUnitDef(Id.UnitDef(unitId));
+		Assert.NotNull(unit);
+		Assert.Equal(_zerg, unit!.PlayerTypeRestriction);
+	}
+
+	[Fact]
+	public void ZergBuildings_HaveValidPrerequisites()
+	{
+		var zergAssets = _gameDef.GetAssetsByPlayerType(_zerg);
+		foreach (var asset in zergAssets) {
+			foreach (var prereq in asset.Prerequisites) {
+				Assert.NotNull(_gameDef.GetAssetDef(prereq));
+			}
+		}
+	}
+
+	[Fact]
+	public void ZergUnits_HaveValidPrerequisites()
+	{
+		var zergUnits = _gameDef.GetUnitsByPlayerType(_zerg);
+		foreach (var unit in zergUnits) {
+			Assert.NotEmpty(unit.Prerequisites);
+			foreach (var prereq in unit.Prerequisites) {
+				Assert.NotNull(_gameDef.GetAssetDef(prereq));
+			}
+		}
+	}
+
+	[Fact]
+	public void ZergUnits_HavePositiveHitpoints()
+	{
+		var zergUnits = _gameDef.GetUnitsByPlayerType(_zerg);
+		foreach (var unit in zergUnits) {
+			Assert.True(unit.Hitpoints > 0, $"{unit.Id} must have positive hitpoints");
+		}
+	}
+
+	[Fact]
+	public void ZergTechTree_SpireBeforeGreaterSpire()
+	{
+		var spire = _gameDef.GetAssetDef(Id.AssetDef("spire"));
+		var greaterSpire = _gameDef.GetAssetDef(Id.AssetDef("greaterspire"));
+		Assert.NotNull(spire);
+		Assert.NotNull(greaterSpire);
+		Assert.Contains(Id.AssetDef("spire"), greaterSpire!.Prerequisites);
+	}
+
+	[Fact]
+	public void ZergTechTree_HiveIsRoot()
+	{
+		var hive = _gameDef.GetAssetDef(Id.AssetDef("hive"));
+		Assert.NotNull(hive);
+		Assert.Empty(hive!.Prerequisites);
+	}
+
+	[Fact]
+	public void ZergWorkerUnit_IsDrone()
+	{
+		var drone = _gameDef.GetUnitDef(Id.UnitDef("drone"));
+		Assert.NotNull(drone);
+		Assert.Equal(0, drone!.Attack);
+		Assert.True(drone.IsMobile);
+	}
+
+	[Fact]
+	public void ZergDefensiveStructures_AreNotMobile()
+	{
+		var sunken = _gameDef.GetUnitDef(Id.UnitDef("sunkencolony"));
+		var spore = _gameDef.GetUnitDef(Id.UnitDef("sporecolony"));
+		Assert.False(sunken!.IsMobile);
+		Assert.False(spore!.IsMobile);
+	}
+
+	[Fact]
+	public void Zerg_HasMinimumBuildingCount()
+	{
+		var zergAssets = _gameDef.GetAssetsByPlayerType(_zerg).ToList();
+		Assert.True(zergAssets.Count >= 9, $"Zerg should have at least 9 buildings, found {zergAssets.Count}");
+	}
+
+	[Fact]
+	public void Zerg_HasMinimumUnitCount()
+	{
+		var zergUnits = _gameDef.GetUnitsByPlayerType(_zerg).ToList();
+		Assert.True(zergUnits.Count >= 13, $"Zerg should have at least 13 units, found {zergUnits.Count}");
+	}
+}


### PR DESCRIPTION
## Summary
- Add missing Zerg buildings: Spire (mid-tier air prereq), Queen's Nest, Defiler Mound
- Add missing Zerg units: Queen, Defiler, Scourge, Spore Colony (anti-air defense)
- Fix Zerg tech tree: Spire → Greater Spire chain, Ultralisk Cavern requires Hydralisk Den
- Zerg now has 9 buildings and 13 units (up from 6 buildings and 9 units)
- Add ZergRaceDataTest with 33 tests covering data loading, prerequisites, and structure

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (383/383)
- [ ] Verify Zerg buildings/units appear correctly in game UI
- [ ] Verify Zerg tech tree prerequisite chain works in-game

Closes BGE-639