### PR TITLE
feat: BGE-675 game lobby system with create/join/spectate

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -3,6 +3,7 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using Microsoft.AspNetCore.Authorization;
@@ -25,6 +26,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly CurrentUserContext currentUserContext;
 		private readonly TimeProvider timeProvider;
 		private readonly GameLifecycleEngine gameLifecycleEngine;
+		private readonly IGameEventPublisher gameEventPublisher;
 
 		public GamesController(
 			ILogger<GamesController> logger,
@@ -34,7 +36,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			GameDef gameDef,
 			CurrentUserContext currentUserContext,
 			TimeProvider timeProvider,
-			GameLifecycleEngine gameLifecycleEngine
+			GameLifecycleEngine gameLifecycleEngine,
+			IGameEventPublisher gameEventPublisher
 		) {
 			this.logger = logger;
 			this.gameRegistry = gameRegistry;
@@ -44,6 +47,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.currentUserContext = currentUserContext;
 			this.timeProvider = timeProvider;
 			this.gameLifecycleEngine = gameLifecycleEngine;
+			this.gameEventPublisher = gameEventPublisher;
 		}
 
 		/// <summary>Returns games where the authenticated user has an active player.</summary>
@@ -107,11 +111,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			));
 		}
 
-		/// <summary>Creates a new game. Requires authentication.</summary>
+		/// <summary>Creates a new game. Any authenticated player can create a game.</summary>
 		/// <param name="request">Game creation parameters.</param>
 		/// <returns>Summary of the newly created game.</returns>
 		[HttpPost]
-		[Authorize(Policy = "Admin")]
 		[ProducesResponseType(typeof(GameSummaryViewModel), StatusCodes.Status201Created)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -123,6 +126,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (!TimeSpan.TryParse(request.TickDuration, out var tickDuration) || tickDuration <= TimeSpan.Zero) {
 				return BadRequest("TickDuration must be a valid positive timespan (HH:MM:SS)");
 			}
+			if (request.MaxPlayers < 0) return BadRequest("MaxPlayers cannot be negative.");
 
 			var gameId = new GameId(Guid.NewGuid().ToString("N")[..12]);
 			var record = new GameRecordImmutable(
@@ -134,7 +138,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				EndTime: request.EndTime.ToUniversalTime(),
 				TickDuration: tickDuration,
 				DiscordWebhookUrl: request.DiscordWebhookUrl,
-				CreatedByUserId: currentUserContext.UserId
+				CreatedByUserId: currentUserContext.UserId,
+				MaxPlayers: request.MaxPlayers
 			);
 
 			// Create a fresh world state for the new game
@@ -217,9 +222,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			));
 		}
 
-		/// <summary>Joins an upcoming game with the current player. Requires authentication.</summary>
+		/// <summary>Joins an upcoming or active game with race selection.</summary>
 		/// <param name="gameId">The game identifier.</param>
-		/// <param name="request">Join request containing the player name.</param>
+		/// <param name="request">Join request containing the player name and optional race.</param>
 		[HttpPost("{gameId}/join")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -238,16 +243,79 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var instance = gameRegistry.TryGetInstance(record.GameId);
 			if (instance == null) return NotFound();
 
+			// Enforce max players
+			if (record.MaxPlayers > 0 && instance.PlayerCount >= record.MaxPlayers)
+				return BadRequest("This game is full.");
+
 			// Check if user already has a player in this game (by UserId)
 			if (instance.HasUserPlayer(currentUserContext.UserId!)) return Conflict("You have already joined this game.");
 
+			// Validate race selection — default to first available race
+			var playerType = request.PlayerType ?? gameDef.PlayerTypes.First().Id.Id;
+			if (!gameDef.PlayerTypes.Any(pt => pt.Id.Id == playerType))
+				return BadRequest($"Invalid race: {playerType}");
+
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
-			playerRepoWrite.CreatePlayer(playerId, currentUserContext.UserId);
+			playerRepoWrite.CreatePlayer(playerId, currentUserContext.UserId, playerType);
 			playerRepoWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, request.PlayerName));
 
-			logger.LogInformation("Player {PlayerId} joined game {GameId} as {PlayerName}", playerId.Id, gameId, request.PlayerName);
+			logger.LogInformation("Player {PlayerId} joined game {GameId} as {PlayerName} ({Race})", playerId.Id, gameId, request.PlayerName, playerType);
+
+			// Broadcast lobby update via SignalR
+			gameEventPublisher.PublishToGame(GameEventTypes.LobbyUpdated, new { GameId = gameId });
+
 			return Ok(new { PlayerId = playerId.Id });
+		}
+
+		/// <summary>Returns lobby details for a game including the player list.</summary>
+		/// <param name="gameId">The game identifier.</param>
+		[AllowAnonymous]
+		[HttpGet("{gameId}/lobby")]
+		[ProducesResponseType(typeof(GameLobbyViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<GameLobbyViewModel> GetLobby(string gameId) {
+			var record = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
+			if (record == null) return NotFound();
+
+			var instance = gameRegistry.TryGetInstance(record.GameId);
+			var players = new List<LobbyPlayerViewModel>();
+			if (instance != null) {
+				players = instance.GetLobbyPlayers()
+					.OrderBy(p => p.Created)
+					.Select(p => new LobbyPlayerViewModel(
+						PlayerId: p.PlayerId.Id,
+						PlayerName: p.Name,
+						PlayerType: p.PlayerType.Id,
+						Joined: p.Created
+					))
+					.ToList();
+			}
+
+			bool canJoin = (record.Status == GameStatus.Upcoming || record.Status == GameStatus.Active)
+				&& (record.MaxPlayers == 0 || players.Count < record.MaxPlayers);
+
+			return Ok(new GameLobbyViewModel(
+				GameId: record.GameId.Id,
+				GameName: record.Name,
+				Status: record.Status.ToString(),
+				MaxPlayers: record.MaxPlayers,
+				StartTime: record.StartTime,
+				EndTime: record.EndTime,
+				Players: players,
+				CanJoin: canJoin
+			));
+		}
+
+		/// <summary>Returns available races for a game definition.</summary>
+		[AllowAnonymous]
+		[HttpGet("races")]
+		[ProducesResponseType(typeof(RaceListViewModel), StatusCodes.Status200OK)]
+		public ActionResult<RaceListViewModel> GetRaces() {
+			var races = gameDef.PlayerTypes
+				.Select(pt => new RaceViewModel(pt.Id.Id, pt.Name))
+				.ToList();
+			return Ok(new RaceListViewModel(races));
 		}
 
 		/// <summary>Manually finalizes an active game early. Only the game creator may do this.</summary>
@@ -335,21 +403,25 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				var instance = gameRegistry.TryGetInstance(record.GameId);
 				isPlayerEnrolled = instance?.HasUserPlayer(currentUserContext.UserId) ?? false;
 			}
+			var playerCount = GetPlayerCount(record);
+			bool canJoin = (record.Status == GameStatus.Upcoming || record.Status == GameStatus.Active)
+				&& (record.MaxPlayers == 0 || playerCount < record.MaxPlayers);
 			return new GameSummaryViewModel(
 				GameId: record.GameId.Id,
 				Name: record.Name,
 				GameDefType: record.GameDefType,
 				Status: record.Status.ToString(),
-				PlayerCount: GetPlayerCount(record),
-				MaxPlayers: 0,
+				PlayerCount: playerCount,
+				MaxPlayers: record.MaxPlayers,
 				StartTime: record.StartTime,
 				EndTime: record.EndTime,
-				CanJoin: record.Status == GameStatus.Upcoming || record.Status == GameStatus.Active,
+				CanJoin: canJoin,
 				WinnerId: record.WinnerId?.Id,
 				WinnerName: winnerName,
 				IsPlayerEnrolled: isPlayerEnrolled,
 				VictoryConditionType: record.VictoryConditionType,
-				DiscordWebhookUrl: record.DiscordWebhookUrl
+				DiscordWebhookUrl: record.DiscordWebhookUrl,
+				CreatedByUserId: record.CreatedByUserId
 			);
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -243,13 +243,6 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var instance = gameRegistry.TryGetInstance(record.GameId);
 			if (instance == null) return NotFound();
 
-			// Enforce max players
-			if (record.MaxPlayers > 0 && instance.PlayerCount >= record.MaxPlayers)
-				return BadRequest("This game is full.");
-
-			// Check if user already has a player in this game (by UserId)
-			if (instance.HasUserPlayer(currentUserContext.UserId!)) return Conflict("You have already joined this game.");
-
 			// Validate race selection — default to first available race
 			var playerType = request.PlayerType ?? gameDef.PlayerTypes.First().Id.Id;
 			if (!gameDef.PlayerTypes.Any(pt => pt.Id.Id == playerType))
@@ -257,7 +250,12 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
-			playerRepoWrite.CreatePlayer(playerId, currentUserContext.UserId, playerType);
+
+			// Atomically check capacity + duplicate user + create player inside the lock
+			var joinResult = playerRepoWrite.TryCreatePlayer(playerId, currentUserContext.UserId, playerType, record.MaxPlayers);
+			if (joinResult == JoinGameResult.GameFull) return BadRequest("This game is full.");
+			if (joinResult == JoinGameResult.AlreadyJoined) return Conflict("You have already joined this game.");
+
 			playerRepoWrite.ChangePlayerName(new ChangePlayerNameCommand(playerId, request.PlayerName));
 
 			logger.LogInformation("Player {PlayerId} joined game {GameId} as {PlayerName} ({Race})", playerId.Id, gameId, request.PlayerName, playerType);

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -17,6 +17,7 @@ namespace BrowserGameEngine.GameModel {
 		DateTime? ActualEndTime = null,
 		string? VictoryConditionType = null,
 		string? CreatedByUserId = null,
-		string? DiscordWebhookUrl = null
+		string? DiscordWebhookUrl = null,
+		int MaxPlayers = 0
 	);
 }

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -16,12 +16,35 @@ namespace BrowserGameEngine.Shared {
 		string? WinnerName = null,
 		bool IsPlayerEnrolled = false,
 		string? VictoryConditionType = null,
-		string? DiscordWebhookUrl = null
+		string? DiscordWebhookUrl = null,
+		string? CreatedByUserId = null
 	);
 
 	public record GameListViewModel(List<GameSummaryViewModel> Games);
 
-	public record JoinGameRequest(string PlayerName);
+	public record JoinGameRequest(string PlayerName, string? PlayerType = null);
 
 	public record JoinGameViewModel(string PlayerId);
+
+	public record GameLobbyViewModel(
+		string GameId,
+		string GameName,
+		string Status,
+		int MaxPlayers,
+		DateTime? StartTime,
+		DateTime? EndTime,
+		List<LobbyPlayerViewModel> Players,
+		bool CanJoin = false
+	);
+
+	public record LobbyPlayerViewModel(
+		string PlayerId,
+		string PlayerName,
+		string PlayerType,
+		DateTime Joined
+	);
+
+	public record RaceViewModel(string Id, string Name);
+
+	public record RaceListViewModel(List<RaceViewModel> Races);
 }

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -23,7 +23,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime StartTime,
 		DateTime EndTime,
 		string TickDuration,
-		string? DiscordWebhookUrl = null
+		string? DiscordWebhookUrl = null,
+		int MaxPlayers = 0
 	);
 
 	public record UpdateGameRequest(

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -78,7 +78,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				game.GameDef,
 				userCtx,
 				TimeProvider.System,
-				lifecycleEngine
+				lifecycleEngine,
+				NullGameEventPublisher.Instance
 			);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
@@ -60,6 +60,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				new NullGameNotificationService(),
 				new InMemoryPlayerNotificationService(NullGameEventPublisher.Instance),
 				userRepositoryWrite,
+				NullGameEventPublisher.Instance,
 				TimeProvider.System,
 				NullLogger<GameLifecycleEngine>.Instance
 			);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
@@ -1,0 +1,267 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Controllers;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class LobbyTest {
+		private static GameRecordImmutable MakeRecord(
+			string gameId,
+			string? createdByUserId = "creator",
+			GameStatus status = GameStatus.Upcoming,
+			int maxPlayers = 0
+		) {
+			var start = DateTime.UtcNow.AddHours(1);
+			var end = DateTime.UtcNow.AddDays(7);
+			return new GameRecordImmutable(
+				new GameId(gameId),
+				"Test Game",
+				"sco",
+				status,
+				start,
+				end,
+				TimeSpan.FromSeconds(30),
+				CreatedByUserId: createdByUserId,
+				MaxPlayers: maxPlayers
+			);
+		}
+
+		private static (GamesController controller, GameRegistry.GameRegistry gameRegistry) MakeControllerWithRegistry(
+			GlobalState globalState,
+			string? userId
+		) {
+			var game = new TestGame();
+			var gameRegistry = new GameRegistry.GameRegistry(globalState);
+			var userCtx = new CurrentUserContext();
+			if (userId != null) {
+				userCtx.UserId = userId;
+				userCtx.Activate(PlayerIdFactory.Create(userId));
+			}
+
+			var storage = new InMemoryBlobStorage();
+			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
+			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
+			var userRepositoryWrite = new UserRepositoryWrite(globalState, game.World, TimeProvider.System);
+			var lifecycleEngine = new GameLifecycleEngine(
+				gameRegistry,
+				globalState,
+				persistenceService,
+				globalPersistenceService,
+				new NullGameNotificationService(),
+				new InMemoryPlayerNotificationService(NullGameEventPublisher.Instance),
+				userRepositoryWrite,
+				TimeProvider.System,
+				NullLogger<GameLifecycleEngine>.Instance
+			);
+
+			var controller = new GamesController(
+				NullLogger<GamesController>.Instance,
+				gameRegistry,
+				globalState,
+				game.WorldStateFactory,
+				game.GameDef,
+				userCtx,
+				TimeProvider.System,
+				lifecycleEngine,
+				NullGameEventPublisher.Instance
+			);
+
+			return (controller, gameRegistry);
+		}
+
+		private static GamesController MakeController(GlobalState globalState, string? userId) =>
+			MakeControllerWithRegistry(globalState, userId).controller;
+
+		[Fact]
+		public void Create_AsNonAdmin_Succeeds() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "user1");
+
+			var request = new CreateGameRequest(
+				Name: "Player's Game",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddHours(1),
+				EndTime: DateTime.UtcNow.AddDays(1),
+				TickDuration: "00:00:30"
+			);
+
+			var result = controller.Create(request);
+
+			var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+			var summary = Assert.IsType<GameSummaryViewModel>(created.Value);
+			Assert.Equal("Player's Game", summary.Name);
+		}
+
+		[Fact]
+		public void Create_WithMaxPlayers_StoresValue() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "user1");
+
+			var request = new CreateGameRequest(
+				Name: "Limited Game",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddHours(1),
+				EndTime: DateTime.UtcNow.AddDays(1),
+				TickDuration: "00:00:30",
+				MaxPlayers: 8
+			);
+
+			var result = controller.Create(request);
+
+			var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+			var summary = Assert.IsType<GameSummaryViewModel>(created.Value);
+			Assert.Equal(8, summary.MaxPlayers);
+		}
+
+		[Fact]
+		public void Join_WithRaceSelection_SetsPlayerType() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1");
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "player1");
+
+			// Register the game instance
+			var game = new TestGame(0);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var request = new JoinGameRequest("Commander", PlayerType: "type2");
+			var result = controller.Join("game1", request);
+
+			Assert.IsType<OkObjectResult>(result);
+
+			// Verify the player was created with the correct type
+			Assert.Equal(1, instance.PlayerCount);
+		}
+
+		[Fact]
+		public void Join_WithInvalidRace_Returns400() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1");
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "player1");
+
+			var game = new TestGame(0);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var request = new JoinGameRequest("Commander", PlayerType: "invalid_race");
+			var result = controller.Join("game1", request);
+
+			Assert.IsType<BadRequestObjectResult>(result);
+		}
+
+		[Fact]
+		public void Join_WhenGameFull_Returns400() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1", maxPlayers: 1);
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "player2");
+
+			// Create a game instance with 1 existing player (at max capacity)
+			var game = new TestGame(1);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var request = new JoinGameRequest("Commander2");
+			var result = controller.Join("game1", request);
+
+			Assert.IsType<BadRequestObjectResult>(result);
+		}
+
+		[Fact]
+		public void GetLobby_ReturnsPlayerList() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1");
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "viewer");
+
+			var game = new TestGame(2);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var result = controller.GetLobby("game1");
+
+			var okResult = Assert.IsType<OkObjectResult>(result.Result);
+			var lobby = Assert.IsType<GameLobbyViewModel>(okResult.Value);
+			Assert.Equal("game1", lobby.GameId);
+			Assert.Equal(2, lobby.Players.Count);
+		}
+
+		[Fact]
+		public void GetLobby_NonexistentGame_Returns404() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "viewer");
+
+			var result = controller.GetLobby("nonexistent");
+
+			Assert.IsType<NotFoundResult>(result.Result);
+		}
+
+		[Fact]
+		public void GetLobby_ShowsCanJoinFalse_WhenGameFull() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1", maxPlayers: 2);
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "viewer");
+
+			var game = new TestGame(2);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var result = controller.GetLobby("game1");
+
+			var okResult = Assert.IsType<OkObjectResult>(result.Result);
+			var lobby = Assert.IsType<GameLobbyViewModel>(okResult.Value);
+			Assert.False(lobby.CanJoin);
+		}
+
+		[Fact]
+		public void GetRaces_ReturnsAvailableRaces() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "user1");
+
+			var result = controller.GetRaces();
+
+			var okResult = Assert.IsType<OkObjectResult>(result.Result);
+			var raceList = Assert.IsType<RaceListViewModel>(okResult.Value);
+			Assert.Equal(2, raceList.Races.Count);
+			Assert.Contains(raceList.Races, r => r.Id == "type1");
+			Assert.Contains(raceList.Races, r => r.Id == "type2");
+		}
+
+		[Fact]
+		public void Join_DefaultsToTerran_WhenNoRaceSpecified() {
+			var globalState = new GlobalState();
+			var record = MakeRecord("game1");
+			globalState.AddGame(record);
+
+			var (controller, gameRegistry) = MakeControllerWithRegistry(globalState, userId: "player1");
+
+			var game = new TestGame(0);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			gameRegistry.Register(instance);
+
+			var request = new JoinGameRequest("Commander");
+			var result = controller.Join("game1", request);
+
+			Assert.IsType<OkObjectResult>(result);
+			Assert.Equal(1, instance.PlayerCount);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
@@ -10,4 +10,5 @@ public static class GameEventTypes
 	public const string GameTickCompleted = "GameTickCompleted";
 	public const string MarketOrderFilled = "MarketOrderFilled";
 	public const string GameFinalized = "GameFinalized";
+	public const string LobbyUpdated = "LobbyUpdated";
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
@@ -33,6 +34,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			return (player.PlayerId, player.Name);
 		}
 
+		/// <summary>Returns immutable snapshots of all non-banned players for lobby display.</summary>
+		public List<PlayerImmutable> GetLobbyPlayers() =>
+			WorldState.Players.Values
+				.Where(p => !p.IsBanned)
+				.Select(p => p.ToImmutable())
+				.ToList();
 
 		public void SetTickEngine(GameTickEngine tickEngine) { TickEngine = tickEngine; }
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -4,9 +4,16 @@ using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
+	public enum JoinGameResult {
+		Success,
+		GameFull,
+		AlreadyJoined
+	}
+
 	public class PlayerRepositoryWrite {
 		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
@@ -91,31 +98,50 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public void CreatePlayer(PlayerId playerId, string? userId = null, string playerType = "terran") {
 			lock (_lock) {
-				if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);
-				world.Players[playerId] = new Player() {
-					Created = timeProvider.GetLocalNow().DateTime,
-					PlayerId = playerId,
-					Name = playerId.Id,
-					PlayerType = Id.PlayerType(playerType),
-					UserId = userId,
-					State = new PlayerState {
-						LastGameTickUpdate = timeProvider.GetLocalNow().DateTime,
-						CurrentGameTick = world.GameTickState.CurrentGameTick,
-						Resources = new Dictionary<ResourceDefId, decimal> {
-							{ Id.ResDef("land"), 50 },
-							{ Id.ResDef("minerals"), 5000 },
-							{ Id.ResDef("gas"), 3000 }
-						},
-						Assets = new HashSet<Asset> {
-							new Asset {
-								AssetDefId = Id.AssetDef("commandcenter"),
-								Level = 1
-							},
-						},
-						ProtectionTicksRemaining = 480  // 4 hours at 30s/tick
-					}
-				};
+				CreatePlayerInternal(playerId, userId, playerType);
 			}
+		}
+
+		/// <summary>
+		/// Atomically checks max player capacity and duplicate user, then creates the player.
+		/// Returns a <see cref="JoinGameResult"/> indicating the outcome.
+		/// </summary>
+		public JoinGameResult TryCreatePlayer(PlayerId playerId, string? userId, string playerType, int maxPlayers) {
+			lock (_lock) {
+				if (userId != null && world.Players.Values.Any(p => p.UserId == userId))
+					return JoinGameResult.AlreadyJoined;
+				if (maxPlayers > 0 && world.Players.Count >= maxPlayers)
+					return JoinGameResult.GameFull;
+				CreatePlayerInternal(playerId, userId, playerType);
+				return JoinGameResult.Success;
+			}
+		}
+
+		private void CreatePlayerInternal(PlayerId playerId, string? userId, string playerType) {
+			if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);
+			world.Players[playerId] = new Player() {
+				Created = timeProvider.GetLocalNow().DateTime,
+				PlayerId = playerId,
+				Name = playerId.Id,
+				PlayerType = Id.PlayerType(playerType),
+				UserId = userId,
+				State = new PlayerState {
+					LastGameTickUpdate = timeProvider.GetLocalNow().DateTime,
+					CurrentGameTick = world.GameTickState.CurrentGameTick,
+					Resources = new Dictionary<ResourceDefId, decimal> {
+						{ Id.ResDef("land"), 50 },
+						{ Id.ResDef("minerals"), 5000 },
+						{ Id.ResDef("gas"), 3000 }
+					},
+					Assets = new HashSet<Asset> {
+						new Asset {
+							AssetDefId = Id.AssetDef("commandcenter"),
+							Level = 1
+						},
+					},
+					ProtectionTicksRemaining = 480  // 4 hours at 30s/tick
+				}
+			};
 		}
 
 		public void CompleteTutorial(PlayerId playerId) {

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -25,6 +25,7 @@ const PlayerProfile = lazy(() => import('@/pages/PlayerProfile').then(m => ({ de
 const InGamePlayerProfile = lazy(() => import('@/pages/InGamePlayerProfile').then(m => ({ default: m.InGamePlayerProfile })))
 const Games = lazy(() => import('@/pages/Games').then(m => ({ default: m.Games })))
 const GameLobby = lazy(() => import('@/pages/GameLobby').then(m => ({ default: m.GameLobby })))
+const GameLobbyDetail = lazy(() => import('@/pages/GameLobbyDetail').then(m => ({ default: m.GameLobbyDetail })))
 const JoinGame = lazy(() => import('@/pages/JoinGame').then(m => ({ default: m.JoinGame })))
 const GameSummary = lazy(() => import('@/pages/GameSummary').then(m => ({ default: m.GameSummary })))
 const GameResults = lazy(() => import('@/pages/GameResults').then(m => ({ default: m.GameResults })))
@@ -182,6 +183,7 @@ const router = createBrowserRouter([
 
       { path: '/createplayer', element: <CreatePlayer /> },
       { path: '/lobby', element: <GameLobby /> },
+      { path: '/lobby/:gameId', element: <GameLobbyDetail /> },
       { path: '/profile', element: <PlayerProfile /> },
       { path: '/profile/:userId', element: <PublicProfile /> },
       { path: '/players', element: <PlayersList /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -275,6 +275,7 @@ export interface GameSummaryViewModel {
   isPlayerEnrolled: boolean
   victoryConditionType: string | null
   discordWebhookUrl: string | null
+  createdByUserId: string | null
 }
 
 export interface GameListViewModel {
@@ -311,6 +312,7 @@ export interface GameResultsViewModel {
 
 export interface JoinGameRequest {
   playerName: string
+  playerType?: string
 }
 
 export interface JoinGameViewModel {
@@ -324,6 +326,7 @@ export interface CreateGameRequest {
   endTime: string
   tickDuration: string
   discordWebhookUrl: string | null
+  maxPlayers: number
 }
 
 // Players / Profile
@@ -823,16 +826,28 @@ export interface UnitDefinitionsViewModel {
 export interface GameLobbyViewModel {
   gameId: string
   gameName: string
-  players: LobbyPlayerViewModel[]
-  startTime: string | null
   status: string
+  maxPlayers: number
+  startTime: string | null
+  endTime: string | null
+  players: LobbyPlayerViewModel[]
+  canJoin: boolean
 }
 
 export interface LobbyPlayerViewModel {
   playerId: string
   playerName: string
   playerType: string
-  isReady: boolean
+  joined: string
+}
+
+export interface RaceViewModel {
+  id: string
+  name: string
+}
+
+export interface RaceListViewModel {
+  races: RaceViewModel[]
 }
 
 // Tick info

--- a/src/ReactClient/src/pages/GameLobby.tsx
+++ b/src/ReactClient/src/pages/GameLobby.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router'
 import apiClient from '@/api/client'
-import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
+import type { GameListViewModel, GameSummaryViewModel, CreateGameRequest } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { useSignalR } from '@/hooks/useSignalR'
+import { useEffect, useCallback } from 'react'
 
 function statusBadge(status: string): { css: string; label: string } {
   switch (status.toLowerCase()) {
@@ -14,10 +17,112 @@ function statusBadge(status: string): { css: string; label: string } {
   }
 }
 
+function CreateGameForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [maxPlayers, setMaxPlayers] = useState(0)
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreateGameRequest) =>
+      apiClient.post('/api/games', req),
+    onSuccess: () => {
+      setOpen(false)
+      setName('')
+      setMaxPlayers(0)
+      setStartTime('')
+      setEndTime('')
+      setError(null)
+      onCreated()
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to create game.'
+      setError(String(msg))
+    },
+  })
+
+  function handleCreate() {
+    if (!name.trim()) { setError('Game name is required.'); return }
+    if (!startTime || !endTime) { setError('Start and end times are required.'); return }
+    setError(null)
+    createMutation.mutate({
+      name: name.trim(),
+      gameDefType: 'sco',
+      startTime: new Date(startTime).toISOString(),
+      endTime: new Date(endTime).toISOString(),
+      tickDuration: '00:00:30',
+      discordWebhookUrl: null,
+      maxPlayers,
+    })
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+        onClick={() => setOpen(true)}
+      >
+        Create Game
+      </button>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 max-w-md space-y-3">
+      <h2 className="font-semibold">Create New Game</h2>
+
+      {error && (
+        <div role="alert" className="rounded border border-danger/50 bg-danger/10 p-2 text-sm text-danger-foreground">{error}</div>
+      )}
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Game Name</label>
+        <input type="text" className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+          value={name} onChange={(e) => setName(e.target.value)} placeholder="My Game" maxLength={60} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Start Time</label>
+          <input type="datetime-local" className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+            value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-medium">End Time</label>
+          <input type="datetime-local" className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+            value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Max Players (0 = unlimited)</label>
+        <input type="number" className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+          value={maxPlayers} onChange={(e) => setMaxPlayers(Number(e.target.value))} min={0} max={100} />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50"
+          onClick={handleCreate} disabled={createMutation.isPending}
+        >
+          {createMutation.isPending ? 'Creating...' : 'Create'}
+        </button>
+        <button
+          className="px-4 py-2 rounded border border-border text-sm hover:bg-muted/30"
+          onClick={() => { setOpen(false); setError(null) }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function GameLobby() {
   const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const { on, off } = useSignalR('/gamehub')
 
   const { data, isLoading, error: queryError, refetch } = useQuery<GameListViewModel>({
     queryKey: ['games'],
@@ -25,83 +130,118 @@ export function GameLobby() {
     refetchInterval: 30_000,
   })
 
-  const joinMutation = useMutation({
-    mutationFn: (game: GameSummaryViewModel) =>
-      apiClient.post(`/api/games/${game.gameId}/join`, {}),
-    onSuccess: (_, game) => {
-      setError(null)
-      setSuccess(`You have joined "${game.name}"!`)
-      void queryClient.invalidateQueries({ queryKey: ['games'] })
-    },
-    onError: async (err: unknown) => {
-      const msg = (err as { response?: { data?: string } })?.response?.data ?? 'Failed to join.'
-      setError(String(msg))
-    },
-  })
+  const handleLobbyUpdate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['games'] })
+  }, [queryClient])
+
+  useEffect(() => {
+    on('LobbyUpdated', handleLobbyUpdate)
+    return () => off('LobbyUpdated', handleLobbyUpdate)
+  }, [on, off, handleLobbyUpdate])
 
   const games = data?.games ?? []
+  const activeGames = games.filter(g => g.status.toLowerCase() !== 'finished')
+  const finishedGames = games.filter(g => g.status.toLowerCase() === 'finished')
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Game Lobby</h1>
-
-      {success && <div className="rounded border border-success/50 bg-success/10 p-3 text-sm">{success}</div>}
-      {error && <div className="rounded border border-danger/50 bg-danger/10 p-3 text-sm text-danger-foreground">{error}</div>}
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Game Lobby</h1>
+        <CreateGameForm onCreated={() => void queryClient.invalidateQueries({ queryKey: ['games'] })} />
+      </div>
 
       {isLoading && <PageLoader message="Loading games..." />}
       {queryError && !data && <ApiError message="Failed to load games." onRetry={() => void refetch()} />}
 
-      {!isLoading && games.length === 0 && (
-        <p className="text-muted-foreground text-sm">No games available.</p>
+      {!isLoading && activeGames.length === 0 && (
+        <p className="text-muted-foreground text-sm">No active or upcoming games. Create one to get started!</p>
       )}
 
-      {games.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm border-collapse">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th scope="col" className="py-2 pr-4">Game</th>
-                <th scope="col" className="py-2 pr-4">Status</th>
-                <th scope="col" className="py-2 pr-4">Players</th>
-                <th scope="col" className="py-2 pr-4">Start Time</th>
-                <th scope="col" className="py-2" />
-              </tr>
-            </thead>
-            <tbody>
-              {games.map((game) => {
-                const badge = statusBadge(game.status)
-                return (
-                  <tr key={game.gameId} className="border-b border-border hover:bg-muted/30">
-                    <td className="py-2 pr-4 font-medium">{game.name}</td>
-                    <td className="py-2 pr-4">
-                      <span className={`text-xs font-bold px-2 py-0.5 rounded ${badge.css}`}>{badge.label}</span>
-                    </td>
-                    <td className="py-2 pr-4">
-                      {game.playerCount} / {game.maxPlayers}
-                    </td>
-                    <td className="py-2 pr-4 text-muted-foreground">
-                      {game.startTime
-                        ? new Date(game.startTime).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
-                        : 'TBD'}
-                    </td>
-                    <td className="py-2">
-                      {game.canJoin && (
-                        <button
-                          className="text-xs px-2 py-1 rounded bg-primary text-primary-foreground hover:opacity-90"
-                          onClick={() => joinMutation.mutate(game)}
-                          disabled={joinMutation.isPending}
-                        >
-                          Join
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
+      {activeGames.length > 0 && (
+        <GameTable games={activeGames} title="Active & Upcoming Games" />
       )}
+
+      {finishedGames.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
+            Finished Games ({finishedGames.length})
+          </summary>
+          <div className="mt-2">
+            <GameTable games={finishedGames} />
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function GameTable({ games, title }: { games: GameSummaryViewModel[]; title?: string }) {
+  return (
+    <div className="space-y-2">
+      {title && <h2 className="text-sm font-semibold text-muted-foreground">{title}</h2>}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-border text-left text-muted-foreground">
+              <th scope="col" className="py-2 pr-4">Game</th>
+              <th scope="col" className="py-2 pr-4">Status</th>
+              <th scope="col" className="py-2 pr-4">Players</th>
+              <th scope="col" className="py-2 pr-4">Start</th>
+              <th scope="col" className="py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {games.map((game) => {
+              const badge = statusBadge(game.status)
+              const isFinished = game.status.toLowerCase() === 'finished'
+              return (
+                <tr key={game.gameId} className="border-b border-border hover:bg-muted/30">
+                  <td className="py-2 pr-4 font-medium">
+                    <Link to={`/lobby/${game.gameId}`} className="hover:underline">{game.name}</Link>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <span className={`text-xs font-bold px-2 py-0.5 rounded ${badge.css}`}>{badge.label}</span>
+                  </td>
+                  <td className="py-2 pr-4">
+                    {game.playerCount}{game.maxPlayers > 0 ? ` / ${game.maxPlayers}` : ''}
+                  </td>
+                  <td className="py-2 pr-4 text-muted-foreground">
+                    {game.startTime
+                      ? new Date(game.startTime).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
+                      : 'TBD'}
+                  </td>
+                  <td className="py-2 flex gap-2">
+                    {game.canJoin && !game.isPlayerEnrolled && (
+                      <Link
+                        to={`/games/${game.gameId}/join`}
+                        className="text-xs px-2 py-1 rounded bg-primary text-primary-foreground hover:opacity-90"
+                      >
+                        Join
+                      </Link>
+                    )}
+                    {game.isPlayerEnrolled && !isFinished && (
+                      <Link
+                        to={`/games/${game.gameId}/base`}
+                        className="text-xs px-2 py-1 rounded bg-success text-success-foreground hover:opacity-90"
+                      >
+                        Play
+                      </Link>
+                    )}
+                    {(game.status.toLowerCase() === 'active' || isFinished) && (
+                      <Link
+                        to={`/games/${game.gameId}/ranking`}
+                        className="text-xs px-2 py-1 rounded border border-border hover:bg-muted/30"
+                      >
+                        Spectate
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/src/ReactClient/src/pages/GameLobbyDetail.tsx
+++ b/src/ReactClient/src/pages/GameLobbyDetail.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useMemo } from 'react'
 import { useParams, Link } from 'react-router'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import apiClient from '@/api/client'
-import type { GameLobbyViewModel } from '@/api/types'
+import type { GameLobbyViewModel, RaceListViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { useSignalR } from '@/hooks/useSignalR'
@@ -13,15 +13,6 @@ function statusBadge(status: string): { css: string; label: string } {
     case 'active': return { css: 'bg-success text-success-foreground', label: 'Active' }
     case 'finished': return { css: 'bg-muted text-muted-foreground', label: 'Finished' }
     default: return { css: 'bg-muted text-muted-foreground', label: status }
-  }
-}
-
-function raceLabel(playerType: string): string {
-  switch (playerType) {
-    case 'terran': return 'Terran'
-    case 'protoss': return 'Protoss'
-    case 'zerg': return 'Zerg'
-    default: return playerType
   }
 }
 
@@ -36,6 +27,17 @@ export function GameLobbyDetail() {
     enabled: !!gameId,
     refetchInterval: 15_000,
   })
+
+  const { data: racesData } = useQuery<RaceListViewModel>({
+    queryKey: ['races'],
+    queryFn: () => apiClient.get('/api/games/races').then((r) => r.data),
+    staleTime: Infinity,
+  })
+
+  const raceLabel = useMemo(() => {
+    const map = new Map(racesData?.races.map((r) => [r.id, r.name]) ?? [])
+    return (playerType: string) => map.get(playerType) ?? playerType
+  }, [racesData])
 
   const handleLobbyUpdate = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['game-lobby', gameId] })

--- a/src/ReactClient/src/pages/GameLobbyDetail.tsx
+++ b/src/ReactClient/src/pages/GameLobbyDetail.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useCallback } from 'react'
+import { useParams, Link } from 'react-router'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { GameLobbyViewModel } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { useSignalR } from '@/hooks/useSignalR'
+
+function statusBadge(status: string): { css: string; label: string } {
+  switch (status.toLowerCase()) {
+    case 'upcoming': return { css: 'bg-warning text-warning-foreground', label: 'Upcoming' }
+    case 'active': return { css: 'bg-success text-success-foreground', label: 'Active' }
+    case 'finished': return { css: 'bg-muted text-muted-foreground', label: 'Finished' }
+    default: return { css: 'bg-muted text-muted-foreground', label: status }
+  }
+}
+
+function raceLabel(playerType: string): string {
+  switch (playerType) {
+    case 'terran': return 'Terran'
+    case 'protoss': return 'Protoss'
+    case 'zerg': return 'Zerg'
+    default: return playerType
+  }
+}
+
+export function GameLobbyDetail() {
+  const { gameId } = useParams<{ gameId: string }>()
+  const queryClient = useQueryClient()
+  const { on, off } = useSignalR('/gamehub')
+
+  const { data: lobby, isLoading, error, refetch } = useQuery<GameLobbyViewModel>({
+    queryKey: ['game-lobby', gameId],
+    queryFn: () => apiClient.get(`/api/games/${gameId}/lobby`).then((r) => r.data),
+    enabled: !!gameId,
+    refetchInterval: 15_000,
+  })
+
+  const handleLobbyUpdate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['game-lobby', gameId] })
+  }, [queryClient, gameId])
+
+  useEffect(() => {
+    on('LobbyUpdated', handleLobbyUpdate)
+    return () => off('LobbyUpdated', handleLobbyUpdate)
+  }, [on, off, handleLobbyUpdate])
+
+  if (isLoading) return <PageLoader message="Loading lobby..." />
+  if (error) return <ApiError message="Failed to load lobby." onRetry={() => void refetch()} />
+  if (!lobby) return <ApiError message="Game not found." />
+
+  const badge = statusBadge(lobby.status)
+  const isActive = lobby.status.toLowerCase() === 'active'
+  const isFinished = lobby.status.toLowerCase() === 'finished'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link to="/lobby" className="text-muted-foreground hover:text-foreground text-sm">&larr; Back</Link>
+        <h1 className="text-2xl font-bold">{lobby.gameName}</h1>
+        <span className={`text-xs font-bold px-2 py-0.5 rounded ${badge.css}`}>{badge.label}</span>
+      </div>
+
+      <div className="flex gap-6 text-sm text-muted-foreground">
+        <div>
+          <span className="font-medium text-foreground">Players:</span>{' '}
+          {lobby.players.length}{lobby.maxPlayers > 0 ? ` / ${lobby.maxPlayers}` : ''}
+        </div>
+        {lobby.startTime && (
+          <div>
+            <span className="font-medium text-foreground">Starts:</span>{' '}
+            {new Date(lobby.startTime).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+          </div>
+        )}
+        {lobby.endTime && (
+          <div>
+            <span className="font-medium text-foreground">Ends:</span>{' '}
+            {new Date(lobby.endTime).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {lobby.canJoin && (
+          <Link
+            to={`/games/${gameId}/join`}
+            className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+          >
+            Join Game
+          </Link>
+        )}
+        {(isActive || isFinished) && (
+          <Link
+            to={`/games/${gameId}/ranking`}
+            className="px-4 py-2 rounded border border-border text-sm hover:bg-muted/30"
+          >
+            {isFinished ? 'View Results' : 'Spectate'}
+          </Link>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold text-muted-foreground">Players</h2>
+        {lobby.players.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No players have joined yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th scope="col" className="py-2 pr-4">Commander</th>
+                  <th scope="col" className="py-2 pr-4">Race</th>
+                  <th scope="col" className="py-2 pr-4">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lobby.players.map((p) => (
+                  <tr key={p.playerId} className="border-b border-border">
+                    <td className="py-2 pr-4 font-medium">{p.playerName}</td>
+                    <td className="py-2 pr-4">{raceLabel(p.playerType)}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {new Date(p.joined).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/JoinGame.tsx
+++ b/src/ReactClient/src/pages/JoinGame.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import apiClient from '@/api/client'
-import type { GameDetailViewModel, JoinGameRequest } from '@/api/types'
+import type { GameDetailViewModel, JoinGameRequest, RaceListViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
@@ -19,6 +19,7 @@ export function JoinGame() {
   const { gameId } = useParams<{ gameId: string }>()
   const navigate = useNavigate()
   const [playerName, setPlayerName] = useState('')
+  const [playerType, setPlayerType] = useState('terran')
   const [joinError, setJoinError] = useState<string | null>(null)
   const [alreadyJoined, setAlreadyJoined] = useState(false)
 
@@ -26,6 +27,11 @@ export function JoinGame() {
     queryKey: ['game', gameId],
     queryFn: () => apiClient.get(`/api/games/${gameId}`).then((r) => r.data),
     enabled: !!gameId,
+  })
+
+  const { data: racesData } = useQuery<RaceListViewModel>({
+    queryKey: ['races'],
+    queryFn: () => apiClient.get('/api/games/races').then((r) => r.data),
   })
 
   const joinMutation = useMutation({
@@ -51,12 +57,18 @@ export function JoinGame() {
       return
     }
     setJoinError(null)
-    joinMutation.mutate({ playerName: playerName.trim() })
+    joinMutation.mutate({ playerName: playerName.trim(), playerType })
   }
 
   if (isLoading) return <PageLoader message="Loading game..." />
   if (loadError) return <ApiError message="Failed to load game." onRetry={() => void refetch()} />
   if (!game) return <ApiError message="Game not found." />
+
+  const races = racesData?.races ?? [
+    { id: 'terran', name: 'Terraner' },
+    { id: 'protoss', name: 'Protoss' },
+    { id: 'zerg', name: 'Zerg' },
+  ]
 
   return (
     <div className="space-y-4">
@@ -93,6 +105,26 @@ export function JoinGame() {
               placeholder="Enter your name"
               maxLength={32}
             />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Race</label>
+            <div className="grid grid-cols-3 gap-2">
+              {races.map((race) => (
+                <button
+                  key={race.id}
+                  className={`rounded border px-3 py-2 text-sm font-medium transition-colors ${
+                    playerType === race.id
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border hover:bg-muted/30'
+                  }`}
+                  onClick={() => setPlayerType(race.id)}
+                  type="button"
+                >
+                  {race.name}
+                </button>
+              ))}
+            </div>
           </div>
 
           <button


### PR DESCRIPTION
## Summary
- Add game lobby system allowing any authenticated player to create, browse, and join games
- Race selection (Terran/Protoss/Zerg) during game join with visual picker UI
- Game lobby detail page showing real-time player list via SignalR (LobbyUpdated event)
- Spectate links for active and finished games (links to ranking view)
- Optional max player limit enforcement on game creation and join
- Create game form with configurable name, start/end time, and max players
- New endpoints: `GET /api/games/{gameId}/lobby`, `GET /api/games/races`
- 8 new lobby-specific controller tests covering race validation, max players, and lobby state

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (506 tests, 0 failures)
- [ ] Verify create game form works (name, times, max players)
- [ ] Verify join flow with race selection (Terran/Protoss/Zerg buttons)
- [ ] Verify lobby detail page shows real-time player list
- [ ] Verify max players enforcement prevents joining full games
- [ ] Verify spectate links work for active/finished games

Closes BGE-675