### PR TITLE
feat: BGE-642 new player tutorial and Help page

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerProfileController.cs
@@ -55,7 +55,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				Score = scoreRepository.GetScore(player.PlayerId),
 				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining,
 				IsOnline = onlineStatusRepository.IsOnline(player.PlayerId),
-				LastOnline = player.LastOnline
+				LastOnline = player.LastOnline,
+				TutorialCompleted = player.State.TutorialCompleted
 			};
 		}
 
@@ -110,6 +111,17 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			playerRepositoryWrite.CreatePlayer(playerId, currentUserContext.UserId);
 			playerRepositoryWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, model.PlayerName!));
 			currentUserContext.Activate(playerId);
+			return Ok();
+		}
+
+		/// <summary>Marks the tutorial as completed for the current player.</summary>
+		[HttpPost]
+		[Route("complete-tutorial")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult CompleteTutorial() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			playerRepositoryWrite.CompleteTutorial(currentUserContext.PlayerId!);
 			return Ok();
 		}
 

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.GameModel {
 		IDictionary<string, SpyResult>? LastSpyResults = null,
 		IList<SpyAttemptLog>? SpyAttemptLogs = null,
 		IList<GameNotification>? Notifications = null,
-		IList<SpyMissionImmutable>? SpyMissions = null
+		IList<SpyMissionImmutable>? SpyMissions = null,
+		bool TutorialCompleted = false
 	);
 }

--- a/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerProfileViewModel.cs
@@ -12,5 +12,6 @@ namespace BrowserGameEngine.Shared {
 		public int ProtectionTicksRemaining { get; set; }
 		public bool IsOnline { get; set; }
 		public DateTime? LastOnline { get; set; }
+		public bool TutorialCompleted { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -28,6 +28,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<SpyAttemptLog> SpyAttemptLogs { get; set; } = new List<SpyAttemptLog>();
 		public List<GameNotification> Notifications { get; set; } = new List<GameNotification>();
 		public List<SpyMission> SpyMissions { get; set; } = new List<SpyMission>();
+		public bool TutorialCompleted { get; set; }
 	}
 
 	internal static class PlayerStateExtensions {
@@ -54,7 +55,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
 				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
 				Notifications: new List<GameNotification>(playerState.Notifications),
-				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList()
+				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList(),
+				TutorialCompleted: playerState.TutorialCompleted
 			);
 		}
 
@@ -93,7 +95,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					? new List<GameNotification>(playerStateImmutable.Notifications)
 					: new List<GameNotification>(),
 				SpyMissions = (playerStateImmutable.SpyMissions ?? new List<SpyMissionImmutable>())
-					.Select(x => x.ToMutable()).ToList()
+					.Select(x => x.ToMutable()).ToList(),
+				TutorialCompleted = playerStateImmutable.TutorialCompleted
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -118,6 +118,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
+		public void CompleteTutorial(PlayerId playerId) {
+			lock (_lock) {
+				world.GetPlayer(playerId).State.TutorialCompleted = true;
+			}
+		}
+
 		public void BanPlayer(PlayerId playerId) {
 			lock (_lock) {
 				world.GetPlayer(playerId).IsBanned = true;

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -41,6 +41,7 @@ const AdminTickControl = lazy(() => import('@/pages/admin/AdminTickControl').the
 const AdminStats = lazy(() => import('@/pages/admin/AdminStats').then(m => ({ default: m.AdminStats })))
 const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ default: m.PlayersList })))
 const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
+const Help = lazy(() => import('@/pages/Help').then(m => ({ default: m.Help })))
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -161,6 +162,7 @@ const router = createBrowserRouter([
           { path: 'spy', element: <SpyReportsPage /> },
           { path: 'selectenemy/:unitId', element: <SelectEnemyPage /> },
           { path: 'unitdefinitions', element: <UnitDefinitions /> },
+          { path: 'help', element: <Help /> },
           { path: 'player/:playerId', element: <InGamePlayerProfilePage /> },
           { path: 'enemybase/:enemyPlayerId', element: <EnemyBasePage /> },
           { path: 'join', element: <JoinGame /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -335,6 +335,7 @@ export interface PlayerProfileViewModel {
   protectionTicksRemaining: number
   isOnline: boolean
   lastOnline: string | null
+  tutorialCompleted: boolean
 }
 
 export interface PublicPlayerViewModel {

--- a/src/ReactClient/src/components/NavMenu.tsx
+++ b/src/ReactClient/src/components/NavMenu.tsx
@@ -15,6 +15,7 @@ import {
   TrophyIcon,
   BookOpenIcon,
   HistoryIcon,
+  HelpCircleIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useCurrentGame } from '@/contexts/CurrentGameContext'
@@ -80,6 +81,7 @@ export function NavMenu() {
         <SectionLabel>Info</SectionLabel>
         <NavItem to={g('unitdefinitions')} icon={BookOpenIcon} label="Unit Types" />
         <NavItem to={g('ranking')} icon={BarChart2Icon} label="Ranking" />
+        <NavItem to={g('help')} icon={HelpCircleIcon} label="Help" />
 
         <SectionLabel>Social</SectionLabel>
         <NavItem to={g('diplomacy')} icon={FlagIcon} label="Diplomacy" />

--- a/src/ReactClient/src/components/TutorialOverlay.tsx
+++ b/src/ReactClient/src/components/TutorialOverlay.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useRef } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { XIcon, ChevronRightIcon, ChevronLeftIcon, SkipForwardIcon } from 'lucide-react'
+import apiClient from '@/api/client'
+import type { PlayerProfileViewModel } from '@/api/types'
+import { cn } from '@/lib/utils'
+
+interface TutorialStep {
+  title: string
+  body: string
+  icon: string
+}
+
+const STEPS: TutorialStep[] = [
+  {
+    title: 'Welcome, Commander!',
+    body: 'This quick tutorial will walk you through the basics. You can skip it at any time or revisit the Help page later.',
+    icon: '👋',
+  },
+  {
+    title: 'Your Base',
+    body: 'Head to Base to see your buildings. Your Command Center is already built — it produces workers that gather resources for you.',
+    icon: '🏗️',
+  },
+  {
+    title: 'Gathering Resources',
+    body: 'Assign workers to mine Minerals and Vespene Gas. Open your Base page and use the worker assignment panel to balance production.',
+    icon: '⛏️',
+  },
+  {
+    title: 'Constructing Buildings',
+    body: 'Buildings unlock new units and upgrades. Each building costs resources and a build slot. Check the Base page to start construction.',
+    icon: '🏭',
+  },
+  {
+    title: 'Training Units',
+    body: 'Go to Units to train military forces. Each unit type has different stats — hover over them to see attack, defense, and speed.',
+    icon: '⚔️',
+  },
+  {
+    title: 'Attacking Enemies',
+    body: 'Select a unit on the Units page and choose an enemy to attack. Battles are resolved automatically based on unit strength and upgrades.',
+    icon: '🎯',
+  },
+  {
+    title: 'You\'re Ready!',
+    body: 'That covers the basics. Explore Research for upgrades, Market for trading, and Alliances to team up. Good luck, Commander!',
+    icon: '🚀',
+  },
+]
+
+export function TutorialOverlay() {
+  const queryClient = useQueryClient()
+  const [step, setStep] = useState(0)
+  const [dismissed, setDismissed] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const { data: profile } = useQuery<PlayerProfileViewModel>({
+    queryKey: ['player-profile-tutorial'],
+    queryFn: () => apiClient.get('/api/playerprofile').then((r) => r.data),
+  })
+
+  const completeMut = useMutation({
+    mutationFn: () => apiClient.post('/api/playerprofile/complete-tutorial'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['player-profile-tutorial'] })
+    },
+  })
+
+  useEffect(() => {
+    dialogRef.current?.focus()
+  }, [step])
+
+  // Handle escape key
+  useEffect(() => {
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleSkip()
+    }
+    window.addEventListener('keydown', handleEscape)
+    return () => window.removeEventListener('keydown', handleEscape)
+  }, [])
+
+  if (!profile || profile.tutorialCompleted || dismissed) return null
+
+  function handleSkip() {
+    setDismissed(true)
+    completeMut.mutate()
+  }
+
+  function handleNext() {
+    if (step < STEPS.length - 1) {
+      setStep(step + 1)
+    } else {
+      handleSkip()
+    }
+  }
+
+  function handlePrev() {
+    if (step > 0) setStep(step - 1)
+  }
+
+  const current = STEPS[step]
+  const isLast = step === STEPS.length - 1
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={handleSkip}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Tutorial"
+        className="relative mx-4 w-full max-w-md rounded-lg border bg-card p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          onClick={handleSkip}
+          className="absolute top-3 right-3 p-1 rounded hover:bg-secondary text-muted-foreground"
+          aria-label="Skip tutorial"
+        >
+          <XIcon className="h-4 w-4" />
+        </button>
+
+        {/* Step indicator */}
+        <div className="flex gap-1 mb-4">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={cn(
+                'h-1 flex-1 rounded-full transition-colors',
+                i <= step ? 'bg-primary' : 'bg-muted'
+              )}
+            />
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="text-center mb-6">
+          <div className="text-4xl mb-3">{current.icon}</div>
+          <h2 className="text-lg font-bold mb-2">{current.title}</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">{current.body}</p>
+        </div>
+
+        {/* Step counter */}
+        <p className="text-xs text-muted-foreground text-center mb-4">
+          Step {step + 1} of {STEPS.length}
+        </p>
+
+        {/* Navigation */}
+        <div className="flex justify-between items-center">
+          <button
+            onClick={handleSkip}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <SkipForwardIcon className="h-3.5 w-3.5" />
+            Skip tutorial
+          </button>
+
+          <div className="flex gap-2">
+            {step > 0 && (
+              <button
+                onClick={handlePrev}
+                className="flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary transition-colors"
+              >
+                <ChevronLeftIcon className="h-4 w-4" />
+                Back
+              </button>
+            )}
+            <button
+              onClick={handleNext}
+              className="flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              {isLast ? 'Get Started' : 'Next'}
+              {!isLast && <ChevronRightIcon className="h-4 w-4" />}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -6,6 +6,7 @@ import { NavMenu } from '@/components/NavMenu'
 import { PlayerResources } from '@/components/PlayerResources'
 import { NotificationBell } from '@/components/NotificationBell'
 import { NotificationToasts, useNotificationToasts } from '@/components/NotificationToast'
+import { TutorialOverlay } from '@/components/TutorialOverlay'
 import { PageLoader } from '@/components/PageLoader'
 import { useSignalR } from '@/hooks/useSignalR'
 import { cn } from '@/lib/utils'
@@ -196,6 +197,9 @@ function GameLayoutInner() {
 
       {/* Real-time notification toasts */}
       <NotificationToasts toasts={toasts} dismiss={dismiss} gameId={gameId} />
+
+      {/* First-time player tutorial */}
+      <TutorialOverlay />
     </div>
   )
 }

--- a/src/ReactClient/src/pages/Help.tsx
+++ b/src/ReactClient/src/pages/Help.tsx
@@ -1,0 +1,111 @@
+interface GuideSection {
+  title: string
+  icon: string
+  items: string[]
+}
+
+const SECTIONS: GuideSection[] = [
+  {
+    title: 'Getting Started',
+    icon: '🏗️',
+    items: [
+      'Your Command Center is built automatically when you join a game.',
+      'Assign workers to Minerals and Vespene Gas on the Base page to start gathering resources.',
+      'Workers are generated passively over time — the more land you control, the more workers you get.',
+    ],
+  },
+  {
+    title: 'Building & Expanding',
+    icon: '🏭',
+    items: [
+      'Construct buildings from the Base page to unlock new unit types and upgrades.',
+      'Each building requires resources and a build slot. Higher-level buildings are more expensive.',
+      'Expand your land by colonizing — this costs resources but gives you more worker capacity.',
+    ],
+  },
+  {
+    title: 'Training Units',
+    icon: '⚔️',
+    items: [
+      'Train military units on the Units page. Different units have different attack, defense, and speed stats.',
+      'Check the Unit Types page under Info for detailed stats on each unit.',
+      'You can merge units of the same type to combine them into a stronger group.',
+    ],
+  },
+  {
+    title: 'Combat',
+    icon: '🎯',
+    items: [
+      'Select a unit and click "Attack" to choose an enemy player.',
+      'Battles are resolved automatically based on unit strength, upgrades, and numbers.',
+      'Defeated units are lost permanently — plan your attacks carefully.',
+      'New players have protection for the first few hours. Use this time to build up.',
+    ],
+  },
+  {
+    title: 'Research & Upgrades',
+    icon: '🔬',
+    items: [
+      'Research upgrades to improve your units\' attack and defense globally.',
+      'Unlock the tech tree to access advanced buildings, units, and abilities.',
+      'Research takes time — queue it early and let it complete while you play.',
+    ],
+  },
+  {
+    title: 'Economy & Trading',
+    icon: '💰',
+    items: [
+      'Trade resources with other players on the Market page.',
+      'Post buy/sell orders or accept existing offers.',
+      'Keep a balanced economy — running out of one resource can stall your progress.',
+    ],
+  },
+  {
+    title: 'Alliances & Diplomacy',
+    icon: '🤝',
+    items: [
+      'Create or join an alliance to team up with other players.',
+      'Alliance members can chat privately and coordinate attacks.',
+      'Declare wars or propose peace through the Diplomacy page.',
+    ],
+  },
+  {
+    title: 'Intelligence',
+    icon: '🕵️',
+    items: [
+      'Use spies on the Operations page to gather intel on enemy players.',
+      'Spy missions reveal enemy resources, units, and base layout.',
+      'Be careful — failed spy attempts can be detected by the target.',
+    ],
+  },
+]
+
+export function Help() {
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-xl font-bold">Game Guide</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          A quick reference for all the game mechanics. New to the game? Read through these sections to get up to speed.
+        </p>
+      </div>
+
+      {SECTIONS.map((section) => (
+        <div key={section.title} className="rounded-lg border bg-card p-4">
+          <h2 className="flex items-center gap-2 text-base font-semibold mb-2">
+            <span>{section.icon}</span>
+            {section.title}
+          </h2>
+          <ul className="space-y-1.5">
+            {section.items.map((item, i) => (
+              <li key={i} className="text-sm text-muted-foreground flex gap-2">
+                <span className="text-muted-foreground/50 shrink-0">•</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `TutorialCompleted` flag to player state model (persisted per player)
- Add `POST /api/playerprofile/complete-tutorial` endpoint to mark tutorial done
- Create a 7-step tutorial overlay for first-time players (Welcome, Base, Resources, Buildings, Units, Combat, Ready)
- Tutorial auto-shows on first game entry, skippable at any time, with step-by-step progress bar
- Create a Help/Guide page with 8 sections covering all key game mechanics
- Add Help link to sidebar navigation under the Info section

## Test plan
- [x] `dotnet build` passes (0 warnings, 0 errors)
- [x] `dotnet test` passes (442 tests, 0 failures)
- [x] React `tsc -b` and `vite build` pass
- [ ] Manual: create new player — tutorial overlay should appear
- [ ] Manual: complete or skip tutorial — overlay should not appear again
- [ ] Manual: verify Help page is accessible from sidebar navigation
- [ ] Manual: verify tutorial works on mobile layout

Closes BGE-642