### PR TITLE
test: BGE-771 comprehensive integration tests for milestone system

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameDefinition.SCO;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Achievements;
+using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using Xunit;
@@ -11,6 +13,7 @@ using Xunit;
 namespace BrowserGameEngine.StatefulGameServer.Test {
 	public class MilestoneRepositoryTest {
 		private const string UserId = "user-1";
+		private const string UserId2 = "user-2";
 		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
 
 		private static GameRegistry.GameRegistry EmptyGameRegistry(GlobalState globalState)
@@ -24,6 +27,64 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				.Select(p => p with { UserId = UserId })
 				.ToDictionary(p => p.PlayerId);
 			return new TestGame(baseState with { Players = players });
+		}
+
+		// Creates a TestGame with configurable resources for Player1 (UserId set)
+		private static TestGame CreateGameWithResources(Dictionary<string, decimal> resources) {
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(1);
+			var resourceDict = resources.ToDictionary(kv => Id.ResDef(kv.Key), kv => kv.Value);
+			var players = baseState.Players.Values
+				.Select(p => p with {
+					UserId = UserId,
+					State = p.State with { Resources = resourceDict }
+				})
+				.ToDictionary(p => p.PlayerId);
+			return new TestGame(baseState with { Players = players });
+		}
+
+		// Creates a TestGame where Player1 (UserId) is in an alliance
+		private static TestGame CreateGameWithAlliance() {
+			var game = CreateGameWithUser();
+			game.AllianceRepositoryWrite.CreateAlliance(new CreateAllianceCommand(Player1, "TestAlliance", "password"));
+			return game;
+		}
+
+		// Creates a TestGame where Player1 (UserId) has techs unlocked via initial immutable state
+		private static TestGame CreateGameWithTechs(int techCount) {
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(1);
+			var techs = Enumerable.Range(0, techCount).Select(i => $"tech-{i}").ToList();
+			var players = baseState.Players.Values
+				.Select(p => p with {
+					UserId = UserId,
+					State = p.State with { UnlockedTechs = techs }
+				})
+				.ToDictionary(p => p.PlayerId);
+			return new TestGame(baseState with { Players = players });
+		}
+
+		// Creates a 2-player TestGame where Player1 (UserId) has a filled market order
+		private static TestGame CreateGameWithFilledMarketOrder() {
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(2);
+			var player2 = PlayerIdFactory.Create("player1");
+			var players = baseState.Players.Values
+				.Select(p => p.PlayerId == Player1 ? p with { UserId = UserId } : p)
+				.ToDictionary(p => p.PlayerId);
+			var game = new TestGame(baseState with { Players = players });
+			var orderId = game.MarketRepository.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: Player1,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50
+			));
+			game.MarketRepository.AcceptOrder(new AcceptMarketOrderCommand(
+				BuyerPlayerId: player2,
+				OrderId: orderId
+			));
+			return game;
 		}
 
 		private static (GlobalState globalState, GameRegistry.GameRegistry registry) SetupWithActiveGame(TestGame game) {
@@ -149,6 +210,400 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			foreach (var id in inGameIds) {
 				Assert.Equal(0, results.Single(r => r.Definition.Id == id).CurrentProgress);
 			}
+		}
+
+		// ── IsUnlocked and UnlockedAt ────────────────────────────────────────────
+
+		[Fact]
+		public void UnlockIfNew_MilestoneAppearsAsUnlocked_InGetMilestones() {
+			var globalState = new GlobalState();
+			var write = new MilestoneRepositoryWrite(globalState);
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var now = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+			write.UnlockIfNew(UserId, "win-first", now);
+			var results = repo.GetMilestonesForUser(UserId);
+
+			var winFirst = results.Single(r => r.Definition.Id == "win-first");
+			Assert.True(winFirst.IsUnlocked);
+			Assert.Equal(now, winFirst.UnlockedAt);
+		}
+
+		[Fact]
+		public void UnlockIfNew_MultipleDifferentMilestones_AllAppearUnlocked() {
+			var globalState = new GlobalState();
+			var write = new MilestoneRepositoryWrite(globalState);
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var now = DateTime.UtcNow;
+
+			write.UnlockIfNew(UserId, "win-first", now);
+			write.UnlockIfNew(UserId, "games-first", now);
+			write.UnlockIfNew(UserId, "top3-first", now);
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.True(results.Single(r => r.Definition.Id == "win-first").IsUnlocked);
+			Assert.True(results.Single(r => r.Definition.Id == "games-first").IsUnlocked);
+			Assert.True(results.Single(r => r.Definition.Id == "top3-first").IsUnlocked);
+			Assert.False(results.Single(r => r.Definition.Id == "win-champion").IsUnlocked);
+		}
+
+		[Fact]
+		public void GetMilestonesForUser_UnlockedMilestone_HasNullUnlockedAtByDefault() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.All(results, m => Assert.Null(m.UnlockedAt));
+		}
+
+		// ── Multi-user isolation ─────────────────────────────────────────────────
+
+		[Fact]
+		public void User1Achievements_DoNotAffectUser2Progress() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 5; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId,
+					GameId: new GameId($"g{i}"),
+					PlayerId: Player1,
+					PlayerName: "player0",
+					FinalRank: 1,
+					FinalScore: 1000,
+					GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var user2Results = repo.GetMilestonesForUser(UserId2);
+
+			Assert.All(user2Results, m => Assert.Equal(0, m.CurrentProgress));
+			Assert.All(user2Results, m => Assert.False(m.IsUnlocked));
+		}
+
+		[Fact]
+		public void User1Unlock_DoesNotShowAsUnlockedForUser2() {
+			var globalState = new GlobalState();
+			var write = new MilestoneRepositoryWrite(globalState);
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			write.UnlockIfNew(UserId, "win-first", DateTime.UtcNow);
+			var user2Results = repo.GetMilestonesForUser(UserId2);
+
+			Assert.False(user2Results.Single(r => r.Definition.Id == "win-first").IsUnlocked);
+		}
+
+		// ── Cross-game milestone thresholds ─────────────────────────────────────
+
+		[Fact]
+		public void FiveWins_WinChampionAtFullProgress() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 5; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId,
+					GameId: new GameId($"g{i}"),
+					PlayerId: Player1,
+					PlayerName: "player0",
+					FinalRank: 1,
+					FinalScore: 1000,
+					GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var champion = results.Single(r => r.Definition.Id == "win-champion");
+
+			Assert.Equal(champion.Definition.TargetProgress, champion.CurrentProgress);
+		}
+
+		[Fact]
+		public void MoreWinsThanTarget_ProgressCappedAtTarget() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 15; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId,
+					GameId: new GameId($"g{i}"),
+					PlayerId: Player1,
+					PlayerName: "player0",
+					FinalRank: 1,
+					FinalScore: 1000,
+					GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var legend = results.Single(r => r.Definition.Id == "win-legend");
+
+			Assert.Equal(legend.Definition.TargetProgress, legend.CurrentProgress);
+			Assert.Equal(10, legend.CurrentProgress);
+		}
+
+		[Fact]
+		public void NonWinGames_DoNotCountTowardWinMilestones() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 10; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId,
+					GameId: new GameId($"g{i}"),
+					PlayerId: Player1,
+					PlayerName: "player0",
+					FinalRank: 2,
+					FinalScore: 500,
+					GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.Equal(0, results.Single(r => r.Definition.Id == "win-first").CurrentProgress);
+			Assert.Equal(0, results.Single(r => r.Definition.Id == "win-champion").CurrentProgress);
+			Assert.Equal(10, results.Single(r => r.Definition.Id == "games-commander").CurrentProgress);
+		}
+
+		// ── In-game mineral / gas milestones ────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_MineralsBelow10000_ReflectsActualAmount() {
+			var game = CreateGameWithResources(new Dictionary<string, decimal> {
+				{ "minerals", 5000 },
+				{ "gas", 100 }
+			});
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var mineralMilestone = results.Single(r => r.Definition.Id == "econ-minerals");
+
+			Assert.Equal(5000, mineralMilestone.CurrentProgress);
+			Assert.False(mineralMilestone.IsUnlocked);
+		}
+
+		[Fact]
+		public void ActiveGame_MineralsAtTarget_ProgressCappedAtTarget() {
+			var game = CreateGameWithResources(new Dictionary<string, decimal> {
+				{ "minerals", 15000 },
+				{ "gas", 0 }
+			});
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var mineralMilestone = results.Single(r => r.Definition.Id == "econ-minerals");
+
+			Assert.Equal(10000, mineralMilestone.CurrentProgress);
+			Assert.Equal(mineralMilestone.Definition.TargetProgress, mineralMilestone.CurrentProgress);
+		}
+
+		[Fact]
+		public void ActiveGame_GasAtAmount_ReflectsInEconGasMilestone() {
+			var game = CreateGameWithResources(new Dictionary<string, decimal> {
+				{ "minerals", 0 },
+				{ "gas", 3000 }
+			});
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var gasMilestone = results.Single(r => r.Definition.Id == "econ-gas");
+
+			Assert.Equal(3000, gasMilestone.CurrentProgress);
+		}
+
+		// ── In-game land-500 milestone ───────────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_LandAt500_ExpansionistMilestoneAtFullProgress() {
+			var game = CreateGameWithResources(new Dictionary<string, decimal> {
+				{ "land", 600 }
+			});
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var expansionist = results.Single(r => r.Definition.Id == "econ-land-500");
+
+			Assert.Equal(500, expansionist.CurrentProgress);
+			Assert.Equal(expansionist.Definition.TargetProgress, expansionist.CurrentProgress);
+		}
+
+		// ── Alliance milestone ───────────────────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_PlayerInAlliance_DiploAllianceProgressIs1() {
+			var game = CreateGameWithAlliance();
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var alliance = results.Single(r => r.Definition.Id == "diplo-alliance");
+
+			Assert.Equal(1, alliance.CurrentProgress);
+		}
+
+		[Fact]
+		public void ActiveGame_PlayerNotInAlliance_DiploAllianceProgressIs0() {
+			var game = CreateGameWithUser(); // no alliance
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var alliance = results.Single(r => r.Definition.Id == "diplo-alliance");
+
+			Assert.Equal(0, alliance.CurrentProgress);
+		}
+
+		// ── Tech upgrade milestone ───────────────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_OneUnlockedTech_UpgradeFirstProgressIs1() {
+			var game = CreateGameWithTechs(1);
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var techMilestone = results.Single(r => r.Definition.Id == "upgrade-first");
+
+			Assert.Equal(1, techMilestone.CurrentProgress);
+		}
+
+		[Fact]
+		public void ActiveGame_NoUnlockedTechs_UpgradeFirstProgressIs0() {
+			var game = CreateGameWithUser();
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var techMilestone = results.Single(r => r.Definition.Id == "upgrade-first");
+
+			Assert.Equal(0, techMilestone.CurrentProgress);
+		}
+
+		// ── Market milestone ─────────────────────────────────────────────────────
+
+		[Fact]
+		public void ActiveGame_FilledMarketOrder_MarketFirstProgressIs1() {
+			var game = CreateGameWithFilledMarketOrder();
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var market = results.Single(r => r.Definition.Id == "market-first");
+
+			Assert.Equal(1, market.CurrentProgress);
+		}
+
+		[Fact]
+		public void ActiveGame_OpenMarketOrder_MarketFirstProgressIs0() {
+			// Create order but don't accept it — remains Open, not Filled
+			var factory = new TestWorldStateFactory();
+			var baseState = factory.CreateDevWorldState(1);
+			var players = baseState.Players.Values
+				.Select(p => p with { UserId = UserId })
+				.ToDictionary(p => p.PlayerId);
+			var game = new TestGame(baseState with { Players = players });
+			game.MarketRepository.CreateOrder(new CreateMarketOrderCommand(
+				PlayerId: Player1,
+				OfferedResourceId: Id.ResDef("res1"),
+				OfferedAmount: 100,
+				WantedResourceId: Id.ResDef("res2"),
+				WantedAmount: 50
+			));
+			var (globalState, registry) = SetupWithActiveGame(game);
+			var repo = new MilestoneRepository(globalState, registry);
+
+			var results = repo.GetMilestonesForUser(UserId);
+			var market = results.Single(r => r.Definition.Id == "market-first");
+
+			Assert.Equal(0, market.CurrentProgress);
+		}
+
+		// ── MilestoneCatalogue completeness (verified via repository output) ─────
+
+		[Fact]
+		public void GetMilestonesForUser_Returns15Milestones() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.Equal(15, results.Count);
+		}
+
+		[Fact]
+		public void GetMilestonesForUser_AllDefinitionIdsAreUnique() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var ids = repo.GetMilestonesForUser(UserId).Select(r => r.Definition.Id).ToList();
+
+			Assert.Equal(ids.Count, ids.Distinct().Count());
+		}
+
+		[Fact]
+		public void GetMilestonesForUser_AllDefinitionsHavePositiveTargetProgress() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+
+			var results = repo.GetMilestonesForUser(UserId);
+
+			Assert.All(results, r => Assert.True(r.Definition.TargetProgress > 0));
+		}
+
+		[Fact]
+		public void GetMilestonesForUser_ContainsExpectedMilestoneIds() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var expectedIds = new[] {
+				"games-first", "games-veteran", "games-commander", "games-legend",
+				"win-first", "win-champion", "win-legend", "top3-first",
+				"econ-minerals", "econ-gas", "econ-land-100", "econ-land-500",
+				"diplo-alliance", "market-first", "upgrade-first"
+			};
+
+			var ids = repo.GetMilestonesForUser(UserId).Select(r => r.Definition.Id).ToHashSet();
+
+			Assert.All(expectedIds, id => Assert.Contains(id, ids));
+		}
+
+		// ── GlobalState milestone storage ────────────────────────────────────────
+
+		[Fact]
+		public void GlobalState_SetMilestones_GetAllMilestones_RoundTrips() {
+			var globalState = new GlobalState();
+			var milestones = new List<UserMilestoneImmutable> {
+				new(UserId, "win-first", DateTime.UtcNow),
+				new(UserId2, "games-first", DateTime.UtcNow)
+			};
+
+			globalState.SetMilestones(milestones);
+			var all = globalState.GetAllMilestones();
+
+			Assert.Equal(2, all.Count);
+			Assert.Contains(all, m => m.UserId == UserId && m.MilestoneId == "win-first");
+			Assert.Contains(all, m => m.UserId == UserId2 && m.MilestoneId == "games-first");
+		}
+
+		[Fact]
+		public void GlobalState_HasMilestone_ReturnsFalseForNonexistent() {
+			var globalState = new GlobalState();
+
+			Assert.False(globalState.HasMilestone(UserId, "win-first"));
+		}
+
+		[Fact]
+		public void GlobalState_HasMilestone_ReturnsTrueAfterAdd() {
+			var globalState = new GlobalState();
+			globalState.AddMilestone(new UserMilestoneImmutable(UserId, "win-first", DateTime.UtcNow));
+
+			Assert.True(globalState.HasMilestone(UserId, "win-first"));
+			Assert.False(globalState.HasMilestone(UserId2, "win-first"));
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Expands `MilestoneRepositoryTest` from 6 to 31 tests covering all milestone categories
- All tests use the public repository API (no internal type access)
- Full test suite passes: 602 tests, 0 failures

## Coverage added
- `IsUnlocked` / `UnlockedAt` populated correctly after `MilestoneRepositoryWrite.UnlockIfNew`
- Multi-user isolation: user A achievements/unlocks do not affect user B
- Cross-game milestones: win counts, threshold capping, non-wins excluded
- In-game resource milestones: minerals and gas via custom initial state
- `econ-land-500` at threshold
- Alliance milestone via `AllianceRepositoryWrite.CreateAlliance`
- Tech upgrade milestone via `UnlockedTechs` in initial immutable state
- Market milestone using filled `MarketOrder` via public repository `CreateOrder`/`AcceptOrder`
- Open market order does not count toward `market-first`
- `MilestoneCatalogue` completeness: 15 milestones, unique IDs, expected IDs, positive targets
- `GlobalState` milestone storage: `SetMilestones`/`GetAllMilestones` round-trip, `HasMilestone` semantics

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (602 tests, 0 failures)
- [x] All 31 `MilestoneRepositoryTest` cases pass

Closes BGE-771