### PR TITLE
fix: BGE-687 round coverage % before threshold comparison

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           tree = ET.parse(files[0])
           root = tree.getroot()
           line_rate = float(root.attrib.get("line-rate", 0))
-          pct = line_rate * 100
+          pct = round(line_rate * 100, 1)
           threshold = 60.0
 
           print(f"Line coverage: {pct:.1f}% (threshold: {threshold}%)")


### PR DESCRIPTION
## Summary
- Floating-point precision caused `line_rate * 100` to produce `59.999...` which displays as `60.0%` but fails the `< 60.0` check
- Fix: `round(pct, 1)` before comparison so the threshold check matches the displayed value

## Test plan
- [ ] CI coverage check passes when coverage is at exactly the threshold