### PR TITLE
feat: BGE-750 implement milestone achievements system

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/MilestoneMapper.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/MilestoneMapper.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.Achievements;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	internal static class MilestoneMapper {
+		internal static MilestoneAchievementsViewModel ToViewModel(IReadOnlyList<MilestoneEvaluation> evaluations) {
+			var achievements = evaluations.Select(e => new MilestoneAchievementViewModel(
+				Id: e.Definition.Id,
+				Name: e.Definition.Name,
+				Description: e.Definition.Description,
+				Category: e.Definition.Category,
+				Icon: e.Definition.Icon,
+				IsUnlocked: e.IsUnlocked,
+				UnlockedAt: e.UnlockedAt,
+				CurrentProgress: e.CurrentProgress,
+				TargetProgress: e.Definition.TargetProgress,
+				Tier: e.Definition.Tier
+			)).ToList();
+
+			var unlockedByCategory = achievements
+				.Where(m => m.IsUnlocked)
+				.GroupBy(m => m.Category)
+				.ToDictionary(g => g.Key, g => g.Count());
+
+			var summary = new MilestoneAchievementsSummaryViewModel(
+				TotalAchievements: achievements.Count,
+				UnlockedCount: achievements.Count(m => m.IsUnlocked),
+				UnlockedByCategory: unlockedByCategory
+			);
+
+			return new MilestoneAchievementsViewModel(achievements, summary);
+		}
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -5,6 +5,7 @@ using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Achievements;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using Microsoft.AspNetCore.Authorization;
@@ -23,6 +24,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly PlayerRepositoryWrite playerRepositoryWrite;
 		private readonly UserRepositoryWrite userRepositoryWrite;
 		private readonly GlobalState globalState;
+		private readonly MilestoneRepository milestoneRepository;
+		private readonly MilestoneRepositoryWrite milestoneRepositoryWrite;
 
 		public PlayerManagementController(
 			ILogger<PlayerManagementController> logger,
@@ -31,7 +34,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			PlayerRepository playerRepository,
 			PlayerRepositoryWrite playerRepositoryWrite,
 			UserRepositoryWrite userRepositoryWrite,
-			GlobalState globalState) {
+			GlobalState globalState,
+			MilestoneRepository milestoneRepository,
+			MilestoneRepositoryWrite milestoneRepositoryWrite) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.userRepository = userRepository;
@@ -39,6 +44,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			this.playerRepositoryWrite = playerRepositoryWrite;
 			this.userRepositoryWrite = userRepositoryWrite;
 			this.globalState = globalState;
+			this.milestoneRepository = milestoneRepository;
+			this.milestoneRepositoryWrite = milestoneRepositoryWrite;
 		}
 
 		/// <summary>Returns all players belonging to the authenticated user.</summary>
@@ -143,6 +150,28 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 
 			var achievements = AchievementMapper.GetForUser(globalState, currentUserContext.UserId);
 			return Ok(new PlayerAchievementsViewModel(achievements));
+		}
+
+		/// <summary>Returns all milestone achievements for the authenticated user, unlocking any newly completed ones.</summary>
+		[HttpGet("me/milestone-achievements")]
+		[ProducesResponseType(typeof(MilestoneAchievementsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<MilestoneAchievementsViewModel> GetMyMilestoneAchievements() {
+			if (currentUserContext.UserId == null) return Unauthorized();
+
+			var userId = currentUserContext.UserId;
+			var evaluations = milestoneRepository.GetMilestonesForUser(userId);
+
+			var now = DateTime.UtcNow;
+			foreach (var m in evaluations) {
+				if (m.CurrentProgress >= m.Definition.TargetProgress) {
+					milestoneRepositoryWrite.UnlockIfNew(userId, m.Definition.Id, now);
+				}
+			}
+
+			// Re-evaluate so newly unlocked milestones reflect their timestamps
+			evaluations = milestoneRepository.GetMilestonesForUser(userId);
+			return Ok(MilestoneMapper.ToViewModel(evaluations));
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
@@ -4,6 +4,7 @@ namespace BrowserGameEngine.GameModel {
 	public record GlobalStateImmutable(
 		IDictionary<string, UserImmutable> Users,
 		IList<GameRecordImmutable> Games,
-		IList<PlayerAchievementImmutable> Achievements
+		IList<PlayerAchievementImmutable> Achievements,
+		IList<UserMilestoneImmutable>? Milestones = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/UserMilestoneImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/UserMilestoneImmutable.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record UserMilestoneImmutable(string UserId, string MilestoneId, DateTime UnlockedAt);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Achievements;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class MilestoneRepositoryTest {
+		private const string UserId = "user-1";
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+
+		private static GameRegistry.GameRegistry EmptyGameRegistry(GlobalState globalState)
+			=> new GameRegistry.GameRegistry(globalState);
+
+		// Creates a TestGame where Player1 has UserId set (accessible via world state immutable)
+		private static TestGame CreateGameWithUser() {
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(1);
+			var players = baseState.Players.Values
+				.Select(p => p with { UserId = UserId })
+				.ToDictionary(p => p.PlayerId);
+			return new TestGame(baseState with { Players = players });
+		}
+
+		private static (GlobalState globalState, GameRegistry.GameRegistry registry) SetupWithActiveGame(TestGame game) {
+			var record = new GameRecordImmutable(
+				GameId: new GameId("test-game"),
+				Name: "Test",
+				GameDefType: "sco",
+				Status: GameStatus.Active,
+				StartTime: DateTime.UtcNow,
+				EndTime: DateTime.UtcNow.AddDays(1),
+				TickDuration: TimeSpan.FromSeconds(10)
+			);
+			var instance = new GameInstance(record, game.World, game.GameDef);
+			var registry = new GameRegistry.GameRegistry(game.GlobalState);
+			registry.Register(instance);
+			return (game.GlobalState, registry);
+		}
+
+		// ── Cross-game milestones ────────────────────────────────────────────────
+
+		[Fact]
+		public void NoCompletedGames_AllCrossGameMilestonesAtZero() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			var crossGameIds = new[] { "games-first", "games-veteran", "games-commander", "games-legend", "win-first", "win-champion", "win-legend", "top3-first" };
+			foreach (var id in crossGameIds) {
+				var m = results.Single(r => r.Definition.Id == id);
+				Assert.Equal(0, m.CurrentProgress);
+				Assert.False(m.IsUnlocked);
+			}
+		}
+
+		[Fact]
+		public void OneCompletedGame_GamesFirstAndWinFirstAtProgress1() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(new PlayerAchievementImmutable(
+				UserId: UserId,
+				GameId: new GameId("g1"),
+				PlayerId: Player1,
+				PlayerName: "player0",
+				FinalRank: 1,
+				FinalScore: 1000,
+				GameDefType: "sco",
+				FinishedAt: DateTime.UtcNow
+			));
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.Equal(1, results.Single(r => r.Definition.Id == "games-first").CurrentProgress);
+			Assert.Equal(1, results.Single(r => r.Definition.Id == "win-first").CurrentProgress);
+			Assert.Equal(1, results.Single(r => r.Definition.Id == "games-veteran").CurrentProgress); // 1 game played, target is 5
+		}
+
+		[Fact]
+		public void ThreeNonWinGames_Top3FirstUnlockable_WinFirstNotUnlockable() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 3; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId,
+					GameId: new GameId($"g{i}"),
+					PlayerId: Player1,
+					PlayerName: "player0",
+					FinalRank: 3,
+					FinalScore: 100,
+					GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			var top3 = results.Single(r => r.Definition.Id == "top3-first");
+			var winFirst = results.Single(r => r.Definition.Id == "win-first");
+
+			Assert.Equal(1, top3.CurrentProgress);
+			Assert.Equal(top3.Definition.TargetProgress, top3.CurrentProgress); // meets target
+			Assert.Equal(0, winFirst.CurrentProgress);
+		}
+
+		// ── MilestoneRepositoryWrite idempotency ─────────────────────────────────
+
+		[Fact]
+		public void UnlockIfNew_CalledTwice_OnlyAddsOneRecord() {
+			var globalState = new GlobalState();
+			var write = new MilestoneRepositoryWrite(globalState);
+			var now = DateTime.UtcNow;
+
+			write.UnlockIfNew(UserId, "win-first", now);
+			write.UnlockIfNew(UserId, "win-first", now);
+
+			var milestones = globalState.GetMilestonesForUser(UserId);
+			Assert.Single(milestones);
+		}
+
+		// ── In-game milestone: land ──────────────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_LandBelow100_SettlerProgressReflectsActualLand() {
+			var game = CreateGameWithUser(); // starts with land=50, UserId set
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var settler = results.Single(r => r.Definition.Id == "econ-land-100");
+
+			Assert.Equal(50, settler.CurrentProgress);
+			Assert.False(settler.IsUnlocked);
+		}
+
+		[Fact]
+		public void NoActiveGame_InGameMilestonesAtZero() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			var inGameIds = new[] { "econ-minerals", "econ-gas", "econ-land-100", "econ-land-500", "diplo-alliance", "market-first", "upgrade-first" };
+			foreach (var id in inGameIds) {
+				Assert.Equal(0, results.Single(r => r.Definition.Id == id).CurrentProgress);
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneCatalogue.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneCatalogue.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.StatefulGameServer.Achievements {
+	public record MilestoneDefinition(
+		string Id,
+		string Name,
+		string Description,
+		string Category,
+		string Icon,
+		string Tier,
+		int TargetProgress
+	);
+
+	internal static class MilestoneCatalogue {
+		internal static readonly IReadOnlyList<MilestoneDefinition> All = new List<MilestoneDefinition> {
+			// Exploration — cross-game
+			new("games-first",    "First Commander",  "Complete 1 game",   "exploration", "🚀", "bronze",    1),
+			new("games-veteran",  "Veteran",           "Complete 5 games",  "exploration", "🚀", "silver",    5),
+			new("games-commander","Commander",         "Complete 10 games", "exploration", "🚀", "gold",     10),
+			new("games-legend",   "Galactic Pioneer",  "Complete 50 games", "exploration", "🚀", "legendary",50),
+
+			// Combat — cross-game
+			new("win-first",    "First Blood",       "Win 1 game",        "combat", "⚔️", "bronze",   1),
+			new("win-champion", "Champion",          "Win 5 games",       "combat", "⚔️", "silver",   5),
+			new("win-legend",   "Supreme Commander", "Win 10 games",      "combat", "⚔️", "gold",    10),
+			new("top3-first",   "Top 3 Finish",      "Finish top 3 in any game", "combat", "🥉", "bronze", 1),
+
+			// Economy — in-game
+			new("econ-minerals",  "Mineral Rush",   "Accumulate 10,000 minerals",   "economy",     "💎", "bronze", 10000),
+			new("econ-gas",       "Gas Giant",      "Accumulate 5,000 gas",          "economy",     "⛽", "silver",  5000),
+
+			// Exploration — in-game (land)
+			new("econ-land-100",  "Settler",        "Own 100 land",                  "exploration", "🏗️", "bronze",   100),
+			new("econ-land-500",  "Expansionist",   "Own 500 land",                  "exploration", "🗺️", "silver",   500),
+
+			// Diplomacy — in-game
+			new("diplo-alliance", "First Contact",  "Join or form an alliance",      "diplomacy",   "🤝", "bronze",     1),
+
+			// Economy — in-game (market)
+			new("market-first",   "Market Mogul",   "Complete a market trade",       "economy",     "📈", "bronze",     1),
+
+			// Exploration — in-game (tech)
+			new("upgrade-first",  "Tech Pioneer",   "Research first tech upgrade",   "exploration", "🔬", "bronze",     1),
+		};
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepository.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+
+namespace BrowserGameEngine.StatefulGameServer.Achievements {
+	public record MilestoneEvaluation(
+		MilestoneDefinition Definition,
+		bool IsUnlocked,
+		DateTime? UnlockedAt,
+		int CurrentProgress
+	);
+
+	public class MilestoneRepository {
+		private readonly GlobalState _globalState;
+		private readonly GameRegistry.GameRegistry _gameRegistry;
+
+		public MilestoneRepository(GlobalState globalState, GameRegistry.GameRegistry gameRegistry) {
+			_globalState = globalState;
+			_gameRegistry = gameRegistry;
+		}
+
+		public IReadOnlyList<MilestoneEvaluation> GetMilestonesForUser(string userId) {
+			var achievements = _globalState.GetAchievements().Where(a => a.UserId == userId).ToList();
+			var unlockedMilestones = _globalState.GetMilestonesForUser(userId);
+
+			var activeInstance = _gameRegistry.GetAllInstances()
+				.FirstOrDefault(i => i.HasUserPlayer(userId));
+			var playerState = activeInstance != null
+				? GetPlayerState(activeInstance, userId)
+				: null;
+
+			var results = new List<MilestoneEvaluation>();
+			foreach (var def in MilestoneCatalogue.All) {
+				var unlocked = unlockedMilestones.FirstOrDefault(m => m.MilestoneId == def.Id);
+				var current = ComputeProgress(def, achievements, playerState, activeInstance, userId);
+
+				results.Add(new MilestoneEvaluation(
+					Definition: def,
+					IsUnlocked: unlocked != null,
+					UnlockedAt: unlocked?.UnlockedAt,
+					CurrentProgress: current
+				));
+			}
+			return results;
+		}
+
+		private static PlayerState? GetPlayerState(GameInstance instance, string userId) {
+			var pair = instance.TryGetUserPlayer(userId);
+			if (pair == null) return null;
+			instance.WorldState.Players.TryGetValue(pair.Value.PlayerId, out var player);
+			return player?.State;
+		}
+
+		private static decimal GetResource(PlayerState state, string resourceId) {
+			state.Resources.TryGetValue(Id.ResDef(resourceId), out var value);
+			return value;
+		}
+
+		private static int ComputeProgress(
+			MilestoneDefinition def,
+			IList<PlayerAchievementImmutable> achievements,
+			PlayerState? playerState,
+			GameInstance? activeInstance,
+			string userId) {
+
+			return def.Id switch {
+				"games-first"     => Math.Min(achievements.Count, def.TargetProgress),
+				"games-veteran"   => Math.Min(achievements.Count, def.TargetProgress),
+				"games-commander" => Math.Min(achievements.Count, def.TargetProgress),
+				"games-legend"    => Math.Min(achievements.Count, def.TargetProgress),
+
+				"win-first"    => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
+				"win-champion" => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
+				"win-legend"   => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
+				"top3-first"   => Math.Min(achievements.Count(a => a.FinalRank <= 3), def.TargetProgress),
+
+				"econ-minerals" => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "minerals"), def.TargetProgress),
+				"econ-gas"      => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "gas"),      def.TargetProgress),
+				"econ-land-100" => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "land"),     def.TargetProgress),
+				"econ-land-500" => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "land"),     def.TargetProgress),
+
+				"diplo-alliance" => activeInstance == null ? 0 : GetAllianceProgress(activeInstance, userId),
+				"market-first"   => activeInstance == null ? 0 : GetMarketProgress(activeInstance, userId),
+
+				"upgrade-first" => playerState == null ? 0 : Math.Min(playerState.UnlockedTechs.Count, def.TargetProgress),
+
+				_ => 0
+			};
+		}
+
+		private static int GetAllianceProgress(GameInstance instance, string userId) {
+			var pair = instance.TryGetUserPlayer(userId);
+			if (pair == null) return 0;
+			if (!instance.WorldState.Players.TryGetValue(pair.Value.PlayerId, out var player)) return 0;
+			return player.AllianceId != null ? 1 : 0;
+		}
+
+		private static int GetMarketProgress(GameInstance instance, string userId) {
+			var pair = instance.TryGetUserPlayer(userId);
+			if (pair == null) return 0;
+			var playerId = pair.Value.PlayerId;
+			lock (instance.WorldState.MarketOrdersLock) {
+				return instance.WorldState.MarketOrders
+					.Any(o => o.SellerPlayerId == playerId && o.Status == MarketOrderStatus.Filled)
+					? 1 : 0;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepositoryWrite.cs
@@ -1,0 +1,18 @@
+using System;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+
+namespace BrowserGameEngine.StatefulGameServer.Achievements {
+	public class MilestoneRepositoryWrite {
+		private readonly GlobalState _globalState;
+
+		public MilestoneRepositoryWrite(GlobalState globalState) {
+			_globalState = globalState;
+		}
+
+		public void UnlockIfNew(string userId, string milestoneId, DateTime unlockedAt) {
+			if (_globalState.HasMilestone(userId, milestoneId)) return;
+			_globalState.AddMilestone(new UserMilestoneImmutable(userId, milestoneId, unlockedAt));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
@@ -13,6 +13,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		private readonly object _achievementsLock = new();
 		private List<PlayerAchievementImmutable> _achievements = new();
 
+		private readonly object _milestonesLock = new();
+		private List<UserMilestoneImmutable> _milestones = new();
+
 		public string? GetUserDisplayName(string userId) {
 			var user = Users.Values.FirstOrDefault(u => u.UserId == userId);
 			return user?.DisplayName;
@@ -48,6 +51,26 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public void SetAchievements(IEnumerable<PlayerAchievementImmutable> achievements) {
 			lock (_achievementsLock) _achievements = achievements.ToList();
 		}
+
+		public IReadOnlyList<UserMilestoneImmutable> GetAllMilestones() {
+			lock (_milestonesLock) return _milestones.ToList();
+		}
+
+		public IReadOnlyList<UserMilestoneImmutable> GetMilestonesForUser(string userId) {
+			lock (_milestonesLock) return _milestones.Where(m => m.UserId == userId).ToList();
+		}
+
+		public bool HasMilestone(string userId, string milestoneId) {
+			lock (_milestonesLock) return _milestones.Any(m => m.UserId == userId && m.MilestoneId == milestoneId);
+		}
+
+		public void AddMilestone(UserMilestoneImmutable milestone) {
+			lock (_milestonesLock) _milestones.Add(milestone);
+		}
+
+		public void SetMilestones(IEnumerable<UserMilestoneImmutable> milestones) {
+			lock (_milestonesLock) _milestones = milestones.ToList();
+		}
 	}
 
 	public static class GlobalStateExtensions {
@@ -55,7 +78,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			return new GlobalStateImmutable(
 				Users: globalState.Users.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				Games: globalState.GetGames().ToList(),
-				Achievements: globalState.GetAchievements().ToList()
+				Achievements: globalState.GetAchievements().ToList(),
+				Milestones: globalState.GetAllMilestones().ToList()
 			);
 		}
 
@@ -66,6 +90,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			};
 			state.SetGames(globalStateImmutable.Games);
 			state.SetAchievements(globalStateImmutable.Achievements);
+			state.SetMilestones(globalStateImmutable.Milestones ?? Enumerable.Empty<UserMilestoneImmutable>());
 			return state;
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -1,5 +1,6 @@
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Achievements;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
@@ -74,6 +75,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<TradeRepositoryWrite>();
 			services.AddSingleton<ResourceHistoryRepository>();
 			services.AddSingleton<ResourceHistoryRepositoryWrite>();
+			services.AddSingleton<MilestoneRepository>();
+			services.AddSingleton<MilestoneRepositoryWrite>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/ReactClient/e2e/tests/06-attack-flow.spec.ts
+++ b/src/ReactClient/e2e/tests/06-attack-flow.spec.ts
@@ -96,7 +96,7 @@ test.describe('Attack flow', () => {
 		const enemySelect = page.locator('select')
 		await enemySelect.selectOption({ value: defenderPlayerId })
 
-		await page.getByRole('button', { name: /send/i }).click()
+		await page.getByRole('button', { name: 'Send Troops' }).click()
 
 		// Should navigate to EnemyBase
 		await expect(page).toHaveURL(

--- a/src/ReactClient/src/pages/Achievements.tsx
+++ b/src/ReactClient/src/pages/Achievements.tsx
@@ -5,6 +5,7 @@ import { TrophyIcon, SwordsIcon, CoinsIcon, HandshakeIcon, CompassIcon, LockIcon
 import apiClient from '@/api/client'
 import type {
 	PlayerAchievementsViewModel,
+	MilestoneAchievementsViewModel,
 	MilestoneAchievementViewModel,
 	MilestoneCategory,
 	MilestoneTier,
@@ -199,12 +200,11 @@ export function Achievements() {
 		queryFn: () => apiClient.get('/api/player-management/me/achievements').then(r => r.data),
 	})
 
-	// TODO: Replace mock data once backend endpoint exists
-	// const { data: milestoneData } = useQuery<MilestoneAchievementsViewModel>({
-	//   queryKey: ['milestone-achievements'],
-	//   queryFn: () => apiClient.get('/api/player-management/me/milestone-achievements').then(r => r.data),
-	// })
-	const milestones = MOCK_MILESTONES
+	const { data: milestoneData } = useQuery<MilestoneAchievementsViewModel>({
+		queryKey: ['milestone-achievements'],
+		queryFn: () => apiClient.get('/api/player-management/me/milestone-achievements').then(r => r.data),
+	})
+	const milestones = milestoneData?.achievements ?? []
 
 	if (isLoading) return <PageLoader message="Loading achievements..." />
 	if (error) return <ApiError message="Failed to load achievements." onRetry={() => void refetch()} />

--- a/src/ReactClient/src/pages/Achievements.tsx
+++ b/src/ReactClient/src/pages/Achievements.tsx
@@ -15,34 +15,6 @@ import { ApiError } from '@/components/ApiError'
 import { cn } from '@/lib/utils'
 import { formatDate, rankBadgeClass } from '@/lib/formatters'
 
-// ── Mock milestone data (backend TBD — defines the API contract) ────────────
-
-const MOCK_MILESTONES: MilestoneAchievementViewModel[] = [
-	// Combat
-	{ id: 'combat-first-blood', name: 'First Blood', description: 'Win your first battle', category: 'combat', icon: '⚔️', isUnlocked: true, unlockedAt: '2026-03-20T12:00:00Z', currentProgress: 1, targetProgress: 1, tier: 'bronze' },
-	{ id: 'combat-warlord', name: 'Warlord', description: 'Win 10 battles in a single game', category: 'combat', icon: '🗡️', isUnlocked: true, unlockedAt: '2026-03-22T15:30:00Z', currentProgress: 10, targetProgress: 10, tier: 'silver' },
-	{ id: 'combat-conqueror', name: 'Conqueror', description: 'Destroy 50 enemy units', category: 'combat', icon: '💀', isUnlocked: false, unlockedAt: null, currentProgress: 32, targetProgress: 50, tier: 'gold' },
-	{ id: 'combat-supreme', name: 'Supreme Commander', description: 'Win a game without losing a single battle', category: 'combat', icon: '👑', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
-
-	// Economy
-	{ id: 'econ-first-mine', name: 'Mineral Rush', description: 'Accumulate 10,000 minerals', category: 'economy', icon: '💎', isUnlocked: true, unlockedAt: '2026-03-19T10:00:00Z', currentProgress: 10000, targetProgress: 10000, tier: 'bronze' },
-	{ id: 'econ-gas-giant', name: 'Gas Giant', description: 'Accumulate 5,000 gas', category: 'economy', icon: '⛽', isUnlocked: true, unlockedAt: '2026-03-21T08:00:00Z', currentProgress: 5000, targetProgress: 5000, tier: 'silver' },
-	{ id: 'econ-market-mogul', name: 'Market Mogul', description: 'Complete 20 market trades', category: 'economy', icon: '📈', isUnlocked: false, unlockedAt: null, currentProgress: 14, targetProgress: 20, tier: 'gold' },
-	{ id: 'econ-tycoon', name: 'Galactic Tycoon', description: 'Accumulate 1,000,000 total resources', category: 'economy', icon: '🏦', isUnlocked: false, unlockedAt: null, currentProgress: 420000, targetProgress: 1000000, tier: 'legendary' },
-
-	// Diplomacy
-	{ id: 'diplo-first-ally', name: 'First Contact', description: 'Join or create an alliance', category: 'diplomacy', icon: '🤝', isUnlocked: true, unlockedAt: '2026-03-20T14:00:00Z', currentProgress: 1, targetProgress: 1, tier: 'bronze' },
-	{ id: 'diplo-peacekeeper', name: 'Peacekeeper', description: 'Sign 3 non-aggression pacts', category: 'diplomacy', icon: '🕊️', isUnlocked: false, unlockedAt: null, currentProgress: 1, targetProgress: 3, tier: 'silver' },
-	{ id: 'diplo-deal-maker', name: 'Deal Maker', description: 'Complete 10 player-to-player trades', category: 'diplomacy', icon: '📜', isUnlocked: false, unlockedAt: null, currentProgress: 4, targetProgress: 10, tier: 'gold' },
-	{ id: 'diplo-united', name: 'United Nations', description: 'Lead an alliance with 5+ members to victory', category: 'diplomacy', icon: '🌍', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
-
-	// Exploration
-	{ id: 'explore-settler', name: 'Settler', description: 'Colonize 100 land', category: 'exploration', icon: '🏗️', isUnlocked: true, unlockedAt: '2026-03-19T11:00:00Z', currentProgress: 100, targetProgress: 100, tier: 'bronze' },
-	{ id: 'explore-expand', name: 'Expansionist', description: 'Colonize 500 land', category: 'exploration', icon: '🗺️', isUnlocked: false, unlockedAt: null, currentProgress: 310, targetProgress: 500, tier: 'silver' },
-	{ id: 'explore-tech-rush', name: 'Tech Rush', description: 'Research 10 technologies', category: 'exploration', icon: '🔬', isUnlocked: false, unlockedAt: null, currentProgress: 6, targetProgress: 10, tier: 'gold' },
-	{ id: 'explore-pioneer', name: 'Galactic Pioneer', description: 'Fully explore the tech tree in a single game', category: 'exploration', icon: '🚀', isUnlocked: false, unlockedAt: null, currentProgress: 0, targetProgress: 1, tier: 'legendary' },
-]
-
 // ── Config ───────────────────────────────────────────────────────────────────
 
 const CATEGORIES: { key: MilestoneCategory; label: string; icon: React.ComponentType<{ className?: string }> }[] = [


### PR DESCRIPTION
## Summary
- Add `UserMilestoneImmutable` record to GameModel for persisting unlocked milestones
- Extend `GlobalStateImmutable` with nullable `Milestones` list (existing state.json deserializes without migration)
- Add thread-safe milestone methods to `GlobalState` (Add/Get/Set/Has) with lock guard
- Add `MilestoneCatalogue` with 15 milestones across 4 categories (exploration, combat, economy, diplomacy)
- Add `MilestoneRepository` (read + on-demand progress evaluation for cross-game and in-game milestones)
- Add `MilestoneRepositoryWrite` (idempotent unlock via `UnlockIfNew`)
- Register both repositories in `GameServerExtensions` DI
- Add `GET /api/player-management/me/milestone-achievements` endpoint that evaluates and auto-unlocks milestones
- Wire up `Achievements.tsx` to real backend endpoint (removes mock data)

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (571 tests, including 6 new milestone-specific tests)
- [ ] Navigate to `/achievements` page while logged in — milestones show real progress
- [ ] Complete a game and verify cross-game milestones (e.g. "First Commander") unlock
- [ ] New user with no history — all milestones show as locked with 0 progress

Closes BGE-750