### PR TITLE
feat: BGE-753 Route 53 external uptime health check

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -20,6 +20,12 @@ provider "aws" {
   region = var.aws_region
 }
 
+# Route 53 health check metrics are published only to us-east-1.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 variable "aws_region" {
   default = "eu-central-1"
 }
@@ -988,6 +994,55 @@ resource "aws_cloudwatch_dashboard" "production" {
       }
     ]
   })
+}
+
+# --- Route 53 Health Check (External Uptime) ---
+
+# External uptime check from multiple AWS regions against the production health endpoint.
+# Route 53 polls every 30s and considers the endpoint unhealthy after 2 consecutive failures.
+resource "aws_route53_health_check" "app" {
+  fqdn              = "ageofagents.net"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/health"
+  request_interval  = 30
+  failure_threshold = 2
+
+  # Checked from multiple AWS edge locations for global coverage.
+  regions = ["us-east-1", "us-west-1", "eu-west-1"]
+
+  tags = {
+    Name = "${var.app_name}-uptime"
+  }
+}
+
+# Route 53 HealthCheckStatus: 1 = healthy, 0 = unhealthy.
+# Alarm triggers when the value drops to 0 (LESS_THAN threshold of 1).
+# NOTE: Route 53 health check metrics are only available in us-east-1.
+resource "aws_cloudwatch_metric_alarm" "route53_health" {
+  provider = aws.us_east_1
+
+  alarm_name          = "${var.app_name}-uptime"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  alarm_description   = "BGE: Production health check failing (ageofagents.net/health)"
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.app.id
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # --- Outputs ---


### PR DESCRIPTION
## Summary

Completes [BGE-753](/BGE/issues/BGE-753) — adds the last missing monitoring component: an external Route 53 uptime check against the production health endpoint.

- **Route 53 health check** polling `ageofagents.net/health` over HTTPS every 30s from 3 AWS regions (`us-east-1`, `us-west-1`, `eu-west-1`); triggers unhealthy after 2 consecutive failures
- **CloudWatch alarm** (`bge-uptime`) in `us-east-1` (required because Route 53 publishes `HealthCheckStatus` metrics only there); routes to the existing `bge-alarms` SNS topic
- **`us-east-1` provider alias** added to support the cross-region alarm resource

All other monitoring items from BGE-753 were already present from previous work (BGE-627 / BGE-469):
- ECS CPU > 80%, Memory > 85%, task count = 0 alarms
- ALB 5xx rate > 1%, P99 latency > 2s alarms
- SNS topic (`bge-alarms`) with email subscription support
- AWS Budget alerts at 80% and 100% of monthly threshold
- CloudWatch dashboard (BGE-Production)

## Test plan

- [ ] `terraform plan` shows 2 new resources: `aws_route53_health_check.app` and `aws_cloudwatch_metric_alarm.route53_health`
- [ ] After `terraform apply`, Route 53 console shows health check in healthy state for `ageofagents.net/health`
- [ ] CloudWatch alarm `bge-uptime` shows OK in `us-east-1`