### PR TITLE
test: BGE-676 E2E smoke tests for leaderboard/army + CI integration

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -48,3 +48,61 @@ jobs:
     - name: Lint
       working-directory: src/ReactClient
       run: npm run lint
+
+  e2e:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Start BGE stack
+      working-directory: src
+      env:
+        GITHUB_CLIENT_ID: placeholder
+        GITHUB_CLIENT_SECRET: placeholder
+      run: docker compose up -d
+
+    - name: Wait for server to be healthy
+      run: |
+        echo "Waiting for http://localhost:8080/health ..."
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:8080/health > /dev/null; then
+            echo "Server is healthy"
+            exit 0
+          fi
+          echo "  attempt $i/30 — sleeping 3 s"
+          sleep 3
+        done
+        echo "Server did not become healthy in time"
+        docker compose -f src/docker-compose.yml logs
+        exit 1
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: src/ReactClient/package-lock.json
+
+    - name: Install dependencies
+      working-directory: src/ReactClient
+      run: npm ci
+
+    - name: Install Playwright browsers
+      working-directory: src/ReactClient
+      run: npx playwright install --with-deps chromium
+
+    - name: Run E2E smoke tests
+      working-directory: src/ReactClient
+      env:
+        E2E_BASE_URL: http://localhost:8080
+      run: npm run test:e2e
+
+    - name: Upload Playwright report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: src/ReactClient/playwright-report/
+        retention-days: 7

--- a/src/ReactClient/e2e/global-setup.ts
+++ b/src/ReactClient/e2e/global-setup.ts
@@ -1,6 +1,9 @@
 import { chromium } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /**
  * Global setup: authenticates as the shared E2E test user via dev auth

--- a/src/ReactClient/e2e/tests/08-leaderboard.spec.ts
+++ b/src/ReactClient/e2e/tests/08-leaderboard.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Leaderboard (Player Ranking) smoke tests.
+ *
+ * Verifies that the ranking page renders, shows the filter controls, and lists
+ * at least the e2e-test-admin player who was enrolled in the default game via
+ * global-setup.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createNavGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Leaderboard Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId as string
+}
+
+test.describe('Player Ranking (leaderboard)', () => {
+	test('ranking page renders heading and filter controls', async ({ page }) => {
+		const gameId = await createNavGame(page)
+
+		await page.goto(`/games/${gameId}/ranking`)
+		await expect(page.getByRole('heading', { name: 'Player Ranking' })).toBeVisible()
+
+		// Filter buttons: All / Human / Agent
+		await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Human' })).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Agent' })).toBeVisible()
+
+		// No crash
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+
+	test('ranking page shows at least one player row', async ({ page }) => {
+		const gameId = await createNavGame(page)
+
+		await page.goto(`/games/${gameId}/ranking`)
+		await expect(page.getByRole('heading', { name: 'Player Ranking' })).toBeVisible()
+
+		// Wait for table to populate (query refetches every 30 s; initial load should be fast)
+		const rows = page.locator('table tbody tr')
+		await expect(rows.first()).toBeVisible({ timeout: 10_000 })
+		expect(await rows.count()).toBeGreaterThan(0)
+	})
+
+	test('Human filter hides agent-only rows without crashing', async ({ page }) => {
+		const gameId = await createNavGame(page)
+
+		await page.goto(`/games/${gameId}/ranking`)
+		await expect(page.getByRole('heading', { name: 'Player Ranking' })).toBeVisible()
+
+		// Switch to Human filter
+		await page.getByRole('button', { name: 'Human' }).click()
+		await expect(page.getByRole('button', { name: 'Human' })).toHaveAttribute('aria-pressed', 'true')
+
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+})

--- a/src/ReactClient/e2e/tests/09-unit-army.spec.ts
+++ b/src/ReactClient/e2e/tests/09-unit-army.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Unit build → army tests.
+ *
+ * Verifies that building a unit via the API causes it to appear on the Units
+ * page. The in-game state lives in the default game world; we create a game
+ * record only for React router navigation.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createNavGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Army Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId as string
+}
+
+test.describe('Unit build — army visibility', () => {
+	test('units page renders heading and shows unit count after building', async ({ page }) => {
+		const gameId = await createNavGame(page)
+
+		// Build WBF units via API
+		const buildRes = await page.request.post(
+			`${baseURL}/api/units/build?unitDefId=wbf&count=3`,
+			{ data: {} }
+		)
+		expect(buildRes.ok()).toBeTruthy()
+
+		await page.goto(`/games/${gameId}/units`)
+		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
+
+		// The units page should report at least 3 total units
+		const countLine = page.getByText(/units in \d+ stack/)
+		await expect(countLine).toBeVisible({ timeout: 10_000 })
+
+		const text = await countLine.textContent()
+		const match = text?.match(/^(\d[\d,]*)/)
+		const total = parseInt((match?.[1] ?? '0').replace(',', ''), 10)
+		expect(total).toBeGreaterThanOrEqual(3)
+	})
+
+	test('units page renders without errors when army is empty', async ({ page }) => {
+		// Fresh user — no units in army yet
+		const freshUserId = `e2e-army-${Date.now()}`
+		await page.request.post(`${baseURL}/signindev`, {
+			form: { playerid: freshUserId, returnUrl: '/' },
+		})
+
+		const gameId = await createNavGame(page)
+
+		await page.goto(`/games/${gameId}/units`)
+		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
+
+		// Empty state message should be shown
+		await expect(page.getByText('Build units from your base buildings')).toBeVisible({
+			timeout: 10_000,
+		})
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+})


### PR DESCRIPTION
## Summary

- Adds two missing E2E smoke tests to complete the BGE-676 acceptance criteria:
  - **`08-leaderboard.spec.ts`** — Player Ranking page: heading renders, filter buttons (All/Human/Agent) are present and functional, at least one player row appears
  - **`09-unit-army.spec.ts`** — Units page: built units appear with correct count, empty-state message shown when no units exist
- Wires the full Playwright suite into CI (`dotnet-core.yml` new `e2e` job): starts the BGE stack via `docker compose up -d`, waits for `/health`, runs tests headless, uploads Playwright report as an artifact

## Context

BGE-650 already set up Playwright and added 7 test files covering signin, games, gameplay, chat, resource management, attack flow, and alliances. This PR fills the two remaining coverage gaps from [BGE-676](/BGE/issues/BGE-676) — leaderboard and unit-army — and adds the CI step that runs the suite on every push/PR.

Race selection was omitted: the current `JoinGameRequest` does not expose a race field, so there is nothing to test yet.

## Test plan

- [ ] CI `e2e` job passes on this PR
- [ ] Playwright report artifact is uploaded after the run
- [ ] `08-leaderboard.spec.ts` — all 3 tests pass
- [ ] `09-unit-army.spec.ts` — both tests pass