### PR TITLE
feat: BGE-746 Sentry error tracking for backend and frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,8 +91,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
-          docker build --build-arg COMMIT_SHA=$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f BrowserGameEngine.FrontendServer/Dockerfile .
+          docker build --build-arg COMMIT_SHA=$IMAGE_TAG --build-arg VITE_SENTRY_DSN="$SENTRY_DSN" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f BrowserGameEngine.FrontendServer/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -46,6 +46,11 @@ variable "github_client_secret" {
   sensitive = true
 }
 
+variable "sentry_dsn" {
+  description = "Sentry DSN for backend error tracking (leave empty to disable)"
+  default     = ""
+}
+
 variable "alarm_email" {
   description = "Email address to receive CloudWatch alarm notifications (leave empty to skip subscription)"
   default     = ""
@@ -373,6 +378,7 @@ resource "aws_ecs_task_definition" "app" {
       { name = "ASPNETCORE_ENVIRONMENT", value = "Production" },
       { name = "Bge__DevAuth", value = "false" },
       { name = "Bge__S3BucketName", value = aws_s3_bucket.game_state.id },
+      { name = "Sentry__Dsn", value = var.sentry_dsn },
     ]
 
     secrets = [

--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+		<PackageReference Include="Sentry.AspNetCore" Version="5.10.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />

--- a/src/BrowserGameEngine.FrontendServer/Dockerfile
+++ b/src/BrowserGameEngine.FrontendServer/Dockerfile
@@ -5,6 +5,8 @@ RUN npm ci
 COPY ReactClient/ ./
 ARG VITE_DEV_AUTH=true
 ENV VITE_DEV_AUTH=$VITE_DEV_AUTH
+ARG VITE_SENTRY_DSN=
+ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN
 RUN npm run build
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -39,6 +39,17 @@ Log.Logger = new LoggerConfiguration()
 
 var builder = WebApplication.CreateBuilder(args);
 
+var sentryDsn = builder.Configuration["Sentry:Dsn"];
+if (!string.IsNullOrWhiteSpace(sentryDsn)) {
+    builder.WebHost.UseSentry(options => {
+        options.Dsn = sentryDsn;
+        options.Environment = builder.Environment.EnvironmentName;
+        options.TracesSampleRate = 0.1;
+        options.SendDefaultPii = false;
+    });
+    Log.Information("Sentry error tracking enabled.");
+}
+
 builder.Host.UseSerilog();
 
 /*

--- a/src/ReactClient/package-lock.json
+++ b/src/ReactClient/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.4",
+        "@sentry/react": "^10.47.0",
         "@tanstack/react-query": "^5.62.0",
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",
@@ -2360,6 +2361,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz",
+      "integrity": "sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz",
+      "integrity": "sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz",
+      "integrity": "sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz",
+      "integrity": "sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz",
+      "integrity": "sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry-internal/feedback": "10.47.0",
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry-internal/replay-canvas": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
+      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz",
+      "integrity": "sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/src/ReactClient/package.json
+++ b/src/ReactClient/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.4",
+    "@sentry/react": "^10.47.0",
     "@tanstack/react-query": "^5.62.0",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",

--- a/src/ReactClient/src/main.tsx
+++ b/src/ReactClient/src/main.tsx
@@ -1,8 +1,19 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: import.meta.env.MODE,
+    tracesSampleRate: 0.1,
+    integrations: [Sentry.browserTracingIntegration()],
+  })
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary

- **Backend**: Adds `Sentry.AspNetCore` to FrontendServer. Sentry is initialized when `Sentry:Dsn` config key is set (via `Sentry__Dsn` env var in ECS); gracefully no-ops when absent.
- **Frontend**: Adds `@sentry/react` to ReactClient. Initialized from `VITE_SENTRY_DSN` build arg; gracefully no-ops when absent.
- **CI/CD**: `deploy.yml` passes `VITE_SENTRY_DSN` from GitHub Actions secret `SENTRY_DSN` as a Docker build arg.
- **Infra**: Terraform `sentry_dsn` variable wired into the ECS task definition as `Sentry__Dsn` env var.

## Activation steps (after PR merges)

1. Create a Sentry project at sentry.io (free tier is sufficient for our scale).
2. Copy the DSN.
3. Add `SENTRY_DSN=<dsn>` as a GitHub Actions secret — the frontend picks it up automatically on next deploy.
4. Run `terraform apply -var="sentry_dsn=<dsn>"` to update the ECS task definition for the backend, then `aws ecs update-service --cluster bge --service bge --force-new-deployment`.
5. Trigger a test error and verify it appears in the Sentry dashboard.

## Test plan

- [x] `dotnet build --configuration Release` passes
- [x] `npm run build` passes (Sentry bundle included in index chunk)
- [ ] After Sentry DSN is configured: trigger a test error and confirm it appears in Sentry dashboard