### PR TITLE
fix: BGE-737 fix 9 failing e2e tests

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AuthenticationController.cs
@@ -77,7 +77,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		/// Direct login without any password. A new user gets created directly if it does not exist.
 		/// </summary>
 		[HttpPost("~/signindev")]
-		public async Task<IActionResult> SignInDev([FromForm] string playerid, [FromForm] bool createPlayer = true) {
+		public async Task<IActionResult> SignInDev([FromForm] string playerid, [FromForm] bool createPlayer = true, [FromForm] int? protectionTicks = null) {
 			// only works if DevAuth setting in appsettings is set (dev only!)
 			if (!options.Value.DevAuth) return BadRequest();
 			if (string.IsNullOrWhiteSpace(playerid)) return BadRequest();
@@ -89,7 +89,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			if (createPlayer) {
 				var playerId = PlayerIdFactory.Create(playerid);
 				if (!playerRepository.Exists(playerId)) {
-					playerRepositoryWrite.CreatePlayer(playerId, userId: user.UserId);
+					playerRepositoryWrite.CreatePlayer(playerId, userId: user.UserId, protectionTicks: protectionTicks);
 				}
 			}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -96,9 +96,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 			world.Players[playerId].LastOnline = time;
 		}
 
-		public void CreatePlayer(PlayerId playerId, string? userId = null, string playerType = "terran") {
+		public void CreatePlayer(PlayerId playerId, string? userId = null, string playerType = "terran", int? protectionTicks = null) {
 			lock (_lock) {
-				CreatePlayerInternal(playerId, userId, playerType);
+				CreatePlayerInternal(playerId, userId, playerType, protectionTicks);
 			}
 		}
 
@@ -117,7 +117,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
-		private void CreatePlayerInternal(PlayerId playerId, string? userId, string playerType) {
+		private void CreatePlayerInternal(PlayerId playerId, string? userId, string playerType, int? protectionTicks = null) {
 			if (world.PlayerExists(playerId)) throw new PlayerAlreadyExistsException(playerId);
 			var settings = world.GameSettings;
 			world.Players[playerId] = new Player() {
@@ -140,7 +140,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 							Level = 1
 						},
 					},
-					ProtectionTicksRemaining = settings.ProtectionTicks
+					ProtectionTicksRemaining = protectionTicks ?? settings.ProtectionTicks
 				}
 			};
 		}

--- a/src/ReactClient/e2e/global-setup.ts
+++ b/src/ReactClient/e2e/global-setup.ts
@@ -25,7 +25,7 @@ export default async function globalSetup() {
 	// Use dev auth to sign in — no UI form required; POST directly to the endpoint.
 	// Bge__DevAuth=true is set in docker-compose so this endpoint is active.
 	await page.request.post(`${baseURL}/signindev`, {
-		form: { playerid: 'e2e-test-admin', returnUrl: '/' },
+		form: { playerid: 'e2e-test-admin', returnUrl: '/', protectionTicks: '0' },
 	})
 
 	// Dismiss the new-player tutorial overlay so it never blocks UI interactions

--- a/src/ReactClient/e2e/tests/03-gameplay.spec.ts
+++ b/src/ReactClient/e2e/tests/03-gameplay.spec.ts
@@ -96,15 +96,21 @@ test.describe('Join game and navigate in-game pages', () => {
 })
 
 test.describe('Create player', () => {
-	test('create player page renders and form is functional', async ({ page }) => {
+	test('create player page renders and form is functional', async ({ browser }) => {
+		// Use a fresh browser context (no admin storageState) so the new user's
+		// auth cookie is the only one present — avoids cookie conflicts with the
+		// shared admin session that the page fixture carries by default.
+		const freshUserId = `e2e-newuser-${Date.now()}`
+		const context = await browser.newContext()
+		const page = await context.newPage()
+
 		// Sign in as a fresh user who has no player profile yet.
 		// createPlayer=false skips the automatic player creation so /createplayer works as intended.
-		const freshUserId = `e2e-newuser-${Date.now()}`
 		await page.request.post(`${baseURL}/signindev`, {
 			form: { playerid: freshUserId, returnUrl: '/', createPlayer: 'false' },
 		})
 
-		await page.goto('/createplayer')
+		await page.goto(`${baseURL}/createplayer`)
 		await expect(page.getByRole('heading', { name: 'Welcome to BGE' })).toBeVisible()
 		await expect(page.getByLabel('Commander name')).toBeVisible()
 
@@ -115,5 +121,7 @@ test.describe('Create player', () => {
 		// After creating player, redirected to games with welcome message
 		await expect(page).toHaveURL(/\/games\?welcome=1/, { timeout: 10_000 })
 		await expect(page.getByText('Welcome to BGE!')).toBeVisible()
+
+		await context.close()
 	})
 })

--- a/src/ReactClient/e2e/tests/04-chat.spec.ts
+++ b/src/ReactClient/e2e/tests/04-chat.spec.ts
@@ -21,12 +21,12 @@ async function createAndJoinGame(page: import('@playwright/test').Page): Promise
 	expect(res.ok()).toBeTruthy()
 	const game = await res.json()
 
-	// Join the game
-	const joinRes = await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, {
-		data: {},
+	// Join the game — POST /api/games/:id/join replaced the old /players endpoint
+	const joinRes = await page.request.post(`${baseURL}/api/games/${game.gameId}/join`, {
+		data: { playerName: 'E2E Chat Player', playerType: null },
 	})
-	// 200 or 409 (already enrolled) are both fine
-	expect([200, 201, 204, 409]).toContain(joinRes.status())
+	// 200 (joined) or 409 (already enrolled) are both fine
+	expect([200, 409]).toContain(joinRes.status())
 
 	return game.gameId
 }

--- a/src/ReactClient/e2e/tests/05-resource-management.spec.ts
+++ b/src/ReactClient/e2e/tests/05-resource-management.spec.ts
@@ -93,10 +93,14 @@ test.describe('Resource management — worker assignment', () => {
 		await page.goto(`/games/${gameId}/base`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
-		// Clear and set a new value for mineral workers
+		// Set a new value for mineral workers; wait for the assign API call to complete
+		// before reading back the state (onChange fires immediately on fill).
 		const mineralInput = page.getByLabel('💎 Mineral Workers')
+		const assignPromise = page.waitForResponse(
+			(r) => r.url().includes('/api/workers/assign') && r.request().method() === 'POST'
+		)
 		await mineralInput.fill('3')
-		await mineralInput.blur()
+		await assignPromise
 
 		// Verify no error boundary was hit
 		await expect(page.getByText('Something went wrong')).not.toBeVisible()

--- a/src/ReactClient/e2e/tests/06-attack-flow.spec.ts
+++ b/src/ReactClient/e2e/tests/06-attack-flow.spec.ts
@@ -39,9 +39,10 @@ async function createFreshDefender(browser: import('@playwright/test').Browser):
 	const freshUserId = `e2e-defender-${Date.now()}`
 	const context = await browser.newContext()
 	const page = await context.newPage()
-	// signindev creates the user and immediately registers them as a player in the default game
+	// signindev creates the user and immediately registers them as a player in the default game.
+	// protectionTicks=0 so the defender is immediately attackable (no new-player protection).
 	const res = await page.request.post(`${baseURL}/signindev`, {
-		form: { playerid: freshUserId, returnUrl: '/' },
+		form: { playerid: freshUserId, returnUrl: '/', protectionTicks: '0' },
 	})
 	// A 200 redirect means the signin succeeded
 	expect([200, 302]).toContain(res.status())

--- a/src/ReactClient/e2e/tests/07-alliances.spec.ts
+++ b/src/ReactClient/e2e/tests/07-alliances.spec.ts
@@ -65,8 +65,9 @@ test('create alliance via UI and see it in the list', async ({ browser }) => {
 	// Success confirmation
 	await expect(page.getByText('Alliance created!')).toBeVisible({ timeout: 5_000 })
 
-	// Alliance should appear in the All Alliances table
-	await expect(page.getByRole('link', { name: allianceName })).toBeVisible({ timeout: 5_000 })
+	// Alliance should appear in the All Alliances table (scope to table to avoid matching
+	// the "Your Alliance" header link which also uses the same name after joining)
+	await expect(page.locator('table').getByRole('link', { name: allianceName })).toBeVisible({ timeout: 5_000 })
 
 	await context.close()
 })
@@ -149,7 +150,9 @@ test('leader invites player and invitee accepts invite via UI', async ({ browser
 
 	// "Pending Invites" section should appear
 	await expect(inviteePage.getByText('Pending Invites')).toBeVisible({ timeout: 10_000 })
-	await expect(inviteePage.getByText(allianceName)).toBeVisible()
+	// Scope to the pending invites section to avoid strict-mode violation from the
+	// same name appearing in the All Alliances table link below.
+	await expect(inviteePage.locator('span.font-medium', { hasText: allianceName })).toBeVisible()
 
 	// Accept the invite — on the Alliances page only "Accept" (invite accept) and "Decline" are visible,
 	// no "Accept Peace" buttons, so exact: true is safe here

--- a/src/ReactClient/src/components/WorkerAssignment.tsx
+++ b/src/ReactClient/src/components/WorkerAssignment.tsx
@@ -17,7 +17,7 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
 
   const assignMutation = useMutation({
     mutationFn: (params: { mineralWorkers: number; gasWorkers: number }) =>
-      apiClient.post('/api/workers/assign', params),
+      apiClient.post('/api/workers/assign', null, { params }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['workers', gameId] })
     },


### PR DESCRIPTION
## Summary

Fixes 9 failing Playwright e2e tests that regressed after recent PRs (#231–#237).

- **04-chat (×2)**: `POST /api/games/:id/players` was removed in #231; switched to the new `/join` endpoint with `playerName`
- **03-gameplay (×1)**: Fresh-user signin via `page.request.post` conflicted with the admin `storageState` already loaded on the page fixture; refactored to `browser.newContext()` with no pre-existing cookies
- **05-resource-management (×1)**: `WorkerAssignment` component was POSTing query params as a JSON body (bug); fixed to use Axios `{ params }` config so they go in the URL; also added `waitForResponse` in the test to avoid reading state before the mutation completes
- **06-attack-flow (×3)**: Both admin (created in global-setup) and fresh defender had `ProtectionTicksRemaining=480`, so `GetAttackablePlayers` returned `[]`; added a `protectionTicks` parameter to `signindev` and `CreatePlayer`/`CreatePlayerInternal`; global-setup and `createFreshDefender` now pass `protectionTicks=0`
- **07-alliances (×2)**: After creating an alliance the creator's name appears in both the "Your Alliance" card AND the All Alliances table — Playwright strict mode rejected the ambiguous `getByRole('link')` and `getByText` locators; scoped them to `table` and `span.font-medium` respectively

## Test plan

- [ ] All 9 previously-failing tests should now pass in CI
- [ ] Existing 549 unit tests still pass (`dotnet test`: 549 passed, 0 failed)
- [ ] `dotnet build --configuration Release` succeeds with 0 warnings
- [ ] Other e2e tests unaffected (protection change is opt-in via new `protectionTicks` param; default remains 480)