### PR TITLE
Add error boundary e2e test and fix live-view/profile assertions (BGE-754)

### DIFF
--- a/src/ReactClient/e2e/tests/11-player-profile.spec.ts
+++ b/src/ReactClient/e2e/tests/11-player-profile.spec.ts
@@ -18,8 +18,12 @@ test.describe('Player profile page', () => {
 		// At minimum the profile card renders
 		await expect(page.locator('.rounded-lg.border')).toBeVisible()
 
-		// Games played stat should be visible
-		await expect(page.getByText(/games played/i)).toBeVisible()
+		// The profile card shows either current game stats or a "not in a game" message
+		await expect(
+			page.getByText(/score/i)
+				.or(page.getByText(/rank/i))
+				.or(page.getByText(/not currently in a game/i))
+		).toBeVisible()
 	})
 
 	test('own profile page shows "not in a game" when player has no active game', async ({ page }) => {

--- a/src/ReactClient/e2e/tests/12-live-game-view.spec.ts
+++ b/src/ReactClient/e2e/tests/12-live-game-view.spec.ts
@@ -31,26 +31,29 @@ async function createActiveGame(page: import('@playwright/test').Page): Promise<
 }
 
 test.describe('Live game view page', () => {
-	test('renders resource and ranking sections for an active game', async ({ page }) => {
+	test('renders leaderboard and unit sections for an active game', async ({ page }) => {
 		const gameId = await createActiveGame(page)
 
 		await page.goto(`/games/${gameId}/live`)
 
-		// Main sections should render
-		await expect(page.getByText('Resources')).toBeVisible({ timeout: 10_000 })
-		await expect(page.getByText('Rankings')).toBeVisible({ timeout: 10_000 })
+		// Page heading
+		await expect(page.getByRole('heading', { name: 'Live View' })).toBeVisible({ timeout: 10_000 })
+
+		// Main sections should render (actual section titles from GameLiveView component)
+		await expect(page.getByText('Live Leaderboard')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByText('Units at Base')).toBeVisible({ timeout: 10_000 })
 
 		// At least one data section or skeleton loaded
 		await expect(page.locator('.rounded-lg.border').first()).toBeVisible()
 	})
 
-	test('shows tick update timestamp', async ({ page }) => {
+	test('shows live indicator and update timestamp', async ({ page }) => {
 		const gameId = await createActiveGame(page)
 
 		await page.goto(`/games/${gameId}/live`)
 
-		// The page displays "Last updated" or a time reference once data loads
-		await expect(page.getByText(/last updated/i).or(page.getByText(/units at base/i))).toBeVisible({ timeout: 10_000 })
+		// The page displays an "Updated" timestamp and a Live indicator once data loads
+		await expect(page.getByText(/updated/i).or(page.getByText(/live/i))).toBeVisible({ timeout: 10_000 })
 	})
 
 	test('shows finish-game notice for a completed game', async ({ page }) => {

--- a/src/ReactClient/e2e/tests/14-error-boundary.spec.ts
+++ b/src/ReactClient/e2e/tests/14-error-boundary.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Error boundary (BGE-746) smoke tests.
+ *
+ * The ErrorBoundary component wraps the entire app in RootLayout and catches
+ * any unhandled React render errors, showing a friendly fallback UI instead of
+ * a blank screen.
+ *
+ * Strategy: load the app so all static (eagerly-imported) chunks are in the
+ * browser's HTTP cache, then intercept future JS chunk requests so the next
+ * lazy-loaded page chunk is aborted.  React.lazy propagates the failed import
+ * as a render error, which the ErrorBoundary catches.
+ *
+ * Note: Sentry integration is not yet wired up in the client; only the UI
+ * fallback behaviour is verified here.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8080'
+
+async function createActiveGame(page: import('@playwright/test').Page): Promise<string> {
+	const now = new Date()
+	const res = await page.request.post(`${baseURL}/api/games`, {
+		data: {
+			name: `E2E Error Boundary Game ${Date.now()}`,
+			gameDefType: 'sco',
+			startTime: new Date(now.getTime() - 60_000).toISOString(),
+			endTime: new Date(now.getTime() + 7 * 24 * 3600_000).toISOString(),
+			tickDuration: '00:01:00',
+			discordWebhookUrl: null,
+		},
+	})
+	expect(res.ok()).toBeTruthy()
+	const game = await res.json()
+	await page.request.post(`${baseURL}/api/games/${game.gameId}/players`, { data: {} })
+	return game.gameId
+}
+
+test.describe('Error boundary fallback UI', () => {
+	test('shows "Something went wrong" heading and Refresh Page button when a lazy chunk fails to load', async ({ page }) => {
+		const gameId = await createActiveGame(page)
+
+		// Load the base page so all eagerly-imported chunks are in browser cache.
+		// After networkidle, only lazy page-specific chunks still need to be fetched.
+		await page.goto(`/games/${gameId}/base`)
+		await page.waitForLoadState('networkidle')
+		await expect(page.getByRole('heading', { name: /base/i })).toBeVisible()
+
+		// Intercept future JS chunk requests — clicking a nav link triggers a SPA
+		// navigation (no page reload), so only the target page's lazy chunk is fetched.
+		// Aborting it causes React.lazy to throw, which ErrorBoundary catches.
+		await page.route('**/assets/*.js', (route) => route.abort())
+
+		// Navigate to the Help page via the sidebar nav link (SPA navigation).
+		await page.getByRole('link', { name: 'Help' }).click()
+
+		// ErrorBoundary should render its fallback.
+		await expect(page.getByRole('heading', { name: 'Something went wrong' })).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByText('An unexpected error occurred. Try refreshing the page.')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Refresh Page' })).toBeVisible()
+	})
+
+	test('normal pages do not trigger the error boundary', async ({ page }) => {
+		const gameId = await createActiveGame(page)
+
+		for (const route of ['base', 'ranking', 'research']) {
+			await page.goto(`/games/${gameId}/${route}`)
+			await expect(page.getByText('Something went wrong')).not.toBeVisible({ timeout: 10_000 })
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Add `14-error-boundary.spec.ts`: new Playwright test for the `ErrorBoundary` component (BGE-746). Verifies the "Something went wrong" fallback renders (with Refresh Page button) when a lazy-loaded page chunk fails to load, using `page.route` to abort the chunk after the main app bundle is cached. Also verifies normal pages do not trigger the boundary.
- Fix `12-live-game-view.spec.ts`: update incorrect section-name assertions to match the real `GameLiveView` component — `"Resources"` → `"Live Leaderboard"`, `"Rankings"` → `"Units at Base"`, heading check added.
- Fix `11-player-profile.spec.ts`: replace `/games played/i` assertion (text not rendered by `PlayerProfile`) with a flex check for score/rank stats or "not in a game" placeholder.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes
- [ ] Playwright `npm run test:e2e` passes against local docker-compose stack
- [ ] `14-error-boundary.spec.ts` shows PASS for both tests
- [ ] `12-live-game-view.spec.ts` assertions now match actual rendered section titles
- [ ] `11-player-profile.spec.ts` no longer fails on missing "games played" text

Closes BGE-754