### PR TITLE
feat: BGE-613 real-time notification toasts + SignalR client

### DIFF
--- a/src/ReactClient/package-lock.json
+++ b/src/ReactClient/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bge-react-client",
       "version": "0.0.0",
       "dependencies": {
+        "@microsoft/signalr": "^10.0.0",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.2",
@@ -1063,6 +1064,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
       }
     },
     "node_modules/@playwright/test": {
@@ -3017,6 +3031,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3712,6 +3738,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3749,6 +3793,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4569,6 +4623,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -4775,15 +4849,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -4908,6 +4999,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -5093,6 +5190,27 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5171,6 +5289,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -5210,6 +5337,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -5331,6 +5468,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5355,6 +5508,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/src/ReactClient/package.json
+++ b/src/ReactClient/package.json
@@ -13,6 +13,7 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
+    "@microsoft/signalr": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.2",

--- a/src/ReactClient/src/components/NotificationBell.tsx
+++ b/src/ReactClient/src/components/NotificationBell.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { BellIcon } from 'lucide-react'
 import { useNotifications } from '@/hooks/useNotifications'
+import type { UseSignalRReturn } from '@/hooks/useSignalR'
 import { relativeTime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 
@@ -12,8 +13,16 @@ function notificationIcon(kind: string): string {
   }
 }
 
-export function NotificationBell() {
-  const { notifications, dismissAll } = useNotifications()
+interface NotificationBellProps {
+  signalR?: UseSignalRReturn
+  onRealTimeNotification?: (n: { type: string; title: string; body?: string; createdAt: string }) => void
+}
+
+export function NotificationBell({ signalR, onRealTimeNotification }: NotificationBellProps) {
+  const { notifications, dismissAll } = useNotifications({
+    signalR,
+    onRealTimeNotification,
+  })
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 

--- a/src/ReactClient/src/components/NotificationToast.tsx
+++ b/src/ReactClient/src/components/NotificationToast.tsx
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router'
+import { XIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface Toast {
+  id: string
+  type: string
+  title: string
+  body?: string
+  createdAt: string
+}
+
+const MAX_VISIBLE = 3
+const AUTO_DISMISS_MS = 5_000
+
+function toastIcon(type: string): string {
+  switch (type) {
+    case 'Attack':
+    case 'BattleResult': return '⚔️'
+    case 'SpyDetected':
+    case 'SpyReport': return '🕵️'
+    case 'TradeComplete':
+    case 'MarketOrderFilled': return '💰'
+    case 'MessageReceived': return '📩'
+    case 'GameEvent': return '⚡'
+    case 'Warning': return '⚠️'
+    default: return 'ℹ️'
+  }
+}
+
+function toastRoute(type: string): string | null {
+  switch (type) {
+    case 'Attack':
+    case 'BattleResult': return 'units'
+    case 'SpyDetected':
+    case 'SpyReport': return 'spy'
+    case 'TradeComplete':
+    case 'MarketOrderFilled': return 'market'
+    case 'MessageReceived': return 'messages'
+    default: return null
+  }
+}
+
+export function useNotificationToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = crypto.randomUUID()
+    setToasts((prev) => [{ ...toast, id }, ...prev].slice(0, MAX_VISIBLE + 5))
+  }, [])
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return { toasts: toasts.slice(0, MAX_VISIBLE), addToast, dismiss }
+}
+
+export function NotificationToasts({
+  toasts,
+  dismiss,
+  gameId,
+}: {
+  toasts: Toast[]
+  dismiss: (id: string) => void
+  gameId: string | null
+}) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="fixed top-3 right-3 z-50 flex flex-col gap-2 w-80">
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} dismiss={dismiss} gameId={gameId} />
+      ))}
+    </div>
+  )
+}
+
+function ToastItem({
+  toast,
+  dismiss,
+  gameId,
+}: {
+  toast: Toast
+  dismiss: (id: string) => void
+  gameId: string | null
+}) {
+  const navigate = useNavigate()
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => dismiss(toast.id), AUTO_DISMISS_MS)
+    return () => clearTimeout(timerRef.current)
+  }, [toast.id, dismiss])
+
+  function handleClick() {
+    const route = toastRoute(toast.type)
+    if (route && gameId) {
+      navigate(`/games/${gameId}/${route}`)
+    }
+    dismiss(toast.id)
+  }
+
+  return (
+    <div
+      onClick={handleClick}
+      className={cn(
+        'flex items-start gap-2.5 rounded-lg border bg-card px-4 py-3 shadow-lg',
+        'animate-in slide-in-from-right-4 fade-in duration-300',
+        'cursor-pointer hover:bg-secondary/40 transition-colors'
+      )}
+    >
+      <span className="text-lg mt-0.5 shrink-0">{toastIcon(toast.type)}</span>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium leading-snug">{toast.title}</p>
+        {toast.body && (
+          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{toast.body}</p>
+        )}
+      </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); dismiss(toast.id) }}
+        className="shrink-0 text-muted-foreground hover:text-foreground p-0.5"
+        aria-label="Dismiss"
+      >
+        <XIcon className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/ReactClient/src/components/NotificationToast.tsx
+++ b/src/ReactClient/src/components/NotificationToast.tsx
@@ -87,7 +87,7 @@ function ToastItem({
   gameId: string | null
 }) {
   const navigate = useNavigate()
-  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
     timerRef.current = setTimeout(() => dismiss(toast.id), AUTO_DISMISS_MS)

--- a/src/ReactClient/src/hooks/useNotifications.ts
+++ b/src/ReactClient/src/hooks/useNotifications.ts
@@ -1,8 +1,15 @@
+import { useEffect, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import apiClient from '@/api/client'
 import type { PlayerNotificationViewModel } from '@/api/types'
+import type { UseSignalRReturn } from './useSignalR'
 
-export function useNotifications() {
+interface UseNotificationsOptions {
+  signalR?: UseSignalRReturn
+  onRealTimeNotification?: (notification: { type: string; title: string; body?: string; createdAt: string }) => void
+}
+
+export function useNotifications(options?: UseNotificationsOptions) {
   const queryClient = useQueryClient()
 
   const { data: notifications = [] } = useQuery({
@@ -11,8 +18,39 @@ export function useNotifications() {
       apiClient
         .get<PlayerNotificationViewModel[]>('/api/notifications/recent')
         .then((r) => r.data),
-    refetchInterval: 30_000,
+    // Poll less frequently if SignalR is connected
+    refetchInterval: options?.signalR?.status === 'connected' ? 120_000 : 30_000,
   })
+
+  // Listen for real-time notifications via SignalR
+  const handler = useCallback(
+    (...args: unknown[]) => {
+      const payload = args[0] as { type?: string; title?: string; body?: string; createdAt?: string }
+      if (!payload?.title) return
+
+      // Refresh the query to pick up the new notification
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+
+      // Fire toast callback
+      options?.onRealTimeNotification?.({
+        type: payload.type ?? 'Info',
+        title: payload.title,
+        body: payload.body,
+        createdAt: payload.createdAt ?? new Date().toISOString(),
+      })
+    },
+    [queryClient, options?.onRealTimeNotification]
+  )
+
+  useEffect(() => {
+    if (!options?.signalR) return
+    options.signalR.on('ReceiveNotification', handler)
+    options.signalR.on('ReceiveAlert', handler)
+    return () => {
+      options.signalR?.off('ReceiveNotification', handler)
+      options.signalR?.off('ReceiveAlert', handler)
+    }
+  }, [options?.signalR, handler])
 
   const dismissAll = useMutation({
     mutationFn: () => apiClient.delete('/api/notifications/recent'),

--- a/src/ReactClient/src/hooks/useSignalR.ts
+++ b/src/ReactClient/src/hooks/useSignalR.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { HubConnection, HubConnectionBuilder, LogLevel, HttpTransportType } from '@microsoft/signalr'
+
+export type SignalRStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting'
+
+export interface UseSignalRReturn {
+  connection: HubConnection | null
+  status: SignalRStatus
+  on: (method: string, handler: (...args: unknown[]) => void) => void
+  off: (method: string, handler: (...args: unknown[]) => void) => void
+}
+
+export function useSignalR(hubUrl: string = '/gamehub'): UseSignalRReturn {
+  const connRef = useRef<HubConnection | null>(null)
+  const [status, setStatus] = useState<SignalRStatus>('disconnected')
+
+  useEffect(() => {
+    const connection = new HubConnectionBuilder()
+      .withUrl(hubUrl, {
+        transport: HttpTransportType.WebSockets | HttpTransportType.LongPolling,
+      })
+      .withAutomaticReconnect([0, 2_000, 5_000, 10_000, 30_000])
+      .configureLogging(LogLevel.Warning)
+      .build()
+
+    connRef.current = connection
+
+    connection.onreconnecting(() => setStatus('reconnecting'))
+    connection.onreconnected(() => setStatus('connected'))
+    connection.onclose(() => setStatus('disconnected'))
+
+    setStatus('connecting')
+    connection
+      .start()
+      .then(() => setStatus('connected'))
+      .catch(() => setStatus('disconnected'))
+
+    return () => {
+      connection.stop()
+      connRef.current = null
+    }
+  }, [hubUrl])
+
+  const on = useCallback(
+    (method: string, handler: (...args: unknown[]) => void) => {
+      connRef.current?.on(method, handler)
+    },
+    []
+  )
+
+  const off = useCallback(
+    (method: string, handler: (...args: unknown[]) => void) => {
+      connRef.current?.off(method, handler)
+    },
+    []
+  )
+
+  return { connection: connRef.current, status, on, off }
+}

--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -1,13 +1,14 @@
-import { Suspense, useState } from 'react'
+import { Suspense, useState, useCallback, useEffect } from 'react'
 import { Outlet, NavLink, useParams, Navigate, useLocation } from 'react-router'
-import { GamepadIcon, LogOutIcon, MenuIcon, XIcon } from 'lucide-react'
+import { GamepadIcon, LogOutIcon, MenuIcon, XIcon, WifiIcon, WifiOffIcon } from 'lucide-react'
 import { CurrentGameProvider, useCurrentGame } from '@/contexts/CurrentGameContext'
 import { NavMenu } from '@/components/NavMenu'
 import { PlayerResources } from '@/components/PlayerResources'
 import { NotificationBell } from '@/components/NotificationBell'
+import { NotificationToasts, useNotificationToasts } from '@/components/NotificationToast'
 import { PageLoader } from '@/components/PageLoader'
+import { useSignalR } from '@/hooks/useSignalR'
 import { cn } from '@/lib/utils'
-import { useEffect } from 'react'
 import { vcText, vcBadgeCss } from '@/lib/victory'
 import type { GameDetailViewModel } from '@/api/types'
 
@@ -96,6 +97,15 @@ function GameLayoutInner() {
   const { gameId, currentGame } = useCurrentGame()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const location = useLocation()
+  const signalR = useSignalR('/gamehub')
+  const { toasts, addToast, dismiss } = useNotificationToasts()
+
+  const onRealTimeNotification = useCallback(
+    (n: { type: string; title: string; body?: string; createdAt: string }) => {
+      addToast(n)
+    },
+    [addToast]
+  )
 
   // Close mobile sidebar on navigation
   useEffect(() => {
@@ -154,7 +164,17 @@ function GameLayoutInner() {
           <div className="hidden md:block" />
           <div className="flex items-center gap-2 sm:gap-3 overflow-x-auto">
             <PlayerResources gameId={gameId} />
-            <NotificationBell />
+            <span
+              className="hidden sm:inline-flex"
+              title={`Real-time: ${signalR.status}`}
+            >
+              {signalR.status === 'connected' ? (
+                <WifiIcon className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <WifiOffIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+            </span>
+            <NotificationBell signalR={signalR} onRealTimeNotification={onRealTimeNotification} />
           </div>
         </header>
 
@@ -173,6 +193,9 @@ function GameLayoutInner() {
           </Suspense>
         </main>
       </div>
+
+      {/* Real-time notification toasts */}
+      <NotificationToasts toasts={toasts} dismiss={dismiss} gameId={gameId} />
     </div>
   )
 }

--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { SendIcon, WifiIcon, WifiOffIcon } from 'lucide-react'
+import { SendIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { ChatMessagesViewModel, ChatMessageViewModel, PostChatMessageRequest } from '@/api/types'
 import { useSignalR } from '@/hooks/useSignalR'

--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { SendIcon } from 'lucide-react'
+import { SendIcon, WifiIcon, WifiOffIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ChatMessagesViewModel, PostChatMessageRequest } from '@/api/types'
+import type { ChatMessagesViewModel, ChatMessageViewModel, PostChatMessageRequest } from '@/api/types'
+import { useSignalR } from '@/hooks/useSignalR'
 import { cn } from '@/lib/utils'
 
 interface ChatProps {
@@ -15,6 +16,8 @@ export function ChatPanel({ gameId }: ChatProps) {
   const [allMessages, setAllMessages] = useState<ChatMessagesViewModel['messages']>([])
   const [error, setError] = useState<string | null>(null)
   const chatEndRef = useRef<HTMLDivElement>(null)
+  const signalR = useSignalR('/gamehub')
+  const isRealTime = signalR.status === 'connected'
 
   // Initial load
   useEffect(() => {
@@ -25,7 +28,26 @@ export function ChatPanel({ gameId }: ChatProps) {
     })
   }, [gameId])
 
-  // Poll for new messages
+  // Listen for real-time chat messages via SignalR
+  const handleChatMessage = useCallback(
+    (...args: unknown[]) => {
+      const msg = args[0] as ChatMessageViewModel | undefined
+      if (!msg?.messageId) return
+      setAllMessages((prev) => {
+        if (prev.some((m) => m.messageId === msg.messageId)) return prev
+        return [...prev, msg]
+      })
+      setLastMessageId(msg.messageId)
+    },
+    []
+  )
+
+  useEffect(() => {
+    signalR.on('ReceiveChatMessage', handleChatMessage)
+    return () => signalR.off('ReceiveChatMessage', handleChatMessage)
+  }, [signalR, handleChatMessage])
+
+  // Fallback polling — only when SignalR is not connected
   useQuery({
     queryKey: ['chat-poll', gameId, lastMessageId],
     queryFn: async () => {
@@ -38,8 +60,8 @@ export function ChatPanel({ gameId }: ChatProps) {
       }
       return r.data
     },
-    refetchInterval: 5_000,
-    enabled: true,
+    refetchInterval: isRealTime ? false : 5_000,
+    enabled: !isRealTime,
   })
 
   // Scroll to bottom on new messages


### PR DESCRIPTION
## Summary

Adds real-time push notifications to the React client using the SignalR GameHub from [BGE-612](/BGE/issues/BGE-612). Implements [BGE-613](/BGE/issues/BGE-613).

### SignalR client setup (`useSignalR` hook)
- Connects to `/gamehub` on mount with WebSocket + LongPolling fallback
- Automatic reconnect: 0 / 2 / 5 / 10 / 30s backoff
- Exposes `{ connection, status, on, off }` — status-driven UI

### Notification toast component (`NotificationToast`)
- Slides in from top-right on real-time events
- Auto-dismisses after 5 seconds
- Shows icon based on event type (attack, spy, trade, message, game event)
- Clicking navigates to the relevant page
- Stacks up to 3 visible toasts

### Notification bell (enhanced)
- Now accepts SignalR connection — listens for `ReceiveNotification` and `ReceiveAlert`
- Badge count updates in real-time; polls less frequently (120s vs 30s) when connected

### Chat integration (real-time)
- Listens for `ReceiveChatMessage` via SignalR — messages appear instantly
- Falls back to 5s polling when SignalR is disconnected
- Deduplicates messages by `messageId`

### Layout additions
- Wifi/WifiOff status indicator in top bar
- Toast container rendered above all page content

## Test plan
- [ ] TypeScript compiles clean
- [ ] Vite production build passes
- [ ] Toast appears when another player sends a notification (attack/spy/trade)
- [ ] Toast auto-dismisses after 5s; clicking navigates to correct page
- [ ] Bell badge updates without page reload
- [ ] Chat messages appear instantly via SignalR
- [ ] Falls back to polling when WebSocket fails
- [ ] Wifi icon reflects connection state