### PR TITLE
test: BGE-747 E2E tests for battle report, player profile, live view, dark mode

### DIFF
--- a/src/ReactClient/e2e/tests/10-battle-report.spec.ts
+++ b/src/ReactClient/e2e/tests/10-battle-report.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Battle report detail page tests (BGE-747).
+ *
+ * Tests the BattleReplay page at /games/:gameId/battles/:reportId
+ * shipped in PR #232.
+ *
+ * Flow:
+ *   1. Admin builds a unit, creates a defender, sends units and attacks.
+ *   2. Fetch the resulting battle report ID from /api/battle/reports.
+ *   3. Navigate to /games/:gameId/battles/:reportId and verify the page renders.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createNavGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Battle Report Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId
+}
+
+async function createFreshDefender(browser: import('@playwright/test').Browser): Promise<string> {
+	const freshUserId = `e2e-defender-br-${Date.now()}`
+	const context = await browser.newContext()
+	const page = await context.newPage()
+	const res = await page.request.post(`${baseURL}/signindev`, {
+		form: { playerid: freshUserId, returnUrl: '/' },
+	})
+	expect([200, 302]).toContain(res.status())
+	await context.close()
+	return freshUserId
+}
+
+async function triggerBattle(page: import('@playwright/test').Page, defenderPlayerId: string): Promise<void> {
+	await page.request.post(`${baseURL}/api/units/build?unitDefId=wbf&count=1`, { data: {} })
+	const unitsRes = await page.request.get(`${baseURL}/api/units`)
+	const units = await unitsRes.json() as { units: Array<{ unitId: string }> }
+	expect(units.units.length).toBeGreaterThan(0)
+	const unitId = units.units[0].unitId
+
+	const sendRes = await page.request.post(
+		`${baseURL}/api/battle/sendunits?unitId=${encodeURIComponent(unitId)}&enemyPlayerId=${encodeURIComponent(defenderPlayerId)}`,
+		{ data: {} }
+	)
+	expect(sendRes.ok()).toBeTruthy()
+}
+
+test.describe('Battle report detail page', () => {
+	test('renders battle report with key stats after completing a battle', async ({ page, browser }) => {
+		const gameId = await createNavGame(page)
+		const defenderPlayerId = await createFreshDefender(browser)
+		await triggerBattle(page, defenderPlayerId)
+
+		// Trigger the attack
+		await page.goto(`/games/${gameId}/enemybase/${encodeURIComponent(defenderPlayerId)}`)
+		await expect(page.getByRole('heading', { name: /enemy base/i })).toBeVisible()
+		await expect(page.getByText(/attacking/i)).toBeVisible({ timeout: 10_000 })
+		await page.getByRole('button', { name: /^attack$/i }).click()
+		await expect(page.getByRole('heading', { name: 'Battle Result' })).toBeVisible({ timeout: 10_000 })
+
+		// Fetch report ID from the API
+		const reportsRes = await page.request.get(`${baseURL}/api/battle/reports`)
+		expect(reportsRes.ok()).toBeTruthy()
+		const reports = await reportsRes.json() as Array<{ id: string }>
+		expect(reports.length).toBeGreaterThan(0)
+		const reportId = reports[0].id
+
+		// Navigate to the battle replay page
+		await page.goto(`/games/${gameId}/battles/${encodeURIComponent(reportId)}`)
+		await expect(page.getByRole('heading', { name: 'Battle Report' })).toBeVisible()
+
+		// Verify key sections render
+		await expect(page.getByText('Initial Forces')).toBeVisible()
+		await expect(page.getByText('Round-by-Round Replay')).toBeVisible()
+
+		// Outcome badge (Victory / Defeat / Draw) should be present
+		const outcomeBadge = page.locator('span').filter({ hasText: /^(Victory|Defeat|Draw)$/ })
+		await expect(outcomeBadge).toBeVisible()
+	})
+
+	test('shows error state for an unknown report ID', async ({ page }) => {
+		const gameId = await createNavGame(page)
+		const fakeReportId = '00000000-0000-0000-0000-000000000000'
+
+		await page.goto(`/games/${gameId}/battles/${fakeReportId}`)
+
+		// The ApiError component renders when the API returns 404
+		await expect(page.getByText(/battle report not found/i)).toBeVisible({ timeout: 10_000 })
+	})
+})

--- a/src/ReactClient/e2e/tests/11-player-profile.spec.ts
+++ b/src/ReactClient/e2e/tests/11-player-profile.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Player profile page tests (BGE-747).
+ *
+ * Tests the PlayerProfile page at /profile (own profile) and
+ * the PublicProfile page at /profile/:userId shipped in PR #235.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+test.describe('Player profile page', () => {
+	test('own profile page renders name and stats', async ({ page }) => {
+		await page.goto('/profile')
+		await expect(page.getByRole('heading', { name: 'My Profile' })).toBeVisible()
+
+		// Should show a display name (avatar initial or name text)
+		// At minimum the profile card renders
+		await expect(page.locator('.rounded-lg.border')).toBeVisible()
+
+		// Games played stat should be visible
+		await expect(page.getByText(/games played/i)).toBeVisible()
+	})
+
+	test('own profile page shows "not in a game" when player has no active game', async ({ page }) => {
+		// The shared e2e-test-admin user may or may not be in a game.
+		// We create a fresh user who definitely has no active game.
+		const freshUserId = `e2e-profile-${Date.now()}`
+		await page.request.post(`${baseURL}/signindev`, {
+			form: { playerid: freshUserId, returnUrl: '/' },
+		})
+		await page.goto('/profile')
+		await expect(page.getByRole('heading', { name: 'My Profile' })).toBeVisible()
+
+		// Fresh user has no active game — the "not in a game" message or Browse games link appears
+		await expect(page.getByText(/not currently in a game/i).or(page.getByRole('link', { name: /browse games/i }))).toBeVisible()
+	})
+
+	test('public profile page renders for a known user', async ({ page }) => {
+		// Create a known user to view their public profile
+		const knownUserId = `e2e-public-profile-${Date.now()}`
+		await page.request.post(`${baseURL}/signindev`, {
+			form: { playerid: knownUserId, returnUrl: '/' },
+		})
+
+		await page.goto(`/profile/${encodeURIComponent(knownUserId)}`)
+
+		// Should render the public profile (not a 404 or error)
+		await expect(page.getByText(/something went wrong/i)).not.toBeVisible({ timeout: 5_000 })
+
+		// The page should show some profile content
+		await expect(page.locator('main, [role="main"], .max-w-lg, .max-w-2xl').first()).toBeVisible()
+	})
+
+	test('public profile page shows not-found state for unknown user', async ({ page }) => {
+		const unknownUserId = 'this-user-does-not-exist-ever-12345'
+		await page.goto(`/profile/${encodeURIComponent(unknownUserId)}`)
+
+		// PublicProfile renders an ApiError or "not found" message for missing users
+		await expect(
+			page.getByText(/not found/i).or(page.getByText(/failed to load/i)).or(page.getByText(/something went wrong/i))
+		).toBeVisible({ timeout: 10_000 })
+	})
+})

--- a/src/ReactClient/e2e/tests/12-live-game-view.spec.ts
+++ b/src/ReactClient/e2e/tests/12-live-game-view.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Live game view page tests (BGE-747).
+ *
+ * Tests the GameLiveView page at /games/:gameId/live shipped in PR #237.
+ *
+ * The page polls /api/resources, /api/playerranking, /api/units,
+ * /api/assets, and /api/notifications/recent every 10 seconds.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createActiveGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Live View Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	// Join the game as admin player
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId
+}
+
+test.describe('Live game view page', () => {
+	test('renders resource and ranking sections for an active game', async ({ page }) => {
+		const gameId = await createActiveGame(page)
+
+		await page.goto(`/games/${gameId}/live`)
+
+		// Main sections should render
+		await expect(page.getByText('Resources')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByText('Rankings')).toBeVisible({ timeout: 10_000 })
+
+		// At least one data section or skeleton loaded
+		await expect(page.locator('.rounded-lg.border').first()).toBeVisible()
+	})
+
+	test('shows tick update timestamp', async ({ page }) => {
+		const gameId = await createActiveGame(page)
+
+		await page.goto(`/games/${gameId}/live`)
+
+		// The page displays "Last updated" or a time reference once data loads
+		await expect(page.getByText(/last updated/i).or(page.getByText(/units at base/i))).toBeVisible({ timeout: 10_000 })
+	})
+
+	test('shows finish-game notice for a completed game', async ({ page }) => {
+		// Create and immediately end a game by setting endTime in the past
+		const now = new Date()
+		const res = await page.request.post(`${baseURL}/api/games`, {
+			data: {
+				name: `E2E Finished Game ${Date.now()}`,
+				gameDefType: 'sco',
+				startTime: new Date(now.getTime() - 7200_000).toISOString(),
+				endTime: new Date(now.getTime() - 3600_000).toISOString(),
+				tickDuration: '00:01:00',
+				discordWebhookUrl: null,
+			},
+		})
+		expect(res.ok()).toBeTruthy()
+		const game = await res.json()
+		await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+
+		await page.goto(`/games/${game.gameId}/live`)
+
+		// Page renders without a crash — the layout still loads
+		await expect(page.locator('.rounded-lg.border').first()).toBeVisible({ timeout: 10_000 })
+
+		// No unhandled error message
+		await expect(page.getByText('Something went wrong')).not.toBeVisible()
+	})
+})

--- a/src/ReactClient/e2e/tests/13-dark-mode.spec.ts
+++ b/src/ReactClient/e2e/tests/13-dark-mode.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Dark mode toggle tests (BGE-747).
+ *
+ * Tests the theme toggle shipped in PR #236.
+ * The toggle lives in the GameLayout header and uses ThemeContext,
+ * which persists the preference in localStorage under key "bge-theme".
+ *
+ * CSS: the <html> element gets the class "light" when light mode is active;
+ * dark mode is the default (no class added).
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createNavGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Dark Mode Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId
+}
+
+test.describe('Dark mode toggle', () => {
+	test('toggle button is present and switches between dark and light mode', async ({ page }) => {
+		const gameId = await createNavGame(page)
+		await page.goto(`/games/${gameId}/base`)
+
+		const toggleBtn = page.getByRole('button', { name: /switch to (light|dark) mode/i })
+		await expect(toggleBtn).toBeVisible()
+
+		// Default is dark — html should NOT have class "light"
+		const htmlEl = page.locator('html')
+		const initialClasses = await htmlEl.getAttribute('class')
+		const startsInDark = !initialClasses?.includes('light')
+
+		if (startsInDark) {
+			// Toggle to light
+			await toggleBtn.click()
+			await expect(htmlEl).toHaveClass(/light/)
+			await expect(page.getByRole('button', { name: /switch to dark mode/i })).toBeVisible()
+
+			// Toggle back to dark
+			await toggleBtn.click()
+			const classes = await htmlEl.getAttribute('class')
+			expect(classes ?? '').not.toContain('light')
+			await expect(page.getByRole('button', { name: /switch to light mode/i })).toBeVisible()
+		} else {
+			// Page loaded in light mode (persisted pref)
+			await toggleBtn.click()
+			const classes = await htmlEl.getAttribute('class')
+			expect(classes ?? '').not.toContain('light')
+		}
+	})
+
+	test('dark mode preference persists across page reload', async ({ page }) => {
+		const gameId = await createNavGame(page)
+		await page.goto(`/games/${gameId}/base`)
+
+		const htmlEl = page.locator('html')
+
+		// Ensure we start in dark mode by clearing any stored preference
+		await page.evaluate(() => localStorage.setItem('bge-theme', 'dark'))
+		await page.reload()
+
+		const toggleBtn = page.getByRole('button', { name: /switch to light mode/i })
+		await expect(toggleBtn).toBeVisible()
+
+		// Toggle to light mode
+		await toggleBtn.click()
+		await expect(htmlEl).toHaveClass(/light/)
+
+		// Verify localStorage updated
+		const storedTheme = await page.evaluate(() => localStorage.getItem('bge-theme'))
+		expect(storedTheme).toBe('light')
+
+		// Reload — should still be in light mode
+		await page.reload()
+		await expect(htmlEl).toHaveClass(/light/)
+		await expect(page.getByRole('button', { name: /switch to dark mode/i })).toBeVisible()
+	})
+
+	test('switching to dark mode removes light class from html', async ({ page }) => {
+		const gameId = await createNavGame(page)
+
+		// Start in light mode
+		await page.evaluate(() => localStorage.setItem('bge-theme', 'light'))
+		await page.goto(`/games/${gameId}/base`)
+
+		const htmlEl = page.locator('html')
+		await expect(htmlEl).toHaveClass(/light/)
+
+		// Toggle to dark
+		const toggleBtn = page.getByRole('button', { name: /switch to dark mode/i })
+		await expect(toggleBtn).toBeVisible()
+		await toggleBtn.click()
+
+		const classes = await htmlEl.getAttribute('class')
+		expect(classes ?? '').not.toContain('light')
+
+		// Verify localStorage
+		const storedTheme = await page.evaluate(() => localStorage.getItem('bge-theme'))
+		expect(storedTheme).toBe('dark')
+	})
+})


### PR DESCRIPTION
## Summary
- Add Playwright E2E test coverage for 4 features shipped in the last sprint
- `10-battle-report.spec.ts` — BattleReplay page at `/games/:gameId/battles/:reportId`: renders key stats (initial forces, round-by-round, outcome badge); handles unknown report ID with error state
- `11-player-profile.spec.ts` — `/profile` (own) and `/profile/:userId` (public): name/stats visible, no-game state, public profile render, 404 for unknown users
- `12-live-game-view.spec.ts` — `/games/:gameId/live`: resource and ranking sections load for active games; no crash on finished games
- `13-dark-mode.spec.ts` — theme toggle in GameLayout: toggles `light` CSS class on `<html>`, preference persists in `localStorage` across page reload

## Test plan
- [x] `dotnet build` passes (549 unit tests, 0 failures)
- [x] `dotnet test` passes
- [ ] Playwright E2E: `npx playwright test` against `docker-compose up` environment
- [ ] Verify all 4 new spec files execute without timeouts

Closes BGE-747