### PR TITLE
ci: add test coverage reporting and optimize Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build & Deploy
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 env:
@@ -14,6 +16,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -25,10 +29,46 @@ jobs:
         run: |
           dotnet restore
           dotnet build --configuration Release --no-restore
-          dotnet test --no-restore --verbosity normal
+          dotnet test --no-restore --verbosity normal \
+            --collect "XPlat Code Coverage" \
+            --results-directory ./coverage
+      - name: Generate coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.4.4
+        with:
+          reports: src/coverage/**/coverage.cobertura.xml
+          targetdir: src/coverage/report
+          reporttypes: MarkdownSummaryGithub;Cobertura
+      - name: Post coverage summary
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: src/coverage/report/SummaryGithub.md
+      - name: Check coverage threshold
+        working-directory: src
+        run: |
+          python3 - <<'EOF'
+          import xml.etree.ElementTree as ET, sys, glob
+
+          files = glob.glob("coverage/report/Cobertura.xml")
+          if not files:
+              print("No Cobertura report found; skipping threshold check.")
+              sys.exit(0)
+
+          tree = ET.parse(files[0])
+          root = tree.getroot()
+          line_rate = float(root.attrib.get("line-rate", 0))
+          pct = line_rate * 100
+          threshold = 60.0
+
+          print(f"Line coverage: {pct:.1f}% (threshold: {threshold}%)")
+          if pct < threshold:
+              print(f"ERROR: Coverage {pct:.1f}% is below threshold {threshold}%")
+              sys.exit(1)
+          EOF
 
   deploy:
     needs: test
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/src/BrowserGameEngine.FrontendServer/Dockerfile
+++ b/src/BrowserGameEngine.FrontendServer/Dockerfile
@@ -1,5 +1,3 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
 FROM node:22-alpine AS react-build
 WORKDIR /app
 COPY ReactClient/package.json ReactClient/package-lock.json* ./
@@ -13,6 +11,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
+# Restore dependencies in a separate layer so they are cached across source-only changes
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj", "BrowserGameEngine.FrontendServer/"]
@@ -27,13 +26,11 @@ RUN dotnet restore "BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendS
 COPY . .
 COPY --from=react-build /app/dist BrowserGameEngine.FrontendServer/wwwroot/
 WORKDIR "/src/BrowserGameEngine.FrontendServer"
-RUN dotnet build "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/build
-
-FROM build AS publish
+# Publish directly; dotnet publish implies build, so a separate build step is redundant
 ARG COMMIT_SHA=dev
-RUN dotnet publish "BrowserGameEngine.FrontendServer.csproj" -c Release -o /app/publish /p:InformationalVersion=$COMMIT_SHA
+RUN dotnet publish "BrowserGameEngine.FrontendServer.csproj" -c Release --no-restore -o /app/publish /p:InformationalVersion=$COMMIT_SHA
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
+COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "BrowserGameEngine.FrontendServer.dll"]


### PR DESCRIPTION
## Summary

Closes [BGE-665](/BGE/issues/BGE-665)

- **Coverage reporting**: `dotnet test` now collects XPlat Code Coverage via `coverlet.collector` (already a project dependency). ReportGenerator converts the Cobertura XML to a Markdown summary posted as a sticky PR comment. A Python threshold check fails the build if line coverage drops below 60%.
- **Docker optimization**: Removed the redundant `dotnet build` stage — `dotnet publish` implies a build, so the previous flow compiled the project twice. The `publish` stage alias is also removed; the final image now copies directly from the `build` stage.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | Add `pull_request` trigger, coverage collection + reporting, threshold gate, guard deploy job to master only |
| `src/BrowserGameEngine.FrontendServer/Dockerfile` | Remove `dotnet build` stage; publish with `--no-restore` in one step |

## Test plan

- [ ] Verify CI passes on this PR (coverage report appears as a PR comment)
- [ ] Confirm coverage % is printed in the Check coverage threshold step
- [ ] Confirm deploy job does not run on PR (only on master push)