### PR TITLE
Add resource production history chart on Base page

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceHistoryController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceHistoryController.cs
@@ -1,0 +1,43 @@
+using BrowserGameEngine.Shared;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/resource-history")]
+	public class ResourceHistoryController : ControllerBase {
+		private readonly ILogger<ResourceHistoryController> logger;
+		private readonly CurrentUserContext currentUserContext;
+		private readonly ResourceHistoryRepository resourceHistoryRepository;
+
+		public ResourceHistoryController(
+				ILogger<ResourceHistoryController> logger,
+				CurrentUserContext currentUserContext,
+				ResourceHistoryRepository resourceHistoryRepository
+			) {
+			this.logger = logger;
+			this.currentUserContext = currentUserContext;
+			this.resourceHistoryRepository = resourceHistoryRepository;
+		}
+
+		[HttpGet]
+		[ProducesResponseType(typeof(ResourceHistoryViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<ResourceHistoryViewModel> Get() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var playerId = currentUserContext.PlayerId!;
+			var history = resourceHistoryRepository.GetHistory(playerId);
+			var snapshots = history.Select(s => new ResourceSnapshotViewModel(
+				s.Tick,
+				s.Minerals,
+				s.Gas,
+				s.Land
+			)).ToList();
+			return new ResourceHistoryViewModel(snapshots);
+		}
+	}
+}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -36,6 +36,7 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 						{ "constraint-resource", "land" },
 					}.ToFrozenDictionary()),
 
+					new GameTickModuleDef("resource-history:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("protection:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("upgradetimer:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("techresearch:1", new Dictionary<string, string> { }.ToFrozenDictionary()),

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -27,6 +27,7 @@ namespace BrowserGameEngine.GameModel {
 		IList<SpyAttemptLog>? SpyAttemptLogs = null,
 		IList<GameNotification>? Notifications = null,
 		IList<SpyMissionImmutable>? SpyMissions = null,
-		bool TutorialCompleted = false
+		bool TutorialCompleted = false,
+		IList<ResourceSnapshot>? ResourceHistory = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/ResourceSnapshot.cs
+++ b/src/BrowserGameEngine.GameModel/ResourceSnapshot.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record ResourceSnapshot(
+		int Tick,
+		DateTime Timestamp,
+		decimal Minerals,
+		decimal Gas,
+		decimal Land
+	);
+}

--- a/src/BrowserGameEngine.Shared/ResourceHistoryViewModel.cs
+++ b/src/BrowserGameEngine.Shared/ResourceHistoryViewModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public record ResourceSnapshotViewModel(
+		int Tick,
+		decimal Minerals,
+		decimal Gas,
+		decimal Land
+	);
+
+	public record ResourceHistoryViewModel(
+		IList<ResourceSnapshotViewModel> Snapshots
+	);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ResourceHistoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ResourceHistoryTest.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using BrowserGameEngine.GameModel;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+
+	public class ResourceHistoryTest {
+		[Fact]
+		public void AppendSnapshot_AddsToHistory() {
+			var g = new TestGame();
+
+			g.ResourceHistoryRepositoryWrite.AppendSnapshot(g.Player1,
+				new ResourceSnapshot(1, DateTime.UtcNow, 100m, 50m, 10m));
+
+			var history = g.ResourceHistoryRepository.GetHistory(g.Player1);
+			Assert.Single(history);
+			Assert.Equal(1, history[0].Tick);
+			Assert.Equal(100m, history[0].Minerals);
+			Assert.Equal(50m, history[0].Gas);
+			Assert.Equal(10m, history[0].Land);
+		}
+
+		[Fact]
+		public void AppendSnapshot_MultipleSnapshots_PreservesOrder() {
+			var g = new TestGame();
+
+			for (int i = 1; i <= 5; i++) {
+				g.ResourceHistoryRepositoryWrite.AppendSnapshot(g.Player1,
+					new ResourceSnapshot(i, DateTime.UtcNow, i * 100m, i * 50m, 10m));
+			}
+
+			var history = g.ResourceHistoryRepository.GetHistory(g.Player1);
+			Assert.Equal(5, history.Count);
+			for (int i = 0; i < history.Count; i++) {
+				Assert.Equal(i + 1, history[i].Tick);
+			}
+		}
+
+		[Fact]
+		public void AppendSnapshot_TrimsAtMaxSize() {
+			var g = new TestGame();
+
+			for (int i = 0; i < 105; i++) {
+				g.ResourceHistoryRepositoryWrite.AppendSnapshot(g.Player1,
+					new ResourceSnapshot(i, DateTime.UtcNow, 100m, 50m, 10m));
+			}
+
+			var history = g.ResourceHistoryRepository.GetHistory(g.Player1);
+			Assert.Equal(100, history.Count);
+			Assert.Equal(5, history[0].Tick);
+			Assert.Equal(104, history[history.Count - 1].Tick);
+		}
+
+		[Fact]
+		public void NewPlayer_HasEmptyHistory() {
+			var g = new TestGame();
+
+			var history = g.ResourceHistoryRepository.GetHistory(g.Player1);
+			Assert.Empty(history);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -50,6 +50,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public SpyRepositoryWrite SpyRepositoryWrite { get; }
 		public SpyMissionRepository SpyMissionRepository { get; }
 		public SpyMissionRepositoryWrite SpyMissionRepositoryWrite { get; }
+		public ResourceHistoryRepository ResourceHistoryRepository { get; }
+		public ResourceHistoryRepositoryWrite ResourceHistoryRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -96,10 +98,13 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			SpyRepositoryWrite = new SpyRepositoryWrite(Accessor, SpyRepository, ResourceRepositoryWrite, TechRepository, GameDef, TimeProvider.System);
 			SpyMissionRepository = new SpyMissionRepository(Accessor);
 			SpyMissionRepositoryWrite = new SpyMissionRepositoryWrite(Accessor, ResourceRepositoryWrite, ResourceRepository, TechRepository, PlayerRepository, NullNotificationService.Instance, TimeProvider.System, GameDef);
+			ResourceHistoryRepository = new ResourceHistoryRepository(Accessor);
+			ResourceHistoryRepositoryWrite = new ResourceHistoryRepositoryWrite(Accessor);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));
 			services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(LoggerFactory.CreateLogger<ResourceGrowthSco>(), GameDef, ResourceRepository, ResourceRepositoryWrite, PlayerRepository, PlayerRepositoryWrite, UnitRepository, UnitRepositoryWrite, new ActionLogger(), TechRepository));
+			services.AddSingleton<IGameTickModule>(new ResourceHistoryModule(ResourceRepository, ResourceHistoryRepositoryWrite, Accessor));
 			GameTickModuleRegistry = new GameTickModuleRegistry(LoggerFactory.CreateLogger<GameTickModuleRegistry>(), services.BuildServiceProvider(), GameDef);
 			TickEngine = new GameTickEngine(LoggerFactory.CreateLogger<GameTickEngine>(), Accessor, GameDef, GameTickModuleRegistry, PlayerRepositoryWrite, TimeProvider.System, NullGameEventPublisher.Instance);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -29,6 +29,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<GameNotification> Notifications { get; set; } = new List<GameNotification>();
 		public List<SpyMission> SpyMissions { get; set; } = new List<SpyMission>();
 		public bool TutorialCompleted { get; set; }
+		public List<ResourceSnapshot> ResourceHistory { get; set; } = new List<ResourceSnapshot>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -56,7 +57,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
 				Notifications: new List<GameNotification>(playerState.Notifications),
 				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList(),
-				TutorialCompleted: playerState.TutorialCompleted
+				TutorialCompleted: playerState.TutorialCompleted,
+				ResourceHistory: new List<ResourceSnapshot>(playerState.ResourceHistory)
 			);
 		}
 
@@ -96,7 +98,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 					: new List<GameNotification>(),
 				SpyMissions = (playerStateImmutable.SpyMissions ?? new List<SpyMissionImmutable>())
 					.Select(x => x.ToMutable()).ToList(),
-				TutorialCompleted = playerStateImmutable.TutorialCompleted
+				TutorialCompleted = playerStateImmutable.TutorialCompleted,
+				ResourceHistory = playerStateImmutable.ResourceHistory != null
+					? new List<ResourceSnapshot>(playerStateImmutable.ResourceHistory)
+					: new List<ResourceSnapshot>()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -70,6 +70,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<TechRepositoryWrite>();
 			services.AddSingleton<TradeRepository>();
 			services.AddSingleton<TradeRepositoryWrite>();
+			services.AddSingleton<ResourceHistoryRepository>();
+			services.AddSingleton<ResourceHistoryRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();
@@ -79,6 +81,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, UpgradeTimer>();
 			services.AddSingleton<IGameTickModule, TechResearchTimerModule>();
 			services.AddSingleton<IGameTickModule, BuildQueueModule>();
+			services.AddSingleton<IGameTickModule, ResourceHistoryModule>();
 			services.AddSingleton<IGameTickModule, SpyMissionModule>();
 			services.AddSingleton<IGameTickModule, ElectionTickModule>();
 			services.AddSingleton<IGameTickModule, VictoryProgressNotificationModule>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceHistoryModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceHistoryModule.cs
@@ -1,0 +1,37 @@
+using System;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	public class ResourceHistoryModule : IGameTickModule {
+		public string Name => "resource-history:1";
+
+		public void SetProperty(string name, string value) { }
+
+		private readonly ResourceRepository resourceRepository;
+		private readonly ResourceHistoryRepositoryWrite resourceHistoryRepositoryWrite;
+		private readonly IWorldStateAccessor worldStateAccessor;
+
+		public ResourceHistoryModule(
+				ResourceRepository resourceRepository,
+				ResourceHistoryRepositoryWrite resourceHistoryRepositoryWrite,
+				IWorldStateAccessor worldStateAccessor
+			) {
+			this.resourceRepository = resourceRepository;
+			this.resourceHistoryRepositoryWrite = resourceHistoryRepositoryWrite;
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public void CalculateTick(PlayerId playerId) {
+			var world = worldStateAccessor.WorldState;
+			int tick = world.GameTickState.CurrentGameTick.Tick;
+			decimal minerals = resourceRepository.GetAmount(playerId, Id.ResDef("minerals"));
+			decimal gas = resourceRepository.GetAmount(playerId, Id.ResDef("gas"));
+			decimal land = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
+
+			var snapshot = new ResourceSnapshot(tick, DateTime.UtcNow, minerals, gas, land);
+			resourceHistoryRepositoryWrite.AppendSnapshot(playerId, snapshot);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepository.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class ResourceHistoryRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public ResourceHistoryRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public IList<ResourceSnapshot> GetHistory(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.ResourceHistory;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class ResourceHistoryRepositoryWrite {
+		private const int MaxHistorySize = 100;
+
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+		private readonly Lock _lock = new();
+
+		public ResourceHistoryRepositoryWrite(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public void AppendSnapshot(PlayerId playerId, ResourceSnapshot snapshot) {
+			lock (_lock) {
+				var history = world.GetPlayer(playerId).State.ResourceHistory;
+				history.Add(snapshot);
+				while (history.Count > MaxHistorySize) {
+					history.RemoveAt(0);
+				}
+			}
+		}
+	}
+}

--- a/src/ReactClient/package-lock.json
+++ b/src/ReactClient/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
@@ -1967,6 +1968,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2324,6 +2361,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2667,6 +2716,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2713,6 +2825,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -3365,6 +3483,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3382,6 +3621,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3494,6 +3739,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3746,6 +4001,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -4076,6 +4337,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4101,6 +4372,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -4899,6 +5179,37 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5000,10 +5311,62 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -5172,6 +5535,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -5390,6 +5759,37 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/src/ReactClient/package.json
+++ b/src/ReactClient/package.json
@@ -29,6 +29,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -99,6 +99,19 @@ export interface PlayerResourcesViewModel {
   colonizationCostPerLand: number
 }
 
+// Resource History
+
+export interface ResourceSnapshotViewModel {
+  tick: number
+  minerals: number
+  gas: number
+  land: number
+}
+
+export interface ResourceHistoryViewModel {
+  snapshots: ResourceSnapshotViewModel[]
+}
+
 // Worker Assignment
 
 export interface WorkerAssignmentViewModel {

--- a/src/ReactClient/src/components/ResourceHistoryChart.tsx
+++ b/src/ReactClient/src/components/ResourceHistoryChart.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { ResourceHistoryViewModel } from '@/api/types'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts'
+
+interface ResourceHistoryChartProps {
+  gameId: string
+}
+
+export function ResourceHistoryChart({ gameId }: ResourceHistoryChartProps) {
+  const { data, isLoading } = useQuery<ResourceHistoryViewModel>({
+    queryKey: ['resource-history', gameId],
+    queryFn: () => apiClient.get('/api/resource-history').then((r) => r.data),
+    refetchInterval: 30_000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="font-semibold mb-3">Economy Trend</h3>
+        <div className="text-sm text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
+  if (!data || data.snapshots.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <h3 className="font-semibold mb-3">Economy Trend</h3>
+        <div className="text-sm text-muted-foreground">
+          No history yet. Data will appear after a few game ticks.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <h3 className="font-semibold mb-3">Economy Trend</h3>
+      <ResponsiveContainer width="100%" height={250}>
+        <LineChart data={data.snapshots}>
+          <XAxis
+            dataKey="tick"
+            tick={{ fontSize: 12 }}
+            label={{ value: 'Tick', position: 'insideBottom', offset: -5, fontSize: 12 }}
+          />
+          <YAxis tick={{ fontSize: 12 }} />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="minerals" stroke="#3b82f6" name="Minerals" dot={false} />
+          <Line type="monotone" dataKey="gas" stroke="#22c55e" name="Gas" dot={false} />
+          <Line type="monotone" dataKey="land" stroke="#f59e0b" name="Land" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -16,6 +16,7 @@ import { WorkerAssignment } from '@/components/WorkerAssignment'
 import { CostBadge } from '@/components/CostBadge'
 import { VictoryProgressBar } from '@/components/VictoryProgressBar'
 import { relativeTime } from '@/lib/utils'
+import { ResourceHistoryChart } from '@/components/ResourceHistoryChart'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
@@ -296,6 +297,8 @@ export function Base({ gameId }: BaseProps) {
       ) : null}
 
       <BuildQueue gameId={gameId} />
+
+      <ResourceHistoryChart gameId={gameId} />
 
       {/* Recent Activity */}
       <div className="rounded-lg border bg-card">


### PR DESCRIPTION
## Summary
- Track per-player resource snapshots (minerals, gas, land) each game tick in a persisted ring buffer (100 entries) in PlayerState
- New `ResourceSnapshot` record in GameModel, `ResourceHistoryModule` tick module, read/write repository pair
- New REST endpoint `GET /api/resource-history` returns snapshot history for the authenticated player
- New `ResourceHistoryChart` React component using recharts, integrated into the Base page below Build Queue
- 4 new unit tests covering append, trim at 100 entries, ordering, and empty state

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (536/536, 4 new)
- [x] `npx tsc -b` passes (pre-existing AdminGames TS error is from a separate issue, fixed in PR #228)
- [ ] Manual: play a game for several ticks and verify the Economy Trend chart appears on the Base page

Closes BGE-691