### PR TITLE
feat: BGE-677 alliance leader election system

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -112,7 +112,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 						IsPending = m.IsPending,
 						JoinedAt = m.JoinedAt,
 						VoteCount = m.VoteCount,
-						IsLeader = m.PlayerId == alliance.LeaderId
+						IsLeader = m.PlayerId == alliance.LeaderId,
+						VotedForPlayerId = m.VotedForPlayerId?.Id
 					};
 				}).ToList()
 			});
@@ -233,6 +234,18 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			try {
 				allianceRepositoryWrite.VoteLeader(
 					new VoteLeaderCommand(currentUserContext.PlayerId!, PlayerIdFactory.Create(request.VoteePlayerId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		[HttpDelete("{id}/leader-vote")]
+		public ActionResult RetractVote(string id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceRepositoryWrite.RetractVote(
+					new RetractVoteCommand(currentUserContext.PlayerId!));
 				return Ok();
 			} catch (NotAllianceMemberException e) {
 				return BadRequest(e.Message);

--- a/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
@@ -6,7 +6,8 @@ namespace BrowserGameEngine.GameModel {
 		PlayerId PlayerId,
 		bool IsPending,
 		DateTime JoinedAt,
-		int VoteCount
+		int VoteCount,
+		PlayerId? VotedForPlayerId = null
 	);
 
 	public record AllianceImmutable(

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -9,6 +9,7 @@ namespace BrowserGameEngine.Shared {
 		public DateTime JoinedAt { get; set; }
 		public int VoteCount { get; set; }
 		public bool IsLeader { get; set; }
+		public string? VotedForPlayerId { get; set; }
 	}
 
 	public class AllianceViewModel {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceRepositoryTest.cs
@@ -94,18 +94,37 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
 			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
 			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
-			// Vote for Player2 to have more votes
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+			// Two members vote for Player2
 			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
-			// Now Player2 has 1 vote, Player1 becomes leader by vote count? Let's just leave and check a leader is assigned
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+			// Player1 (leader by creation) leaves — Player2 should become leader (most votes)
 			game.AllianceRepositoryWrite.LeaveAlliance(new LeaveAllianceCommand(Player1));
 
 			var alliance = game.AllianceRepository.Get(allianceId);
 			Assert.NotNull(alliance);
-			Assert.NotEqual(Player1, alliance.LeaderId);
+			Assert.Equal(Player2, alliance.LeaderId);
 		}
 
 		[Fact]
 		public void VoteLeader_ChangesLeaderWhenVoteeOvertakes() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+			// Two votes for Player2 vs zero for Player1
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			Assert.Equal(Player2, alliance.LeaderId);
+		}
+
+		[Fact]
+		public void VoteLeader_SetsVotedForPlayerId() {
 			var game = new TestGame(playerCount: 2);
 			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
 			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
@@ -113,7 +132,105 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
 
 			var alliance = game.AllianceRepository.Get(allianceId)!;
-			Assert.Equal(Player2, alliance.LeaderId);
+			var voter = alliance.Members.Single(m => m.PlayerId == Player1);
+			Assert.Equal(Player2, voter.VotedForPlayerId);
+		}
+
+		[Fact]
+		public void VoteLeader_ChangeVote_UpdatesLeader() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+
+			// Player2 and Player3 vote for Player2
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player2, Player2));
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+			Assert.Equal(Player2, game.AllianceRepository.Get(allianceId)!.LeaderId);
+
+			// Player3 changes vote to Player3 — now tied 1:1, incumbent Player2 stays
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player3));
+			Assert.Equal(Player2, game.AllianceRepository.Get(allianceId)!.LeaderId);
+
+			// Player1 also votes for Player3 — now Player3 has 2 votes, Player2 has 1
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player3));
+			Assert.Equal(Player3, game.AllianceRepository.Get(allianceId)!.LeaderId);
+		}
+
+		[Fact]
+		public void VoteLeader_SameVoteTwice_NoChange() {
+			var game = new TestGame(playerCount: 2);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
+
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			var votee = alliance.Members.Single(m => m.PlayerId == Player2);
+			Assert.Equal(1, votee.VoteCount);
+		}
+
+		[Fact]
+		public void RetractVote_ClearsVoteAndRecalculates() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+
+			// Vote for Player2
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+			Assert.Equal(Player2, game.AllianceRepository.Get(allianceId)!.LeaderId);
+
+			// Retract one vote — Player2 still has 1 vote from Player3
+			game.AllianceRepositoryWrite.RetractVote(new RetractVoteCommand(Player1));
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			var voter = alliance.Members.Single(m => m.PlayerId == Player1);
+			Assert.Null(voter.VotedForPlayerId);
+			Assert.Equal(Player2, alliance.LeaderId); // Still leader with 1 vote
+		}
+
+		[Fact]
+		public void VoteLeader_TiedVotes_IncumbentStays() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+
+			// Player2 votes for Player1 (incumbent), Player3 votes for Player2 — tied 1:1
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player2, Player1));
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			// Incumbent Player1 stays as leader in a tie
+			Assert.Equal(Player1, alliance.LeaderId);
+		}
+
+		[Fact]
+		public void LeaveAlliance_VoterLeaves_VoteCountUpdated() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "secret"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "secret"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+
+			// Player3 votes for Player2
+			game.AllianceRepositoryWrite.VoteLeader(new VoteLeaderCommand(Player3, Player2));
+			Assert.Equal(1, game.AllianceRepository.Get(allianceId)!.Members.Single(m => m.PlayerId == Player2).VoteCount);
+
+			// Player3 leaves — Player2 should have 0 votes now
+			game.AllianceRepositoryWrite.LeaveAlliance(new LeaveAllianceCommand(Player3));
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			Assert.Equal(0, alliance.Members.Single(m => m.PlayerId == Player2).VoteCount);
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -18,6 +18,7 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record LeaveAllianceCommand(PlayerId PlayerId) : ICommand;
 	public record KickMemberCommand(PlayerId PlayerId, PlayerId MemberPlayerId) : ICommand;
 	public record VoteLeaderCommand(PlayerId PlayerId, PlayerId VoteePlayerId) : ICommand;
+	public record RetractVoteCommand(PlayerId PlayerId) : ICommand;
 	public record SetAlliancePasswordCommand(PlayerId PlayerId, string NewPassword) : ICommand;
 	public record SetAllianceMessageCommand(PlayerId PlayerId, string Message) : ICommand;
 	public record PostAllianceChatCommand(PlayerId PlayerId, AllianceId AllianceId, string Body) : ICommand;

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
@@ -9,6 +9,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public bool IsPending { get; set; }
 		public DateTime JoinedAt { get; set; }
 		public int VoteCount { get; set; }
+		public PlayerId? VotedForPlayerId { get; set; }
 	}
 
 	internal class AlliancePost {
@@ -46,7 +47,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				PlayerId: member.PlayerId,
 				IsPending: member.IsPending,
 				JoinedAt: member.JoinedAt,
-				VoteCount: member.VoteCount
+				VoteCount: member.VoteCount,
+				VotedForPlayerId: member.VotedForPlayerId
 			);
 		}
 
@@ -55,7 +57,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				PlayerId = member.PlayerId,
 				IsPending = member.IsPending,
 				JoinedAt = member.JoinedAt,
-				VoteCount = member.VoteCount
+				VoteCount = member.VoteCount,
+				VotedForPlayerId = member.VotedForPlayerId
 			};
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceRepositoryWrite.cs
@@ -108,7 +108,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				player.AllianceId = null;
 				if (!alliance.Members.Any()) {
 					world.Alliances.Remove(alliance.AllianceId);
-				} else if (alliance.LeaderId == command.PlayerId) {
+				} else {
 					RecalculateLeader(alliance);
 				}
 			}
@@ -125,6 +125,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				alliance.Members.Remove(member);
 				var kickedPlayer = world.GetPlayer(command.MemberPlayerId);
 				kickedPlayer.AllianceId = null;
+				RecalculateLeader(alliance);
 			}
 		}
 
@@ -137,7 +138,19 @@ namespace BrowserGameEngine.StatefulGameServer {
 				if (voterMember == null) throw new NotAllianceMemberException();
 				var voteeMember = alliance.Members.FirstOrDefault(m => m.PlayerId == command.VoteePlayerId && !m.IsPending);
 				if (voteeMember == null) throw new NotAllianceMemberException();
-				voteeMember.VoteCount++;
+				voterMember.VotedForPlayerId = command.VoteePlayerId;
+				RecalculateLeader(alliance);
+			}
+		}
+
+		public void RetractVote(RetractVoteCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null) throw new NotAllianceMemberException();
+				var alliance = world.GetAlliance(player.AllianceId);
+				var voterMember = alliance.Members.FirstOrDefault(m => m.PlayerId == command.PlayerId && !m.IsPending);
+				if (voterMember == null) throw new NotAllianceMemberException();
+				voterMember.VotedForPlayerId = null;
 				RecalculateLeader(alliance);
 			}
 		}
@@ -165,13 +178,26 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private static void RecalculateLeader(Alliance alliance) {
 			var acceptedMembers = alliance.Members.Where(m => !m.IsPending).ToList();
 			if (!acceptedMembers.Any()) return;
-			var currentLeaderMember = acceptedMembers.FirstOrDefault(m => m.PlayerId == alliance.LeaderId);
+
+			// Clean up dangling votes (voted-for player is no longer an accepted member)
+			var acceptedPlayerIds = acceptedMembers.Select(m => m.PlayerId).ToHashSet();
+			foreach (var member in acceptedMembers) {
+				if (member.VotedForPlayerId != null && !acceptedPlayerIds.Contains(member.VotedForPlayerId)) {
+					member.VotedForPlayerId = null;
+				}
+			}
+
+			// Derive vote counts from VotedForPlayerId
+			foreach (var member in acceptedMembers) {
+				member.VoteCount = acceptedMembers.Count(m => m.VotedForPlayerId == member.PlayerId);
+			}
+
 			var topVoteCount = acceptedMembers.Max(m => m.VoteCount);
 			if (topVoteCount == 0) {
 				// No votes cast — current leader stays if still present
-				if (currentLeaderMember != null) return;
-				// Otherwise pick first accepted member
-				alliance.LeaderId = acceptedMembers.First().PlayerId;
+				if (acceptedMembers.Any(m => m.PlayerId == alliance.LeaderId)) return;
+				// Otherwise pick longest-tenured accepted member
+				alliance.LeaderId = acceptedMembers.OrderBy(m => m.JoinedAt).First().PlayerId;
 				return;
 			}
 			var topVoted = acceptedMembers.Where(m => m.VoteCount == topVoteCount).ToList();

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -399,6 +399,7 @@ export interface AllianceMemberViewModel {
   joinedAt: string
   voteCount: number
   isLeader: boolean
+  votedForPlayerId?: string | null
 }
 
 export interface AllianceViewModel {

--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -18,6 +18,7 @@ import type {
 	AllianceWarViewModel,
 	AllianceViewModel,
 	PublicPlayerViewModel,
+	PlayerProfileViewModel,
 	PaginatedResponse,
 } from '@/api/types'
 import { cn, relativeTime } from '@/lib/utils'
@@ -44,9 +45,6 @@ export function AllianceDetail() {
 	const [chatBody, setChatBody] = useState('')
 	const chatEndRef = useRef<HTMLDivElement>(null)
 
-	// Vote state
-	const [votePlayerId, setVotePlayerId] = useState('')
-
 	const { data: detail, isLoading, error: detailError, refetch: refetchDetail } = useQuery<AllianceDetailViewModel>({
 		queryKey: ['alliance-detail', allianceId],
 		queryFn: () => apiClient.get(`/api/alliances/${allianceId}`).then((r) => r.data),
@@ -59,8 +57,16 @@ export function AllianceDetail() {
 		refetchInterval: 10_000,
 	})
 
+	const { data: profile } = useQuery<PlayerProfileViewModel>({
+		queryKey: ['player-profile-alliance'],
+		queryFn: () => apiClient.get('/api/playerprofile').then((r) => r.data),
+	})
+
 	const isMember = myStatus?.allianceId === allianceId && myStatus?.isMember && !myStatus?.isPending
 	const isLeader = myStatus?.allianceId === allianceId && myStatus?.isLeader
+	const myPlayerId = profile?.playerId ?? null
+	const myMember = detail?.members.find((m) => m.playerId === myPlayerId)
+	const myVotedFor = myMember?.votedForPlayerId ?? null
 
 	const { data: posts } = useQuery<AllianceChatPostViewModel[]>({
 		queryKey: ['alliance-chat', allianceId],
@@ -137,6 +143,13 @@ export function AllianceDetail() {
 		mutationFn: (voteePlayerId: string) =>
 			apiClient.post(`/api/alliances/${allianceId}/leader-vote`, { voteePlayerId }),
 		onSuccess: () => { setSuccess('Vote cast!'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const retractVoteMut = useMutation({
+		mutationFn: () =>
+			apiClient.delete(`/api/alliances/${allianceId}/leader-vote`),
+		onSuccess: () => { setSuccess('Vote retracted.'); invalidateAll() },
 		onError: handleError,
 	})
 
@@ -256,33 +269,14 @@ export function AllianceDetail() {
 			<div className="rounded-lg border bg-card">
 				<div className="border-b px-4 py-3 flex items-center justify-between">
 					<strong className="text-sm">Members ({confirmedMembers.length})</strong>
-					{isMember && (
-						<div className="flex items-center gap-2">
-							{/* Vote for leader */}
-							<select
-								value={votePlayerId}
-								onChange={(e) => setVotePlayerId(e.target.value)}
-								className="rounded border bg-input px-2 py-1 text-xs"
-							>
-								<option value="">Vote for leader…</option>
-								{confirmedMembers.map((m) => (
-									<option key={m.playerId} value={m.playerId}>{m.playerName}</option>
-								))}
-							</select>
-							<button
-								onClick={() => {
-									if (votePlayerId) {
-										setError(null); setSuccess(null)
-										voteMut.mutate(votePlayerId)
-									}
-								}}
-								disabled={!votePlayerId || voteMut.isPending}
-								className="rounded bg-secondary px-2 py-1 text-xs hover:opacity-90 disabled:opacity-50 flex items-center gap-1"
-							>
-								<VoteIcon className="h-3 w-3" />
-								Vote
-							</button>
-						</div>
+					{isMember && myVotedFor && (
+						<button
+							onClick={() => { setError(null); setSuccess(null); retractVoteMut.mutate() }}
+							disabled={retractVoteMut.isPending}
+							className="rounded border border-muted-foreground px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-foreground disabled:opacity-50"
+						>
+							Retract Vote
+						</button>
 					)}
 				</div>
 				<div className="overflow-x-auto">
@@ -292,21 +286,37 @@ export function AllianceDetail() {
 								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Player</th>
 								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Votes</th>
 								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Joined</th>
-								{isLeader && <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>}
+								<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
 							</tr>
 						</thead>
 						<tbody>
-							{confirmedMembers.map((m) => (
-								<tr key={m.playerId} className="border-b border-border">
-									<td className="py-2 px-3 font-medium flex items-center gap-1.5">
-										{m.isLeader && <CrownIcon className="h-3.5 w-3.5 text-warning-foreground" />}
-										{m.playerName}
-									</td>
-									<td className="py-2 px-3">{m.voteCount}</td>
-									<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(m.joinedAt)}</td>
-									{isLeader && (
-										<td className="py-2 px-3">
-											{!m.isLeader && (
+							{confirmedMembers.map((m) => {
+								const isMyVote = myVotedFor === m.playerId
+								return (
+									<tr key={m.playerId} className="border-b border-border">
+										<td className="py-2 px-3 font-medium flex items-center gap-1.5">
+											{m.isLeader && <CrownIcon className="h-3.5 w-3.5 text-warning-foreground" />}
+											{m.playerName}
+										</td>
+										<td className="py-2 px-3">{m.voteCount}</td>
+										<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(m.joinedAt)}</td>
+										<td className="py-2 px-3 flex items-center gap-2">
+											{isMember && (
+												<button
+													onClick={() => { setError(null); setSuccess(null); voteMut.mutate(m.playerId) }}
+													disabled={voteMut.isPending || isMyVote}
+													className={cn(
+														'rounded px-2 py-0.5 text-xs flex items-center gap-1 disabled:opacity-50',
+														isMyVote
+															? 'bg-primary text-primary-foreground'
+															: 'border border-primary text-primary hover:bg-primary/10'
+													)}
+												>
+													<VoteIcon className="h-3 w-3" />
+													{isMyVote ? 'Voted' : 'Vote'}
+												</button>
+											)}
+											{isLeader && !m.isLeader && (
 												<button
 													onClick={() => { setError(null); kickMemberMut.mutate(m.playerId) }}
 													className="text-xs text-destructive hover:underline"
@@ -315,9 +325,9 @@ export function AllianceDetail() {
 												</button>
 											)}
 										</td>
-									)}
-								</tr>
-							))}
+									</tr>
+								)
+							})}
 						</tbody>
 					</table>
 				</div>


### PR DESCRIPTION
## Summary
- Replace broken vote-stacking alliance election with proper 1-person-1-vote system
- Each member holds one standing vote (`VotedForPlayerId`) that can be changed or retracted at any time
- Vote counts are now derived from member data, preventing accumulation bugs
- New `DELETE /api/alliances/{id}/leader-vote` endpoint for vote retraction
- Updated React UI with per-member vote buttons and retract vote functionality
- Dangling votes cleaned up automatically when members leave or are kicked

## Test plan
- [x] `dotnet build` passes (0 warnings, 0 errors)
- [x] `dotnet test` passes (496 tests, all passing)
- [ ] Verify voting UI shows per-member vote buttons with highlight for current vote
- [ ] Verify vote retraction works via UI button
- [ ] Verify leader changes correctly when votes shift
- [ ] Verify existing alliances with no votes continue working (null VotedForPlayerId defaults)

Closes BGE-677