### PR TITLE
feat: BGE-690 alliance leader election with voting mechanism

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AlliancesController.cs
@@ -26,6 +26,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly AllianceInviteRepositoryWrite allianceInviteRepositoryWrite;
 		private readonly AllianceWarRepository allianceWarRepository;
 		private readonly AllianceWarRepositoryWrite allianceWarRepositoryWrite;
+		private readonly AllianceElectionRepository allianceElectionRepository;
+		private readonly AllianceElectionRepositoryWrite allianceElectionRepositoryWrite;
 
 		public AlliancesController(
 			CurrentUserContext currentUserContext,
@@ -38,7 +40,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			AllianceInviteRepository allianceInviteRepository,
 			AllianceInviteRepositoryWrite allianceInviteRepositoryWrite,
 			AllianceWarRepository allianceWarRepository,
-			AllianceWarRepositoryWrite allianceWarRepositoryWrite
+			AllianceWarRepositoryWrite allianceWarRepositoryWrite,
+			AllianceElectionRepository allianceElectionRepository,
+			AllianceElectionRepositoryWrite allianceElectionRepositoryWrite
 		) {
 			this.currentUserContext = currentUserContext;
 			this.allianceRepository = allianceRepository;
@@ -51,6 +55,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.allianceInviteRepositoryWrite = allianceInviteRepositoryWrite;
 			this.allianceWarRepository = allianceWarRepository;
 			this.allianceWarRepositoryWrite = allianceWarRepositoryWrite;
+			this.allianceElectionRepository = allianceElectionRepository;
+			this.allianceElectionRepositoryWrite = allianceElectionRepositoryWrite;
 		}
 
 		/// <summary>Returns all alliances in the current game.</summary>
@@ -486,6 +492,186 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			} catch (NotAtWarException e) {
 				return BadRequest(e.Message);
 			}
+		}
+
+		/// <summary>Returns the active election for an alliance.</summary>
+		[HttpGet("{id}/election")]
+		[ProducesResponseType(typeof(AllianceElectionViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<AllianceElectionViewModel> GetActiveElection(string id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var allianceId = AllianceIdFactory.Create(id);
+			var election = allianceElectionRepository.GetActiveElection(allianceId);
+			if (election == null) return NotFound();
+			return Ok(MapElectionViewModel(election, currentUserContext.PlayerId));
+		}
+
+		/// <summary>Starts a new election for the alliance.</summary>
+		[HttpPost("{id}/elections")]
+		[ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status409Conflict)]
+		public ActionResult<string> StartElection(string id, [FromBody] StartElectionRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				var nominationDuration = request.NominationDurationHours.HasValue ? TimeSpan.FromHours(request.NominationDurationHours.Value) : (TimeSpan?)null;
+				var votingDuration = request.VotingDurationHours.HasValue ? TimeSpan.FromHours(request.VotingDurationHours.Value) : (TimeSpan?)null;
+				var electionId = allianceElectionRepositoryWrite.StartElection(
+					new StartElectionCommand(currentUserContext.PlayerId!, AllianceIdFactory.Create(id), nominationDuration, votingDuration));
+				return Ok(electionId.ToString());
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (ElectionAlreadyActiveException e) {
+				return Conflict(e.Message);
+			} catch (InvalidElectionDurationException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		/// <summary>Nominate yourself as a candidate in the active election.</summary>
+		[HttpPost("{id}/elections/{electionId}/nominate")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult Nominate(string id, string electionId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceElectionRepositoryWrite.Nominate(
+					new NominateForElectionCommand(currentUserContext.PlayerId!, AllianceElectionIdFactory.Create(electionId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (ElectionNotFoundException e) {
+				return NotFound(e.Message);
+			} catch (ElectionNotInNominationPhaseException e) {
+				return BadRequest(e.Message);
+			} catch (AlreadyNominatedException e) {
+				return Conflict(e.Message);
+			}
+		}
+
+		/// <summary>Withdraw your nomination from the active election.</summary>
+		[HttpDelete("{id}/elections/{electionId}/nominate")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult WithdrawNomination(string id, string electionId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceElectionRepositoryWrite.WithdrawNomination(
+					new WithdrawNominationCommand(currentUserContext.PlayerId!, AllianceElectionIdFactory.Create(electionId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (ElectionNotFoundException e) {
+				return NotFound(e.Message);
+			} catch (ElectionNotInNominationPhaseException e) {
+				return BadRequest(e.Message);
+			} catch (NotACandidateException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		/// <summary>Cast or change your vote in the active election.</summary>
+		[HttpPost("{id}/elections/{electionId}/vote")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult CastVote(string id, string electionId, [FromBody] CastElectionVoteRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceElectionRepositoryWrite.CastVote(
+					new CastElectionVoteCommand(currentUserContext.PlayerId!, AllianceElectionIdFactory.Create(electionId), PlayerIdFactory.Create(request.CandidatePlayerId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (ElectionNotFoundException e) {
+				return NotFound(e.Message);
+			} catch (ElectionNotInVotingPhaseException e) {
+				return BadRequest(e.Message);
+			} catch (NotACandidateException e) {
+				return BadRequest(e.Message);
+			}
+		}
+
+		/// <summary>Cancel the active election (leader only).</summary>
+		[HttpDelete("{id}/elections/{electionId}")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		public ActionResult CancelElection(string id, string electionId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			try {
+				allianceElectionRepositoryWrite.CancelElection(
+					new CancelElectionCommand(currentUserContext.PlayerId!, AllianceElectionIdFactory.Create(electionId)));
+				return Ok();
+			} catch (NotAllianceMemberException e) {
+				return BadRequest(e.Message);
+			} catch (NotAllianceLeaderException e) {
+				return StatusCode(403, e.Message);
+			} catch (ElectionNotFoundException e) {
+				return NotFound(e.Message);
+			}
+		}
+
+		/// <summary>Returns the election history for an alliance.</summary>
+		[HttpGet("{id}/elections/history")]
+		[ProducesResponseType(typeof(IEnumerable<AllianceElectionViewModel>), StatusCodes.Status200OK)]
+		public ActionResult<IEnumerable<AllianceElectionViewModel>> GetElectionHistory(string id) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var allianceId = AllianceIdFactory.Create(id);
+			var history = allianceElectionRepository.GetElectionHistory(allianceId);
+			return Ok(history.Select(e => MapElectionViewModel(e, currentUserContext.PlayerId)));
+		}
+
+		private AllianceElectionViewModel MapElectionViewModel(GameModel.AllianceElectionImmutable election, PlayerId? currentPlayerId) {
+			string startedByName;
+			try { startedByName = playerRepository.Get(election.StartedByPlayerId).Name; }
+			catch { startedByName = election.StartedByPlayerId.Id; }
+
+			string? winnerName = null;
+			if (election.WinnerId != null) {
+				try { winnerName = playerRepository.Get(election.WinnerId).Name; }
+				catch { winnerName = election.WinnerId.Id; }
+			}
+
+			// Count votes per candidate
+			var voteCounts = election.Candidates.ToDictionary(c => c.PlayerId, _ => 0);
+			foreach (var vote in election.Votes) {
+				if (voteCounts.ContainsKey(vote.CandidatePlayerId)) {
+					voteCounts[vote.CandidatePlayerId]++;
+				}
+			}
+
+			var myVote = currentPlayerId != null
+				? election.Votes.FirstOrDefault(v => v.VoterPlayerId == currentPlayerId)?.CandidatePlayerId?.Id
+				: null;
+
+			return new AllianceElectionViewModel {
+				ElectionId = election.ElectionId.ToString(),
+				AllianceId = election.AllianceId.ToString(),
+				Status = election.Status.ToString(),
+				StartedByPlayerName = startedByName,
+				StartedAt = election.StartedAt,
+				NominationEndsAt = election.NominationEndsAt,
+				VotingEndsAt = election.VotingEndsAt,
+				Candidates = election.Candidates.Select(c => {
+					string playerName;
+					try { playerName = playerRepository.Get(c.PlayerId).Name; }
+					catch { playerName = c.PlayerId.Id; }
+					return new ElectionCandidateViewModel {
+						PlayerId = c.PlayerId.Id,
+						PlayerName = playerName,
+						NominatedAt = c.NominatedAt,
+						VoteCount = election.Status == GameModel.AllianceElectionStatus.Nominating ? 0 : voteCounts.GetValueOrDefault(c.PlayerId, 0)
+					};
+				}).ToList(),
+				MyVote = myVote,
+				WinnerId = election.WinnerId?.Id,
+				WinnerName = winnerName,
+				CompletedAt = election.CompletedAt
+			};
 		}
 
 		/// <summary>Returns all active and recent wars for an alliance.</summary>

--- a/src/BrowserGameEngine.GameModel/AllianceElectionId.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceElectionId.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record AllianceElectionId(Guid Id) {
+		public override string ToString() => Id.ToString();
+	}
+
+	public static class AllianceElectionIdFactory {
+		public static AllianceElectionId Create(Guid id) => new AllianceElectionId(id);
+		public static AllianceElectionId Create(string id) => new AllianceElectionId(Guid.Parse(id));
+		public static AllianceElectionId NewAllianceElectionId() => new AllianceElectionId(Guid.NewGuid());
+	}
+}

--- a/src/BrowserGameEngine.GameModel/AllianceElectionImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceElectionImmutable.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameModel {
+	public enum AllianceElectionStatus { Nominating, Voting, Completed, Cancelled }
+
+	public record AllianceElectionCandidateImmutable(
+		PlayerId PlayerId,
+		DateTime NominatedAt
+	);
+
+	public record AllianceElectionVoteImmutable(
+		PlayerId VoterPlayerId,
+		PlayerId CandidatePlayerId,
+		DateTime VotedAt
+	);
+
+	public record AllianceElectionImmutable(
+		AllianceElectionId ElectionId,
+		AllianceId AllianceId,
+		AllianceElectionStatus Status,
+		PlayerId StartedByPlayerId,
+		DateTime StartedAt,
+		DateTime NominationEndsAt,
+		DateTime VotingEndsAt,
+		IList<AllianceElectionCandidateImmutable> Candidates,
+		IList<AllianceElectionVoteImmutable> Votes,
+		PlayerId? WinnerId = null,
+		DateTime? CompletedAt = null
+	);
+}

--- a/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/AllianceImmutable.cs
@@ -19,6 +19,8 @@ namespace BrowserGameEngine.GameModel {
 		IList<AllianceMemberImmutable> Members,
 		string? Message = null,
 		IList<AlliancePostImmutable>? Posts = null,
-		IList<AllianceInviteImmutable>? Invites = null
+		IList<AllianceInviteImmutable>? Invites = null,
+		AllianceElectionImmutable? ActiveElection = null,
+		IList<AllianceElectionImmutable>? ElectionHistory = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/AllianceViewModels.cs
+++ b/src/BrowserGameEngine.Shared/AllianceViewModels.cs
@@ -91,6 +91,37 @@ namespace BrowserGameEngine.Shared {
 		public string? ProposerAllianceId { get; set; }
 	}
 
+	public class ElectionCandidateViewModel {
+		public required string PlayerId { get; set; }
+		public required string PlayerName { get; set; }
+		public DateTime NominatedAt { get; set; }
+		public int VoteCount { get; set; }
+	}
+
+	public class AllianceElectionViewModel {
+		public required string ElectionId { get; set; }
+		public required string AllianceId { get; set; }
+		public required string Status { get; set; }
+		public required string StartedByPlayerName { get; set; }
+		public DateTime StartedAt { get; set; }
+		public DateTime NominationEndsAt { get; set; }
+		public DateTime VotingEndsAt { get; set; }
+		public List<ElectionCandidateViewModel> Candidates { get; set; } = new();
+		public string? MyVote { get; set; }
+		public string? WinnerId { get; set; }
+		public string? WinnerName { get; set; }
+		public DateTime? CompletedAt { get; set; }
+	}
+
+	public class StartElectionRequest {
+		public double? NominationDurationHours { get; set; }
+		public double? VotingDurationHours { get; set; }
+	}
+
+	public class CastElectionVoteRequest {
+		public required string CandidatePlayerId { get; set; }
+	}
+
 	public class InvitePlayerRequest {
 		public required string TargetPlayerId { get; set; }
 	}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AllianceElectionTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AllianceElectionTest.cs
@@ -1,0 +1,297 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class AllianceElectionTest {
+
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+		private static readonly PlayerId Player3 = PlayerIdFactory.Create("player2");
+
+		private (TestGame game, AllianceId allianceId) SetupAllianceWith3Members() {
+			var game = new TestGame(playerCount: 3);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "pw"));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player2, allianceId, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player2));
+			game.AllianceRepositoryWrite.JoinAlliance(new JoinAllianceCommand(Player3, allianceId, "pw"));
+			game.AllianceRepositoryWrite.AcceptMember(new AcceptMemberCommand(Player1, Player3));
+			return (game, allianceId);
+		}
+
+		[Fact]
+		public void StartElection_HappyPath_CreatesActiveElection() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(
+				new StartElectionCommand(Player1, allianceId));
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId);
+			Assert.NotNull(election);
+			Assert.Equal(electionId, election.ElectionId);
+			Assert.Equal(AllianceElectionStatus.Nominating, election.Status);
+			Assert.Single(election.Candidates);
+			Assert.Equal(Player1, election.Candidates[0].PlayerId);
+		}
+
+		[Fact]
+		public void StartElection_AlreadyActive_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+
+			Assert.Throws<ElectionAlreadyActiveException>(() =>
+				game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player2, allianceId)));
+		}
+
+		[Fact]
+		public void StartElection_NonMember_Throws() {
+			var game = new TestGame(playerCount: 2);
+			var allianceId = game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "pw"));
+
+			Assert.Throws<NotAllianceMemberException>(() =>
+				game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player2, allianceId)));
+		}
+
+		[Fact]
+		public void StartElection_InvalidDuration_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+
+			Assert.Throws<InvalidElectionDurationException>(() =>
+				game.AllianceElectionRepositoryWrite.StartElection(
+					new StartElectionCommand(Player1, allianceId, TimeSpan.FromMinutes(30))));
+
+			Assert.Throws<InvalidElectionDurationException>(() =>
+				game.AllianceElectionRepositoryWrite.StartElection(
+					new StartElectionCommand(Player1, allianceId, TimeSpan.FromHours(100))));
+		}
+
+		[Fact]
+		public void Nominate_HappyPath_AddsCandiate() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId)!;
+			Assert.Equal(2, election.Candidates.Count);
+			Assert.Contains(election.Candidates, c => c.PlayerId == Player2);
+		}
+
+		[Fact]
+		public void Nominate_AlreadyNominated_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+
+			Assert.Throws<AlreadyNominatedException>(() =>
+				game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player1, electionId)));
+		}
+
+		[Fact]
+		public void Nominate_WrongPhase_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			// Force transition to voting
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			Assert.Throws<ElectionNotInNominationPhaseException>(() =>
+				game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player3, electionId)));
+		}
+
+		[Fact]
+		public void WithdrawNomination_HappyPath_RemovesCandidate() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+
+			game.AllianceElectionRepositoryWrite.WithdrawNomination(new WithdrawNominationCommand(Player2, electionId));
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId)!;
+			Assert.Single(election.Candidates);
+			Assert.DoesNotContain(election.Candidates, c => c.PlayerId == Player2);
+		}
+
+		[Fact]
+		public void WithdrawNomination_NotACandidate_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+
+			Assert.Throws<NotACandidateException>(() =>
+				game.AllianceElectionRepositoryWrite.WithdrawNomination(new WithdrawNominationCommand(Player2, electionId)));
+		}
+
+		[Fact]
+		public void CastVote_HappyPath_RecordsVote() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			game.AllianceElectionRepositoryWrite.CastVote(
+				new CastElectionVoteCommand(Player3, electionId, Player1));
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId)!;
+			Assert.Single(election.Votes);
+			Assert.Equal(Player3, election.Votes[0].VoterPlayerId);
+			Assert.Equal(Player1, election.Votes[0].CandidatePlayerId);
+		}
+
+		[Fact]
+		public void CastVote_ChangeVote_ReplacesExisting() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player1));
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player2));
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId)!;
+			Assert.Single(election.Votes);
+			Assert.Equal(Player2, election.Votes[0].CandidatePlayerId);
+		}
+
+		[Fact]
+		public void CastVote_WrongPhase_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+
+			Assert.Throws<ElectionNotInVotingPhaseException>(() =>
+				game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player1)));
+		}
+
+		[Fact]
+		public void CastVote_NonCandidate_Throws() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			Assert.Throws<NotACandidateException>(() =>
+				game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player3)));
+		}
+
+		[Fact]
+		public void TransitionToVoting_SingleCandidate_AutoCompletes() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player2, allianceId));
+			// Only Player2 is nominated (auto-nominated on start)
+
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			// Election should be completed and moved to history
+			Assert.Null(game.AllianceElectionRepository.GetActiveElection(allianceId));
+			var history = game.AllianceElectionRepository.GetElectionHistory(allianceId).ToList();
+			Assert.Single(history);
+			Assert.Equal(AllianceElectionStatus.Completed, history[0].Status);
+			Assert.Equal(Player2, history[0].WinnerId);
+
+			// Player2 should now be leader
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			Assert.Equal(Player2, alliance.LeaderId);
+		}
+
+		[Fact]
+		public void TransitionToVoting_MultipleCandidates_MovesToVoting() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			var election = game.AllianceElectionRepository.GetActiveElection(allianceId)!;
+			Assert.Equal(AllianceElectionStatus.Voting, election.Status);
+		}
+
+		[Fact]
+		public void CompleteElection_TalliesVotesAndTransfersLeadership() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			// Player1 votes for Player2, Player2 votes for Player2, Player3 votes for Player1
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player1, electionId, Player2));
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player2, electionId, Player2));
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player1));
+
+			game.AllianceElectionRepositoryWrite.CompleteElection(electionId);
+
+			Assert.Null(game.AllianceElectionRepository.GetActiveElection(allianceId));
+			var history = game.AllianceElectionRepository.GetElectionHistory(allianceId).ToList();
+			Assert.Single(history);
+			Assert.Equal(Player2, history[0].WinnerId);
+			Assert.Equal(AllianceElectionStatus.Completed, history[0].Status);
+
+			var alliance = game.AllianceRepository.Get(allianceId)!;
+			Assert.Equal(Player2, alliance.LeaderId);
+		}
+
+		[Fact]
+		public void CompleteElection_TieBreak_EarliestNominationWins() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.Nominate(new NominateForElectionCommand(Player2, electionId));
+			game.AllianceElectionRepositoryWrite.TransitionToVoting(electionId);
+
+			// Tie: each gets 1 vote
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player3, electionId, Player1));
+			game.AllianceElectionRepositoryWrite.CastVote(new CastElectionVoteCommand(Player2, electionId, Player2));
+
+			game.AllianceElectionRepositoryWrite.CompleteElection(electionId);
+
+			var history = game.AllianceElectionRepository.GetElectionHistory(allianceId).ToList();
+			// Player1 was nominated first (auto-nominated on start), so they win the tie
+			Assert.Equal(Player1, history[0].WinnerId);
+		}
+
+		[Fact]
+		public void CancelElection_LeaderOnly() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+			var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player2, allianceId));
+
+			// Non-leader cannot cancel
+			Assert.Throws<NotAllianceLeaderException>(() =>
+				game.AllianceElectionRepositoryWrite.CancelElection(new CancelElectionCommand(Player2, electionId)));
+
+			// Leader can cancel
+			game.AllianceElectionRepositoryWrite.CancelElection(new CancelElectionCommand(Player1, electionId));
+
+			Assert.Null(game.AllianceElectionRepository.GetActiveElection(allianceId));
+			var history = game.AllianceElectionRepository.GetElectionHistory(allianceId).ToList();
+			Assert.Single(history);
+			Assert.Equal(AllianceElectionStatus.Cancelled, history[0].Status);
+		}
+
+		[Fact]
+		public void ElectionHistory_BoundedToMax10() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+
+			for (int i = 0; i < 12; i++) {
+				var electionId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+				game.AllianceElectionRepositoryWrite.CancelElection(new CancelElectionCommand(Player1, electionId));
+			}
+
+			var history = game.AllianceElectionRepository.GetElectionHistory(allianceId).ToList();
+			Assert.Equal(10, history.Count);
+		}
+
+		[Fact]
+		public void GetElection_FindsByIdAcrossActiveAndHistory() {
+			var (game, allianceId) = SetupAllianceWith3Members();
+
+			// Create and cancel one election (goes to history)
+			var histId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+			game.AllianceElectionRepositoryWrite.CancelElection(new CancelElectionCommand(Player1, histId));
+
+			// Create another (active)
+			var activeId = game.AllianceElectionRepositoryWrite.StartElection(new StartElectionCommand(Player1, allianceId));
+
+			Assert.NotNull(game.AllianceElectionRepository.GetElection(histId));
+			Assert.NotNull(game.AllianceElectionRepository.GetElection(activeId));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/AlliancesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/AlliancesControllerTest.cs
@@ -26,7 +26,9 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				game.AllianceInviteRepository,
 				game.AllianceInviteRepositoryWrite,
 				game.AllianceWarRepository,
-				game.AllianceWarRepositoryWrite
+				game.AllianceWarRepositoryWrite,
+				game.AllianceElectionRepository,
+				game.AllianceElectionRepositoryWrite
 			);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -26,6 +26,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public AllianceInviteRepositoryWrite AllianceInviteRepositoryWrite { get; }
 		public AllianceWarRepository AllianceWarRepository { get; }
 		public AllianceWarRepositoryWrite AllianceWarRepositoryWrite { get; }
+		public AllianceElectionRepository AllianceElectionRepository { get; }
+		public AllianceElectionRepositoryWrite AllianceElectionRepositoryWrite { get; }
 		public PlayerRepository PlayerRepository { get; }
 		public PlayerRepositoryWrite PlayerRepositoryWrite { get; }
 		public ResourceRepository ResourceRepository { get; }
@@ -70,6 +72,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			AllianceInviteRepositoryWrite = new AllianceInviteRepositoryWrite(Accessor, AllianceInviteRepository);
 			AllianceWarRepository = new AllianceWarRepository(Accessor);
 			AllianceWarRepositoryWrite = new AllianceWarRepositoryWrite(Accessor);
+			AllianceElectionRepository = new AllianceElectionRepository(Accessor);
+			AllianceElectionRepositoryWrite = new AllianceElectionRepositoryWrite(Accessor, AllianceElectionRepository, AllianceRepository);
 			PlayerRepository = new PlayerRepository(Accessor, ScoreRepository, AllianceRepository);
 			PlayerRepositoryWrite = new PlayerRepositoryWrite(Accessor, TimeProvider.System);
 			ResourceRepository = new ResourceRepository(Accessor, GameDef);

--- a/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Commands/Commands.cs
@@ -23,6 +23,12 @@ namespace BrowserGameEngine.StatefulGameServer.Commands {
 	public record SetAllianceMessageCommand(PlayerId PlayerId, string Message) : ICommand;
 	public record PostAllianceChatCommand(PlayerId PlayerId, AllianceId AllianceId, string Body) : ICommand;
 
+	public record StartElectionCommand(PlayerId PlayerId, AllianceId AllianceId, TimeSpan? NominationDuration = null, TimeSpan? VotingDuration = null) : ICommand;
+	public record NominateForElectionCommand(PlayerId PlayerId, AllianceElectionId ElectionId) : ICommand;
+	public record WithdrawNominationCommand(PlayerId PlayerId, AllianceElectionId ElectionId) : ICommand;
+	public record CastElectionVoteCommand(PlayerId PlayerId, AllianceElectionId ElectionId, PlayerId CandidatePlayerId) : ICommand;
+	public record CancelElectionCommand(PlayerId PlayerId, AllianceElectionId ElectionId) : ICommand;
+
 	public record BuildAssetCommand(PlayerId PlayerId, AssetDefId AssetDefId) : ICommand;
 	public record BuildUnitCommand(PlayerId PlayerId, UnitDefId UnitDefId, int Count) : ICommand;
 	public record MergeUnitsCommand(PlayerId PlayerId, UnitDefId UnitDefId) : ICommand;

--- a/src/BrowserGameEngine.StatefulGameServer/Exceptions/ElectionExceptions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Exceptions/ElectionExceptions.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class ElectionAlreadyActiveException : Exception {
+		public ElectionAlreadyActiveException() : base("An election is already active for this alliance.") { }
+	}
+
+	public class ElectionNotFoundException : Exception {
+		public ElectionNotFoundException() : base("Election not found.") { }
+	}
+
+	public class ElectionNotInNominationPhaseException : Exception {
+		public ElectionNotInNominationPhaseException() : base("Election is not in the nomination phase.") { }
+	}
+
+	public class ElectionNotInVotingPhaseException : Exception {
+		public ElectionNotInVotingPhaseException() : base("Election is not in the voting phase.") { }
+	}
+
+	public class AlreadyNominatedException : Exception {
+		public AlreadyNominatedException() : base("You are already nominated as a candidate.") { }
+	}
+
+	public class NotACandidateException : Exception {
+		public NotACandidateException() : base("The specified player is not a candidate in this election.") { }
+	}
+
+	public class InvalidElectionDurationException : Exception {
+		public InvalidElectionDurationException(string message) : base(message) { }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Alliance.cs
@@ -39,6 +39,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public string? Message { get; set; }
 		public List<AlliancePost> Posts { get; set; } = new List<AlliancePost>();
 		public List<AllianceInvite> Invites { get; set; } = new List<AllianceInvite>();
+		public AllianceElection? ActiveElection { get; set; }
+		public List<AllianceElection> ElectionHistory { get; set; } = new List<AllianceElection>();
 	}
 
 	internal static class AllianceExtensions {
@@ -114,7 +116,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Members: alliance.Members.Select(m => m.ToImmutable()).ToList(),
 				Message: alliance.Message,
 				Posts: alliance.Posts.Select(p => p.ToImmutable()).ToList(),
-				Invites: alliance.Invites.Select(i => i.ToImmutable()).ToList()
+				Invites: alliance.Invites.Select(i => i.ToImmutable()).ToList(),
+				ActiveElection: alliance.ActiveElection?.ToImmutable(),
+				ElectionHistory: alliance.ElectionHistory.Select(e => e.ToImmutable()).ToList()
 			);
 		}
 
@@ -128,7 +132,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Members = alliance.Members.Select(m => m.ToMutable()).ToList(),
 				Message = alliance.Message,
 				Posts = alliance.Posts?.Select(p => p.ToMutable()).ToList() ?? new List<AlliancePost>(),
-				Invites = alliance.Invites?.Select(i => i.ToMutable()).ToList() ?? new List<AllianceInvite>()
+				Invites = alliance.Invites?.Select(i => i.ToMutable()).ToList() ?? new List<AllianceInvite>(),
+				ActiveElection = alliance.ActiveElection?.ToMutable(),
+				ElectionHistory = alliance.ElectionHistory?.Select(e => e.ToMutable()).ToList() ?? new List<AllianceElection>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AllianceElection.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AllianceElection.cs
@@ -1,0 +1,75 @@
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class AllianceElectionCandidate {
+		public required PlayerId PlayerId { get; set; }
+		public DateTime NominatedAt { get; set; }
+	}
+
+	internal class AllianceElectionVote {
+		public required PlayerId VoterPlayerId { get; set; }
+		public required PlayerId CandidatePlayerId { get; set; }
+		public DateTime VotedAt { get; set; }
+	}
+
+	internal class AllianceElection {
+		public required AllianceElectionId ElectionId { get; init; }
+		public required AllianceId AllianceId { get; init; }
+		public AllianceElectionStatus Status { get; set; }
+		public required PlayerId StartedByPlayerId { get; init; }
+		public DateTime StartedAt { get; set; }
+		public DateTime NominationEndsAt { get; set; }
+		public DateTime VotingEndsAt { get; set; }
+		public List<AllianceElectionCandidate> Candidates { get; set; } = new();
+		public List<AllianceElectionVote> Votes { get; set; } = new();
+		public PlayerId? WinnerId { get; set; }
+		public DateTime? CompletedAt { get; set; }
+	}
+
+	internal static class AllianceElectionExtensions {
+		internal static AllianceElectionCandidateImmutable ToImmutable(this AllianceElectionCandidate c) =>
+			new AllianceElectionCandidateImmutable(c.PlayerId, c.NominatedAt);
+
+		internal static AllianceElectionCandidate ToMutable(this AllianceElectionCandidateImmutable c) =>
+			new AllianceElectionCandidate { PlayerId = c.PlayerId, NominatedAt = c.NominatedAt };
+
+		internal static AllianceElectionVoteImmutable ToImmutable(this AllianceElectionVote v) =>
+			new AllianceElectionVoteImmutable(v.VoterPlayerId, v.CandidatePlayerId, v.VotedAt);
+
+		internal static AllianceElectionVote ToMutable(this AllianceElectionVoteImmutable v) =>
+			new AllianceElectionVote { VoterPlayerId = v.VoterPlayerId, CandidatePlayerId = v.CandidatePlayerId, VotedAt = v.VotedAt };
+
+		internal static AllianceElectionImmutable ToImmutable(this AllianceElection e) =>
+			new AllianceElectionImmutable(
+				ElectionId: e.ElectionId,
+				AllianceId: e.AllianceId,
+				Status: e.Status,
+				StartedByPlayerId: e.StartedByPlayerId,
+				StartedAt: e.StartedAt,
+				NominationEndsAt: e.NominationEndsAt,
+				VotingEndsAt: e.VotingEndsAt,
+				Candidates: e.Candidates.Select(c => c.ToImmutable()).ToList(),
+				Votes: e.Votes.Select(v => v.ToImmutable()).ToList(),
+				WinnerId: e.WinnerId,
+				CompletedAt: e.CompletedAt
+			);
+
+		internal static AllianceElection ToMutable(this AllianceElectionImmutable e) =>
+			new AllianceElection {
+				ElectionId = e.ElectionId,
+				AllianceId = e.AllianceId,
+				Status = e.Status,
+				StartedByPlayerId = e.StartedByPlayerId,
+				StartedAt = e.StartedAt,
+				NominationEndsAt = e.NominationEndsAt,
+				VotingEndsAt = e.VotingEndsAt,
+				Candidates = e.Candidates.Select(c => c.ToMutable()).ToList(),
+				Votes = e.Votes.Select(v => v.ToMutable()).ToList(),
+				WinnerId = e.WinnerId,
+				CompletedAt = e.CompletedAt
+			};
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -43,6 +43,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<AllianceInviteRepositoryWrite>();
 			services.AddSingleton<AllianceWarRepository>();
 			services.AddSingleton<AllianceWarRepositoryWrite>();
+			services.AddSingleton<AllianceElectionRepository>();
+			services.AddSingleton<AllianceElectionRepositoryWrite>();
 			services.AddSingleton<ChatRepositoryWrite>();
 			services.AddSingleton<AllianceScoreRepository>();
 			services.AddSingleton<AssetRepository>();
@@ -78,6 +80,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, TechResearchTimerModule>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
 			services.AddSingleton<IGameTickModule, SpyMissionModule>();
+			services.AddSingleton<IGameTickModule, ElectionTickModule>();
 			services.AddSingleton<IGameTickModule, VictoryProgressNotificationModule>();
 			services.AddSingleton<IGameTickModule, VictoryConditionModule>();
 			services.AddSingleton<IGameTickModule, GameFinalizationModule>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ElectionTickModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ElectionTickModule.cs
@@ -1,0 +1,44 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class ElectionTickModule : IGameTickModule {
+		public string Name => "electiontick:1";
+
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private readonly AllianceElectionRepositoryWrite electionRepositoryWrite;
+		private readonly object _checkLock = new();
+		private readonly HashSet<AllianceElectionId> _processedThisTick = new();
+
+		public ElectionTickModule(
+			IWorldStateAccessor worldStateAccessor,
+			AllianceElectionRepositoryWrite electionRepositoryWrite) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.electionRepositoryWrite = electionRepositoryWrite;
+		}
+
+		public void SetProperty(string name, string value) { }
+
+		public void CalculateTick(PlayerId playerId) {
+			var player = worldStateAccessor.WorldState.Players.TryGetValue(playerId, out var p) ? p : null;
+			if (player?.AllianceId == null) return;
+			if (!worldStateAccessor.WorldState.Alliances.TryGetValue(player.AllianceId, out var alliance)) return;
+			var election = alliance.ActiveElection;
+			if (election == null) return;
+
+			lock (_checkLock) {
+				if (_processedThisTick.Contains(election.ElectionId)) return;
+				_processedThisTick.Add(election.ElectionId);
+			}
+
+			var now = DateTime.UtcNow;
+			if (election.Status == AllianceElectionStatus.Nominating && now >= election.NominationEndsAt) {
+				electionRepositoryWrite.TransitionToVoting(election.ElectionId);
+			} else if (election.Status == AllianceElectionStatus.Voting && now >= election.VotingEndsAt) {
+				electionRepositoryWrite.CompleteElection(election.ElectionId);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceElectionRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceElectionRepository.cs
@@ -1,0 +1,39 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceElectionRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public AllianceElectionRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public AllianceElectionImmutable? GetActiveElection(AllianceId allianceId) {
+			if (!world.Alliances.TryGetValue(allianceId, out var alliance)) return null;
+			return alliance.ActiveElection?.ToImmutable();
+		}
+
+		public AllianceElectionImmutable? GetElection(AllianceElectionId electionId) {
+			foreach (var alliance in world.Alliances.Values) {
+				if (alliance.ActiveElection?.ElectionId == electionId) {
+					return alliance.ActiveElection.ToImmutable();
+				}
+				var historical = alliance.ElectionHistory.FirstOrDefault(e => e.ElectionId == electionId);
+				if (historical != null) {
+					return historical.ToImmutable();
+				}
+			}
+			return null;
+		}
+
+		public System.Collections.Generic.IEnumerable<AllianceElectionImmutable> GetElectionHistory(AllianceId allianceId) {
+			if (!world.Alliances.TryGetValue(allianceId, out var alliance)) {
+				return System.Linq.Enumerable.Empty<AllianceElectionImmutable>();
+			}
+			return alliance.ElectionHistory.Select(e => e.ToImmutable());
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceElectionRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Alliance/AllianceElectionRepositoryWrite.cs
@@ -1,0 +1,215 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class AllianceElectionRepositoryWrite {
+		private static readonly TimeSpan DefaultNominationDuration = TimeSpan.FromHours(12);
+		private static readonly TimeSpan DefaultVotingDuration = TimeSpan.FromHours(24);
+		private static readonly TimeSpan MinDuration = TimeSpan.FromHours(1);
+		private static readonly TimeSpan MaxDuration = TimeSpan.FromHours(72);
+		private const int MaxElectionHistory = 10;
+
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly AllianceElectionRepository electionRepository;
+		private readonly AllianceRepository allianceRepository;
+
+		public AllianceElectionRepositoryWrite(
+			IWorldStateAccessor worldStateAccessor,
+			AllianceElectionRepository electionRepository,
+			AllianceRepository allianceRepository) {
+			this.worldStateAccessor = worldStateAccessor;
+			this.electionRepository = electionRepository;
+			this.allianceRepository = allianceRepository;
+		}
+
+		public AllianceElectionId StartElection(StartElectionCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null || player.AllianceId != command.AllianceId) throw new NotAllianceMemberException();
+				var alliance = world.GetAlliance(command.AllianceId);
+				var member = alliance.Members.FirstOrDefault(m => m.PlayerId == command.PlayerId && !m.IsPending);
+				if (member == null) throw new NotAllianceMemberException();
+				if (alliance.ActiveElection != null) throw new ElectionAlreadyActiveException();
+
+				var nominationDuration = command.NominationDuration ?? DefaultNominationDuration;
+				var votingDuration = command.VotingDuration ?? DefaultVotingDuration;
+				ValidateDuration(nominationDuration, "Nomination");
+				ValidateDuration(votingDuration, "Voting");
+
+				var now = DateTime.UtcNow;
+				var electionId = AllianceElectionIdFactory.NewAllianceElectionId();
+				var election = new AllianceElection {
+					ElectionId = electionId,
+					AllianceId = command.AllianceId,
+					Status = AllianceElectionStatus.Nominating,
+					StartedByPlayerId = command.PlayerId,
+					StartedAt = now,
+					NominationEndsAt = now + nominationDuration,
+					VotingEndsAt = now + nominationDuration + votingDuration,
+					Candidates = new List<AllianceElectionCandidate> {
+						new AllianceElectionCandidate { PlayerId = command.PlayerId, NominatedAt = now }
+					}
+				};
+				alliance.ActiveElection = election;
+				return electionId;
+			}
+		}
+
+		public void Nominate(NominateForElectionCommand command) {
+			lock (_lock) {
+				var (alliance, election) = GetActiveElectionForPlayer(command.PlayerId, command.ElectionId);
+				if (election.Status != AllianceElectionStatus.Nominating) throw new ElectionNotInNominationPhaseException();
+				if (election.Candidates.Any(c => c.PlayerId == command.PlayerId)) throw new AlreadyNominatedException();
+
+				election.Candidates.Add(new AllianceElectionCandidate {
+					PlayerId = command.PlayerId,
+					NominatedAt = DateTime.UtcNow
+				});
+			}
+		}
+
+		public void WithdrawNomination(WithdrawNominationCommand command) {
+			lock (_lock) {
+				var (alliance, election) = GetActiveElectionForPlayer(command.PlayerId, command.ElectionId);
+				if (election.Status != AllianceElectionStatus.Nominating) throw new ElectionNotInNominationPhaseException();
+				var candidate = election.Candidates.FirstOrDefault(c => c.PlayerId == command.PlayerId);
+				if (candidate == null) throw new NotACandidateException();
+
+				election.Candidates.Remove(candidate);
+			}
+		}
+
+		public void CastVote(CastElectionVoteCommand command) {
+			lock (_lock) {
+				var (alliance, election) = GetActiveElectionForPlayer(command.PlayerId, command.ElectionId);
+				if (election.Status != AllianceElectionStatus.Voting) throw new ElectionNotInVotingPhaseException();
+				if (!election.Candidates.Any(c => c.PlayerId == command.CandidatePlayerId)) throw new NotACandidateException();
+
+				var existingVote = election.Votes.FirstOrDefault(v => v.VoterPlayerId == command.PlayerId);
+				if (existingVote != null) {
+					election.Votes.Remove(existingVote);
+				}
+				election.Votes.Add(new AllianceElectionVote {
+					VoterPlayerId = command.PlayerId,
+					CandidatePlayerId = command.CandidatePlayerId,
+					VotedAt = DateTime.UtcNow
+				});
+			}
+		}
+
+		public void CancelElection(CancelElectionCommand command) {
+			lock (_lock) {
+				var player = world.GetPlayer(command.PlayerId);
+				if (player.AllianceId == null) throw new NotAllianceMemberException();
+				var alliance = world.GetAlliance(player.AllianceId);
+				if (alliance.LeaderId != command.PlayerId) throw new NotAllianceLeaderException();
+				if (alliance.ActiveElection == null || alliance.ActiveElection.ElectionId != command.ElectionId) throw new ElectionNotFoundException();
+
+				var election = alliance.ActiveElection;
+				election.Status = AllianceElectionStatus.Cancelled;
+				election.CompletedAt = DateTime.UtcNow;
+				MoveToHistory(alliance, election);
+			}
+		}
+
+		public void TransitionToVoting(AllianceElectionId electionId) {
+			lock (_lock) {
+				var alliance = FindAllianceWithActiveElection(electionId);
+				if (alliance == null) return;
+				var election = alliance.ActiveElection!;
+				if (election.Status != AllianceElectionStatus.Nominating) return;
+
+				if (election.Candidates.Count <= 1) {
+					// Single candidate (or none) — auto-complete
+					election.Status = AllianceElectionStatus.Completed;
+					election.CompletedAt = DateTime.UtcNow;
+					if (election.Candidates.Count == 1) {
+						election.WinnerId = election.Candidates[0].PlayerId;
+						alliance.LeaderId = election.WinnerId;
+					}
+					MoveToHistory(alliance, election);
+				} else {
+					election.Status = AllianceElectionStatus.Voting;
+				}
+			}
+		}
+
+		public void CompleteElection(AllianceElectionId electionId) {
+			lock (_lock) {
+				var alliance = FindAllianceWithActiveElection(electionId);
+				if (alliance == null) return;
+				var election = alliance.ActiveElection!;
+				if (election.Status != AllianceElectionStatus.Voting) return;
+
+				election.Status = AllianceElectionStatus.Completed;
+				election.CompletedAt = DateTime.UtcNow;
+
+				// Tally votes
+				var voteCounts = election.Candidates.ToDictionary(c => c.PlayerId, _ => 0);
+				foreach (var vote in election.Votes) {
+					if (voteCounts.ContainsKey(vote.CandidatePlayerId)) {
+						voteCounts[vote.CandidatePlayerId]++;
+					}
+				}
+
+				var maxVotes = voteCounts.Values.Max();
+				var tied = voteCounts.Where(kv => kv.Value == maxVotes).Select(kv => kv.Key).ToList();
+
+				PlayerId winnerId;
+				if (tied.Count == 1) {
+					winnerId = tied[0];
+				} else {
+					// Tie-break: earliest nomination
+					winnerId = election.Candidates
+						.Where(c => tied.Contains(c.PlayerId))
+						.OrderBy(c => c.NominatedAt)
+						.First().PlayerId;
+				}
+
+				election.WinnerId = winnerId;
+				alliance.LeaderId = winnerId;
+				MoveToHistory(alliance, election);
+			}
+		}
+
+		private Alliance? FindAllianceWithActiveElection(AllianceElectionId electionId) {
+			foreach (var alliance in world.Alliances.Values) {
+				if (alliance.ActiveElection?.ElectionId == electionId) {
+					return alliance;
+				}
+			}
+			return null;
+		}
+
+		private (Alliance alliance, AllianceElection election) GetActiveElectionForPlayer(PlayerId playerId, AllianceElectionId electionId) {
+			var player = world.GetPlayer(playerId);
+			if (player.AllianceId == null) throw new NotAllianceMemberException();
+			var alliance = world.GetAlliance(player.AllianceId);
+			var member = alliance.Members.FirstOrDefault(m => m.PlayerId == playerId && !m.IsPending);
+			if (member == null) throw new NotAllianceMemberException();
+			if (alliance.ActiveElection == null || alliance.ActiveElection.ElectionId != electionId) throw new ElectionNotFoundException();
+			return (alliance, alliance.ActiveElection);
+		}
+
+		private static void MoveToHistory(Alliance alliance, AllianceElection election) {
+			alliance.ActiveElection = null;
+			alliance.ElectionHistory.Insert(0, election);
+			while (alliance.ElectionHistory.Count > MaxElectionHistory) {
+				alliance.ElectionHistory.RemoveAt(alliance.ElectionHistory.Count - 1);
+			}
+		}
+
+		private static void ValidateDuration(TimeSpan duration, string phaseName) {
+			if (duration < MinDuration || duration > MaxDuration) {
+				throw new InvalidElectionDurationException($"{phaseName} duration must be between {MinDuration.TotalHours}h and {MaxDuration.TotalHours}h.");
+			}
+		}
+	}
+}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -448,6 +448,28 @@ export interface AllianceInviteViewModel {
   expiresAt: string
 }
 
+export interface ElectionCandidateViewModel {
+  playerId: string
+  playerName: string
+  nominatedAt: string
+  voteCount: number
+}
+
+export interface AllianceElectionViewModel {
+  electionId: string
+  allianceId: string
+  status: string
+  startedByPlayerName: string
+  startedAt: string
+  nominationEndsAt: string
+  votingEndsAt: string
+  candidates: ElectionCandidateViewModel[]
+  myVote: string | null
+  winnerId: string | null
+  winnerName: string | null
+  completedAt: string | null
+}
+
 export interface AllianceWarViewModel {
   warId: string
   attackerAllianceId: string

--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -16,6 +16,7 @@ import type {
 	MyAllianceStatusViewModel,
 	AllianceChatPostViewModel,
 	AllianceWarViewModel,
+	AllianceElectionViewModel,
 	AllianceViewModel,
 	PublicPlayerViewModel,
 	PlayerProfileViewModel,
@@ -81,6 +82,13 @@ export function AllianceDetail() {
 		refetchInterval: 10_000,
 	})
 
+	const { data: election } = useQuery<AllianceElectionViewModel>({
+		queryKey: ['alliance-election', allianceId],
+		queryFn: () => apiClient.get(`/api/alliances/${allianceId}/election`).then((r) => r.data),
+		refetchInterval: 10_000,
+		retry: false,
+	})
+
 	const { data: allAlliances } = useQuery<AllianceViewModel[]>({
 		queryKey: ['alliances-for-war'],
 		queryFn: () => apiClient.get('/api/alliances').then((r) => r.data),
@@ -108,6 +116,7 @@ export function AllianceDetail() {
 		void queryClient.invalidateQueries({ queryKey: ['alliance-detail', allianceId] })
 		void queryClient.invalidateQueries({ queryKey: ['alliance-chat', allianceId] })
 		void queryClient.invalidateQueries({ queryKey: ['alliance-wars', allianceId] })
+		void queryClient.invalidateQueries({ queryKey: ['alliance-election', allianceId] })
 		void queryClient.invalidateQueries({ queryKey: ['alliance-status-detail'] })
 	}
 
@@ -185,6 +194,41 @@ export function AllianceDetail() {
 		mutationFn: (warId: string) =>
 			apiClient.post(`/api/alliances/wars/${warId}/peace`, { warId }),
 		onSuccess: () => { setSuccess('Peace action sent.'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const startElectionMut = useMutation({
+		mutationFn: () =>
+			apiClient.post(`/api/alliances/${allianceId}/elections`, {}),
+		onSuccess: () => { setSuccess('Election started!'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const nominateMut = useMutation({
+		mutationFn: (electionId: string) =>
+			apiClient.post(`/api/alliances/${allianceId}/elections/${electionId}/nominate`),
+		onSuccess: () => { setSuccess('Nominated!'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const withdrawNominationMut = useMutation({
+		mutationFn: (electionId: string) =>
+			apiClient.delete(`/api/alliances/${allianceId}/elections/${electionId}/nominate`),
+		onSuccess: () => { setSuccess('Nomination withdrawn.'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const castElectionVoteMut = useMutation({
+		mutationFn: ({ electionId, candidatePlayerId }: { electionId: string; candidatePlayerId: string }) =>
+			apiClient.post(`/api/alliances/${allianceId}/elections/${electionId}/vote`, { candidatePlayerId }),
+		onSuccess: () => { setSuccess('Vote cast!'); invalidateAll() },
+		onError: handleError,
+	})
+
+	const cancelElectionMut = useMutation({
+		mutationFn: (electionId: string) =>
+			apiClient.delete(`/api/alliances/${allianceId}/elections/${electionId}`),
+		onSuccess: () => { setSuccess('Election cancelled.'); invalidateAll() },
 		onError: handleError,
 	})
 
@@ -362,6 +406,119 @@ export function AllianceDetail() {
 							</div>
 						))}
 					</div>
+				</div>
+			)}
+
+			{/* Election Panel (members only) */}
+			{isMember && (
+				<div className="rounded-lg border bg-card">
+					<div className="border-b px-4 py-3 flex items-center justify-between">
+						<strong className="text-sm flex items-center gap-1.5">
+							<VoteIcon className="h-4 w-4 text-primary" />
+							Leader Election
+						</strong>
+						{!election && (
+							<button
+								onClick={() => { setError(null); setSuccess(null); startElectionMut.mutate() }}
+								disabled={startElectionMut.isPending}
+								className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
+							>
+								{startElectionMut.isPending ? 'Starting…' : 'Start Election'}
+							</button>
+						)}
+						{election && isLeader && (
+							<button
+								onClick={() => { setError(null); setSuccess(null); cancelElectionMut.mutate(election.electionId) }}
+								disabled={cancelElectionMut.isPending}
+								className="rounded border border-destructive px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50"
+							>
+								Cancel Election
+							</button>
+						)}
+					</div>
+
+					{!election ? (
+						<div className="p-4 text-sm text-muted-foreground">
+							No active election. Any member can start one.
+						</div>
+					) : election.status === 'Nominating' ? (
+						<div className="p-4 space-y-3">
+							<div className="flex items-center justify-between">
+								<span className="text-sm font-medium">Nomination Phase</span>
+								<span className="text-xs text-muted-foreground">
+									Ends {relativeTime(election.nominationEndsAt)}
+								</span>
+							</div>
+							<div className="space-y-1">
+								{election.candidates.map((c) => (
+									<div key={c.playerId} className="flex items-center justify-between rounded border px-3 py-2">
+										<span className="text-sm font-medium">{c.playerName}</span>
+										{c.playerId === myPlayerId && (
+											<button
+												onClick={() => { setError(null); withdrawNominationMut.mutate(election.electionId) }}
+												disabled={withdrawNominationMut.isPending}
+												className="text-xs text-destructive hover:underline"
+											>
+												Withdraw
+											</button>
+										)}
+									</div>
+								))}
+							</div>
+							{myPlayerId && !election.candidates.some((c) => c.playerId === myPlayerId) && (
+								<button
+									onClick={() => { setError(null); nominateMut.mutate(election.electionId) }}
+									disabled={nominateMut.isPending}
+									className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
+								>
+									{nominateMut.isPending ? 'Nominating…' : 'Nominate Yourself'}
+								</button>
+							)}
+						</div>
+					) : election.status === 'Voting' ? (
+						<div className="p-4 space-y-3">
+							<div className="flex items-center justify-between">
+								<span className="text-sm font-medium">Voting Phase</span>
+								<span className="text-xs text-muted-foreground">
+									Ends {relativeTime(election.votingEndsAt)}
+								</span>
+							</div>
+							<div className="space-y-1">
+								{election.candidates.map((c) => {
+									const isMyVote = election.myVote === c.playerId
+									return (
+										<div key={c.playerId} className="flex items-center justify-between rounded border px-3 py-2">
+											<div>
+												<span className="text-sm font-medium">{c.playerName}</span>
+												<span className="ml-2 text-xs text-muted-foreground">
+													{c.voteCount} vote{c.voteCount !== 1 ? 's' : ''}
+												</span>
+											</div>
+											<button
+												onClick={() => { setError(null); castElectionVoteMut.mutate({ electionId: election.electionId, candidatePlayerId: c.playerId }) }}
+												disabled={castElectionVoteMut.isPending || isMyVote}
+												className={cn(
+													'rounded px-2 py-0.5 text-xs disabled:opacity-50',
+													isMyVote
+														? 'bg-primary text-primary-foreground'
+														: 'border border-primary text-primary hover:bg-primary/10'
+												)}
+											>
+												{isMyVote ? 'Voted' : 'Vote'}
+											</button>
+										</div>
+									)
+								})}
+							</div>
+						</div>
+					) : (
+						<div className="p-4 text-sm text-muted-foreground">
+							Election {election.status.toLowerCase()}.
+							{election.winnerName && (
+								<span className="font-medium text-foreground"> Winner: {election.winnerName}</span>
+							)}
+						</div>
+					)}
 				</div>
 			)}
 


### PR DESCRIPTION
## Summary
- Add time-bounded leader election system with nomination (default 12h) and voting (default 24h) phases
- Any accepted alliance member can start an election; starter is auto-nominated
- Members nominate themselves, cast changeable votes; single-candidate auto-wins
- ElectionTickModule handles phase transitions; tie-break by earliest nomination
- 7 new API endpoints: start, nominate, withdraw, vote, cancel, get active, get history
- React election panel on AllianceDetail page with real-time polling
- 20 new tests covering all election operations and edge cases (522 total, 0 failures)

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (522 tests, 0 failures)
- [ ] Verify start election creates nomination phase with countdown
- [ ] Verify nominate/withdraw works during nomination phase
- [ ] Verify voting with candidate selection and vote change
- [ ] Verify leader transfers to winner on election completion
- [ ] Verify leader can cancel active election

Closes BGE-690