### PR TITLE
docs: BGE-668 update IMPL-STATUS.md and PLAN.md to current state

### DIFF
--- a/docs/IMPL-STATUS.md
+++ b/docs/IMPL-STATUS.md
@@ -1,34 +1,71 @@
 # BGE Implementation Status
 
-Last updated: 2026-03-30. See [PLAN.md](PLAN.md) for the full feature registry.
+Last updated: 2026-04-05. See [PLAN.md](PLAN.md) for the full feature registry.
 
 ---
 
-## Recently Merged (last ~30 commits on master)
+## Recently Merged (PRs #150–#210)
 
 | BGE | Feature | PR |
 |---|---|---|
-| BGE-267 | In-app player notification center (bell icon, ring buffer, push on attack/game events) | #85 |
-| BGE-276 | Fix: register AddAuthorizationCore in Blazor WASM client | — |
-| BGE-241 | Discord webhook notifications for game start/end | #81 |
-| BGE-189 | 10-second auto-refresh timer on all game-state pages | #58 |
-| BGE-164 | Game Admin Page — Create & Manage Games | #50 |
-| BGE-232 | End-to-end multi-game lifecycle integration test | #72 |
-| BGE-218 | Replace async void timer callbacks with PeriodicTimer | #67 |
-| BGE-217 | Redesign /games as Season Schedule with Bootstrap cards | #73 |
-| BGE-224 | Post-game summary screen at /games/{id}/summary | #74 |
-| BGE-213 | Player public profile page with cross-game stats | #76 |
-| BGE-223 | Redirect to original page after OAuth sign-in | #75 |
-| BGE-135 | Improve login UX — copy updates and persistent session | #77 |
-| BGE-226 | Ending-soon alert fires only once per game window | #70 |
-| BGE-220 | Add currentUser.IsValid guard in GamesController.Create | #71 |
-| BGE-211 | Game auto-finalization engine | #68 |
-| BGE-249 | Fix HistoryController to use GlobalState methods | #78 |
-| BGE-212 | End-of-game countdown banner | — |
-| BGE-192 | Player game history & stats page | — |
-| BGE-165 | Game results screen with auto-redirect | — |
-| BGE-163 | All-time cross-game leaderboard | — |
-| BGE-162 | Game-scoped Blazor routing (Phase 3) | — |
+| — | ci: add test coverage reporting and optimize Docker build | #210 |
+| BGE-651 | Security hardening Steps 1-6 | #209 |
+| BGE-613 | Real-time notification toasts + SignalR client | #208 |
+| BGE-650 | E2E integration tests for critical game flows | #207 |
+| BGE-640 | Complete Protoss race data with shields mechanic | #206 |
+| BGE-639 | Complete Zerg race data | #205 |
+| BGE-649 | Fix MarketController route ambiguity (405 on integration tests) | #204 |
+| BGE-629 | Admin dashboard with player moderation and game management | #203 |
+| BGE-614 | API pagination for list endpoints | #202 |
+| BGE-612 | SignalR GameHub and real-time event publishing | #201 |
+| BGE-626 | Mobile responsive UI pass | #200 |
+| BGE-628 | Performance benchmarks for game tick engine | #199 |
+| BGE-627 | Production monitoring and alerting | #198 |
+| — | Fix Diplomacy, Spy, and Players page crashes | #196 |
+| BGE-597 | Replace hardcoded colors with theme variables | #195 |
+| BGE-610 | Structured logging, request timing, ECS container health check | #194 |
+| BGE-598 | Route-based code splitting for React client | #193 |
+| BGE-599 | Full accessibility pass | #192 |
+| BGE-586 | Balance simulation CLI (`tools/BalanceSim`) | #191 |
+| BGE-584 | E2E Playwright tests — resources, attack flow, alliances | #190 |
+| BGE-578 | Show winner name and condition badge in victory banner | #189 |
+| BGE-588 | UX polish — theme colors, mobile sidebar, accessibility | #188 |
+| — | Fix MarketController route template (integration tests) | #187 |
+| BGE-580 | Fix message thread view causing browser freeze | #186 |
+| BGE-581 | Alliance Chat as third Messages tab | #185 |
+| BGE-577 | Trade page for player-to-player trading | #184 |
+| BGE-579 | EconomicThreshold victory progress bar on game dashboard | #183 |
+| — | Add integration tests for API controllers | #181 |
+| BGE-571 | Sort ranking by score + highlight current player | #180 |
+| BGE-570 | Rename 'spies' route to 'operations' | #179 |
+| — | Add error boundaries and consistent loading/error states | #178 |
+| BGE-562 | Playwright E2E test framework for React client | #177 |
+| BGE-560 | React client build + lint in CI pipeline | #176 |
+| BGE-549 | Player Profile pages (my profile + public) | #175 |
+| BGE-550 | All-time players list page | #174 |
+| BGE-548 | React Alliances pages (list + detail) | #173 |
+| — | Fix Messages: recipient name in Sent tab + reply pre-fill | #172 |
+| BGE-526 | React pages — Achievements, History, AdminGames; delete BlazorClient | #171 |
+| BGE-522 | React social pages — Chat, Messages, Rankings, Profiles | #170 |
+| BGE-520 | React app shell — layout, nav, auth, CurrentGame context | #168 |
+| BGE-534–537 | Fix spy missions, alliance name/route, ranking highlight | #169 |
+| BGE-525 | React pages — Games, Lobby, JoinGame, Summary, Results, CreatePlayer, UnitDefinitions | #167 |
+| BGE-524 | React pages — Alliances, AllianceDetail, AllianceRanking | #166 |
+| BGE-523 | React pages — Spies, SpyReports, Diplomacy, EnemyBase, SelectEnemy | #164/165 |
+| BGE-512 | xUnit tests for victory conditions | #163 |
+| BGE-521 | React client scaffold + core game pages (Base, Units, Research, Market) | #162 |
+| — | Merge Tech Tree and Upgrades into single Research section | #161 |
+| BGE-513 | Victory conditions UI — banner, progress bar, contextual badges | #160 |
+| BGE-511 | Victory conditions — EconomicThreshold module + VictoryConditionType tracking | #159 |
+| BGE-471 | Alliance UI — war status indicators, invite, declare war, peace | #158 |
+| BGE-489 | Player trading system + in-game messaging overhaul (Sprint 7) | #157 |
+| BGE-466 | In-game leaderboard page + API endpoint | #156 |
+| — | Address BGE-465 code review nits | #155 |
+| BGE-479 | Add Incoming Intel tab to Spy page | #154 |
+| BGE-482 | Controller-level tests for spy, alliance, market, leaderboard, research APIs | #153 |
+| — | Remove WriteIndented and cache JsonSerializerOptions in blob serializers | #152 |
+| BGE-465 | Spy offensive actions backend | #151 |
+| BGE-467 | Alliance invite & war system | #150 |
 
 ---
 
@@ -36,9 +73,8 @@ Last updated: 2026-03-30. See [PLAN.md](PLAN.md) for the full feature registry.
 
 | PR | BGE | Description | Status |
 |---|---|---|---|
-| #64 | BGE-157 | Player registration UI | Blocked — needs rebase + review (BGE-284) |
-| #60 | BGE-158 | JoinGame UI improvements | Blocked — needs rebase + review (BGE-284) |
-| #85 | BGE-269 | Season subscription + auto-join | In progress — needs fix for 3 blocking issues (BGE-300) |
+| #211 | BGE-667 | Cross-race integration tests for Zerg and Protoss | In review |
+| #212 | BGE-641 | Real-time game chat with alliance channel and rate limiting | In review |
 
 ---
 
@@ -46,29 +82,15 @@ Last updated: 2026-03-30. See [PLAN.md](PLAN.md) for the full feature registry.
 
 | BGE | Title | Status |
 |---|---|---|
-| BGE-300 | Fix PR #85 (BGE-269): rebase + fix 3 blocking issues | todo |
-| BGE-284 | Merge PR #60 (BGE-158) and PR #64 (BGE-157) | blocked |
-| BGE-182 | Keep /docs up to date | in_progress (this PR) |
-
----
-
-## Next Up (todo, no PR open)
-
-| BGE | Title | Priority |
-|---|---|---|
-| BGE-290 | Resource Trading Market | high |
-| BGE-296 | Detailed Battle Reports | high |
-| BGE-292 | Player Achievements Page | medium |
-| BGE-291 | Spy / Scout Mission | medium |
-| BGE-294 | Game-wide Chat Channel | medium |
+| BGE-668 | Update IMPL-STATUS.md and PLAN.md with current project state | in_progress (this PR) |
+| BGE-667 | Cross-race integration tests for Zerg and Protoss | PR #211 open |
+| BGE-641 | Real-time game chat with alliance channel and rate limiting | PR #212 open |
 
 ---
 
 ## What Remains from the Original Spec
 
-1. **Complete Zerg & Protoss definitions** — Terran is fully defined. Zerg and Protoss buildings/units need data work in `GameDefinition.SCO`. Requires balance simulation CLI first (see below).
-2. **Alliance leader election** — Currently leader = creator. Voting mechanism not yet built.
-3. **Balance simulation CLI** — Standalone `tools/BalanceSim` project to run combat simulations. Pre-requisite for safe Zerg/Protoss data work.
+1. **Alliance leader election** — Currently leader = creator. Voting mechanism not yet built.
 
 ---
 
@@ -76,6 +98,7 @@ Last updated: 2026-03-30. See [PLAN.md](PLAN.md) for the full feature registry.
 
 - **Production**: AWS ECS Fargate at [ageofagents.net](https://ageofagents.net)
 - **State storage**: S3 with versioning (`games/{gameId}/state.json`, `global/state.json`)
-- **CI**: GitHub Actions — `dotnet build --configuration Release` + `dotnet test` on push/PR to master
+- **CI**: GitHub Actions — `dotnet build --configuration Release` + `dotnet test` + React lint/build on push/PR to master. Test coverage reporting added.
 - **Secrets**: AWS SSM Parameter Store (GitHub OAuth, Discord webhook URL)
-- **Observability**: Serilog console, Prometheus metrics, OpenTelemetry tracing, CloudWatch alarms
+- **Observability**: Serilog structured logging, Prometheus metrics, OpenTelemetry tracing, CloudWatch alarms, ECS health check at `/health`
+- **SignalR**: Real-time event publishing via `GameHub`; real-time notification toasts on React client

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -11,7 +11,7 @@ These features exist and are functional in the current codebase.
 | Spec Section | Feature | Notes |
 |---|---|---|
 | 1.1 | Tick-based game world | Per-player tick engine with pluggable modules. 30s ticks (configurable). |
-| 1.2 | Race selection at registration | Terran/Zerg/Protoss choice, permanent. Terran fully defined; Zerg & Protoss partially defined. |
+| 1.2 | Race selection at registration | Terran/Zerg/Protoss choice, permanent. All three races fully defined. (BGE-639, BGE-640) |
 | 2.1 | Two resource types (Minerals, Gas) | Tracked per player. Land is the score resource. |
 | 2.2 | Worker roles (mineral / gas / idle) | `MineralWorkers` and `GasWorkers` on player state. `AssignWorkersCommand` + `WorkersController`. |
 | 2.3 | Resource income per round | `ResourceGrowthSco` tick module. Full efficiency formula implemented: `efficiency = clamp(land / (workers * factor), 0.2, 100)`. |
@@ -63,6 +63,19 @@ These features exist and are functional in the current codebase.
 | — | Action feed / log | `IActionLogger` ring buffer in `StatefulGameServer`. `GET /api/admin/action-log`. |
 | — | 10s auto-refresh | All game-state pages poll every 10s via `PeriodicTimer`. (BGE-189) |
 | — | Bot client support | `BearerTokenMiddleware` + API key auth. Bot quickstart guide in `docs/BOT-CLIENT.md`. |
+| — | React client | Full React SPA replacing Blazor WASM. All pages migrated. BlazorClient deleted. (BGE-520–526, BGE-548–550) |
+| — | Victory conditions | `EconomicThreshold` win condition with progress bar and winner banner. `VictoryConditionType` tracking. (BGE-511, BGE-513) |
+| — | Spy / offensive actions | Spy operations backend + UI with Intel tab. (BGE-465, BGE-479) |
+| — | Alliance war system | Declare war, peace, invite. Alliance invite & war backend + UI. (BGE-467, BGE-471) |
+| — | Player-to-player trading | `TradePlayerResourceCommand` + Trade UI page. (BGE-489, BGE-577) |
+| — | In-game leaderboard | Dedicated leaderboard page + API endpoint. (BGE-466) |
+| — | Balance simulation CLI | `tools/BalanceSim` standalone console project for combat simulations. (BGE-586) |
+| — | SignalR real-time events | `GameHub` publishes game events; React client shows real-time notification toasts. (BGE-612, BGE-613) |
+| — | Admin dashboard | Player moderation, game management, admin controls UI. (BGE-629) |
+| — | API pagination | Cursor-based pagination on all list endpoints. (BGE-614) |
+| — | Production monitoring | CloudWatch alarms, ECS health check, performance benchmarks. (BGE-627, BGE-628, BGE-610) |
+| — | Security hardening | Steps 1-6 applied. (BGE-651) |
+| — | E2E Playwright tests | Full E2E test framework + tests for resources, attacks, alliances, critical flows. (BGE-562, BGE-584, BGE-650) |
 
 ---
 
@@ -74,27 +87,28 @@ These features are specified, not yet implemented, or have PRs pending merge.
 
 | Spec Section | Feature | What to Build |
 |---|---|---|
-| 1.2 | Complete Zerg & Protoss definitions | `GameDefinition.SCO` has Terran fully defined. Port the spec tables for Zerg and Protoss buildings + units. Purely data work. |
+| 1.2 | Complete Zerg & Protoss definitions | **Done** — Zerg (PR #205) and Protoss with shields mechanic (PR #206) fully implemented. All three races complete. |
 
 ### Multi-Game Registration & Season Flow
 
 | Feature | What to Build | Status |
 |---|---|---|
-| Player registration UI | Dedicated registration page with name/race form. (BGE-157) | PR #64 open, pending merge |
-| Join game UI improvements | Polished join-game flow with validation and error states. (BGE-158) | PR #60 open, pending merge |
-| Season subscription + auto-join | Users subscribe to a season; auto-enrolled in the next game start. (BGE-269) | PR #85 open, pending merge |
+| Player registration UI | Dedicated registration page with name/race form. (BGE-157) | **Done** — React client (PR #525 area) includes full join/registration UI |
+| Join game UI improvements | Polished join-game flow with validation and error states. (BGE-158) | **Done** — React client includes polished join game flow |
+| Season subscription + auto-join | Users subscribe to a season; auto-enrolled in the next game start. (BGE-269) | **Done** — implemented and merged |
 
 ### Social & Communication Polish
 
 | Spec Section | Feature | What to Build |
 |---|---|---|
 | 9.1 | Alliance leader election | Voting mechanism for alliance leader. Leader management of members. Currently leader = creator. |
+| — | Real-time game chat | In-game chat with alliance channel and rate limiting (BGE-641) | PR #212 open, pending merge |
 
 ### Developer Tooling
 
 | Feature | What to Build |
 |---|---|
-| Balance simulation CLI | Standalone console project (`tools/BalanceSim`) — run combat simulations without the server. Critical before completing Zerg/Protoss data. |
+| Balance simulation CLI | **Done** — `tools/BalanceSim` standalone console project (PR #191, BGE-586). |
 
 ---
 
@@ -104,7 +118,7 @@ These features from the spec or era are intentionally excluded.
 
 | Feature | Reason |
 |---|---|
-| Real-time chat (public + alliance) | Adds significant complexity (WebSockets/SignalR). Discord serves this purpose externally. Revisit if player demand warrants it. |
+| Real-time chat (public + alliance) | **Moved to planned** — BGE-641 implements in-game chat via SignalR (PR #212). |
 | Forum / MBBS integration | The spec notes this should be dropped. Use external community tools. |
 | Photo album, calendar | Unrelated to the game. Omit permanently. |
 | Multi-account detection | Complex anti-cheat. Not needed for a small player base. Add if abuse becomes a problem. |
@@ -134,9 +148,11 @@ These features from the spec or era are intentionally excluded.
 ## Suggested Build Order
 
 ```
-Merge BGE-157/158 PRs            (player registration + join UI)
-Merge BGE-269 PR                 (season subscription + auto-join)
-Balance simulation CLI           (before Zerg/Protoss data)
-Zerg & Protoss data              (complete core game)
-Alliance leader election         (social completeness)
+✅ Merge BGE-157/158 PRs            (player registration + join UI) — DONE (React client)
+✅ Merge BGE-269 PR                 (season subscription + auto-join) — DONE
+✅ Balance simulation CLI           (before Zerg/Protoss data) — DONE (PR #191)
+✅ Zerg & Protoss data              (complete core game) — DONE (PRs #205, #206)
+   Merge PR #211                   (cross-race integration tests for Zerg/Protoss)
+   Merge PR #212 / BGE-641         (real-time game chat)
+   Alliance leader election        (social completeness)
 ```


### PR DESCRIPTION
## Summary

- Updates `docs/IMPL-STATUS.md` to reflect PRs #150–#210 (~60 PRs merged since the last update on 2026-03-30)
- Updates `docs/PLAN.md` to mark completed items (Zerg/Protoss, balance sim CLI, registration UI, season subscription), add new Already Implemented rows (React client, victory conditions, spy system, alliance war, SignalR, security hardening, E2E tests), and revise the suggested build order
- Removes stale open PR entries (#60, #64, #85) and completed Next Up items that have shipped
- Updates the What Remains section: only Alliance leader election remains outstanding from the original spec

## Test plan

- [ ] Review `docs/IMPL-STATUS.md` for accuracy against recent merged PRs
- [ ] Review `docs/PLAN.md` for accuracy — especially the Already Implemented additions and Planned section
- [ ] No code changes; CI passes trivially