### PR TITLE
feat: BGE-726 player profile page with game history

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -26,6 +26,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				var displayName = globalState.GetUserDisplayName(g.Key) ?? list.First().PlayerName;
 				return new AllTimePlayerEntryViewModel(
 					DisplayName: displayName,
+					UserId: g.Key,
 					TotalGames: list.Count,
 					TotalWins: list.Count(a => a.FinalRank == 1),
 					BestRank: list.Min(a => a.FinalRank),

--- a/src/BrowserGameEngine.Shared/AllTimePlayerListViewModel.cs
+++ b/src/BrowserGameEngine.Shared/AllTimePlayerListViewModel.cs
@@ -1,6 +1,7 @@
 namespace BrowserGameEngine.Shared {
 	public record AllTimePlayerEntryViewModel(
 		string DisplayName,
+		string UserId,
 		int TotalGames,
 		int TotalWins,
 		int BestRank,

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -833,6 +833,7 @@ export interface UpdateGameRequest {
 
 export interface AllTimePlayerEntryViewModel {
   displayName: string
+  userId: string
   totalGames: number
   totalWins: number
   bestRank: number

--- a/src/ReactClient/src/pages/PlayersList.tsx
+++ b/src/ReactClient/src/pages/PlayersList.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { AllTimePlayerListViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
@@ -41,7 +42,9 @@ export function PlayersList() {
                 <tr key={p.displayName} className="hover:bg-secondary/20 transition-colors">
                   <td className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
                   <td className="px-4 py-2 font-medium">
-                    {p.displayName}
+                    <Link to={`/profile/${encodeURIComponent(p.userId)}`} className="hover:underline text-primary">
+                      {p.displayName}
+                    </Link>
                   </td>
                   <td className="px-4 py-2 text-right font-mono">
                     {Math.floor(p.totalScore).toLocaleString()}

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -1,14 +1,33 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router'
-import { UserIcon, TrophyIcon, StarIcon } from 'lucide-react'
+import { UserIcon, TrophyIcon, StarIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { PlayerCrossGameStatsViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
+const PAGE_SIZE = 10
+
+function avatarInitials(name: string | null | undefined): string {
+  if (!name) return '?'
+  const words = name.trim().split(/\s+/)
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase()
+}
+
+function outcomeLabel(isWinner: boolean, gameStatus: string): { label: string; className: string } {
+  if (isWinner) return { label: 'Win', className: 'bg-green-700/30 text-green-300' }
+  if (gameStatus.toLowerCase() === 'active' || gameStatus.toLowerCase() === 'running') {
+    return { label: 'DNF', className: 'bg-secondary/40 text-muted-foreground' }
+  }
+  return { label: 'Loss', className: 'bg-red-900/30 text-red-300' }
+}
+
 export function PublicProfile() {
   const { userId } = useParams<{ userId: string }>()
+  const [page, setPage] = useState(0)
 
   const { data: stats, isLoading, error, refetch } = useQuery<PlayerCrossGameStatsViewModel>({
     queryKey: ['public-profile', userId],
@@ -21,8 +40,8 @@ export function PublicProfile() {
   if (error) return <ApiError message="Failed to load player profile." onRetry={() => void refetch()} />
   if (!stats) {
     return (
-      <div className="max-w-lg p-4">
-        <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+      <div className="max-w-2xl p-4">
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
           <UserIcon className="h-10 w-10 mx-auto mb-2 opacity-40" />
           <p className="text-sm">Player not found or no game history yet.</p>
         </div>
@@ -30,27 +49,52 @@ export function PublicProfile() {
     )
   }
 
-  return (
-    <div className="max-w-lg space-y-5">
-      <h1 className="text-xl font-bold flex items-center gap-2">
-        <UserIcon className="h-5 w-5 text-primary" />
-        {stats.playerName ?? 'Unknown Player'}
-      </h1>
+  const losses = stats.totalGames - stats.totalWins
+  const winRate = stats.totalGames > 0 ? (stats.totalWins / stats.totalGames) * 100 : 0
+  const avgRank =
+    stats.games.length > 0
+      ? stats.games.reduce((sum, g) => sum + g.finalRank, 0) / stats.games.length
+      : 0
 
-      {/* Summary stats */}
+  const totalPages = Math.ceil(stats.games.length / PAGE_SIZE)
+  const pagedGames = stats.games.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      {/* Profile header */}
+      <div className="rounded-lg border bg-card p-5 flex items-center gap-4">
+        <div
+          className="flex-shrink-0 h-14 w-14 rounded-full bg-primary/20 border border-primary/30 flex items-center justify-center text-lg font-bold text-primary select-none"
+          aria-hidden="true"
+        >
+          {avatarInitials(stats.playerName)}
+        </div>
+        <div>
+          <h1 className="text-xl font-bold">{stats.playerName ?? 'Unknown Player'}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {stats.totalGames} {stats.totalGames === 1 ? 'game' : 'games'} played
+          </p>
+        </div>
+      </div>
+
+      {/* Statistics panel */}
       <div className="rounded-lg border bg-card p-5 space-y-3">
         <strong className="text-sm flex items-center gap-1.5">
           <TrophyIcon className="h-4 w-4 text-primary" />
           Career Stats
         </strong>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <div className="rounded border bg-secondary/20 p-3 text-center">
-            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Games</div>
-            <div className="text-xl font-bold">{stats.totalGames}</div>
-          </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           <div className="rounded border bg-secondary/20 p-3 text-center">
             <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Wins</div>
             <div className="text-xl font-bold text-green-400">{stats.totalWins}</div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Losses</div>
+            <div className="text-xl font-bold text-red-400">{losses}</div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Win Rate</div>
+            <div className="text-xl font-bold">{winRate.toFixed(0)}%</div>
           </div>
           <div className="rounded border bg-secondary/20 p-3 text-center">
             <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Best Rank</div>
@@ -64,53 +108,86 @@ export function PublicProfile() {
             </div>
           </div>
           <div className="rounded border bg-secondary/20 p-3 text-center">
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Avg Rank</div>
+            <div className="text-xl font-bold">{avgRank > 0 ? `#${avgRank.toFixed(1)}` : '—'}</div>
+          </div>
+          <div className="rounded border bg-secondary/20 p-3 text-center">
             <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Total Score</div>
             <div className="text-xl font-bold">{Math.floor(stats.totalScore).toLocaleString()}</div>
           </div>
         </div>
       </div>
 
-      {/* Game History */}
-      {stats.games.length > 0 && (
+      {/* Game history table */}
+      {stats.games.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+          <p className="text-sm">No games played yet.</p>
+        </div>
+      ) : (
         <div className="rounded-lg border bg-card">
-          <div className="border-b px-4 py-3">
+          <div className="border-b px-4 py-3 flex items-center justify-between">
             <strong className="text-sm">Game History</strong>
+            {totalPages > 1 && (
+              <span className="text-xs text-muted-foreground">
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, stats.games.length)} of {stats.games.length}
+              </span>
+            )}
           </div>
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm" aria-label="Game history">
               <thead className="border-b">
                 <tr>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Result</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Date</th>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Score</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Ended</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Outcome</th>
                 </tr>
               </thead>
               <tbody>
-                {stats.games.map((g) => (
-                  <tr key={g.gameId} className="border-b border-border">
-                    <td className="py-2 px-3 font-medium">{g.gameName}</td>
-                    <td className="py-2 px-3">
-                      {g.isWinner ? (
-                        <span className="inline-flex items-center gap-1 rounded bg-green-700/30 px-2 py-0.5 text-xs text-green-300">
-                          <StarIcon className="h-3 w-3" />
-                          Winner
+                {pagedGames.map((g) => {
+                  const outcome = outcomeLabel(g.isWinner, g.gameStatus)
+                  return (
+                    <tr key={g.gameId} className="border-b border-border last:border-0">
+                      <td className="py-2 px-3 font-medium">{g.gameName}</td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground whitespace-nowrap">
+                        {relativeTime(g.gameEndTime)}
+                      </td>
+                      <td className="py-2 px-3 font-mono">#{g.finalRank}</td>
+                      <td className="py-2 px-3">
+                        <span className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium ${outcome.className}`}>
+                          {g.isWinner && <StarIcon className="h-3 w-3" />}
+                          {outcome.label}
                         </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">{g.gameStatus}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3">#{g.finalRank}</td>
-                    <td className="py-2 px-3">{Math.floor(g.finalScore).toLocaleString()}</td>
-                    <td className="py-2 px-3 text-xs text-muted-foreground">
-                      {relativeTime(g.gameEndTime)}
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>
+          {totalPages > 1 && (
+            <div className="border-t px-4 py-2 flex items-center justify-end gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="rounded p-1 hover:bg-secondary/40 disabled:opacity-40 disabled:cursor-not-allowed"
+                aria-label="Previous page"
+              >
+                <ChevronLeftIcon className="h-4 w-4" />
+              </button>
+              <span className="text-xs text-muted-foreground">
+                Page {page + 1} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+                className="rounded p-1 hover:bg-secondary/40 disabled:opacity-40 disabled:cursor-not-allowed"
+                aria-label="Next page"
+              >
+                <ChevronRightIcon className="h-4 w-4" />
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Enhanced `PublicProfile` page** (`/profile/:userId`): avatar initials circle, expanded stats panel (wins, losses, win rate %, best rank, avg rank, total score), paginated game history table with Win/Loss/DNF outcome badges
- **Backend**: added `UserId` field to `AllTimePlayerEntryViewModel` so the frontend can link to player profiles
- **`PlayersList`** (`/players`): player names now link to their public profile page

## Details

### PublicProfile enhancements
- Avatar circle with derived initials (e.g. "John Doe" → "JD")
- Stats grid: Wins (green), Losses (red), Win Rate %, Best Rank (with gold star for #1), Avg Rank, Total Score
- Game history table paginated at 10 rows per page with prev/next controls
- Outcome column shows **Win** (green), **Loss** (red), or **DNF** (grey, for games still in active/running status)
- Empty state when player has no games

### Accessibility
- Table has `aria-label`
- Pagination buttons have `aria-label`
- Avatar circle is `aria-hidden` (decorative)

## Test plan
- [ ] Navigate to `/players`, click a player name — should land on `/profile/:userId`
- [ ] Profile header shows avatar initials and game count
- [ ] Stats panel shows correct wins, losses, win rate, ranks
- [ ] Game history table shows rows with outcome badges; pagination appears when > 10 games
- [ ] Empty state shown when player has no game history