### PR TITLE
Fix AdminGames.tsx TS2345: add missing maxPlayers

### DIFF
--- a/src/ReactClient/src/pages/admin/AdminGames.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGames.tsx
@@ -108,6 +108,7 @@ export function AdminGames() {
       endTime: toUtcIso(createEndTime),
       tickDuration: createTickDuration,
       discordWebhookUrl: null,
+      maxPlayers: 0,
     })
   }
 


### PR DESCRIPTION
## Summary
- AdminGames.tsx create-game form was missing the required `maxPlayers` field in the `CreateGameRequest` object, causing a TS2345 build error
- Added `maxPlayers: 0` to match the C# record default

## Test plan
- [x] `npx tsc -b` passes with no errors
- [x] `dotnet build` passes
- [x] `dotnet test` passes (532/532)

Closes BGE-701