### PR TITLE
Move GetLeaderboard from PlayerRankingController to GamesController

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -27,6 +27,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly TimeProvider timeProvider;
 		private readonly GameLifecycleEngine gameLifecycleEngine;
 		private readonly IGameEventPublisher gameEventPublisher;
+		private readonly PlayerRepository playerRepository;
+		private readonly ScoreRepository scoreRepository;
+		private readonly UserRepository userRepository;
 
 		public GamesController(
 			ILogger<GamesController> logger,
@@ -37,7 +40,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			CurrentUserContext currentUserContext,
 			TimeProvider timeProvider,
 			GameLifecycleEngine gameLifecycleEngine,
-			IGameEventPublisher gameEventPublisher
+			IGameEventPublisher gameEventPublisher,
+			PlayerRepository playerRepository,
+			ScoreRepository scoreRepository,
+			UserRepository userRepository
 		) {
 			this.logger = logger;
 			this.gameRegistry = gameRegistry;
@@ -48,6 +54,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.timeProvider = timeProvider;
 			this.gameLifecycleEngine = gameLifecycleEngine;
 			this.gameEventPublisher = gameEventPublisher;
+			this.playerRepository = playerRepository;
+			this.scoreRepository = scoreRepository;
+			this.userRepository = userRepository;
 		}
 
 		/// <summary>Returns games where the authenticated user has an active player.</summary>
@@ -385,6 +394,33 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				VictoryConditionType: record.VictoryConditionType,
 				VictoryConditionLabel: GetVictoryConditionLabel(record.VictoryConditionType)
 			));
+		}
+
+		/// <summary>Returns the current game's leaderboard ranked by score.</summary>
+		/// <param name="gameId">The game identifier (used for routing; server uses current player's game context).</param>
+		[HttpGet("{gameId}/leaderboard")]
+		[ProducesResponseType(typeof(IEnumerable<LeaderboardEntryViewModel>), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<IEnumerable<LeaderboardEntryViewModel>> GetLeaderboard(string gameId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var players = playerRepository.GetAll()
+				.Select(p => (
+					player: p,
+					score: scoreRepository.GetScore(p.PlayerId),
+					name: p.UserId != null ? userRepository.GetDisplayNameByUserId(p.UserId) ?? p.Name : p.Name
+				))
+				.OrderByDescending(x => x.score)
+				.ToList();
+
+			return players
+				.Select((x, idx) => new LeaderboardEntryViewModel(
+					Rank: idx + 1,
+					PlayerId: x.player.PlayerId.Id,
+					PlayerName: x.name,
+					Score: x.score,
+					IsCurrentPlayer: x.player.PlayerId == currentUserContext.PlayerId
+				))
+				.ToList();
 		}
 
 		private string? ResolveWinnerName(GameRecordImmutable record) {

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -58,34 +58,6 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return PaginatedResponse<PublicPlayerViewModel>.Create(players, page, pageSize);
 		}
 
-		/// <summary>Returns the current game's leaderboard ranked by score.</summary>
-		/// <param name="gameId">The game identifier (used for routing; server uses current player's game context).</param>
-		[HttpGet]
-		[Route("api/games/{gameId}/leaderboard")]
-		[ProducesResponseType(typeof(IEnumerable<LeaderboardEntryViewModel>), StatusCodes.Status200OK)]
-		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
-		public ActionResult<IEnumerable<LeaderboardEntryViewModel>> GetLeaderboard(string gameId) {
-			if (!currentUserContext.IsValid) return Unauthorized();
-			var players = playerRepository.GetAll()
-				.Select(p => (
-					player: p,
-					score: scoreRepository.GetScore(p.PlayerId),
-					name: p.UserId != null ? userRepository.GetDisplayNameByUserId(p.UserId) ?? p.Name : p.Name
-				))
-				.OrderByDescending(x => x.score)
-				.ToList();
-
-			return players
-				.Select((x, idx) => new LeaderboardEntryViewModel(
-					Rank: idx + 1,
-					PlayerId: x.player.PlayerId.Id,
-					PlayerName: x.name,
-					Score: x.score,
-					IsCurrentPlayer: x.player.PlayerId == currentUserContext.PlayerId
-				))
-				.ToList();
-		}
-
 		/// <summary>Returns the in-game profile for a specific player by player ID.</summary>
 		/// <param name="playerId">The player ID to look up.</param>
 		[HttpGet("{playerId}")]

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -79,7 +79,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userCtx,
 				TimeProvider.System,
 				lifecycleEngine,
-				NullGameEventPublisher.Instance
+				NullGameEventPublisher.Instance,
+				game.PlayerRepository,
+				game.ScoreRepository,
+				new UserRepository(globalState, game.World)
 			);
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
@@ -74,7 +74,10 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userCtx,
 				TimeProvider.System,
 				lifecycleEngine,
-				NullGameEventPublisher.Instance
+				NullGameEventPublisher.Instance,
+				game.PlayerRepository,
+				game.ScoreRepository,
+				new UserRepository(globalState, game.World)
 			);
 
 			return (controller, gameRegistry);


### PR DESCRIPTION
## Summary
- Moved `GetLeaderboard` method from `PlayerRankingController` to `GamesController` where its route (`api/games/{gameId}/leaderboard`) naturally belongs
- Added `PlayerRepository`, `ScoreRepository`, and `UserRepository` as constructor dependencies to `GamesController`
- Updated test constructors in `GamesControllerTest.cs` and `LobbyTest.cs` to pass the new dependencies

## Test plan
- [x] `dotnet build` succeeds
- [x] All 536 unit tests pass
- [ ] Verify `/api/games/{gameId}/leaderboard` endpoint works in dev environment
- [ ] Verify VictoryProgressBar renders correctly (uses this endpoint)