### PR TITLE
fix: BGE-697 fix 14 failing E2E Playwright tests

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -77,7 +77,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		/// Direct login without any password. A new user gets created directly if it does not exist.
 		/// </summary>
 		[HttpPost("~/signindev")]
-		public async Task<IActionResult> SignInDev([FromForm] string playerid) {
+		public async Task<IActionResult> SignInDev([FromForm] string playerid, [FromForm] bool createPlayer = true) {
 			// only works if DevAuth setting in appsettings is set (dev only!)
 			if (!options.Value.DevAuth) return BadRequest();
 			if (string.IsNullOrWhiteSpace(playerid)) return BadRequest();
@@ -86,9 +86,11 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			var user = userRepositoryWrite.GetOrCreateUser(
 				githubId: playerid, githubLogin: playerid, displayName: playerid);
 
-			var playerId = PlayerIdFactory.Create(playerid);
-			if (!playerRepository.Exists(playerId)) {
-				playerRepositoryWrite.CreatePlayer(playerId, userId: user.UserId);
+			if (createPlayer) {
+				var playerId = PlayerIdFactory.Create(playerid);
+				if (!playerRepository.Exists(playerId)) {
+					playerRepositoryWrite.CreatePlayer(playerId, userId: user.UserId);
+				}
 			}
 
 			// Create a claims identity so the cookie auth and CurrentUserMiddleware work correctly

--- a/src/ReactClient/e2e/global-setup.ts
+++ b/src/ReactClient/e2e/global-setup.ts
@@ -28,6 +28,10 @@ export default async function globalSetup() {
 		form: { playerid: 'e2e-test-admin', returnUrl: '/' },
 	})
 
+	// Dismiss the new-player tutorial overlay so it never blocks UI interactions
+	// in tests that use the shared auth state.
+	await page.request.post(`${baseURL}/api/playerprofile/complete-tutorial`)
+
 	// Save auth cookies so all tests share the session
 	await context.storageState({ path: path.join(authDir, 'state.json') })
 	await browser.close()

--- a/src/ReactClient/e2e/tests/01-signin.spec.ts
+++ b/src/ReactClient/e2e/tests/01-signin.spec.ts
@@ -12,10 +12,10 @@ test.describe('Sign-in page', () => {
 	test.use({ storageState: { cookies: [], origins: [] } }) // run unauthenticated
 
 	test('sign-in page renders with GitHub login button', async ({ page }) => {
+		// GET /signin is handled server-side and renders the Razor Signin.cshtml view.
 		await page.goto('/signin')
-		await expect(page.getByRole('heading', { name: 'Age of Agents' })).toBeVisible()
-		await expect(page.getByText('Sign in to continue')).toBeVisible()
-		await expect(page.getByRole('button', { name: /sign in with github/i })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Browser Game Engine' })).toBeVisible()
+		await expect(page.getByRole('button', { name: /continue with github/i })).toBeVisible()
 	})
 
 	test('unauthenticated access to protected route redirects to sign-in', async ({ page }) => {

--- a/src/ReactClient/e2e/tests/03-gameplay.spec.ts
+++ b/src/ReactClient/e2e/tests/03-gameplay.spec.ts
@@ -97,10 +97,11 @@ test.describe('Join game and navigate in-game pages', () => {
 
 test.describe('Create player', () => {
 	test('create player page renders and form is functional', async ({ page }) => {
-		// Sign in as a fresh user who has no player profile yet
+		// Sign in as a fresh user who has no player profile yet.
+		// createPlayer=false skips the automatic player creation so /createplayer works as intended.
 		const freshUserId = `e2e-newuser-${Date.now()}`
 		await page.request.post(`${baseURL}/signindev`, {
-			form: { playerid: freshUserId, returnUrl: '/' },
+			form: { playerid: freshUserId, returnUrl: '/', createPlayer: 'false' },
 		})
 
 		await page.goto('/createplayer')

--- a/src/ReactClient/e2e/tests/05-resource-management.spec.ts
+++ b/src/ReactClient/e2e/tests/05-resource-management.spec.ts
@@ -44,7 +44,8 @@ test.describe('Resource management — worker assignment', () => {
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 		await expect(page.getByText('Total')).toBeVisible()
 		await expect(page.getByText(/Mining/)).toBeVisible()
-		await expect(page.getByText(/Gas/)).toBeVisible()
+		// Use a label-specific locator to avoid matching unrelated 'Gas' occurrences on the page
+		await expect(page.getByText('⚗️ Gas Workers')).toBeVisible()
 		await expect(page.getByText('Something went wrong')).not.toBeVisible()
 	})
 

--- a/src/ReactClient/e2e/tests/07-alliances.spec.ts
+++ b/src/ReactClient/e2e/tests/07-alliances.spec.ts
@@ -38,6 +38,8 @@ async function signInFreshUser(
 	const page = await context.newPage()
 	// signindev creates the user AND the player in the default game world state
 	await page.request.post(`${baseURL}/signindev`, { form: { playerid: playerId, returnUrl: '/' } })
+	// Dismiss the new-player tutorial overlay so it never blocks UI interactions
+	await page.request.post(`${baseURL}/api/playerprofile/complete-tutorial`)
 	return { page, context, playerId }
 }
 
@@ -77,13 +79,14 @@ test('player joins alliance with password and leader accepts via UI', async ({ b
 	const { page: memberPage, context: memberCtx } = await signInFreshUser(browser, 'joiner')
 
 	// Leader creates alliance via API
+	// The endpoint returns the alliance ID as plain text (not JSON-encoded), so use .text()
 	const allianceName = `JoinTest-${Date.now()}`
 	const password = 'joinpass'
 	const createRes = await leaderPage.request.post(`${baseURL}/api/alliances`, {
 		data: { allianceName, password },
 	})
 	expect(createRes.ok()).toBeTruthy()
-	const allianceId = (await createRes.json()) as string
+	const allianceId = await createRes.text()
 
 	const gameId = await createNavGame(leaderPage)
 
@@ -125,12 +128,13 @@ test('leader invites player and invitee accepts invite via UI', async ({ browser
 	const { page: inviteePage, context: inviteeCtx, playerId: inviteePlayerId } = await signInFreshUser(browser, 'invitee')
 
 	// Leader creates alliance via API
+	// The endpoint returns the alliance ID as plain text (not JSON-encoded), so use .text()
 	const allianceName = `InviteTest-${Date.now()}`
 	const createRes = await leaderPage.request.post(`${baseURL}/api/alliances`, {
 		data: { allianceName, password: 'invpass' },
 	})
 	expect(createRes.ok()).toBeTruthy()
-	const allianceId = (await createRes.json()) as string
+	const allianceId = await createRes.text()
 
 	// Leader sends an invite via API (avoids dropdown complexity in UI)
 	const inviteRes = await leaderPage.request.post(`${baseURL}/api/alliances/${allianceId}/invite`, {

--- a/src/ReactClient/src/components/WorkerAssignment.tsx
+++ b/src/ReactClient/src/components/WorkerAssignment.tsx
@@ -60,8 +60,9 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="text-xs text-muted-foreground">💎 Mineral Workers</label>
+          <label htmlFor="mineralWorkers" className="text-xs text-muted-foreground">💎 Mineral Workers</label>
           <input
+            id="mineralWorkers"
             type="number"
             min={0}
             max={data.totalWorkers}
@@ -71,8 +72,9 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
           />
         </div>
         <div>
-          <label className="text-xs text-muted-foreground">⚗️ Gas Workers</label>
+          <label htmlFor="gasWorkers" className="text-xs text-muted-foreground">⚗️ Gas Workers</label>
           <input
+            id="gasWorkers"
             type="number"
             min={0}
             max={data.totalWorkers}


### PR DESCRIPTION
## Summary

Fixes 14 failing Playwright E2E tests introduced by recent merges (PR #215 tutorial overlay, PR #221 alliance/leaderboard tests).

**Root causes fixed:**

- **TutorialOverlay blocking UI** — New player tutorial overlay (`fixed inset-0 z-[60]`) blocked all UI interactions for freshly created test users. Fixed by calling `POST /api/playerprofile/complete-tutorial` in `global-setup.ts` and in `signInFreshUser()` helper.
- **Alliance ID JSON parse error** — `POST /api/alliances` returns a plain-text GUID (not JSON). Tests were calling `.json()` on it, causing `SyntaxError`. Fixed by using `.text()` instead.
- **`signindev` always creates a player** — The "create player" test expects `/createplayer` to be accessible, but `signindev` auto-enrolled the user. Added optional `createPlayer` parameter (default `true`) to `SignInDev` action so the test can skip player creation.
- **Sign-in page wrong assertions** — `GET /signin` is a server-side Razor view, not the React SPA. Updated assertions to match `Signin.cshtml` content ("Browser Game Engine", "Continue with GitHub").
- **`getByText(/Gas/)` strict-mode violation** — Matched 4 elements including TutorialOverlay text. Narrowed to `getByText('⚗️ Gas Workers')`.
- **`WorkerAssignment` labels not associated** — Input labels lacked `htmlFor`/`id` attributes, breaking `page.getByLabel()`. Added proper `id` to inputs and `htmlFor` to labels.

## Files changed

- `src/ReactClient/e2e/global-setup.ts` — dismiss tutorial overlay for e2e-test-admin
- `src/ReactClient/e2e/tests/01-signin.spec.ts` — fix assertions to match Razor sign-in view
- `src/ReactClient/e2e/tests/03-gameplay.spec.ts` — use `createPlayer=false` for new-user test
- `src/ReactClient/e2e/tests/05-resource-management.spec.ts` — narrow Gas locator
- `src/ReactClient/e2e/tests/07-alliances.spec.ts` — dismiss tutorial + use `.text()` for alliance ID
- `src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs` — add `createPlayer` param
- `src/ReactClient/src/components/WorkerAssignment.tsx` — add `id`/`htmlFor` for label association

## Test plan

- [ ] `dotnet build` passes (0 errors)
- [ ] `dotnet test` passes (502 tests)
- [ ] Playwright E2E tests pass (all 14 previously-failing tests)