### PR TITLE
feat: BGE-694 dark mode toggle with theme persistence

### DIFF
--- a/src/ReactClient/src/contexts/ThemeContext.tsx
+++ b/src/ReactClient/src/contexts/ThemeContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'dark' | 'light'
+
+interface ThemeContextValue {
+	theme: Theme
+	toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function getInitialTheme(): Theme {
+	const stored = localStorage.getItem('bge-theme')
+	if (stored === 'dark' || stored === 'light') return stored
+	if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
+	return 'dark'
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+	const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+	useEffect(() => {
+		const root = document.documentElement
+		root.classList.toggle('light', theme === 'light')
+		localStorage.setItem('bge-theme', theme)
+	}, [theme])
+
+	function toggleTheme() {
+		setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+	}
+
+	return (
+		<ThemeContext.Provider value={{ theme, toggleTheme }}>
+			{children}
+		</ThemeContext.Provider>
+	)
+}
+
+export function useTheme(): ThemeContextValue {
+	const ctx = useContext(ThemeContext)
+	if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+	return ctx
+}

--- a/src/ReactClient/src/index.css
+++ b/src/ReactClient/src/index.css
@@ -33,6 +33,39 @@
   --color-info-foreground: hsl(217 91% 90%);
 }
 
+/* Light theme overrides — applied when html.light class is present */
+html.light {
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(222.2 84% 4.9%);
+  --color-popover: hsl(0 0% 100%);
+  --color-popover-foreground: hsl(222.2 84% 4.9%);
+  --color-primary: hsl(217.2 91.2% 45%);
+  --color-primary-foreground: hsl(210 40% 98%);
+  --color-secondary: hsl(210 40% 94%);
+  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --color-muted: hsl(210 40% 94%);
+  --color-muted-foreground: hsl(215 16% 40%);
+  --color-accent: hsl(210 40% 94%);
+  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --color-destructive: hsl(0 72% 45%);
+  --color-destructive-foreground: hsl(210 40% 98%);
+  --color-border: hsl(214 32% 86%);
+  --color-input: hsl(214 32% 86%);
+  --color-ring: hsl(217.2 91.2% 59.8%);
+
+  /* Game status colors */
+  --color-success: hsl(142 71% 30%);
+  --color-success-foreground: hsl(142 76% 15%);
+  --color-warning: hsl(38 92% 38%);
+  --color-warning-foreground: hsl(38 92% 15%);
+  --color-danger: hsl(0 72% 40%);
+  --color-danger-foreground: hsl(0 72% 15%);
+  --color-info: hsl(217 91% 45%);
+  --color-info-foreground: hsl(217 91% 15%);
+}
+
 * {
   border-color: var(--color-border);
 }

--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -1,7 +1,8 @@
 import { Suspense, useState, useCallback, useEffect, useRef } from 'react'
 import { Outlet, NavLink, useParams, Navigate, useLocation, useNavigate } from 'react-router'
-import { GamepadIcon, LogOutIcon, MenuIcon, XIcon, WifiIcon, WifiOffIcon } from 'lucide-react'
+import { GamepadIcon, LogOutIcon, MenuIcon, XIcon, WifiIcon, WifiOffIcon, SunIcon, MoonIcon } from 'lucide-react'
 import { CurrentGameProvider, useCurrentGame } from '@/contexts/CurrentGameContext'
+import { useTheme } from '@/contexts/ThemeContext'
 import { NavMenu } from '@/components/NavMenu'
 import { PlayerResources } from '@/components/PlayerResources'
 import { NotificationBell } from '@/components/NotificationBell'
@@ -140,6 +141,23 @@ function SidebarContent({ currentGame }: { currentGame: { name: string } | null 
   )
 }
 
+function ThemeToggleButton() {
+  const { theme, toggleTheme } = useTheme()
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-1.5 rounded hover:bg-secondary"
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {theme === 'dark' ? (
+        <SunIcon className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <MoonIcon className="h-4 w-4" aria-hidden="true" />
+      )}
+    </button>
+  )
+}
+
 function GameLayoutInner() {
   const { gameId, currentGame } = useCurrentGame()
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -240,6 +258,7 @@ function GameLayoutInner() {
               )}
             </span>
             <NotificationBell signalR={signalR} onRealTimeNotification={onRealTimeNotification} />
+            <ThemeToggleButton />
           </div>
         </header>
 

--- a/src/ReactClient/src/layouts/RootLayout.tsx
+++ b/src/ReactClient/src/layouts/RootLayout.tsx
@@ -1,17 +1,20 @@
 import { Suspense } from 'react'
 import { Outlet } from 'react-router'
 import { CurrentUserProvider } from '@/contexts/CurrentUserContext'
+import { ThemeProvider } from '@/contexts/ThemeContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { PageLoader } from '@/components/PageLoader'
 
 export function RootLayout() {
   return (
     <ErrorBoundary>
-      <CurrentUserProvider>
-        <Suspense fallback={<PageLoader />}>
-          <Outlet />
-        </Suspense>
-      </CurrentUserProvider>
+      <ThemeProvider>
+        <CurrentUserProvider>
+          <Suspense fallback={<PageLoader />}>
+            <Outlet />
+          </Suspense>
+        </CurrentUserProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
## Summary
- Add `ThemeContext` with `ThemeProvider` and `useTheme` hook that manages dark/light theme state
- Theme defaults to user's OS preference (`prefers-color-scheme`) then falls back to dark; persists to `localStorage` key `bge-theme`
- Add light theme CSS variable overrides on `html.light` class in `index.css`
- Add sun/moon toggle button in the game header (top-right, next to notification bell)
- `ThemeProvider` wraps the entire app via `RootLayout`, so all pages get consistent theming

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (549/549)
- [ ] Toggle button appears in game header and switches between sun/moon icon
- [ ] Switching theme updates colors across all pages (backgrounds, cards, text, borders)
- [ ] Preference persists across page reloads (check `localStorage.getItem('bge-theme')`)
- [ ] On first visit with no stored preference, dark/light matches OS `prefers-color-scheme`

Closes BGE-694