### PR TITLE
Add battle report detail page with round-by-round replay

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BattleController.cs
@@ -9,6 +9,7 @@ using BrowserGameEngine.StatefulGameServer;
 using Microsoft.AspNetCore.Authorization;
 using BrowserGameEngine.FrontendServer;
 using BrowserGameEngine.GameModel;
+using BattleReport = BrowserGameEngine.StatefulGameServer.GameModelInternal.BattleReport;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.GameDefinition;
 using System.Diagnostics;
@@ -29,6 +30,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly BattleReportGenerator battleReportGenerator;
 		private readonly OnlineStatusRepository onlineStatusRepository;
 		private readonly SpyRepositoryWrite spyRepositoryWrite;
+		private readonly BattleReportRepository battleReportRepository;
 
 		public BattleController(ILogger<BattleController> logger
 				, GameDef gameDef
@@ -41,6 +43,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				, BattleReportGenerator battleReportGenerator
 				, OnlineStatusRepository onlineStatusRepository
 				, SpyRepositoryWrite spyRepositoryWrite
+				, BattleReportRepository battleReportRepository
 			) {
 			this.logger = logger;
 			this.gameDef = gameDef;
@@ -53,6 +56,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.battleReportGenerator = battleReportGenerator;
 			this.onlineStatusRepository = onlineStatusRepository;
 			this.spyRepositoryWrite = spyRepositoryWrite;
+			this.battleReportRepository = battleReportRepository;
 		}
 
 		/// <summary>Lists players that the current player can attack.</summary>
@@ -165,5 +169,87 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				WorkersCaptured = result.BtlResult.WorkersCaptured,
 			};
 		}
+
+		/// <summary>Returns a detailed battle report with round-by-round replay data.</summary>
+		/// <param name="reportId">The battle report ID.</param>
+		[HttpGet]
+		[ProducesResponseType(typeof(BattleReportDetailViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<BattleReportDetailViewModel> Report([FromQuery] Guid reportId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var report = battleReportRepository.GetBattleReport(currentUserContext.PlayerId!, reportId);
+			if (report == null) return NotFound();
+			return MapToDetailViewModel(report);
+		}
+
+		/// <summary>Returns a summary list of the current player's battle reports.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(List<BattleReportSummaryViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<List<BattleReportSummaryViewModel>> Reports() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var reports = battleReportRepository.GetBattleReports(currentUserContext.PlayerId!);
+			bool isAttacker(BattleReport r) => r.AttackerId.Equals(currentUserContext.PlayerId);
+			return reports.Select(r => new BattleReportSummaryViewModel {
+				Id = r.Id.ToString(),
+				OpponentName = isAttacker(r) ? r.DefenderName : r.AttackerName,
+				Outcome = r.Outcome,
+				CreatedAt = r.CreatedAt.ToString("o")
+			}).OrderByDescending(r => r.CreatedAt).ToList();
+		}
+
+		private BattleReportDetailViewModel MapToDetailViewModel(BattleReport report) {
+			return new BattleReportDetailViewModel {
+				Id = report.Id.ToString(),
+				AttackerId = report.AttackerId.Id,
+				AttackerName = report.AttackerName,
+				DefenderId = report.DefenderId.Id,
+				DefenderName = report.DefenderName,
+				AttackerRace = report.AttackerRace,
+				DefenderRace = report.DefenderRace,
+				Outcome = report.Outcome,
+				TotalAttackerStrengthBefore = report.TotalAttackerStrengthBefore,
+				TotalDefenderStrengthBefore = report.TotalDefenderStrengthBefore,
+				AttackerUnitsInitial = report.AttackerUnitsInitial
+					.Select(uc => new UnitCountViewModel {
+						UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+						Count = uc.Count
+					}).ToList(),
+				DefenderUnitsInitial = report.DefenderUnitsInitial
+					.Select(uc => new UnitCountViewModel {
+						UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+						Count = uc.Count
+					}).ToList(),
+				Rounds = report.Rounds.Select(round => new BattleRoundViewModel {
+					RoundNumber = round.RoundNumber,
+					AttackerUnitsRemaining = round.AttackerUnitsRemaining
+						.Select(uc => new UnitCountViewModel {
+							UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+							Count = uc.Count
+						}).ToList(),
+					DefenderUnitsRemaining = round.DefenderUnitsRemaining
+						.Select(uc => new UnitCountViewModel {
+							UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+							Count = uc.Count
+						}).ToList(),
+					AttackerCasualties = round.AttackerCasualties
+						.Select(uc => new UnitCountViewModel {
+							UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+							Count = uc.Count
+						}).ToList(),
+					DefenderCasualties = round.DefenderCasualties
+						.Select(uc => new UnitCountViewModel {
+							UnitName = gameDef.GetUnitDef(uc.UnitDefId)?.Name ?? uc.UnitDefId.Id,
+							Count = uc.Count
+						}).ToList()
+				}).ToList(),
+				LandTransferred = report.LandTransferred,
+				WorkersCaptured = report.WorkersCaptured,
+				ResourcesStolen = new Dictionary<string, decimal>(report.ResourcesStolen),
+				CreatedAt = report.CreatedAt.ToString("o")
+			};
+		}
 	}
 }
+

--- a/src/BrowserGameEngine.GameModel/BattleReportImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/BattleReportImmutable.cs
@@ -1,0 +1,33 @@
+using BrowserGameEngine.GameDefinition;
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameModel {
+	public record BattleRoundSnapshotImmutable(
+		int RoundNumber,
+		List<UnitCount> AttackerUnitsRemaining,
+		List<UnitCount> DefenderUnitsRemaining,
+		List<UnitCount> AttackerCasualties,
+		List<UnitCount> DefenderCasualties
+	);
+
+	public record BattleReportImmutable(
+		Guid Id,
+		PlayerId AttackerId,
+		PlayerId DefenderId,
+		string AttackerName,
+		string DefenderName,
+		string AttackerRace,
+		string DefenderRace,
+		string Outcome,
+		int TotalAttackerStrengthBefore,
+		int TotalDefenderStrengthBefore,
+		List<UnitCount> AttackerUnitsInitial,
+		List<UnitCount> DefenderUnitsInitial,
+		List<BattleRoundSnapshotImmutable> Rounds,
+		int LandTransferred,
+		int WorkersCaptured,
+		Dictionary<string, decimal> ResourcesStolen,
+		DateTime CreatedAt
+	);
+}

--- a/src/BrowserGameEngine.GameModel/BattleResult.cs
+++ b/src/BrowserGameEngine.GameModel/BattleResult.cs
@@ -19,5 +19,6 @@ namespace BrowserGameEngine.GameModel {
 		public int WorkersCaptured { get; set; }
 		public int TotalAttackerStrengthBefore { get; set; }
 		public int TotalDefenderStrengthBefore { get; set; }
+		public List<BattleRoundSnapshotImmutable> Rounds { get; set; } = new();
 	}
 }

--- a/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerStateImmutable.cs
@@ -28,6 +28,7 @@ namespace BrowserGameEngine.GameModel {
 		IList<GameNotification>? Notifications = null,
 		IList<SpyMissionImmutable>? SpyMissions = null,
 		bool TutorialCompleted = false,
-		IList<ResourceSnapshot>? ResourceHistory = null
+		IList<ResourceSnapshot>? ResourceHistory = null,
+		IList<BattleReportImmutable>? BattleReports = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/BattleReportDetailViewModel.cs
+++ b/src/BrowserGameEngine.Shared/BattleReportDetailViewModel.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public class UnitCountViewModel {
+		public string UnitName { get; set; } = "";
+		public int Count { get; set; }
+	}
+
+	public class BattleRoundViewModel {
+		public int RoundNumber { get; set; }
+		public List<UnitCountViewModel> AttackerUnitsRemaining { get; set; } = new();
+		public List<UnitCountViewModel> DefenderUnitsRemaining { get; set; } = new();
+		public List<UnitCountViewModel> AttackerCasualties { get; set; } = new();
+		public List<UnitCountViewModel> DefenderCasualties { get; set; } = new();
+	}
+
+	public class BattleReportSummaryViewModel {
+		public string Id { get; set; } = "";
+		public string OpponentName { get; set; } = "";
+		public string Outcome { get; set; } = "";
+		public string CreatedAt { get; set; } = "";
+	}
+
+	public class BattleReportDetailViewModel {
+		public string Id { get; set; } = "";
+		public string AttackerId { get; set; } = "";
+		public string AttackerName { get; set; } = "";
+		public string DefenderId { get; set; } = "";
+		public string DefenderName { get; set; } = "";
+		public string AttackerRace { get; set; } = "";
+		public string DefenderRace { get; set; } = "";
+		public string Outcome { get; set; } = "";
+		public int TotalAttackerStrengthBefore { get; set; }
+		public int TotalDefenderStrengthBefore { get; set; }
+		public List<UnitCountViewModel> AttackerUnitsInitial { get; set; } = new();
+		public List<UnitCountViewModel> DefenderUnitsInitial { get; set; } = new();
+		public List<BattleRoundViewModel> Rounds { get; set; } = new();
+		public int LandTransferred { get; set; }
+		public int WorkersCaptured { get; set; }
+		public Dictionary<string, decimal> ResourcesStolen { get; set; } = new();
+		public string CreatedAt { get; set; } = "";
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BattleReportRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BattleReportRepositoryTest.cs
@@ -119,6 +119,67 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public void GetBattleReports_EmptyByDefault() {
+			var game = new TestGame(playerCount: 2);
+			var reports = game.BattleReportRepository.GetBattleReports(Player1);
+			Assert.Empty(reports);
+		}
+
+		[Fact]
+		public void AddBattleReport_BothPlayersGetSameReport() {
+			var game = new TestGame(playerCount: 2);
+			var reportId = Guid.NewGuid();
+			var report = CreateTestReport(reportId);
+
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, report);
+			game.BattleReportRepositoryWrite.AddBattleReport(Player2, report);
+
+			var p1Report = game.BattleReportRepository.GetBattleReport(Player1, reportId);
+			var p2Report = game.BattleReportRepository.GetBattleReport(Player2, reportId);
+			Assert.NotNull(p1Report);
+			Assert.NotNull(p2Report);
+			Assert.Equal(p1Report!.Id, p2Report!.Id);
+			Assert.Equal("Attacker won", p1Report.Outcome);
+			Assert.Equal(100, p1Report.TotalAttackerStrengthBefore);
+			Assert.Equal(80, p1Report.TotalDefenderStrengthBefore);
+		}
+
+		[Fact]
+		public void BattleReport_PreservesRoundDetails() {
+			var game = new TestGame(playerCount: 2);
+			var report = CreateTestReport();
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, report);
+
+			var retrieved = game.BattleReportRepository.GetBattleReports(Player1)[0];
+			Assert.Single(retrieved.Rounds);
+			var round = retrieved.Rounds[0];
+			Assert.Equal(1, round.RoundNumber);
+			Assert.Single(round.AttackerUnitsRemaining);
+			Assert.Equal(9, round.AttackerUnitsRemaining[0].Count);
+			Assert.Single(round.DefenderUnitsRemaining);
+			Assert.Equal(5, round.DefenderUnitsRemaining[0].Count);
+			Assert.Single(round.AttackerCasualties);
+			Assert.Equal(1, round.AttackerCasualties[0].Count);
+			Assert.Single(round.DefenderCasualties);
+			Assert.Equal(3, round.DefenderCasualties[0].Count);
+		}
+
+		[Fact]
+		public void BattleReport_PreservesResourcesAndSpoils() {
+			var game = new TestGame(playerCount: 2);
+			var report = CreateTestReport();
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, report);
+
+			var retrieved = game.BattleReportRepository.GetBattleReports(Player1)[0];
+			Assert.Equal(5, retrieved.LandTransferred);
+			Assert.Equal(2, retrieved.WorkersCaptured);
+			Assert.Single(retrieved.ResourcesStolen);
+			Assert.Equal(100m, retrieved.ResourcesStolen["minerals"]);
+			Assert.Equal("Terran", retrieved.AttackerRace);
+			Assert.Equal("Zerg", retrieved.DefenderRace);
+		}
+
+		[Fact]
 		public void BattleReport_ToImmutable_RoundTrip() {
 			var report = CreateTestReport();
 			var immutable = report.ToImmutable();

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BattleReportRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BattleReportRepositoryTest.cs
@@ -1,0 +1,143 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class BattleReportRepositoryTest {
+
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player1");
+
+		private BattleReport CreateTestReport(Guid? id = null) {
+			return new BattleReport {
+				Id = id ?? Guid.NewGuid(),
+				AttackerId = Player1,
+				DefenderId = Player2,
+				AttackerName = "Attacker",
+				DefenderName = "Defender",
+				AttackerRace = "Terran",
+				DefenderRace = "Zerg",
+				Outcome = "Attacker won",
+				TotalAttackerStrengthBefore = 100,
+				TotalDefenderStrengthBefore = 80,
+				AttackerUnitsInitial = new List<UnitCount> {
+					new UnitCount(Id.UnitDef("marine"), 10)
+				},
+				DefenderUnitsInitial = new List<UnitCount> {
+					new UnitCount(Id.UnitDef("zergling"), 8)
+				},
+				Rounds = new List<BattleRoundSnapshotImmutable> {
+					new BattleRoundSnapshotImmutable(
+						RoundNumber: 1,
+						AttackerUnitsRemaining: new List<UnitCount> { new UnitCount(Id.UnitDef("marine"), 9) },
+						DefenderUnitsRemaining: new List<UnitCount> { new UnitCount(Id.UnitDef("zergling"), 5) },
+						AttackerCasualties: new List<UnitCount> { new UnitCount(Id.UnitDef("marine"), 1) },
+						DefenderCasualties: new List<UnitCount> { new UnitCount(Id.UnitDef("zergling"), 3) }
+					)
+				},
+				LandTransferred = 5,
+				WorkersCaptured = 2,
+				ResourcesStolen = new Dictionary<string, decimal> { { "minerals", 100m } },
+				CreatedAt = DateTime.UtcNow
+			};
+		}
+
+		[Fact]
+		public void AddBattleReport_CanBeRetrievedById() {
+			var game = new TestGame(playerCount: 2);
+			var reportId = Guid.NewGuid();
+			var report = CreateTestReport(reportId);
+
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, report);
+
+			var retrieved = game.BattleReportRepository.GetBattleReport(Player1, reportId);
+			Assert.NotNull(retrieved);
+			Assert.Equal(reportId, retrieved!.Id);
+			Assert.Equal("Attacker", retrieved.AttackerName);
+			Assert.Equal("Defender", retrieved.DefenderName);
+			Assert.Equal("Attacker won", retrieved.Outcome);
+		}
+
+		[Fact]
+		public void GetBattleReport_NonExistentId_ReturnsNull() {
+			var game = new TestGame(playerCount: 2);
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport());
+
+			var result = game.BattleReportRepository.GetBattleReport(Player1, Guid.NewGuid());
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void GetBattleReports_ReturnsAllReports() {
+			var game = new TestGame(playerCount: 2);
+
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport());
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport());
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport());
+
+			var reports = game.BattleReportRepository.GetBattleReports(Player1);
+			Assert.Equal(3, reports.Count);
+		}
+
+		[Fact]
+		public void AddBattleReport_ExceedsMaxReports_OldestRemoved() {
+			var game = new TestGame(playerCount: 2);
+			var oldestId = Guid.NewGuid();
+
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport(oldestId));
+			for (int i = 1; i < BattleReportRepositoryWrite.MaxReportsPerPlayer; i++) {
+				game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport());
+			}
+
+			Assert.Equal(BattleReportRepositoryWrite.MaxReportsPerPlayer,
+				game.BattleReportRepository.GetBattleReports(Player1).Count);
+
+			// Adding one more should evict the oldest
+			var newestId = Guid.NewGuid();
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, CreateTestReport(newestId));
+
+			var reports = game.BattleReportRepository.GetBattleReports(Player1);
+			Assert.Equal(BattleReportRepositoryWrite.MaxReportsPerPlayer, reports.Count);
+			Assert.Null(game.BattleReportRepository.GetBattleReport(Player1, oldestId));
+			Assert.NotNull(game.BattleReportRepository.GetBattleReport(Player1, newestId));
+		}
+
+		[Fact]
+		public void AddBattleReport_DifferentPlayers_ReportsIsolated() {
+			var game = new TestGame(playerCount: 2);
+			var reportId = Guid.NewGuid();
+			var report = CreateTestReport(reportId);
+
+			game.BattleReportRepositoryWrite.AddBattleReport(Player1, report);
+
+			Assert.NotNull(game.BattleReportRepository.GetBattleReport(Player1, reportId));
+			Assert.Empty(game.BattleReportRepository.GetBattleReports(Player2));
+		}
+
+		[Fact]
+		public void BattleReport_ToImmutable_RoundTrip() {
+			var report = CreateTestReport();
+			var immutable = report.ToImmutable();
+			var roundTripped = BattleReport.FromImmutable(immutable);
+
+			Assert.Equal(report.Id, roundTripped.Id);
+			Assert.Equal(report.AttackerId, roundTripped.AttackerId);
+			Assert.Equal(report.DefenderId, roundTripped.DefenderId);
+			Assert.Equal(report.AttackerName, roundTripped.AttackerName);
+			Assert.Equal(report.DefenderName, roundTripped.DefenderName);
+			Assert.Equal(report.Outcome, roundTripped.Outcome);
+			Assert.Equal(report.TotalAttackerStrengthBefore, roundTripped.TotalAttackerStrengthBefore);
+			Assert.Equal(report.TotalDefenderStrengthBefore, roundTripped.TotalDefenderStrengthBefore);
+			Assert.Equal(report.LandTransferred, roundTripped.LandTransferred);
+			Assert.Equal(report.WorkersCaptured, roundTripped.WorkersCaptured);
+			Assert.Equal(report.Rounds.Count, roundTripped.Rounds.Count);
+			Assert.Equal(report.AttackerUnitsInitial.Count, roundTripped.AttackerUnitsInitial.Count);
+			Assert.Equal(report.DefenderUnitsInitial.Count, roundTripped.DefenderUnitsInitial.Count);
+			Assert.Equal(report.ResourcesStolen["minerals"], roundTripped.ResourcesStolen["minerals"]);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BattleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BattleTest.cs
@@ -120,6 +120,82 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			Assert.Equal(3, result.DefendingUnitsDestroyed.Sum(x => x.Count));
 			Assert.Equal(1, result.AttackingUnitsDestroyed.Sum(x => x.Count));
 		}
+		[Fact]
+		public void BattleRounds_PopulatedWithCorrectCount() {
+			var battleBehavior = new BattleBehaviorScoOriginal(OutputHelper.ToLogger<IBattleBehavior>());
+
+			var attackers = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+			var defenders = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+
+			var result = battleBehavior.CalculateResult(attackers, defenders);
+
+			Assert.NotNull(result.Rounds);
+			Assert.Equal(8, result.Rounds.Count); // all 8 rounds run (neither side eliminated)
+			Assert.All(result.Rounds, r => Assert.True(r.RoundNumber >= 1 && r.RoundNumber <= 8));
+		}
+
+		[Fact]
+		public void BattleRounds_EarlyTermination_ProducesFewerRounds() {
+			var battleBehavior = new BattleBehaviorScoOriginal(OutputHelper.ToLogger<IBattleBehavior>());
+
+			// Strong attacker destroys weak defender quickly
+			var attackers = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 20, Defense = 10, Count = 10 }
+			};
+			var defenders = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+
+			var result = battleBehavior.CalculateResult(attackers, defenders);
+
+			Assert.NotNull(result.Rounds);
+			Assert.True(result.Rounds.Count < 8, $"Expected fewer than 8 rounds but got {result.Rounds.Count}");
+			// Last round should have no defender units remaining
+			var lastRound = result.Rounds[^1];
+			Assert.Empty(lastRound.DefenderUnitsRemaining);
+		}
+
+		[Fact]
+		public void BattleRounds_CasualtiesSumToTotals() {
+			var battleBehavior = new BattleBehaviorScoOriginal(OutputHelper.ToLogger<IBattleBehavior>());
+
+			var attackers = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+			var defenders = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+
+			var result = battleBehavior.CalculateResult(attackers, defenders);
+
+			int totalAttackerCasualties = result.Rounds.SelectMany(r => r.AttackerCasualties).Sum(u => u.Count);
+			int totalDefenderCasualties = result.Rounds.SelectMany(r => r.DefenderCasualties).Sum(u => u.Count);
+
+			Assert.Equal(result.AttackingUnitsDestroyed.Sum(u => u.Count), totalAttackerCasualties);
+			Assert.Equal(result.DefendingUnitsDestroyed.Sum(u => u.Count), totalDefenderCasualties);
+		}
+
+		[Fact]
+		public void BattleRounds_RoundNumbersAreSequential() {
+			var battleBehavior = new BattleBehaviorScoOriginal(OutputHelper.ToLogger<IBattleBehavior>());
+
+			var attackers = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+			var defenders = new List<BtlUnit> {
+				new BtlUnit { UnitDefId = Id.UnitDef("unit1"), Hitpoints = 100, Attack = 10, Defense = 10, Count = 10 }
+			};
+
+			var result = battleBehavior.CalculateResult(attackers, defenders);
+
+			for (int i = 0; i < result.Rounds.Count; i++) {
+				Assert.Equal(i + 1, result.Rounds[i].RoundNumber);
+			}
+		}
 	}
 
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BattleControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/BattleControllerIntegrationTest.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Net;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
+using BrowserGameEngine.Shared;
 using Xunit;
 
 namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
@@ -68,6 +71,44 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			// No units sent → attack fails with BadRequest
 			var response = await client.PostAsync($"/api/battle/attack?enemyPlayerId={defenderPlayerId}", null);
 			Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Reports_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync("/api/battle/reports");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Reports_Authenticated_ReturnsOk() {
+			var userId = "user-battle-reports-1";
+			await CreatePlayerAsync(userId, "ReportsPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync("/api/battle/reports");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+			var reports = await DeserializeAsync<BattleReportSummaryViewModel[]>(response);
+			Assert.NotNull(reports);
+			Assert.Empty(reports!);
+		}
+
+		[Fact]
+		public async Task Report_Unauthenticated_Returns401() {
+			var client = CreateClient();
+			var response = await client.GetAsync($"/api/battle/report?reportId={Guid.NewGuid()}");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task Report_NonExistentReport_Returns404() {
+			var userId = "user-battle-report-1";
+			await CreatePlayerAsync(userId, "ReportPlayer1");
+
+			var client = CreateClient(userId);
+			var response = await client.GetAsync($"/api/battle/report?reportId={Guid.NewGuid()}");
+			Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TestGame/TestGame.cs
@@ -52,6 +52,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		public SpyMissionRepositoryWrite SpyMissionRepositoryWrite { get; }
 		public ResourceHistoryRepository ResourceHistoryRepository { get; }
 		public ResourceHistoryRepositoryWrite ResourceHistoryRepositoryWrite { get; }
+		public BattleReportRepository BattleReportRepository { get; }
+		public BattleReportRepositoryWrite BattleReportRepositoryWrite { get; }
 		public TestWorldStateFactory WorldStateFactory { get; }
 		public GameTickModuleRegistry GameTickModuleRegistry { get; }
 		public GameTickEngine TickEngine { get; }
@@ -100,6 +102,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			SpyMissionRepositoryWrite = new SpyMissionRepositoryWrite(Accessor, ResourceRepositoryWrite, ResourceRepository, TechRepository, PlayerRepository, NullNotificationService.Instance, TimeProvider.System, GameDef);
 			ResourceHistoryRepository = new ResourceHistoryRepository(Accessor);
 			ResourceHistoryRepositoryWrite = new ResourceHistoryRepositoryWrite(Accessor);
+			BattleReportRepository = new BattleReportRepository(Accessor);
+			BattleReportRepositoryWrite = new BattleReportRepositoryWrite(Accessor);
 
 			var services = new ServiceCollection();
 			services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(AssetRepositoryWrite));

--- a/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/BattleReportGenerator.cs
@@ -1,6 +1,8 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.Notifications;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,22 +11,28 @@ namespace BrowserGameEngine.StatefulGameServer {
 	public class BattleReportGenerator {
 		private readonly PlayerRepository playerRepository;
 		private readonly MessageRepositoryWrite messageRepositoryWrite;
+		private readonly BattleReportRepositoryWrite battleReportRepositoryWrite;
 		private readonly GameDef gameDef;
 		private readonly IPlayerNotificationService playerNotificationService;
 		private readonly INotificationService notificationService;
+		private readonly TimeProvider timeProvider;
 
 		public BattleReportGenerator(
 			PlayerRepository playerRepository,
 			MessageRepositoryWrite messageRepositoryWrite,
+			BattleReportRepositoryWrite battleReportRepositoryWrite,
 			GameDef gameDef,
 			IPlayerNotificationService playerNotificationService,
-			INotificationService notificationService
+			INotificationService notificationService,
+			TimeProvider timeProvider
 		) {
 			this.playerRepository = playerRepository;
 			this.messageRepositoryWrite = messageRepositoryWrite;
+			this.battleReportRepositoryWrite = battleReportRepositoryWrite;
 			this.gameDef = gameDef;
 			this.playerNotificationService = playerNotificationService;
 			this.notificationService = notificationService;
+			this.timeProvider = timeProvider;
 		}
 
 		public void GenerateReports(BattleResult battleResult) {
@@ -44,6 +52,54 @@ namespace BrowserGameEngine.StatefulGameServer {
 				.GroupBy(x => x.Key.Id)
 				.ToDictionary(g => g.Key, g => g.Sum(x => x.Value));
 
+			// Persist structured battle report
+			var reportId = Guid.NewGuid();
+			var initialAttackerUnits = battleResult.BtlResult.Rounds.Count > 0
+				? battleResult.BtlResult.Rounds[0].AttackerUnitsRemaining
+					.Concat(battleResult.BtlResult.Rounds[0].AttackerCasualties)
+					.GroupBy(u => u.UnitDefId)
+					.Select(g => new UnitCount(g.Key, g.Sum(x => x.Count)))
+					.ToList()
+				: battleResult.BtlResult.AttackingUnitsSurvived
+					.Concat(battleResult.BtlResult.AttackingUnitsDestroyed)
+					.GroupBy(u => u.UnitDefId)
+					.Select(g => new UnitCount(g.Key, g.Sum(x => x.Count)))
+					.ToList();
+			var initialDefenderUnits = battleResult.BtlResult.Rounds.Count > 0
+				? battleResult.BtlResult.Rounds[0].DefenderUnitsRemaining
+					.Concat(battleResult.BtlResult.Rounds[0].DefenderCasualties)
+					.GroupBy(u => u.UnitDefId)
+					.Select(g => new UnitCount(g.Key, g.Sum(x => x.Count)))
+					.ToList()
+				: battleResult.BtlResult.DefendingUnitsSurvived
+					.Concat(battleResult.BtlResult.DefendingUnitsDestroyed)
+					.GroupBy(u => u.UnitDefId)
+					.Select(g => new UnitCount(g.Key, g.Sum(x => x.Count)))
+					.ToList();
+
+			var report = new BattleReport {
+				Id = reportId,
+				AttackerId = battleResult.Attacker,
+				DefenderId = battleResult.Defender,
+				AttackerName = attacker.Name,
+				DefenderName = defender.Name,
+				AttackerRace = attackerRace,
+				DefenderRace = defenderRace,
+				Outcome = outcome,
+				TotalAttackerStrengthBefore = battleResult.BtlResult.TotalAttackerStrengthBefore,
+				TotalDefenderStrengthBefore = battleResult.BtlResult.TotalDefenderStrengthBefore,
+				AttackerUnitsInitial = initialAttackerUnits,
+				DefenderUnitsInitial = initialDefenderUnits,
+				Rounds = new List<BattleRoundSnapshotImmutable>(battleResult.BtlResult.Rounds),
+				LandTransferred = (int)battleResult.BtlResult.LandTransferred,
+				WorkersCaptured = battleResult.BtlResult.WorkersCaptured,
+				ResourcesStolen = resourcesStolen,
+				CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+			};
+
+			battleReportRepositoryWrite.AddBattleReport(battleResult.Attacker, report);
+			battleReportRepositoryWrite.AddBattleReport(battleResult.Defender, report);
+
 			string body = BuildBody(
 				attacker.Name, attackerRace,
 				defender.Name, defenderRace,
@@ -52,7 +108,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				battleResult.BtlResult.WorkersCaptured,
 				resourcesStolen,
 				battleResult.BtlResult.AttackingUnitsDestroyed,
-				battleResult.BtlResult.DefendingUnitsDestroyed
+				battleResult.BtlResult.DefendingUnitsDestroyed,
+				reportId
 			);
 
 			messageRepositoryWrite.SendMessage(
@@ -93,7 +150,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			int workersCaptured,
 			Dictionary<string, decimal> resourcesStolen,
 			List<UnitCount> attackerLosses,
-			List<UnitCount> defenderLosses
+			List<UnitCount> defenderLosses,
+			Guid reportId
 		) {
 			bool attackerWon = outcome == "Attacker won";
 			bool draw = outcome == "Draw";
@@ -129,6 +187,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 				}
 				sb.AppendLine("  </div>");
 			}
+			sb.AppendLine($"  <p><a href=\"/battles/{reportId}\">View detailed battle replay</a></p>");
 			sb.AppendLine("</div>");
 			return sb.ToString();
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BattleReport.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/BattleReport.cs
@@ -1,0 +1,71 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	public class BattleReport {
+		public Guid Id { get; set; }
+		public PlayerId AttackerId { get; set; } = null!;
+		public PlayerId DefenderId { get; set; } = null!;
+		public string AttackerName { get; set; } = "";
+		public string DefenderName { get; set; } = "";
+		public string AttackerRace { get; set; } = "";
+		public string DefenderRace { get; set; } = "";
+		public string Outcome { get; set; } = "";
+		public int TotalAttackerStrengthBefore { get; set; }
+		public int TotalDefenderStrengthBefore { get; set; }
+		public List<UnitCount> AttackerUnitsInitial { get; set; } = new();
+		public List<UnitCount> DefenderUnitsInitial { get; set; } = new();
+		public List<BattleRoundSnapshotImmutable> Rounds { get; set; } = new();
+		public int LandTransferred { get; set; }
+		public int WorkersCaptured { get; set; }
+		public Dictionary<string, decimal> ResourcesStolen { get; set; } = new();
+		public DateTime CreatedAt { get; set; }
+
+		public BattleReportImmutable ToImmutable() {
+			return new BattleReportImmutable(
+				Id: Id,
+				AttackerId: AttackerId,
+				DefenderId: DefenderId,
+				AttackerName: AttackerName,
+				DefenderName: DefenderName,
+				AttackerRace: AttackerRace,
+				DefenderRace: DefenderRace,
+				Outcome: Outcome,
+				TotalAttackerStrengthBefore: TotalAttackerStrengthBefore,
+				TotalDefenderStrengthBefore: TotalDefenderStrengthBefore,
+				AttackerUnitsInitial: new List<UnitCount>(AttackerUnitsInitial),
+				DefenderUnitsInitial: new List<UnitCount>(DefenderUnitsInitial),
+				Rounds: new List<BattleRoundSnapshotImmutable>(Rounds),
+				LandTransferred: LandTransferred,
+				WorkersCaptured: WorkersCaptured,
+				ResourcesStolen: new Dictionary<string, decimal>(ResourcesStolen),
+				CreatedAt: CreatedAt
+			);
+		}
+
+		public static BattleReport FromImmutable(BattleReportImmutable immutable) {
+			return new BattleReport {
+				Id = immutable.Id,
+				AttackerId = immutable.AttackerId,
+				DefenderId = immutable.DefenderId,
+				AttackerName = immutable.AttackerName,
+				DefenderName = immutable.DefenderName,
+				AttackerRace = immutable.AttackerRace,
+				DefenderRace = immutable.DefenderRace,
+				Outcome = immutable.Outcome,
+				TotalAttackerStrengthBefore = immutable.TotalAttackerStrengthBefore,
+				TotalDefenderStrengthBefore = immutable.TotalDefenderStrengthBefore,
+				AttackerUnitsInitial = new List<UnitCount>(immutable.AttackerUnitsInitial),
+				DefenderUnitsInitial = new List<UnitCount>(immutable.DefenderUnitsInitial),
+				Rounds = new List<BattleRoundSnapshotImmutable>(immutable.Rounds),
+				LandTransferred = immutable.LandTransferred,
+				WorkersCaptured = immutable.WorkersCaptured,
+				ResourcesStolen = new Dictionary<string, decimal>(immutable.ResourcesStolen),
+				CreatedAt = immutable.CreatedAt
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -30,6 +30,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public List<SpyMission> SpyMissions { get; set; } = new List<SpyMission>();
 		public bool TutorialCompleted { get; set; }
 		public List<ResourceSnapshot> ResourceHistory { get; set; } = new List<ResourceSnapshot>();
+		public List<BattleReport> BattleReports { get; set; } = new List<BattleReport>();
 	}
 
 	internal static class PlayerStateExtensions {
@@ -58,7 +59,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Notifications: new List<GameNotification>(playerState.Notifications),
 				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList(),
 				TutorialCompleted: playerState.TutorialCompleted,
-				ResourceHistory: new List<ResourceSnapshot>(playerState.ResourceHistory)
+				ResourceHistory: new List<ResourceSnapshot>(playerState.ResourceHistory),
+				BattleReports: playerState.BattleReports.Select(x => x.ToImmutable()).ToList()
 			);
 		}
 
@@ -101,7 +103,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				TutorialCompleted = playerStateImmutable.TutorialCompleted,
 				ResourceHistory = playerStateImmutable.ResourceHistory != null
 					? new List<ResourceSnapshot>(playerStateImmutable.ResourceHistory)
-					: new List<ResourceSnapshot>()
+					: new List<ResourceSnapshot>(),
+				BattleReports = (playerStateImmutable.BattleReports ?? new List<BattleReportImmutable>())
+					.Select(x => BattleReport.FromImmutable(x)).ToList()
 			};
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -56,6 +56,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MessageRepository>();
 			services.AddSingleton<MessageRepositoryWrite>();
 			services.AddSingleton<BattleReportGenerator>();
+			services.AddSingleton<BattleReportRepository>();
+			services.AddSingleton<BattleReportRepositoryWrite>();
 			services.AddSingleton<UpgradeRepository>();
 			services.AddSingleton<UpgradeRepositoryWrite>();
 			services.AddSingleton<BuildQueueRepository>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleBehaviorScoOriginal.cs
@@ -41,12 +41,20 @@ namespace BrowserGameEngine.StatefulGameServer {
 				AttackingUnits = new List<BtlUnit>(attackingUnits),
 				DefendingUnits = new List<BtlUnit>(defendingUnits)
 			};
+			var rounds = new List<BattleRoundSnapshotImmutable>();
 			for (int i = 0; i < MaxBattleRounds; i++) {
 				logger.LogDebug("Round {RoundNr}", i);
 				battleState.DefendingUnits = Fight(battleState.AttackingUnits, battleState.DefendingUnits, FightMode.Attack, out var defendingUnitsDestroyed);
 				battleState.DefendingUnitsDestroyed.AddRange(defendingUnitsDestroyed);
 				battleState.AttackingUnits = Fight(battleState.DefendingUnits, battleState.AttackingUnits, FightMode.Defend, out var attackingUnitsDestroyed);
 				battleState.AttackingUnitsDestroyed.AddRange(attackingUnitsDestroyed);
+				rounds.Add(new BattleRoundSnapshotImmutable(
+					RoundNumber: i + 1,
+					AttackerUnitsRemaining: battleState.AttackingUnits.ToGroupedUnitCounts().ToList(),
+					DefenderUnitsRemaining: battleState.DefendingUnits.ToGroupedUnitCounts().ToList(),
+					AttackerCasualties: attackingUnitsDestroyed.GroupByUnitDefId().ToList(),
+					DefenderCasualties: defendingUnitsDestroyed.GroupByUnitDefId().ToList()
+				));
 				if (!battleState.DefendingUnits.Any()) break;
 				if (!battleState.AttackingUnits.Any()) break;
 			}
@@ -56,7 +64,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 				DefendingUnitsDestroyed = battleState.DefendingUnitsDestroyed.GroupByUnitDefId().ToList(),
 				DefendingUnitsSurvived = battleState.DefendingUnits.ToGroupedUnitCounts().ToList(),
 				ResourcesDestroyed = new List<Cost>(), // TODO
-				ResourcesStolen = new List<Cost>() // TODO
+				ResourcesStolen = new List<Cost>(), // TODO
+				Rounds = rounds
 			};
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepository.cs
@@ -1,0 +1,26 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class BattleReportRepository {
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public BattleReportRepository(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		public BattleReport? GetBattleReport(PlayerId playerId, Guid reportId) {
+			return world.GetPlayer(playerId).State.BattleReports
+				.FirstOrDefault(r => r.Id == reportId);
+		}
+
+		public List<BattleReport> GetBattleReports(PlayerId playerId) {
+			return world.GetPlayer(playerId).State.BattleReports;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
@@ -1,0 +1,27 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Threading;
+
+namespace BrowserGameEngine.StatefulGameServer {
+	public class BattleReportRepositoryWrite {
+		internal const int MaxReportsPerPlayer = 50;
+		private readonly Lock _lock = new();
+		private readonly IWorldStateAccessor worldStateAccessor;
+		private WorldState world => worldStateAccessor.WorldState;
+
+		public BattleReportRepositoryWrite(IWorldStateAccessor worldStateAccessor) {
+			this.worldStateAccessor = worldStateAccessor;
+		}
+
+		internal void AddBattleReport(PlayerId playerId, BattleReport report) {
+			lock (_lock) {
+				var reports = world.GetPlayer(playerId).State.BattleReports;
+				reports.Add(report);
+				while (reports.Count > MaxReportsPerPlayer) {
+					reports.RemoveAt(0);
+				}
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class BattleReportRepositoryWrite {
-		internal const int MaxReportsPerPlayer = 50;
+		public const int MaxReportsPerPlayer = 50;
 		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
@@ -14,7 +14,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.worldStateAccessor = worldStateAccessor;
 		}
 
-		internal void AddBattleReport(PlayerId playerId, BattleReport report) {
+		public void AddBattleReport(PlayerId playerId, BattleReport report) {
 			lock (_lock) {
 				var reports = world.GetPlayer(playerId).State.BattleReports;
 				reports.Add(report);

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -43,6 +43,7 @@ const AdminStats = lazy(() => import('@/pages/admin/AdminStats').then(m => ({ de
 const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ default: m.PlayersList })))
 const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
 const Help = lazy(() => import('@/pages/Help').then(m => ({ default: m.Help })))
+const BattleReplay = lazy(() => import('@/pages/BattleReplay').then(m => ({ default: m.BattleReplay })))
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -128,6 +129,11 @@ function TradePage() {
   if (!gameId) return null
   return <Trade gameId={gameId} />
 }
+function BattleReplayPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <BattleReplay gameId={gameId} />
+}
 function AlliancesPage() {
   const { gameId } = useParams<{ gameId: string }>()
   if (!gameId) return null
@@ -166,6 +172,7 @@ const router = createBrowserRouter([
           { path: 'help', element: <Help /> },
           { path: 'player/:playerId', element: <InGamePlayerProfilePage /> },
           { path: 'enemybase/:enemyPlayerId', element: <EnemyBasePage /> },
+          { path: 'battles/:reportId', element: <BattleReplayPage /> },
           { path: 'join', element: <JoinGame /> },
           { path: 'summary', element: <GameSummary /> },
           { path: 'results', element: <GameResults /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -688,6 +688,48 @@ export interface SelectEnemyViewModel {
   attackablePlayers: PublicPlayerViewModel[]
 }
 
+// Battle Reports
+
+export interface UnitCountViewModel {
+  unitName: string
+  count: number
+}
+
+export interface BattleRoundViewModel {
+  roundNumber: number
+  attackerUnitsRemaining: UnitCountViewModel[]
+  defenderUnitsRemaining: UnitCountViewModel[]
+  attackerCasualties: UnitCountViewModel[]
+  defenderCasualties: UnitCountViewModel[]
+}
+
+export interface BattleReportSummaryViewModel {
+  id: string
+  opponentName: string
+  outcome: string
+  createdAt: string
+}
+
+export interface BattleReportDetailViewModel {
+  id: string
+  attackerId: string
+  attackerName: string
+  defenderId: string
+  defenderName: string
+  attackerRace: string
+  defenderRace: string
+  outcome: string
+  totalAttackerStrengthBefore: number
+  totalDefenderStrengthBefore: number
+  attackerUnitsInitial: UnitCountViewModel[]
+  defenderUnitsInitial: UnitCountViewModel[]
+  rounds: BattleRoundViewModel[]
+  landTransferred: number
+  workersCaptured: number
+  resourcesStolen: Record<string, number>
+  createdAt: string
+}
+
 // Chat
 
 export interface ChatMessageViewModel {

--- a/src/ReactClient/src/pages/BattleReplay.tsx
+++ b/src/ReactClient/src/pages/BattleReplay.tsx
@@ -1,0 +1,174 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams, Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { BattleReportDetailViewModel, UnitCountViewModel } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+
+interface BattleReplayProps {
+  gameId: string
+}
+
+function UnitList({ units, label }: { units: UnitCountViewModel[]; label?: string }) {
+  if (units.length === 0) return <span className="text-muted-foreground text-xs">None</span>
+  return (
+    <span>
+      {label && <span className="text-xs text-muted-foreground mr-1">{label}</span>}
+      {units.map((u, i) => (
+        <span key={u.unitName}>
+          {i > 0 && ', '}
+          {u.count}x {u.unitName}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  const isVictory = outcome === 'Attacker won'
+  const isDraw = outcome === 'Draw'
+  const cls = isVictory
+    ? 'bg-green-500/20 text-green-400 border-green-500/30'
+    : isDraw
+      ? 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+      : 'bg-red-500/20 text-red-400 border-red-500/30'
+  return (
+    <span className={`inline-block rounded border px-2 py-0.5 text-sm font-semibold ${cls}`}>
+      {isVictory ? 'Victory' : isDraw ? 'Draw' : 'Defeat'}
+    </span>
+  )
+}
+
+export function BattleReplay({ gameId }: BattleReplayProps) {
+  const { reportId } = useParams<{ reportId: string }>()
+
+  const { data: report, isLoading, error, refetch } = useQuery<BattleReportDetailViewModel>({
+    queryKey: ['battle-report', gameId, reportId],
+    queryFn: () =>
+      apiClient
+        .get(`/api/battle/report?reportId=${encodeURIComponent(reportId ?? '')}`)
+        .then((r) => r.data),
+    enabled: !!reportId,
+  })
+
+  if (isLoading) return <PageLoader message="Loading battle report..." />
+  if (error) return <ApiError message="Battle report not found." onRetry={() => void refetch()} />
+  if (!report) return null
+
+  const date = new Date(report.createdAt)
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold">Battle Report</h1>
+          <OutcomeBadge outcome={report.outcome} />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {date.toLocaleDateString()} {date.toLocaleTimeString()}
+        </p>
+        <p className="text-sm">
+          <Link to={`/games/${gameId}/player/${report.attackerId}`} className="text-primary hover:underline font-medium">
+            {report.attackerName}
+          </Link>
+          <span className="text-muted-foreground"> ({report.attackerRace})</span>
+          {' vs '}
+          <Link to={`/games/${gameId}/player/${report.defenderId}`} className="text-primary hover:underline font-medium">
+            {report.defenderName}
+          </Link>
+          <span className="text-muted-foreground"> ({report.defenderRace})</span>
+        </p>
+      </div>
+
+      {/* Initial Forces */}
+      <div className="rounded-lg border p-4 space-y-3">
+        <h2 className="font-semibold text-sm">Initial Forces</h2>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">Attacker (Strength: {report.totalAttackerStrengthBefore})</div>
+            <UnitList units={report.attackerUnitsInitial} />
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">Defender (Strength: {report.totalDefenderStrengthBefore})</div>
+            <UnitList units={report.defenderUnitsInitial} />
+          </div>
+        </div>
+      </div>
+
+      {/* Round-by-round */}
+      <div className="space-y-3">
+        <h2 className="font-semibold text-sm">Round-by-Round Replay</h2>
+        <div className="space-y-2">
+          {report.rounds.map((round) => (
+            <div key={round.roundNumber} className="rounded-lg border p-3">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-xs font-semibold bg-secondary px-2 py-0.5 rounded">
+                  Round {round.roundNumber}
+                </span>
+              </div>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Attacker</div>
+                  {round.attackerCasualties.length > 0 && (
+                    <div className="text-red-400 text-xs">
+                      Lost: {round.attackerCasualties.map((u, i) => (
+                        <span key={u.unitName}>{i > 0 && ', '}{u.count}x {u.unitName}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div>
+                    <UnitList units={round.attackerUnitsRemaining} label="Remaining:" />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Defender</div>
+                  {round.defenderCasualties.length > 0 && (
+                    <div className="text-red-400 text-xs">
+                      Lost: {round.defenderCasualties.map((u, i) => (
+                        <span key={u.unitName}>{i > 0 && ', '}{u.count}x {u.unitName}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div>
+                    <UnitList units={round.defenderUnitsRemaining} label="Remaining:" />
+                  </div>
+                </div>
+              </div>
+              {round.attackerUnitsRemaining.length === 0 && (
+                <div className="mt-1 text-xs text-red-400 font-medium">Attacker eliminated</div>
+              )}
+              {round.defenderUnitsRemaining.length === 0 && (
+                <div className="mt-1 text-xs text-green-400 font-medium">Defender eliminated</div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Spoils */}
+      {(report.landTransferred > 0 || report.workersCaptured > 0 || Object.keys(report.resourcesStolen).length > 0) && (
+        <div className="rounded-lg border p-4 space-y-2">
+          <h2 className="font-semibold text-sm">Spoils of War</h2>
+          <div className="flex flex-wrap gap-2 text-sm">
+            {report.landTransferred > 0 && (
+              <span className="rounded bg-green-500/20 text-green-400 border border-green-500/30 px-2 py-0.5 text-xs">
+                +{report.landTransferred} land captured
+              </span>
+            )}
+            {report.workersCaptured > 0 && (
+              <span className="rounded bg-green-500/20 text-green-400 border border-green-500/30 px-2 py-0.5 text-xs">
+                +{report.workersCaptured} workers captured
+              </span>
+            )}
+            {Object.entries(report.resourcesStolen).map(([resource, amount]) => (
+              <span key={resource} className="rounded bg-green-500/20 text-green-400 border border-green-500/30 px-2 py-0.5 text-xs">
+                +{amount} {resource} pillaged
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/Messages.tsx
+++ b/src/ReactClient/src/pages/Messages.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
 import { PenSquareIcon, InboxIcon, SendIcon, ReplyIcon, MessageSquareIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { MessageInboxViewModel, MessageViewModel, MessageThreadViewModel, SendMessageViewModel, PublicPlayerViewModel, PaginatedResponse } from '@/api/types'
@@ -91,6 +92,38 @@ function ComposeForm({
       </button>
     </div>
   )
+}
+
+function MessageBody({ body, isSystemMessage, gameId }: { body: string; isSystemMessage: boolean; gameId: string }) {
+  const navigate = useNavigate()
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement
+      const anchor = target.closest('a')
+      if (!anchor) return
+      const href = anchor.getAttribute('href')
+      if (href && href.startsWith('/battles/')) {
+        e.preventDefault()
+        const reportId = href.replace('/battles/', '')
+        void navigate(`/games/${gameId}/battles/${reportId}`)
+      }
+    },
+    [gameId, navigate],
+  )
+
+  // System messages (senderId is null) contain server-generated HTML that is safe
+  // to render — player names are HTML-encoded by BattleReportGenerator.
+  if (isSystemMessage) {
+    return (
+      <div
+        className="text-sm battle-report-message"
+        onClick={handleClick}
+        dangerouslySetInnerHTML={{ __html: body }}
+      />
+    )
+  }
+  return <p className="text-sm whitespace-pre-wrap">{body}</p>
 }
 
 export function Messages({ gameId }: MessagesProps) {
@@ -283,13 +316,13 @@ export function Messages({ gameId }: MessagesProps) {
                           <span>{isMine ? 'You' : msg.senderName}</span>
                           <span>{relativeTime(msg.sentAt)}</span>
                         </div>
-                        <p className="whitespace-pre-wrap">{msg.body}</p>
+                        <MessageBody body={msg.body} isSystemMessage={msg.senderId === null} gameId={gameId} />
                       </li>
                     )
                   })}
                 </ul>
               ) : (
-                <p className="text-sm whitespace-pre-wrap">{selected.body}</p>
+                <MessageBody body={selected.body} isSystemMessage={selected.senderId === null} gameId={gameId} />
               )}
               {tab === 'inbox' && (
                 <button


### PR DESCRIPTION
## Summary
- Capture per-round snapshots during battle calculation (up to 8 rounds) and persist structured battle reports per player (capped at 50)
- Add `GET /api/battle/report?reportId` and `GET /api/battle/reports` API endpoints
- Add React BattleReplay page at `/games/:gameId/battles/:reportId` showing round-by-round casualties, unit counts, and spoils of war
- Render system messages (battle reports) as HTML in the Messages inbox, with clickable links to the replay page
- 4 new tests verifying round snapshot count, early termination, casualty consistency, and sequential numbering

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (535 tests, 4 new)
- [ ] Manual: trigger a battle and verify the battle report message contains a "View detailed battle replay" link
- [ ] Manual: click the replay link and verify the BattleReplay page shows round-by-round data
- [ ] Manual: verify old messages (without replay links) still render correctly

Closes BGE-693