### PR TITLE
feat: BGE-692 configurable game parameters at creation time

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -137,6 +137,37 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 			if (request.MaxPlayers < 0) return BadRequest("MaxPlayers cannot be negative.");
 
+			GameSettings? gameSettings = null;
+			if (request.Settings != null) {
+				var s = request.Settings;
+				if (s.StartingLand < 0) return BadRequest("StartingLand cannot be negative.");
+				if (s.StartingMinerals < 0) return BadRequest("StartingMinerals cannot be negative.");
+				if (s.StartingGas < 0) return BadRequest("StartingGas cannot be negative.");
+				if (s.ProtectionTicks < 0) return BadRequest("ProtectionTicks cannot be negative.");
+				if (s.VictoryThreshold <= 0) return BadRequest("VictoryThreshold must be greater than zero.");
+				if (s.MaxPlayers < 0) return BadRequest("Settings.MaxPlayers cannot be negative.");
+				if (s.VictoryConditionType != null) {
+					var validTypes = new[] {
+						VictoryConditionTypes.EconomicThreshold,
+						VictoryConditionTypes.TimeExpired,
+						VictoryConditionTypes.AdminFinalized
+					};
+					if (!validTypes.Contains(s.VictoryConditionType)) {
+						return BadRequest($"Unknown victory condition type: {s.VictoryConditionType}. Valid types: EconomicThreshold, TimeExpired, AdminFinalized");
+					}
+				}
+				var defaults = GameSettings.Default;
+				gameSettings = new GameSettings(
+					StartingLand: s.StartingLand ?? defaults.StartingLand,
+					StartingMinerals: s.StartingMinerals ?? defaults.StartingMinerals,
+					StartingGas: s.StartingGas ?? defaults.StartingGas,
+					ProtectionTicks: s.ProtectionTicks ?? defaults.ProtectionTicks,
+					VictoryThreshold: s.VictoryThreshold ?? defaults.VictoryThreshold,
+					VictoryConditionType: s.VictoryConditionType ?? defaults.VictoryConditionType,
+					MaxPlayers: s.MaxPlayers ?? defaults.MaxPlayers
+				);
+			}
+
 			var gameId = new GameId(Guid.NewGuid().ToString("N")[..12]);
 			var record = new GameRecordImmutable(
 				GameId: gameId,
@@ -148,14 +179,15 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				TickDuration: tickDuration,
 				DiscordWebhookUrl: request.DiscordWebhookUrl,
 				CreatedByUserId: currentUserContext.UserId,
-				MaxPlayers: request.MaxPlayers
+				MaxPlayers: request.MaxPlayers,
+				Settings: gameSettings
 			);
 
 			// Create a fresh world state for the new game
 			var wsImm = worldStateFactory.CreateDevWorldState(0) with { GameId = gameId };
 			var ws = wsImm.ToMutable();
 
-			// Register the game instance
+			// Register the game instance (GameInstance applies record.Settings to WorldState)
 			var instance = new GameInstance(record, ws, gameDef);
 			gameRegistry.Register(instance);
 			globalState.AddGame(record);
@@ -281,6 +313,20 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			bool canJoin = (record.Status == GameStatus.Upcoming || record.Status == GameStatus.Active)
 				&& (record.MaxPlayers == 0 || players.Count < record.MaxPlayers);
 
+			GameSettingsViewModel? settingsVm = null;
+			if (record.Settings != null) {
+				var s = record.Settings;
+				settingsVm = new GameSettingsViewModel(
+					StartingLand: s.StartingLand,
+					StartingMinerals: s.StartingMinerals,
+					StartingGas: s.StartingGas,
+					ProtectionTicks: s.ProtectionTicks,
+					VictoryThreshold: s.VictoryThreshold,
+					VictoryConditionType: s.VictoryConditionType,
+					MaxPlayers: s.MaxPlayers
+				);
+			}
+
 			return Ok(new GameLobbyViewModel(
 				GameId: record.GameId.Id,
 				GameName: record.Name,
@@ -289,7 +335,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				StartTime: record.StartTime,
 				EndTime: record.EndTime,
 				Players: players,
-				CanJoin: canJoin
+				CanJoin: canJoin,
+				Settings: settingsVm
 			));
 		}
 

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -18,6 +18,7 @@ namespace BrowserGameEngine.GameModel {
 		string? VictoryConditionType = null,
 		string? CreatedByUserId = null,
 		string? DiscordWebhookUrl = null,
-		int MaxPlayers = 0
+		int MaxPlayers = 0,
+		GameSettings? Settings = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/GameSettings.cs
+++ b/src/BrowserGameEngine.GameModel/GameSettings.cs
@@ -1,0 +1,13 @@
+namespace BrowserGameEngine.GameModel {
+	public record GameSettings(
+		int StartingLand = 50,
+		int StartingMinerals = 5000,
+		int StartingGas = 3000,
+		int ProtectionTicks = 480,
+		int VictoryThreshold = 500000,
+		string VictoryConditionType = "EconomicThreshold",
+		int MaxPlayers = 0
+	) {
+		public static GameSettings Default => new GameSettings();
+	}
+}

--- a/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameLobbyViewModels.cs
@@ -32,7 +32,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime? StartTime,
 		DateTime? EndTime,
 		List<LobbyPlayerViewModel> Players,
-		bool CanJoin = false
+		bool CanJoin = false,
+		GameSettingsViewModel? Settings = null
 	);
 
 	public record LobbyPlayerViewModel(

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -17,6 +17,26 @@ namespace BrowserGameEngine.Shared {
 		string? VictoryConditionLabel = null
 	);
 
+	public record GameSettingsRequest(
+		int? StartingLand = null,
+		int? StartingMinerals = null,
+		int? StartingGas = null,
+		int? ProtectionTicks = null,
+		int? VictoryThreshold = null,
+		string? VictoryConditionType = null,
+		int? MaxPlayers = null
+	);
+
+	public record GameSettingsViewModel(
+		int StartingLand,
+		int StartingMinerals,
+		int StartingGas,
+		int ProtectionTicks,
+		int VictoryThreshold,
+		string VictoryConditionType,
+		int MaxPlayers
+	);
+
 	public record CreateGameRequest(
 		string Name,
 		string GameDefType,
@@ -24,7 +44,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime EndTime,
 		string TickDuration,
 		string? DiscordWebhookUrl = null,
-		int MaxPlayers = 0
+		int MaxPlayers = 0,
+		GameSettingsRequest? Settings = null
 	);
 
 	public record UpdateGameRequest(

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
@@ -1,0 +1,155 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Linq;
+using Xunit;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class GameSettingsTest {
+		private const string TestGameId = "default";
+
+		private static GameRecordImmutable MakeRecord(
+			GameSettings? settings = null,
+			GameStatus status = GameStatus.Active
+		) {
+			return new GameRecordImmutable(
+				new GameId(TestGameId),
+				"Settings Test Game",
+				"sco",
+				status,
+				DateTime.UtcNow.AddHours(-1),
+				DateTime.UtcNow.AddHours(1),
+				TimeSpan.FromSeconds(30),
+				Settings: settings
+			);
+		}
+
+		private static TestGame SetupWithSettings(GameSettings? settings) {
+			var record = MakeRecord(settings);
+			var game = new TestGame(0);
+			// Create a GameInstance so the record.Settings propagates to WorldState
+			var _ = new GameInstance(record, game.World, game.GameDef);
+			return game;
+		}
+
+		private static (TestGame game, GameRegistryNs.GameRegistry registry, VictoryConditionModule module) SetupVictoryModule(
+			GameSettings? settings = null, int playerCount = 1
+		) {
+			var game = new TestGame(playerCount);
+			var record = MakeRecord(settings);
+			game.GlobalState.AddGame(record);
+
+			var registry = new GameRegistryNs.GameRegistry(game.GlobalState);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			registry.Register(instance);
+
+			var storage = new InMemoryBlobStorage();
+			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
+			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
+			var userRepositoryWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+			var lifecycleEngine = new GameRegistryNs.GameLifecycleEngine(
+				registry,
+				game.GlobalState,
+				persistenceService,
+				globalPersistenceService,
+				new GameRegistryNs.NullGameNotificationService(),
+				new InMemoryPlayerNotificationService(NullGameEventPublisher.Instance),
+				userRepositoryWrite,
+				NullGameEventPublisher.Instance,
+				TimeProvider.System,
+				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
+			);
+
+			var module = new VictoryConditionModule(game.Accessor, game.GlobalState, game.GameDef, lifecycleEngine);
+			module.SetProperty("type", VictoryConditionTypes.EconomicThreshold);
+
+			return (game, registry, module);
+		}
+
+		[Fact]
+		public void CreatePlayer_WithCustomSettings_UsesConfiguredStartingResources() {
+			var settings = new GameSettings(
+				StartingLand: 100,
+				StartingMinerals: 10000,
+				StartingGas: 7500,
+				ProtectionTicks: 240
+			);
+			var game = SetupWithSettings(settings);
+
+			var playerId = PlayerIdFactory.Create("test-player");
+			game.PlayerRepositoryWrite.CreatePlayer(playerId);
+
+			var player = game.PlayerRepository.Get(playerId);
+			Assert.Equal(100m, player.State.Resources[Id.ResDef("land")]);
+			Assert.Equal(10000m, player.State.Resources[Id.ResDef("minerals")]);
+			Assert.Equal(7500m, player.State.Resources[Id.ResDef("gas")]);
+			Assert.Equal(240, player.State.ProtectionTicksRemaining);
+		}
+
+		[Fact]
+		public void CreatePlayer_WithNullSettings_UsesDefaults() {
+			var game = SetupWithSettings(settings: null);
+
+			var playerId = PlayerIdFactory.Create("test-player");
+			game.PlayerRepositoryWrite.CreatePlayer(playerId);
+
+			var player = game.PlayerRepository.Get(playerId);
+			Assert.Equal(50m, player.State.Resources[Id.ResDef("land")]);
+			Assert.Equal(5000m, player.State.Resources[Id.ResDef("minerals")]);
+			Assert.Equal(3000m, player.State.Resources[Id.ResDef("gas")]);
+			Assert.Equal(480, player.State.ProtectionTicksRemaining);
+		}
+
+		[Fact]
+		public void VictoryConditionModule_UsesPerGameThreshold_LowThreshold() {
+			// Test player starts with res1=1000 (from TestWorldStateFactory)
+			// Set a threshold of 500 so it's already exceeded
+			var settings = new GameSettings(VictoryThreshold: 500);
+			var (game, _, module) = SetupVictoryModule(settings, playerCount: 1);
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Finished, gameRecord.Status);
+			Assert.Equal(VictoryConditionTypes.EconomicThreshold, gameRecord.VictoryConditionType);
+		}
+
+		[Fact]
+		public void VictoryConditionModule_HighThreshold_DoesNotFinalize() {
+			// Test player starts with res1=1000, high threshold won't be reached
+			var settings = new GameSettings(VictoryThreshold: 999999);
+			var (game, _, module) = SetupVictoryModule(settings, playerCount: 1);
+
+			module.CalculateTick(game.Player1);
+
+			var gameRecord = game.GlobalState.GetGames().Single();
+			Assert.Equal(GameStatus.Active, gameRecord.Status);
+		}
+
+		[Fact]
+		public void GameSettings_Default_HasExpectedValues() {
+			var defaults = GameSettings.Default;
+			Assert.Equal(50, defaults.StartingLand);
+			Assert.Equal(5000, defaults.StartingMinerals);
+			Assert.Equal(3000, defaults.StartingGas);
+			Assert.Equal(480, defaults.ProtectionTicks);
+			Assert.Equal(500000, defaults.VictoryThreshold);
+			Assert.Equal(VictoryConditionTypes.EconomicThreshold, defaults.VictoryConditionType);
+			Assert.Equal(0, defaults.MaxPlayers);
+		}
+
+		[Fact]
+		public void GameRecordImmutable_WithNullSettings_IsBackwardCompatible() {
+			var record = MakeRecord(settings: null);
+			Assert.Null(record.Settings);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -184,5 +184,142 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var statusResult = Assert.IsType<ObjectResult>(result.Result);
 			Assert.Equal(403, statusResult.StatusCode);
 		}
+
+		private static CreateGameRequest MakeCreateRequest(GameSettingsRequest? settings = null) {
+			return new CreateGameRequest(
+				Name: "Test Game",
+				GameDefType: "sco",
+				StartTime: DateTime.UtcNow.AddMinutes(5),
+				EndTime: DateTime.UtcNow.AddDays(7),
+				TickDuration: "00:00:30",
+				Settings: settings
+			);
+		}
+
+		[Fact]
+		public void Create_WithNegativeStartingLand_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(StartingLand: -1));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithNegativeStartingMinerals_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(StartingMinerals: -1));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithNegativeStartingGas_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(StartingGas: -1));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithNegativeProtectionTicks_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(ProtectionTicks: -1));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithZeroVictoryThreshold_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(VictoryThreshold: 0));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithNegativeSettingsMaxPlayers_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(MaxPlayers: -1));
+
+			var result = controller.Create(request);
+
+			Assert.IsType<BadRequestObjectResult>(result.Result);
+		}
+
+		[Fact]
+		public void Create_WithInvalidVictoryConditionType_Returns400() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(new GameSettingsRequest(VictoryConditionType: "InvalidType"));
+
+			var result = controller.Create(request);
+
+			var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+			Assert.Contains("Unknown victory condition type", badRequest.Value!.ToString());
+		}
+
+		[Fact]
+		public void Create_WithValidSettings_CreatesGame() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var settings = new GameSettingsRequest(
+				StartingLand: 100,
+				StartingMinerals: 10000,
+				StartingGas: 6000,
+				ProtectionTicks: 120,
+				VictoryThreshold: 250000,
+				VictoryConditionType: "EconomicThreshold",
+				MaxPlayers: 10
+			);
+			var request = MakeCreateRequest(settings);
+
+			var result = controller.Create(request);
+
+			var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+			var summary = Assert.IsType<GameSummaryViewModel>(created.Value);
+			Assert.NotNull(summary);
+			Assert.Equal("Test Game", summary.Name);
+		}
+
+		[Fact]
+		public void Create_WithNoSettings_CreatesGame() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var request = MakeCreateRequest(settings: null);
+
+			var result = controller.Create(request);
+
+			var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+			var summary = Assert.IsType<GameSummaryViewModel>(created.Value);
+			Assert.NotNull(summary);
+		}
+
+		[Fact]
+		public void Create_WithTimeExpiredVictoryCondition_CreatesGame() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+			var settings = new GameSettingsRequest(VictoryConditionType: "TimeExpired");
+			var request = MakeCreateRequest(settings);
+
+			var result = controller.Create(request);
+
+			Assert.IsType<CreatedAtActionResult>(result.Result);
+		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/WorldState.cs
@@ -11,6 +11,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	public class WorldState {
 		internal GameId GameId { get; set; } = new GameId("default");
 
+		internal GameSettings GameSettings { get; set; } = GameSettings.Default;
+
 		internal IDictionary<PlayerId, Player> Players { get; set; } = new ConcurrentDictionary<PlayerId, Player>();
 
 		internal IDictionary<AllianceId, Alliance> Alliances { get; set; } = new ConcurrentDictionary<AllianceId, Alliance>();

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -18,6 +18,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			WorldState = worldState;
 			WorldStateAccessor = new SingletonWorldStateAccessor(worldState);
 			GameDef = gameDef;
+			worldState.GameSettings = record.Settings ?? GameSettings.Default;
 		}
 
 		public int PlayerCount => WorldState.Players.Count;

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/VictoryConditionModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/VictoryConditionModule.cs
@@ -17,7 +17,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		private readonly object _checkLock = new();
 
 		private string _type = VictoryConditionTypes.EconomicThreshold;
-		private decimal _threshold = 500_000;
+		private decimal? _thresholdOverride = null;
 
 		public VictoryConditionModule(
 			IWorldStateAccessor worldStateAccessor,
@@ -32,14 +32,15 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 
 		public void SetProperty(string name, string value) {
 			if (name == "type") _type = value;
-			else if (name == "threshold" && decimal.TryParse(value, out var t)) _threshold = t;
+			else if (name == "threshold" && decimal.TryParse(value, out var t)) _thresholdOverride = t;
 		}
 
 		public void CalculateTick(PlayerId playerId) {
 			if (_type != VictoryConditionTypes.EconomicThreshold) return;
 
 			var score = GetScore(playerId);
-			if (score < _threshold) return;
+			var threshold = _thresholdOverride ?? (decimal)worldStateAccessor.WorldState.GameSettings.VictoryThreshold;
+			if (score < threshold) return;
 
 			var gameId = worldStateAccessor.WorldState.GameId;
 			var gameRecord = globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -119,6 +119,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		private void CreatePlayerInternal(PlayerId playerId, string? userId, string playerType) {
 			if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);
+			var settings = world.GameSettings;
 			world.Players[playerId] = new Player() {
 				Created = timeProvider.GetLocalNow().DateTime,
 				PlayerId = playerId,
@@ -129,9 +130,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 					LastGameTickUpdate = timeProvider.GetLocalNow().DateTime,
 					CurrentGameTick = world.GameTickState.CurrentGameTick,
 					Resources = new Dictionary<ResourceDefId, decimal> {
-						{ Id.ResDef("land"), 50 },
-						{ Id.ResDef("minerals"), 5000 },
-						{ Id.ResDef("gas"), 3000 }
+						{ Id.ResDef("land"), settings.StartingLand },
+						{ Id.ResDef("minerals"), settings.StartingMinerals },
+						{ Id.ResDef("gas"), settings.StartingGas }
 					},
 					Assets = new HashSet<Asset> {
 						new Asset {
@@ -139,7 +140,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 							Level = 1
 						},
 					},
-					ProtectionTicksRemaining = 480  // 4 hours at 30s/tick
+					ProtectionTicksRemaining = settings.ProtectionTicks
 				}
 			};
 		}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -315,6 +315,26 @@ export interface JoinGameRequest {
   playerType?: string
 }
 
+export interface GameSettingsViewModel {
+  startingLand: number
+  startingMinerals: number
+  startingGas: number
+  protectionTicks: number
+  victoryThreshold: number
+  victoryConditionType: string
+  maxPlayers: number
+}
+
+export interface GameSettingsRequest {
+  startingLand?: number | null
+  startingMinerals?: number | null
+  startingGas?: number | null
+  protectionTicks?: number | null
+  victoryThreshold?: number | null
+  victoryConditionType?: string | null
+  maxPlayers?: number | null
+}
+
 export interface CreateGameRequest {
   name: string
   gameDefType: string
@@ -323,6 +343,7 @@ export interface CreateGameRequest {
   tickDuration: string
   discordWebhookUrl: string | null
   maxPlayers: number
+  settings?: GameSettingsRequest | null
 }
 
 // Players / Profile
@@ -851,6 +872,7 @@ export interface GameLobbyViewModel {
   endTime: string | null
   players: LobbyPlayerViewModel[]
   canJoin: boolean
+  settings?: GameSettingsViewModel | null
 }
 
 export interface LobbyPlayerViewModel {

--- a/src/ReactClient/src/pages/GameLobbyDetail.tsx
+++ b/src/ReactClient/src/pages/GameLobbyDetail.tsx
@@ -7,6 +7,15 @@ import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { useSignalR } from '@/hooks/useSignalR'
 
+function victoryLabel(type: string | null | undefined): string {
+  switch (type) {
+    case 'EconomicThreshold': return 'Economic Threshold'
+    case 'TimeExpired': return 'Time Expired'
+    case 'AdminFinalized': return 'Admin Finalized'
+    default: return type ?? 'Unknown'
+  }
+}
+
 function statusBadge(status: string): { css: string; label: string } {
   switch (status.toLowerCase()) {
     case 'upcoming': return { css: 'bg-warning text-warning-foreground', label: 'Upcoming' }
@@ -101,6 +110,30 @@ export function GameLobbyDetail() {
           </Link>
         )}
       </div>
+
+      {lobby.settings && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-semibold text-muted-foreground">Game Rules</h2>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+            <dt className="text-muted-foreground font-medium">Starting Resources</dt>
+            <dd>
+              {lobby.settings.startingMinerals.toLocaleString()} Minerals
+              {' / '}{lobby.settings.startingGas.toLocaleString()} Gas
+              {' / '}{lobby.settings.startingLand} Land
+            </dd>
+            <dt className="text-muted-foreground font-medium">Victory Condition</dt>
+            <dd>
+              {victoryLabel(lobby.settings.victoryConditionType)}
+              {lobby.settings.victoryConditionType === 'EconomicThreshold' &&
+                ` — reach ${lobby.settings.victoryThreshold.toLocaleString()} pts`}
+            </dd>
+            <dt className="text-muted-foreground font-medium">Protection</dt>
+            <dd>{lobby.settings.protectionTicks} ticks after joining</dd>
+            <dt className="text-muted-foreground font-medium">Max Players</dt>
+            <dd>{lobby.settings.maxPlayers > 0 ? lobby.settings.maxPlayers : 'Unlimited'}</dd>
+          </dl>
+        </div>
+      )}
 
       <div className="space-y-2">
         <h2 className="text-sm font-semibold text-muted-foreground">Players</h2>

--- a/src/ReactClient/src/pages/admin/AdminGames.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGames.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
-import type { GameListViewModel, GameSummaryViewModel, CreateGameRequest, UpdateGameRequest } from '@/api/types'
+import type { GameListViewModel, GameSummaryViewModel, CreateGameRequest, UpdateGameRequest, GameSettingsRequest } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
@@ -32,6 +32,14 @@ export function AdminGames() {
   const [createEndTime, setCreateEndTime] = useState(toDatetimeLocal(new Date(Date.now() + 7 * 86400000).toISOString()))
   const [createError, setCreateError] = useState<string | null>(null)
   const [createSuccess, setCreateSuccess] = useState<string | null>(null)
+
+  const [createStartingLand, setCreateStartingLand] = useState<number | undefined>(undefined)
+  const [createStartingMinerals, setCreateStartingMinerals] = useState<number | undefined>(undefined)
+  const [createStartingGas, setCreateStartingGas] = useState<number | undefined>(undefined)
+  const [createProtectionTicks, setCreateProtectionTicks] = useState<number | undefined>(undefined)
+  const [createVictoryThreshold, setCreateVictoryThreshold] = useState<number | undefined>(undefined)
+  const [createVictoryConditionType, setCreateVictoryConditionType] = useState('EconomicThreshold')
+  const [createMaxPlayers, setCreateMaxPlayers] = useState<number | undefined>(undefined)
 
   const [editState, setEditState] = useState<EditState | null>(null)
   const [editError, setEditError] = useState<string | null>(null)
@@ -101,6 +109,21 @@ export function AdminGames() {
     e.preventDefault()
     setCreateError(null)
     setCreateSuccess(null)
+    const hasAdvanced = createStartingLand !== undefined || createStartingMinerals !== undefined
+      || createStartingGas !== undefined || createProtectionTicks !== undefined
+      || createVictoryThreshold !== undefined || createMaxPlayers !== undefined
+      || createVictoryConditionType !== 'EconomicThreshold'
+    const settings: GameSettingsRequest | null = hasAdvanced
+      ? {
+          startingLand: createStartingLand ?? null,
+          startingMinerals: createStartingMinerals ?? null,
+          startingGas: createStartingGas ?? null,
+          protectionTicks: createProtectionTicks ?? null,
+          victoryThreshold: createVictoryThreshold ?? null,
+          victoryConditionType: createVictoryConditionType,
+          maxPlayers: createMaxPlayers ?? null,
+        }
+      : null
     createMutation.mutate({
       name: createName,
       gameDefType: 'sco',
@@ -109,6 +132,7 @@ export function AdminGames() {
       tickDuration: createTickDuration,
       discordWebhookUrl: null,
       maxPlayers: 0,
+      settings,
     })
   }
 
@@ -205,6 +229,73 @@ export function AdminGames() {
               required
             />
           </div>
+          <details className="rounded border border-border">
+            <summary className="px-3 py-2 text-sm font-medium cursor-pointer hover:bg-muted/30 select-none">
+              Advanced Settings
+            </summary>
+            <div className="grid grid-cols-2 gap-3 p-3 border-t border-border">
+              <div>
+                <label className="block text-sm font-medium mb-1">Starting Land</label>
+                <input type="number" min={0} placeholder="50 (default)"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createStartingLand ?? ''}
+                  onChange={(e) => setCreateStartingLand(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Starting Minerals</label>
+                <input type="number" min={0} placeholder="5000 (default)"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createStartingMinerals ?? ''}
+                  onChange={(e) => setCreateStartingMinerals(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Starting Gas</label>
+                <input type="number" min={0} placeholder="3000 (default)"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createStartingGas ?? ''}
+                  onChange={(e) => setCreateStartingGas(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Protection Ticks</label>
+                <input type="number" min={0} placeholder="480 (default)"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createProtectionTicks ?? ''}
+                  onChange={(e) => setCreateProtectionTicks(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Victory Threshold</label>
+                <input type="number" min={1} placeholder="500000 (default)"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createVictoryThreshold ?? ''}
+                  onChange={(e) => setCreateVictoryThreshold(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Max Players (0=unlimited)</label>
+                <input type="number" min={0} placeholder="0 = unlimited"
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createMaxPlayers ?? ''}
+                  onChange={(e) => setCreateMaxPlayers(e.target.value ? Number(e.target.value) : undefined)}
+                />
+              </div>
+              <div className="col-span-2">
+                <label className="block text-sm font-medium mb-1">Victory Condition</label>
+                <select
+                  className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                  value={createVictoryConditionType}
+                  onChange={(e) => setCreateVictoryConditionType(e.target.value)}
+                >
+                  <option value="EconomicThreshold">Economic Threshold (default)</option>
+                  <option value="TimeExpired">Time Expired</option>
+                  <option value="AdminFinalized">Admin Finalized</option>
+                </select>
+              </div>
+            </div>
+          </details>
           {createError && <p className="text-destructive text-sm">{createError}</p>}
           {createSuccess && <p className="text-success-foreground text-sm">{createSuccess}</p>}
           <button


### PR DESCRIPTION
## Summary
- Add `GameSettings` record to `GameModel` with configurable parameters: starting land/minerals/gas, protection ticks, victory threshold, victory condition type, max players
- `GameRecordImmutable` gains optional `Settings` field (null = backward compatible with legacy games)
- `GameInstance` initializes `WorldState.GameSettings` from the record at creation/load time
- `PlayerRepositoryWrite.CreatePlayerInternal` uses per-game starting resources and protection ticks from `WorldState.GameSettings`
- `VictoryConditionModule` reads victory threshold from `WorldState.GameSettings` (SetProperty still works as an explicit override)
- `GamesController.Create` validates and applies `GameSettingsRequest`; `GetLobby` exposes settings in response
- `AdminGames.tsx`: collapsible "Advanced Settings" disclosure on the create-game form
- `GameLobbyDetail.tsx`: "Game Rules" section showing active settings
- 6 new tests in `GameSettingsTest` covering starting resources, protection ticks, victory threshold, defaults, and backward compatibility

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (555 tests, 0 failures)
- [ ] Create a game via Admin UI with custom starting resources — verify players get the configured amounts
- [ ] Create a game with low victory threshold — verify game finalizes when player score exceeds it
- [ ] Create a game with `MaxPlayers=2`, join 2 players — verify 3rd join is rejected
- [ ] Create a game with default settings (no Advanced Settings) — verify backward-compatible defaults apply
- [ ] Open the lobby detail page for a game with custom settings — verify Game Rules section displays

Closes BGE-692