### PR TITLE
feat: BGE-641 real-time game chat with alliance channel and rate limiting

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -4,6 +4,7 @@ using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.Notifications;
+using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
@@ -277,12 +278,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var posts = allianceChatRepository.GetPosts(allianceId);
 			return Ok(posts.Select(p => {
 				string authorName;
-				try { authorName = playerRepository.Get(p.AuthorPlayerId).Name; }
-				catch { authorName = p.AuthorPlayerId.Id; }
+				string playerType;
+				try {
+					var player = playerRepository.Get(p.AuthorPlayerId);
+					authorName = player.Name;
+					playerType = player.PlayerType.Id;
+				} catch {
+					authorName = p.AuthorPlayerId.Id;
+					playerType = "";
+				}
 				return new AllianceChatPostViewModel {
 					PostId = p.PostId.ToString(),
 					AuthorPlayerId = p.AuthorPlayerId.Id,
 					AuthorName = authorName,
+					PlayerType = playerType,
 					Body = p.Body,
 					CreatedAt = p.CreatedAt
 				};
@@ -302,6 +311,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				return NotFound();
 			} catch (NotAllianceMemberException e) {
 				return StatusCode(403, e.Message);
+			} catch (ChatRateLimitException e) {
+				return StatusCode(429, e.Message);
 			}
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ChatController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ChatController.cs
@@ -43,12 +43,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			var vms = messages.Select(m => {
 				string authorName;
-				try { authorName = playerRepository.Get(m.AuthorPlayerId).Name; }
-				catch { authorName = m.AuthorPlayerId.Id; }
+				string playerType;
+				try {
+					var player = playerRepository.Get(m.AuthorPlayerId);
+					authorName = player.Name;
+					playerType = player.PlayerType.Id;
+				} catch {
+					authorName = m.AuthorPlayerId.Id;
+					playerType = "";
+				}
 				return new ChatMessageViewModel(
 					MessageId: m.MessageId.ToString(),
 					AuthorPlayerId: m.AuthorPlayerId.Id,
 					AuthorName: authorName,
+					PlayerType: playerType,
 					Body: m.Body,
 					CreatedAt: m.CreatedAt
 				);
@@ -67,10 +75,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (string.IsNullOrWhiteSpace(request.Body)) return BadRequest("Message body cannot be empty.");
 			if (request.Body.Length > 500) return BadRequest("Message body cannot exceed 500 characters.");
 
-			var messageId = chatRepositoryWrite.PostMessage(
-				new PostChatMessageCommand(currentUserContext.PlayerId!, request.Body));
-			logger.LogInformation("Player {PlayerId} posted chat message {MessageId}", currentUserContext.PlayerId!.Id, messageId);
-			return Ok(messageId.ToString());
+			try {
+				var messageId = chatRepositoryWrite.PostMessage(
+					new PostChatMessageCommand(currentUserContext.PlayerId!, request.Body));
+				logger.LogInformation("Player {PlayerId} posted chat message {MessageId}", currentUserContext.PlayerId!.Id, messageId);
+				return Ok(messageId.ToString());
+			} catch (ChatRateLimitException e) {
+				return StatusCode(429, e.Message);
+			}
 		}
 	}
 }

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -62,6 +62,7 @@ namespace BrowserGameEngine.Shared {
 		public required string PostId { get; set; }
 		public required string AuthorPlayerId { get; set; }
 		public required string AuthorName { get; set; }
+		public string PlayerType { get; set; } = "";
 		public required string Body { get; set; }
 		public DateTime CreatedAt { get; set; }
 	}

--- a/src/BrowserGameEngine.Shared/ChatViewModels.cs
+++ b/src/BrowserGameEngine.Shared/ChatViewModels.cs
@@ -6,6 +6,7 @@ namespace BrowserGameEngine.Shared {
 		string MessageId,
 		string AuthorPlayerId,
 		string AuthorName,
+		string PlayerType,
 		string Body,
 		DateTime CreatedAt
 	);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ChatTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ChatTest.cs
@@ -22,10 +22,12 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void PostMessage_RingBuffer_KeepsLast200() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
+			var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, time, NullGameEventPublisher.Instance);
 
 			for (int i = 0; i < 205; i++) {
 				chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, $"Message {i}"));
+				time.Advance(TimeSpan.FromSeconds(3));
 			}
 
 			var messages = chatRepo.GetMessages(300);
@@ -37,10 +39,13 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		[Fact]
 		public void GetMessagesAfter_ReturnsOnlyNewMessages() {
 			var game = new TestGame();
-			var chatRepo = new ChatRepositoryWrite(game.Accessor, TimeProvider.System, NullGameEventPublisher.Instance);
+			var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, time, NullGameEventPublisher.Instance);
 
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "First"));
+			time.Advance(TimeSpan.FromSeconds(3));
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Second"));
+			time.Advance(TimeSpan.FromSeconds(3));
 			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Third"));
 
 			var all = chatRepo.GetMessages();
@@ -63,6 +68,52 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var result = chatRepo.GetMessagesAfter(Guid.NewGuid().ToString());
 			Assert.Single(result);
 			Assert.Equal("Hello", result[0].Body);
+		}
+
+		[Fact]
+		public void PostMessage_RateLimit_ThrowsWhenTooFast() {
+			var game = new TestGame();
+			var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, time, NullGameEventPublisher.Instance);
+
+			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "First"));
+
+			// Second message within 2 seconds should throw
+			time.Advance(TimeSpan.FromSeconds(1));
+			Assert.Throws<ChatRateLimitException>(() =>
+				chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Second")));
+		}
+
+		[Fact]
+		public void PostMessage_RateLimit_AllowsAfterInterval() {
+			var game = new TestGame();
+			var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, time, NullGameEventPublisher.Instance);
+
+			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "First"));
+
+			// After 2 seconds, should succeed
+			time.Advance(TimeSpan.FromSeconds(2));
+			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Second"));
+
+			var messages = chatRepo.GetMessages();
+			Assert.Equal(2, messages.Count);
+		}
+
+		[Fact]
+		public void PostMessage_RateLimit_IndependentPerPlayer() {
+			var game = new TestGame(2);
+			var player2 = GameModel.PlayerIdFactory.Create("player1");
+			var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+			var chatRepo = new ChatRepositoryWrite(game.Accessor, time, NullGameEventPublisher.Instance);
+
+			chatRepo.PostMessage(new PostChatMessageCommand(game.Player1, "Player1 msg"));
+
+			// Player2 can send immediately even though Player1 just sent
+			chatRepo.PostMessage(new PostChatMessageCommand(player2, "Player2 msg"));
+
+			var messages = chatRepo.GetMessages();
+			Assert.Equal(2, messages.Count);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceChatRepositoryWrite.cs
@@ -2,7 +2,9 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
@@ -12,6 +14,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
 		private readonly IGameEventPublisher eventPublisher;
+		private static readonly TimeSpan RateLimitInterval = TimeSpan.FromSeconds(2);
+		private readonly ConcurrentDictionary<PlayerId, DateTime> lastMessageTime = new();
 
 		public AllianceChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider, IGameEventPublisher eventPublisher) {
 			this.worldStateAccessor = worldStateAccessor;
@@ -20,6 +24,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public AlliancePostId Post(PostAllianceChatCommand command) {
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			if (lastMessageTime.TryGetValue(command.PlayerId, out var lastTime)
+				&& (now - lastTime) < RateLimitInterval) {
+				throw new ChatRateLimitException();
+			}
+
 			var postId = AlliancePostIdFactory.NewPostId();
 			lock (_lock) {
 				var alliance = world.GetAlliance(command.AllianceId);
@@ -31,16 +41,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 					AllianceId = command.AllianceId,
 					AuthorPlayerId = command.PlayerId,
 					Body = command.Body,
-					CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+					CreatedAt = now
 				});
 			}
-			var authorName = world.GetPlayer(command.PlayerId).Name;
+			lastMessageTime[command.PlayerId] = now;
+			var player = world.GetPlayer(command.PlayerId);
 			eventPublisher.PublishToAlliance(command.AllianceId, GameEventTypes.ReceiveAllianceChatMessage, new {
 				postId = postId.Id.ToString(),
 				authorPlayerId = command.PlayerId.Id,
-				authorName,
+				authorName = player.Name,
+				playerType = player.PlayerType.Id,
 				body = command.Body,
-				createdAt = timeProvider.GetUtcNow().UtcDateTime
+				createdAt = now
 			});
 			return postId;
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Chat/ChatRepositoryWrite.cs
@@ -3,11 +3,16 @@ using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
+	public class ChatRateLimitException : Exception {
+		public ChatRateLimitException() : base("You can only send one message every 2 seconds.") { }
+	}
+
 	public class ChatRepositoryWrite {
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
@@ -15,6 +20,8 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 		private readonly TimeProvider timeProvider;
 		private readonly IGameEventPublisher eventPublisher;
 		private const int MaxMessages = 200;
+		private static readonly TimeSpan RateLimitInterval = TimeSpan.FromSeconds(2);
+		private readonly ConcurrentDictionary<PlayerId, DateTime> lastMessageTime = new();
 
 		public ChatRepositoryWrite(IWorldStateAccessor worldStateAccessor, TimeProvider timeProvider, IGameEventPublisher eventPublisher) {
 			this.worldStateAccessor = worldStateAccessor;
@@ -62,6 +69,12 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 		}
 
 		public ChatMessageId PostMessage(PostChatMessageCommand command) {
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			if (lastMessageTime.TryGetValue(command.AuthorPlayerId, out var lastTime)
+				&& (now - lastTime) < RateLimitInterval) {
+				throw new ChatRateLimitException();
+			}
+
 			var messageId = ChatMessageIdFactory.NewChatMessageId();
 			lock (ChatMessagesLock) {
 				world.ValidatePlayer(command.AuthorPlayerId);
@@ -69,20 +82,22 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Chat {
 					MessageId = messageId,
 					AuthorPlayerId = command.AuthorPlayerId,
 					Body = command.Body,
-					CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+					CreatedAt = now
 				});
 				// Ring buffer: drop oldest when over the limit
 				while (world.ChatMessages.Count > MaxMessages) {
 					world.ChatMessages.RemoveAt(0);
 				}
 			}
-			var authorName = world.GetPlayer(command.AuthorPlayerId).Name;
+			lastMessageTime[command.AuthorPlayerId] = now;
+			var player = world.GetPlayer(command.AuthorPlayerId);
 			eventPublisher.PublishToGame(GameEventTypes.ReceiveChatMessage, new {
 				messageId = messageId.Id,
 				authorPlayerId = command.AuthorPlayerId.Id,
-				authorName,
+				authorName = player.Name,
+				playerType = player.PlayerType.Id,
 				body = command.Body,
-				createdAt = timeProvider.GetUtcNow().UtcDateTime
+				createdAt = now
 			});
 			return messageId;
 		}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -461,6 +461,7 @@ export interface AllianceChatPostViewModel {
   postId: string
   authorPlayerId: string
   authorName: string
+  playerType: string
   body: string
   createdAt: string
 }
@@ -653,6 +654,7 @@ export interface ChatMessageViewModel {
   messageId: string
   authorPlayerId: string
   authorName: string
+  playerType: string
   body: string
   createdAt: string
 }

--- a/src/ReactClient/src/pages/Chat.tsx
+++ b/src/ReactClient/src/pages/Chat.tsx
@@ -1,22 +1,39 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { SendIcon } from 'lucide-react'
+import { SendIcon, ShieldIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ChatMessagesViewModel, ChatMessageViewModel, PostChatMessageRequest } from '@/api/types'
+import type {
+  ChatMessagesViewModel,
+  ChatMessageViewModel,
+  PostChatMessageRequest,
+  AllianceChatPostViewModel,
+  MyAllianceStatusViewModel,
+  PostAllianceChatRequest,
+} from '@/api/types'
 import { useSignalR } from '@/hooks/useSignalR'
 import { cn } from '@/lib/utils'
+
+const RACE_ICONS: Record<string, string> = {
+  terran: '🔧',
+  protoss: '🔮',
+  zerg: '🦠',
+}
+
+function raceIcon(playerType: string): string {
+  return RACE_ICONS[playerType] ?? ''
+}
 
 interface ChatProps {
   gameId: string
 }
 
-export function ChatPanel({ gameId }: ChatProps) {
+function GameChat({ gameId, signalR }: { gameId: string; signalR: ReturnType<typeof useSignalR> }) {
   const [body, setBody] = useState('')
   const [lastMessageId, setLastMessageId] = useState<string | null>(null)
-  const [allMessages, setAllMessages] = useState<ChatMessagesViewModel['messages']>([])
+  const [allMessages, setAllMessages] = useState<ChatMessageViewModel[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [rateLimited, setRateLimited] = useState(false)
   const chatEndRef = useRef<HTMLDivElement>(null)
-  const signalR = useSignalR('/gamehub')
   const isRealTime = signalR.status === 'connected'
 
   // Initial load
@@ -54,7 +71,11 @@ export function ChatPanel({ gameId }: ChatProps) {
       const url = lastMessageId ? `/api/chat?after=${lastMessageId}` : '/api/chat'
       const r = await apiClient.get<ChatMessagesViewModel>(url)
       if (r.data.messages.length > 0) {
-        setAllMessages((prev) => [...prev, ...r.data.messages])
+        setAllMessages((prev) => {
+          const ids = new Set(prev.map((m) => m.messageId))
+          const newMsgs = r.data.messages.filter((m) => !ids.has(m.messageId))
+          return newMsgs.length > 0 ? [...prev, ...newMsgs] : prev
+        })
         const last = r.data.messages[r.data.messages.length - 1]
         setLastMessageId(last.messageId)
       }
@@ -72,31 +93,31 @@ export function ChatPanel({ gameId }: ChatProps) {
   const send = useMutation({
     mutationFn: (req: PostChatMessageRequest) =>
       apiClient.post('/api/chat', req),
-    onSuccess: async () => {
+    onSuccess: () => {
       setBody('')
-      const r = await apiClient.get<ChatMessagesViewModel>(
-        lastMessageId ? `/api/chat?after=${lastMessageId}` : '/api/chat'
-      )
-      if (r.data.messages.length > 0) {
-        setAllMessages((prev) => [...prev, ...r.data.messages])
-        const last = r.data.messages[r.data.messages.length - 1]
-        setLastMessageId(last.messageId)
-      }
+      setError(null)
+      setRateLimited(false)
     },
-    onError: async (err: unknown) => {
-      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to send'
-      setError(msg)
+    onError: (err: unknown) => {
+      const axErr = err as { response?: { status?: number; data?: string } }
+      if (axErr?.response?.status === 429) {
+        setRateLimited(true)
+        setError(axErr.response.data ?? 'Rate limited — wait 2 seconds')
+        setTimeout(() => setRateLimited(false), 2000)
+      } else {
+        setError(axErr?.response?.data ?? 'Failed to send')
+      }
     },
   })
 
   function handleSend() {
-    if (!body.trim()) return
+    if (!body.trim() || rateLimited) return
     setError(null)
     send.mutate({ body: body.trim() })
   }
 
   return (
-    <div className="space-y-3">
+    <>
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
@@ -119,7 +140,7 @@ export function ChatPanel({ gameId }: ChatProps) {
         />
         <button
           onClick={handleSend}
-          disabled={!body.trim() || send.isPending}
+          disabled={!body.trim() || send.isPending || rateLimited}
           className={cn(
             'flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground',
             'hover:bg-primary/90 disabled:opacity-50 transition-colors'
@@ -132,14 +153,16 @@ export function ChatPanel({ gameId }: ChatProps) {
       <p className="text-xs text-muted-foreground">{body.length} / 500</p>
 
       {/* Chat window */}
-      <div className="h-[min(420px,60vh)] overflow-y-auto rounded-lg border bg-card p-2 space-y-1.5" role="log" aria-label="Chat messages">
+      <div className="h-[min(420px,60vh)] overflow-y-auto rounded-lg border bg-card p-2 space-y-1.5" role="log" aria-label="Game chat messages">
         {allMessages.length === 0 ? (
           <p className="text-center text-muted-foreground text-sm mt-8">No messages yet. Start the conversation!</p>
         ) : (
           allMessages.map((msg) => (
             <div key={msg.messageId} className="rounded-md border-l-2 border-primary/60 bg-secondary/30 px-3 py-2">
               <div className="flex justify-between text-xs mb-0.5">
-                <span className="font-semibold text-primary">{msg.authorName}</span>
+                <span className="font-semibold text-primary">
+                  {raceIcon(msg.playerType)} {msg.authorName}
+                </span>
                 <span className="text-muted-foreground">
                   {new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                 </span>
@@ -150,6 +173,202 @@ export function ChatPanel({ gameId }: ChatProps) {
         )}
         <div ref={chatEndRef} />
       </div>
+    </>
+  )
+}
+
+function AllianceChat({ allianceId, signalR }: { allianceId: string; signalR: ReturnType<typeof useSignalR> }) {
+  const [body, setBody] = useState('')
+  const [allPosts, setAllPosts] = useState<AllianceChatPostViewModel[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [rateLimited, setRateLimited] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  const chatEndRef = useRef<HTMLDivElement>(null)
+  const isRealTime = signalR.status === 'connected'
+
+  // Initial load
+  useEffect(() => {
+    apiClient.get<AllianceChatPostViewModel[]>(`/api/alliances/${allianceId}/posts`).then((r) => {
+      setAllPosts(r.data)
+      setLoaded(true)
+    })
+  }, [allianceId])
+
+  // Listen for real-time alliance chat messages via SignalR
+  const handleAllianceMessage = useCallback(
+    (...args: unknown[]) => {
+      const msg = args[0] as AllianceChatPostViewModel | undefined
+      if (!msg?.postId) return
+      setAllPosts((prev) => {
+        if (prev.some((p) => p.postId === msg.postId)) return prev
+        return [...prev, msg]
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    signalR.on('ReceiveAllianceChatMessage', handleAllianceMessage)
+    return () => signalR.off('ReceiveAllianceChatMessage', handleAllianceMessage)
+  }, [signalR, handleAllianceMessage])
+
+  // Fallback polling when SignalR not connected
+  useQuery({
+    queryKey: ['alliance-chat-poll', allianceId],
+    queryFn: async () => {
+      const r = await apiClient.get<AllianceChatPostViewModel[]>(`/api/alliances/${allianceId}/posts`)
+      setAllPosts(r.data)
+      return r.data
+    },
+    refetchInterval: isRealTime ? false : 5_000,
+    enabled: !isRealTime && loaded,
+  })
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [allPosts])
+
+  const send = useMutation({
+    mutationFn: (req: PostAllianceChatRequest) =>
+      apiClient.post(`/api/alliances/${allianceId}/posts`, req),
+    onSuccess: () => {
+      setBody('')
+      setError(null)
+      setRateLimited(false)
+    },
+    onError: (err: unknown) => {
+      const axErr = err as { response?: { status?: number; data?: string } }
+      if (axErr?.response?.status === 429) {
+        setRateLimited(true)
+        setError(axErr.response.data ?? 'Rate limited — wait 2 seconds')
+        setTimeout(() => setRateLimited(false), 2000)
+      } else {
+        setError(axErr?.response?.data ?? 'Failed to send')
+      }
+    },
+  })
+
+  function handleSend() {
+    if (!body.trim() || rateLimited) return
+    setError(null)
+    send.mutate({ body: body.trim() })
+  }
+
+  return (
+    <>
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Send box */}
+      <div className="flex gap-2">
+        <input
+          className={cn(
+            'flex-1 rounded-md border bg-input px-3 py-2 text-sm',
+            'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+          )}
+          placeholder="Message your alliance…"
+          aria-label="Alliance chat message"
+          maxLength={1000}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend() } }}
+        />
+        <button
+          onClick={handleSend}
+          disabled={!body.trim() || send.isPending || rateLimited}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground',
+            'hover:bg-primary/90 disabled:opacity-50 transition-colors'
+          )}
+        >
+          <SendIcon className="h-4 w-4" />
+          Send
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground">{body.length} / 1000</p>
+
+      {/* Chat window */}
+      <div className="h-[min(420px,60vh)] overflow-y-auto rounded-lg border bg-card p-2 space-y-1.5" role="log" aria-label="Alliance chat messages">
+        {allPosts.length === 0 ? (
+          <p className="text-center text-muted-foreground text-sm mt-8">No alliance messages yet.</p>
+        ) : (
+          allPosts.map((p) => (
+            <div key={p.postId} className="rounded-md border-l-2 border-green-500/60 bg-secondary/30 px-3 py-2">
+              <div className="flex justify-between text-xs mb-0.5">
+                <span className="font-semibold text-green-600 dark:text-green-400">
+                  {raceIcon(p.playerType)} {p.authorName}
+                </span>
+                <span className="text-muted-foreground">
+                  {new Date(p.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                </span>
+              </div>
+              <p className="text-sm">{p.body}</p>
+            </div>
+          ))
+        )}
+        <div ref={chatEndRef} />
+      </div>
+    </>
+  )
+}
+
+type ChatTab = 'game' | 'alliance'
+
+export function ChatPanel({ gameId }: ChatProps) {
+  const [tab, setTab] = useState<ChatTab>('game')
+  const signalR = useSignalR('/gamehub')
+
+  const { data: allianceStatus } = useQuery<MyAllianceStatusViewModel>({
+    queryKey: ['alliance-status-chat'],
+    queryFn: () => apiClient.get('/api/alliances/my-status').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  const hasAlliance = allianceStatus?.allianceId && allianceStatus.isMember && !allianceStatus.isPending
+
+  return (
+    <div className="space-y-3">
+      {/* Connection indicator */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className={cn(
+          'inline-block h-2 w-2 rounded-full',
+          signalR.status === 'connected' ? 'bg-green-500' : signalR.status === 'reconnecting' ? 'bg-yellow-500' : 'bg-gray-400'
+        )} />
+        {signalR.status === 'connected' ? 'Live' : signalR.status === 'reconnecting' ? 'Reconnecting…' : 'Polling'}
+      </div>
+
+      {/* Tabs */}
+      {hasAlliance && (
+        <div className="flex gap-1 border-b">
+          <button
+            onClick={() => setTab('game')}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+              tab === 'game' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Game
+          </button>
+          <button
+            onClick={() => setTab('alliance')}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px flex items-center gap-1',
+              tab === 'alliance' ? 'border-green-500 text-green-600 dark:text-green-400' : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <ShieldIcon className="h-3.5 w-3.5" />
+            Alliance
+          </button>
+        </div>
+      )}
+
+      {tab === 'game' && <GameChat gameId={gameId} signalR={signalR} />}
+      {tab === 'alliance' && hasAlliance && (
+        <AllianceChat allianceId={allianceStatus.allianceId!} signalR={signalR} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add 2-second per-player rate limiting to game chat and alliance chat (returns HTTP 429)
- Include `playerType` (race) in chat message view models and SignalR event payloads for race icon display
- Upgrade React Chat.tsx with Game/Alliance tab switching, real-time SignalR for alliance messages, race emoji icons (🔧 Terran, 🔮 Protoss, 🦠 Zerg), live connection indicator, and fallback polling
- Add 3 new unit tests for rate limiting behavior (too-fast rejection, interval passage, per-player independence)

## Test plan
- [x] `dotnet build` passes (0 warnings, 0 errors)
- [x] `dotnet test` passes (445 tests, 0 failures)
- [x] React `tsc -b` and `vite build` pass
- [ ] Manual: send two game chat messages within 2 seconds — second should show rate limit error
- [ ] Manual: verify alliance tab appears only for alliance members
- [ ] Manual: verify race icons appear next to player names in chat

Closes BGE-641