### PR TITLE
feat: BGE-760 add GET /api/stats endpoint

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/StatsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/StatsController.cs
@@ -1,0 +1,80 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/stats")]
+	public class StatsController : ControllerBase {
+		private readonly GlobalState globalState;
+		private readonly CurrentUserContext currentUser;
+
+		public StatsController(GlobalState globalState, CurrentUserContext currentUser) {
+			this.globalState = globalState;
+			this.currentUser = currentUser;
+		}
+
+		/// <summary>Returns aggregate statistics for the current user across all games played.</summary>
+		[HttpGet]
+		[ProducesResponseType(typeof(PlayerStatsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public IActionResult GetMyStats() {
+			if (!currentUser.IsValid) return Unauthorized();
+
+			var achievements = globalState.GetAchievements()
+				.Where(a => a.UserId == currentUser.UserId)
+				.ToList();
+
+			var gameMap = globalState.GetGames()
+				.ToDictionary(g => g.GameId.Id);
+
+			var playersPerGame = globalState.GetAchievements()
+				.GroupBy(a => a.GameId.Id)
+				.ToDictionary(g => g.Key, g => g.Select(a => a.UserId).Distinct().Count());
+
+			var entries = achievements.Select(a => {
+				gameMap.TryGetValue(a.GameId.Id, out var rec);
+				long? durationMs = rec?.ActualEndTime != null
+					? (long)(rec.ActualEndTime.Value - rec.StartTime).TotalMilliseconds
+					: null;
+				return new PlayerStatsGameEntry(
+					GameId: a.GameId.Id,
+					GameName: rec?.Name ?? a.GameId.Id,
+					EndTime: rec?.ActualEndTime ?? rec?.EndTime ?? DateTime.MinValue,
+					FinalRank: a.FinalRank,
+					PlayersInGame: playersPerGame.GetValueOrDefault(a.GameId.Id, 1),
+					FinalScore: a.FinalScore,
+					IsWin: a.FinalRank == 1,
+					DurationMs: durationMs
+				);
+			}).ToList();
+
+			int totalGamesPlayed = entries.Count;
+			int totalWins = entries.Count(e => e.IsWin);
+			double winRate = totalGamesPlayed > 0 ? (double)totalWins / totalGamesPlayed : 0.0;
+			int bestRank = entries.Count > 0 ? entries.Min(e => e.FinalRank) : 0;
+			double avgFinalRank = entries.Count > 0 ? entries.Average(e => e.FinalRank) : 0.0;
+			decimal totalScore = entries.Sum(e => e.FinalScore);
+			decimal avgScorePerGame = totalGamesPlayed > 0 ? totalScore / totalGamesPlayed : 0;
+			var durations = entries.Where(e => e.DurationMs != null).Select(e => e.DurationMs!.Value).ToList();
+			long? avgGameDurationMs = durations.Count > 0 ? (long?)durations.Average() : null;
+
+			return Ok(new PlayerStatsViewModel(
+				TotalGamesPlayed: totalGamesPlayed,
+				TotalWins: totalWins,
+				WinRate: winRate,
+				BestRank: bestRank,
+				AvgFinalRank: avgFinalRank,
+				TotalScore: totalScore,
+				AvgScorePerGame: avgScorePerGame,
+				AvgGameDurationMs: avgGameDurationMs,
+				Games: entries
+			));
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/PlayerStatsViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerStatsViewModel.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared {
+	public record PlayerStatsGameEntry(
+		string GameId,
+		string GameName,
+		DateTime EndTime,
+		int FinalRank,
+		int PlayersInGame,
+		decimal FinalScore,
+		bool IsWin,
+		long? DurationMs
+	);
+
+	public record PlayerStatsViewModel(
+		int TotalGamesPlayed,
+		int TotalWins,
+		double WinRate,
+		int BestRank,
+		double AvgFinalRank,
+		decimal TotalScore,
+		decimal AvgScorePerGame,
+		long? AvgGameDurationMs,
+		IReadOnlyList<PlayerStatsGameEntry> Games
+	);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/StatsControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/StatsControllerTest.cs
@@ -1,0 +1,165 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Controllers;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class StatsControllerTest {
+		private static StatsController MakeController(GlobalState globalState, string? userId) {
+			var userCtx = new CurrentUserContext();
+			if (userId != null) {
+				userCtx.UserId = userId;
+				userCtx.Activate(PlayerIdFactory.Create(userId));
+			}
+			return new StatsController(globalState, userCtx);
+		}
+
+		private static PlayerAchievementImmutable MakeAchievement(string userId, string gameId, int rank, decimal score) {
+			return new PlayerAchievementImmutable(
+				UserId: userId,
+				GameId: new GameId(gameId),
+				PlayerId: PlayerIdFactory.Create(userId),
+				PlayerName: userId,
+				FinalRank: rank,
+				FinalScore: score,
+				GameDefType: "sco",
+				FinishedAt: DateTime.UtcNow
+			);
+		}
+
+		private static GameRecordImmutable MakeGameRecord(string gameId, DateTime? actualEndTime = null) {
+			var start = DateTime.UtcNow.AddDays(-2);
+			var end = DateTime.UtcNow.AddDays(-1);
+			return new GameRecordImmutable(
+				new GameId(gameId),
+				"Test Game " + gameId,
+				"sco",
+				GameStatus.Finished,
+				start,
+				end,
+				TimeSpan.FromSeconds(10),
+				ActualEndTime: actualEndTime ?? end,
+				CreatedByUserId: "admin"
+			);
+		}
+
+		[Fact]
+		public void GetMyStats_Unauthenticated_ReturnsUnauthorized() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: null);
+
+			var result = controller.GetMyStats();
+
+			Assert.IsType<UnauthorizedResult>(result);
+		}
+
+		[Fact]
+		public void GetMyStats_NoHistory_ReturnsEmptyStats() {
+			var globalState = new GlobalState();
+			var controller = MakeController(globalState, userId: "alice");
+
+			var result = controller.GetMyStats();
+
+			var ok = Assert.IsType<OkObjectResult>(result);
+			var stats = Assert.IsType<PlayerStatsViewModel>(ok.Value);
+			Assert.Equal(0, stats.TotalGamesPlayed);
+			Assert.Equal(0, stats.TotalWins);
+			Assert.Equal(0.0, stats.WinRate);
+			Assert.Equal(0, stats.BestRank);
+			Assert.Equal(0.0, stats.AvgFinalRank);
+			Assert.Equal(0m, stats.TotalScore);
+			Assert.Equal(0m, stats.AvgScorePerGame);
+			Assert.Null(stats.AvgGameDurationMs);
+			Assert.Empty(stats.Games);
+		}
+
+		[Fact]
+		public void GetMyStats_OneWin_ReturnsCorrectAggregates() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(MakeAchievement("alice", "game1", rank: 1, score: 1000m));
+			globalState.AddGame(MakeGameRecord("game1"));
+			var controller = MakeController(globalState, userId: "alice");
+
+			var result = controller.GetMyStats();
+
+			var ok = Assert.IsType<OkObjectResult>(result);
+			var stats = Assert.IsType<PlayerStatsViewModel>(ok.Value);
+			Assert.Equal(1, stats.TotalGamesPlayed);
+			Assert.Equal(1, stats.TotalWins);
+			Assert.Equal(1.0, stats.WinRate);
+			Assert.Equal(1, stats.BestRank);
+			Assert.Equal(1000m, stats.TotalScore);
+			Assert.Single(stats.Games);
+			Assert.True(stats.Games[0].IsWin);
+		}
+
+		[Fact]
+		public void GetMyStats_MultipleGames_ComputesAggregatesCorrectly() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(MakeAchievement("alice", "game1", rank: 1, score: 2000m));
+			globalState.AddAchievement(MakeAchievement("alice", "game2", rank: 3, score: 1000m));
+			globalState.AddGame(MakeGameRecord("game1"));
+			globalState.AddGame(MakeGameRecord("game2"));
+			var controller = MakeController(globalState, userId: "alice");
+
+			var result = controller.GetMyStats();
+
+			var ok = Assert.IsType<OkObjectResult>(result);
+			var stats = Assert.IsType<PlayerStatsViewModel>(ok.Value);
+			Assert.Equal(2, stats.TotalGamesPlayed);
+			Assert.Equal(1, stats.TotalWins);
+			Assert.Equal(0.5, stats.WinRate);
+			Assert.Equal(1, stats.BestRank);
+			Assert.Equal(2.0, stats.AvgFinalRank);
+			Assert.Equal(3000m, stats.TotalScore);
+			Assert.Equal(1500m, stats.AvgScorePerGame);
+		}
+
+		[Fact]
+		public void GetMyStats_OtherUsersAchievements_AreIgnored() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(MakeAchievement("bob", "game1", rank: 1, score: 5000m));
+			var controller = MakeController(globalState, userId: "alice");
+
+			var result = controller.GetMyStats();
+
+			var ok = Assert.IsType<OkObjectResult>(result);
+			var stats = Assert.IsType<PlayerStatsViewModel>(ok.Value);
+			Assert.Equal(0, stats.TotalGamesPlayed);
+			Assert.Empty(stats.Games);
+		}
+
+		[Fact]
+		public void GetMyStats_WithDuration_ComputesAvgDuration() {
+			var globalState = new GlobalState();
+			var start = DateTime.UtcNow.AddHours(-4);
+			var end = DateTime.UtcNow.AddHours(-2);
+			var gameRecord = new GameRecordImmutable(
+				new GameId("game1"),
+				"Timed Game",
+				"sco",
+				GameStatus.Finished,
+				start,
+				end,
+				TimeSpan.FromSeconds(10),
+				ActualEndTime: end,
+				CreatedByUserId: "admin"
+			);
+			globalState.AddAchievement(MakeAchievement("alice", "game1", rank: 2, score: 500m));
+			globalState.AddGame(gameRecord);
+			var controller = MakeController(globalState, userId: "alice");
+
+			var result = controller.GetMyStats();
+
+			var ok = Assert.IsType<OkObjectResult>(result);
+			var stats = Assert.IsType<PlayerStatsViewModel>(ok.Value);
+			Assert.NotNull(stats.AvgGameDurationMs);
+			Assert.True(stats.AvgGameDurationMs!.Value > 0);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `PlayerStatsGameEntry` and `PlayerStatsViewModel` records in `BrowserGameEngine.Shared`
- Add `StatsController` with `GET /api/stats` endpoint that aggregates per-user achievement data
- Follows `HistoryController` pattern: direct `GlobalState` access, no repository layer
- Computes: TotalGamesPlayed, TotalWins, WinRate, BestRank, AvgFinalRank, TotalScore, AvgScorePerGame, AvgGameDurationMs, and per-game entries
- Returns zero/null empty state when player has no game history

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (565 tests)
- [ ] Log in as user with history; call `GET /api/stats`; verify aggregates match data
- [ ] Log in as new user with no history; verify zero/null empty state response

Closes BGE-760