### PR TITLE
feat: BGE-666 enhanced achievements page with milestones and profile badges

### DIFF
--- a/src/BrowserGameEngine.Shared/AchievementViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AchievementViewModels.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
+	// Game-completion achievements (earned when a game ends)
 	public record AchievementViewModel(
 		string AchievementType,
 		string AchievementLabel,
@@ -16,5 +17,30 @@ namespace BrowserGameEngine.Shared {
 
 	public record PlayerAchievementsViewModel(
 		List<AchievementViewModel> Achievements
+	);
+
+	// In-game milestone achievements (progress-based, unlockable)
+	public record MilestoneAchievementViewModel(
+		string Id,
+		string Name,
+		string Description,
+		string Category,
+		string Icon,
+		bool IsUnlocked,
+		DateTime? UnlockedAt,
+		int CurrentProgress,
+		int TargetProgress,
+		string Tier
+	);
+
+	public record MilestoneAchievementsViewModel(
+		List<MilestoneAchievementViewModel> Achievements,
+		MilestoneAchievementsSummaryViewModel Summary
+	);
+
+	public record MilestoneAchievementsSummaryViewModel(
+		int TotalAchievements,
+		int UnlockedCount,
+		Dictionary<string, int> UnlockedByCategory
 	);
 }

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -711,6 +711,35 @@ export interface AchievementsViewModel {
   achievements: AchievementViewModel[]
 }
 
+// Milestone achievements (progress-based, unlockable)
+
+export type MilestoneCategory = 'combat' | 'economy' | 'diplomacy' | 'exploration'
+export type MilestoneTier = 'bronze' | 'silver' | 'gold' | 'legendary'
+
+export interface MilestoneAchievementViewModel {
+  id: string
+  name: string
+  description: string
+  category: MilestoneCategory
+  icon: string
+  isUnlocked: boolean
+  unlockedAt: string | null
+  currentProgress: number
+  targetProgress: number
+  tier: MilestoneTier
+}
+
+export interface MilestoneAchievementsSummaryViewModel {
+  totalAchievements: number
+  unlockedCount: number
+  unlockedByCategory: Record<string, number>
+}
+
+export interface MilestoneAchievementsViewModel {
+  achievements: MilestoneAchievementViewModel[]
+  summary: MilestoneAchievementsSummaryViewModel
+}
+
 // Player game-completion achievements (api/player-management/me/achievements)
 
 export interface PlayerAchievementViewModel {

--- a/src/ReactClient/src/pages/Achievements.tsx
+++ b/src/ReactClient/src/pages/Achievements.tsx
@@ -1,75 +1,358 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
+import { TrophyIcon, SwordsIcon, CoinsIcon, HandshakeIcon, CompassIcon, LockIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { PlayerAchievementsViewModel } from '@/api/types'
+import type {
+	PlayerAchievementsViewModel,
+	MilestoneAchievementViewModel,
+	MilestoneCategory,
+	MilestoneTier,
+} from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { cn } from '@/lib/utils'
+
+// ── Mock milestone data (backend TBD — defines the API contract) ────────────
+
+const MOCK_MILESTONES: MilestoneAchievementViewModel[] = [
+	// Combat
+	{ id: 'combat-first-blood', name: 'First Blood', description: 'Win your first battle', category: 'combat', icon: '⚔️', isUnlocked: true, unlockedAt: '2026-03-20T12:00:00Z', currentProgress: 1, targetProgress: 1, tier: 'bronze' },
+	{ id: 'combat-warlord', name: 'Warlord', description: 'Win 10 battles in a single game', category: 'combat', icon: '🗡️', isUnlocked: true, unlockedAt: '2026-03-22T15:30:00Z', currentProgress: 10, targetProgress: 10, tier: 'silver' },
+	{ id: 'combat-conqueror', name: 'Conqueror', description: 'Destroy 50 enemy units', category: 'combat', icon: '💀', isUnlocked: false, unlockedAt: null, currentProgress: 32, targetProgress: 50, tier: 'gold' },
+	{ id: 'combat-supreme', name: 'Supreme Commander', description: 'Win a game without losing a single battle', category: 'combat', icon: '👑', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
+
+	// Economy
+	{ id: 'econ-first-mine', name: 'Mineral Rush', description: 'Accumulate 10,000 minerals', category: 'economy', icon: '💎', isUnlocked: true, unlockedAt: '2026-03-19T10:00:00Z', currentProgress: 10000, targetProgress: 10000, tier: 'bronze' },
+	{ id: 'econ-gas-giant', name: 'Gas Giant', description: 'Accumulate 5,000 gas', category: 'economy', icon: '⛽', isUnlocked: true, unlockedAt: '2026-03-21T08:00:00Z', currentProgress: 5000, targetProgress: 5000, tier: 'silver' },
+	{ id: 'econ-market-mogul', name: 'Market Mogul', description: 'Complete 20 market trades', category: 'economy', icon: '📈', isUnlocked: false, unlockedAt: null, currentProgress: 14, targetProgress: 20, tier: 'gold' },
+	{ id: 'econ-tycoon', name: 'Galactic Tycoon', description: 'Accumulate 1,000,000 total resources', category: 'economy', icon: '🏦', isUnlocked: false, unlockedAt: null, currentProgress: 420000, targetProgress: 1000000, tier: 'legendary' },
+
+	// Diplomacy
+	{ id: 'diplo-first-ally', name: 'First Contact', description: 'Join or create an alliance', category: 'diplomacy', icon: '🤝', isUnlocked: true, unlockedAt: '2026-03-20T14:00:00Z', currentProgress: 1, targetProgress: 1, tier: 'bronze' },
+	{ id: 'diplo-peacekeeper', name: 'Peacekeeper', description: 'Sign 3 non-aggression pacts', category: 'diplomacy', icon: '🕊️', isUnlocked: false, unlockedAt: null, currentProgress: 1, targetProgress: 3, tier: 'silver' },
+	{ id: 'diplo-deal-maker', name: 'Deal Maker', description: 'Complete 10 player-to-player trades', category: 'diplomacy', icon: '📜', isUnlocked: false, unlockedAt: null, currentProgress: 4, targetProgress: 10, tier: 'gold' },
+	{ id: 'diplo-united', name: 'United Nations', description: 'Lead an alliance with 5+ members to victory', category: 'diplomacy', icon: '🌍', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
+
+	// Exploration
+	{ id: 'explore-settler', name: 'Settler', description: 'Colonize 100 land', category: 'exploration', icon: '🏗️', isUnlocked: true, unlockedAt: '2026-03-19T11:00:00Z', currentProgress: 100, targetProgress: 100, tier: 'bronze' },
+	{ id: 'explore-expand', name: 'Expansionist', description: 'Colonize 500 land', category: 'exploration', icon: '🗺️', isUnlocked: false, unlockedAt: null, currentProgress: 310, targetProgress: 500, tier: 'silver' },
+	{ id: 'explore-tech-rush', name: 'Tech Rush', description: 'Research 10 technologies', category: 'exploration', icon: '🔬', isUnlocked: false, unlockedAt: null, currentProgress: 6, targetProgress: 10, tier: 'gold' },
+	{ id: 'explore-pioneer', name: 'Galactic Pioneer', description: 'Fully explore the tech tree in a single game', category: 'exploration', icon: '🚀', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
+]
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+const CATEGORIES: { key: MilestoneCategory; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+	{ key: 'combat', label: 'Combat', icon: SwordsIcon },
+	{ key: 'economy', label: 'Economy', icon: CoinsIcon },
+	{ key: 'diplomacy', label: 'Diplomacy', icon: HandshakeIcon },
+	{ key: 'exploration', label: 'Exploration', icon: CompassIcon },
+]
+
+const TIER_STYLES: Record<MilestoneTier, { ring: string; bg: string; label: string; glow: string }> = {
+	bronze: { ring: 'ring-amber-700/60', bg: 'bg-amber-900/20', label: 'text-amber-600', glow: '' },
+	silver: { ring: 'ring-gray-400/60', bg: 'bg-gray-500/10', label: 'text-gray-400', glow: '' },
+	gold: { ring: 'ring-yellow-500/70', bg: 'bg-yellow-500/10', label: 'text-yellow-500', glow: 'shadow-[0_0_12px_rgba(234,179,8,0.15)]' },
+	legendary: { ring: 'ring-purple-500/70', bg: 'bg-purple-500/10', label: 'text-purple-400', glow: 'shadow-[0_0_16px_rgba(168,85,247,0.2)]' },
+}
+
+const TIER_ORDER: MilestoneTier[] = ['bronze', 'silver', 'gold', 'legendary']
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDate(d: string) {
+	return new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function rankBadge(rank: number): string {
+	if (rank === 1) return 'bg-yellow-500 text-black'
+	if (rank === 2) return 'bg-gray-400 text-black'
+	if (rank === 3) return 'bg-amber-700 text-white'
+	return 'bg-secondary text-secondary-foreground'
+}
+
+function progressPercent(current: number, target: number) {
+	if (target === 0) return 100
+	return Math.min(100, Math.round((current / target) * 100))
+}
+
+function formatProgress(current: number, target: number) {
+	const fmt = (n: number) => n >= 10000 ? `${(n / 1000).toFixed(n >= 100000 ? 0 : 1)}k` : n.toLocaleString()
+	return `${fmt(current)} / ${fmt(target)}`
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function MilestoneCard({ m }: { m: MilestoneAchievementViewModel }) {
+	const tier = TIER_STYLES[m.tier]
+	const pct = progressPercent(m.currentProgress, m.targetProgress)
+
+	return (
+		<div
+			className={cn(
+				'relative rounded-lg border p-4 flex flex-col gap-2.5 transition-all duration-200',
+				m.isUnlocked
+					? `ring-1 ${tier.ring} ${tier.bg} ${tier.glow} border-transparent`
+					: 'border-border/50 bg-card/50 opacity-65 hover:opacity-80'
+			)}
+		>
+			{/* Icon + tier badge */}
+			<div className="flex items-start justify-between">
+				<div className={cn('text-3xl leading-none', !m.isUnlocked && 'grayscale')}>
+					{m.isUnlocked ? m.icon : <LockIcon className="h-7 w-7 text-muted-foreground/50" />}
+				</div>
+				<span className={cn('text-[10px] font-bold uppercase tracking-wider', tier.label)}>
+					{m.tier}
+				</span>
+			</div>
+
+			{/* Name + description */}
+			<div>
+				<div className={cn('font-semibold text-sm', m.isUnlocked ? 'text-foreground' : 'text-muted-foreground')}>
+					{m.name}
+				</div>
+				<div className="text-xs text-muted-foreground mt-0.5">{m.description}</div>
+			</div>
+
+			{/* Progress bar */}
+			<div className="mt-auto">
+				<div className="flex justify-between items-center text-[11px] text-muted-foreground mb-1">
+					<span>{formatProgress(m.currentProgress, m.targetProgress)}</span>
+					<span>{pct}%</span>
+				</div>
+				<div className="h-1.5 rounded-full bg-secondary overflow-hidden">
+					<div
+						className={cn(
+							'h-full rounded-full transition-all duration-500',
+							m.isUnlocked
+								? m.tier === 'legendary' ? 'bg-purple-500' : m.tier === 'gold' ? 'bg-yellow-500' : 'bg-primary'
+								: 'bg-muted-foreground/40'
+						)}
+						style={{ width: `${pct}%` }}
+					/>
+				</div>
+			</div>
+
+			{/* Unlocked date */}
+			{m.isUnlocked && m.unlockedAt && (
+				<div className="text-[10px] text-muted-foreground">
+					Unlocked {formatDate(m.unlockedAt)}
+				</div>
+			)}
+		</div>
+	)
+}
+
+function TrophyCard({ a }: { a: { achievementIcon: string; achievementLabel: string; gameName: string; finalRank: number; score: number; earnedAt: string } }) {
+	return (
+		<div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-2 hover:border-border/80 transition-colors">
+			<div className="text-3xl leading-none">{a.achievementIcon}</div>
+			<div className="font-semibold text-sm">{a.achievementLabel}</div>
+			<div className="text-sm text-muted-foreground">{a.gameName}</div>
+			<div className="flex justify-between items-center mt-auto text-xs text-muted-foreground">
+				<span className={`px-2 py-0.5 rounded font-mono font-bold ${rankBadge(a.finalRank)}`}>
+					#{a.finalRank}
+				</span>
+				<span>{Number(a.score).toLocaleString()} pts</span>
+				<span>{formatDate(a.earnedAt)}</span>
+			</div>
+		</div>
+	)
+}
+
+function SummaryStats({ milestones, trophyCount }: { milestones: MilestoneAchievementViewModel[]; trophyCount: number }) {
+	const unlocked = milestones.filter(m => m.isUnlocked).length
+	const total = milestones.length
+	const overallPct = total > 0 ? Math.round((unlocked / total) * 100) : 0
+
+	return (
+		<div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+			<div className="rounded-lg border bg-secondary/20 p-3 text-center">
+				<div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Trophies</div>
+				<div className="text-2xl font-bold text-yellow-500">{trophyCount}</div>
+			</div>
+			<div className="rounded-lg border bg-secondary/20 p-3 text-center">
+				<div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Milestones</div>
+				<div className="text-2xl font-bold">{unlocked}<span className="text-sm font-normal text-muted-foreground"> / {total}</span></div>
+			</div>
+			<div className="rounded-lg border bg-secondary/20 p-3 text-center">
+				<div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Completion</div>
+				<div className="text-2xl font-bold">{overallPct}%</div>
+			</div>
+			<div className="rounded-lg border bg-secondary/20 p-3 text-center">
+				<div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Best Tier</div>
+				<div className="text-2xl font-bold">
+					{unlocked > 0
+						? (() => {
+								const unlockTiers = TIER_ORDER.filter((t: MilestoneTier) => milestones.some(m => m.isUnlocked && m.tier === t))
+								const best = unlockTiers.length > 0 ? unlockTiers[unlockTiers.length - 1] : undefined
+								return best ? <span className={TIER_STYLES[best].label}>{best.charAt(0).toUpperCase() + best.slice(1)}</span> : '—'
+							})()
+						: '—'}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+type Tab = 'milestones' | 'trophies'
 
 export function Achievements() {
-  const { data, isLoading, error, refetch } = useQuery<PlayerAchievementsViewModel>({
-    queryKey: ['achievements'],
-    queryFn: () => apiClient.get('/api/player-management/me/achievements').then((r) => r.data),
-  })
+	const [tab, setTab] = useState<Tab>('milestones')
+	const [selectedCategory, setSelectedCategory] = useState<MilestoneCategory | 'all'>('all')
 
-  const formatDate = (d: string) =>
-    new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+	const { data, isLoading, error, refetch } = useQuery<PlayerAchievementsViewModel>({
+		queryKey: ['achievements'],
+		queryFn: () => apiClient.get('/api/player-management/me/achievements').then(r => r.data),
+	})
 
-  const rankBadge = (rank: number): string => {
-    if (rank === 1) return 'bg-yellow-500 text-black'
-    if (rank === 2) return 'bg-gray-400 text-black'
-    if (rank === 3) return 'bg-amber-700 text-white'
-    return 'bg-secondary text-secondary-foreground'
-  }
+	// TODO: Replace mock data once backend endpoint exists
+	// const { data: milestoneData } = useQuery<MilestoneAchievementsViewModel>({
+	//   queryKey: ['milestone-achievements'],
+	//   queryFn: () => apiClient.get('/api/player-management/me/milestone-achievements').then(r => r.data),
+	// })
+	const milestones = MOCK_MILESTONES
 
-  if (isLoading) return <PageLoader message="Loading achievements..." />
-  if (error) return <ApiError message="Failed to load achievements." onRetry={() => void refetch()} />
+	if (isLoading) return <PageLoader message="Loading achievements..." />
+	if (error) return <ApiError message="Failed to load achievements." onRetry={() => void refetch()} />
 
-  const achievements = data?.achievements ?? []
+	const trophies = data?.achievements ?? []
 
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-1">Achievements</h1>
-      <p className="text-muted-foreground mb-6">Your earned badges across all games.</p>
+	const filteredMilestones = selectedCategory === 'all'
+		? milestones
+		: milestones.filter(m => m.category === selectedCategory)
 
-      {achievements.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <div className="text-6xl mb-4 opacity-30">🎯</div>
-          <h3 className="text-lg font-semibold mb-1">No achievements yet</h3>
-          <p className="text-muted-foreground mb-4">Complete your first game to earn your first badge!</p>
-          <Link
-            to="/games"
-            className="px-4 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90 text-sm"
-          >
-            Browse Games
-          </Link>
-        </div>
-      ) : (
-        <>
-          <p className="mb-4 text-sm text-muted-foreground">
-            <strong className="text-foreground">{achievements.length}</strong>{' '}
-            achievement{achievements.length !== 1 ? 's' : ''} earned
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {achievements.map((a, idx) => (
-              <div
-                key={idx}
-                className="rounded-lg border border-border bg-card p-4 flex flex-col gap-2 hover:border-border/80 transition-colors"
-              >
-                <div className="text-3xl leading-none">{a.achievementIcon}</div>
-                <div className="font-semibold text-sm">{a.achievementLabel}</div>
-                <div className="text-sm text-muted-foreground">{a.gameName}</div>
-                <div className="flex justify-between items-center mt-auto text-xs text-muted-foreground">
-                  <span className={`px-2 py-0.5 rounded font-mono font-bold ${rankBadge(a.finalRank)}`}>
-                    #{a.finalRank}
-                  </span>
-                  <span>{Number(a.score).toLocaleString()} pts</span>
-                  <span>{formatDate(a.earnedAt)}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
-    </div>
-  )
+	// Sort: unlocked first (by tier desc), then locked (by progress desc)
+	const sortedMilestones = [...filteredMilestones].sort((a, b) => {
+		if (a.isUnlocked !== b.isUnlocked) return a.isUnlocked ? -1 : 1
+		if (a.isUnlocked && b.isUnlocked) {
+			return TIER_ORDER.indexOf(b.tier) - TIER_ORDER.indexOf(a.tier)
+		}
+		return progressPercent(b.currentProgress, b.targetProgress) - progressPercent(a.currentProgress, a.targetProgress)
+	})
+
+	return (
+		<div className="p-4 sm:p-6 max-w-5xl mx-auto">
+			{/* Header */}
+			<div className="flex items-center gap-3 mb-1">
+				<TrophyIcon className="h-6 w-6 text-yellow-500" />
+				<h1 className="text-2xl font-bold">Achievements</h1>
+			</div>
+			<p className="text-muted-foreground mb-5">Track your progress and earn rewards across all games.</p>
+
+			{/* Summary stats */}
+			<SummaryStats milestones={milestones} trophyCount={trophies.length} />
+
+			{/* Tab bar */}
+			<div className="flex gap-1 mb-5 border-b border-border">
+				<button
+					onClick={() => setTab('milestones')}
+					className={cn(
+						'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+						tab === 'milestones'
+							? 'border-primary text-primary'
+							: 'border-transparent text-muted-foreground hover:text-foreground'
+					)}
+				>
+					Milestones
+				</button>
+				<button
+					onClick={() => setTab('trophies')}
+					className={cn(
+						'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+						tab === 'trophies'
+							? 'border-primary text-primary'
+							: 'border-transparent text-muted-foreground hover:text-foreground'
+					)}
+				>
+					Game Trophies
+					{trophies.length > 0 && (
+						<span className="ml-1.5 px-1.5 py-0.5 rounded-full bg-secondary text-xs">{trophies.length}</span>
+					)}
+				</button>
+			</div>
+
+			{/* ── Milestones tab ── */}
+			{tab === 'milestones' && (
+				<>
+					{/* Category filter pills */}
+					<div className="flex flex-wrap gap-2 mb-5">
+						<button
+							onClick={() => setSelectedCategory('all')}
+							className={cn(
+								'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+								selectedCategory === 'all'
+									? 'bg-primary text-primary-foreground'
+									: 'bg-secondary text-muted-foreground hover:text-foreground'
+							)}
+						>
+							All
+						</button>
+						{CATEGORIES.map(cat => {
+							const Icon = cat.icon
+							const count = milestones.filter(m => m.category === cat.key && m.isUnlocked).length
+							const total = milestones.filter(m => m.category === cat.key).length
+							return (
+								<button
+									key={cat.key}
+									onClick={() => setSelectedCategory(cat.key)}
+									className={cn(
+										'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+										selectedCategory === cat.key
+											? 'bg-primary text-primary-foreground'
+											: 'bg-secondary text-muted-foreground hover:text-foreground'
+									)}
+								>
+									<Icon className="h-3 w-3" />
+									{cat.label}
+									<span className="opacity-70">{count}/{total}</span>
+								</button>
+							)
+						})}
+					</div>
+
+					{/* Milestone grid */}
+					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+						{sortedMilestones.map(m => (
+							<MilestoneCard key={m.id} m={m} />
+						))}
+					</div>
+				</>
+			)}
+
+			{/* ── Trophies tab ── */}
+			{tab === 'trophies' && (
+				<>
+					{trophies.length === 0 ? (
+						<div className="flex flex-col items-center justify-center py-20 text-center">
+							<div className="text-6xl mb-4 opacity-30">🎯</div>
+							<h3 className="text-lg font-semibold mb-1">No trophies yet</h3>
+							<p className="text-muted-foreground mb-4">Complete your first game to earn your first trophy!</p>
+							<Link
+								to="/games"
+								className="px-4 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90 text-sm"
+							>
+								Browse Games
+							</Link>
+						</div>
+					) : (
+						<>
+							<p className="mb-4 text-sm text-muted-foreground">
+								<strong className="text-foreground">{trophies.length}</strong>{' '}
+								troph{trophies.length !== 1 ? 'ies' : 'y'} earned
+							</p>
+							<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+								{trophies.map((a, idx) => (
+									<TrophyCard key={idx} a={a} />
+								))}
+							</div>
+						</>
+					)}
+				</>
+			)}
+		</div>
+	)
 }

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
-import { TrophyIcon, SwordsIcon, StarIcon } from 'lucide-react'
+import { TrophyIcon, SwordsIcon, StarIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ProfileViewModel } from '@/api/types'
+import type { ProfileViewModel, PlayerAchievementsViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
@@ -10,6 +10,11 @@ export function PlayerProfile() {
   const { data: profile, isLoading, error, refetch } = useQuery({
     queryKey: ['profile'],
     queryFn: () => apiClient.get<ProfileViewModel>('/api/profile').then((r) => r.data),
+  })
+
+  const { data: achievementsData } = useQuery<PlayerAchievementsViewModel>({
+    queryKey: ['achievements'],
+    queryFn: () => apiClient.get('/api/player-management/me/achievements').then(r => r.data),
   })
 
   if (isLoading) return <PageLoader message="Loading profile..." />
@@ -127,6 +132,49 @@ export function PlayerProfile() {
           </div>
         </div>
       )}
+
+      {/* Achievement badges */}
+      {(() => {
+        const badges = achievementsData?.achievements ?? []
+        if (badges.length === 0) return null
+        const shown = badges.slice(0, 4)
+        return (
+          <div className="rounded-lg border bg-card p-5 space-y-3">
+            <div className="flex items-center justify-between">
+              <strong className="text-sm flex items-center gap-1.5">
+                <TrophyIcon className="h-4 w-4 text-yellow-500" />
+                Recent Achievements
+              </strong>
+              <Link
+                to="/achievements"
+                className="text-xs text-primary hover:underline flex items-center gap-0.5"
+              >
+                View all <ChevronRightIcon className="h-3 w-3" />
+              </Link>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {shown.map((a, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-2 rounded-full border bg-secondary/20 px-3 py-1.5"
+                  title={`${a.achievementLabel} — ${a.gameName}`}
+                >
+                  <span className="text-lg leading-none">{a.achievementIcon}</span>
+                  <span className="text-xs font-medium">{a.achievementLabel}</span>
+                </div>
+              ))}
+              {badges.length > 4 && (
+                <Link
+                  to="/achievements"
+                  className="flex items-center rounded-full border border-dashed px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  +{badges.length - 4} more
+                </Link>
+              )}
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Redesigned achievements page with tabbed layout: **Milestones** (progress-based, categorized) and **Game Trophies** (existing completion badges)
- Milestone cards feature progress bars, tier badges (bronze/silver/gold/legendary), locked/unlocked visual states with distinct styling (ring colors, glows, grayscale locks)
- Category filter pills: combat, economy, diplomacy, exploration — each showing unlock count
- Summary stats bar: trophies count, milestone progress, completion %, best tier
- Added **achievement badges section** to the Player Profile page with recent badges and "view all" link
- New C# DTOs (`MilestoneAchievementViewModel`, `MilestoneAchievementsViewModel`, `MilestoneAchievementsSummaryViewModel`) define the API contract for the engineer to build the backend
- New TypeScript types (`MilestoneCategory`, `MilestoneTier`, etc.) mirror the C# contract
- Milestones currently use mock data (16 achievements across 4 categories × 4 tiers) until backend endpoint (`GET /api/player-management/me/milestone-achievements`) is built
- Mobile responsive grid (1→2→3→4 columns)

## Test plan

- [x] C# build passes (0 errors, 0 warnings)
- [x] TypeScript type-check passes
- [x] All 419 existing tests pass
- [ ] Manual: verify achievements page renders with both tabs
- [ ] Manual: verify category filter pills filter correctly
- [ ] Manual: verify profile page shows achievement badges section
- [ ] Manual: verify mobile responsiveness at sm/md/lg breakpoints