### PR TITLE
feat: BGE-792 wire agent1 game loop to DecisionEngine and ActionDispatcher

### DIFF
--- a/agent1/client.py
+++ b/agent1/client.py
@@ -1,0 +1,72 @@
+"""Thin HTTP client for the BGE REST API.
+
+Uses only stdlib so no external dependencies are required.
+Auth: ``Authorization: Bearer <api_key>`` where api_key starts with ``bge_k_``.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+class BgeClient:
+	"""Synchronous HTTP client for BGE API endpoints used by the bot."""
+
+	def __init__(self, base_url: str, api_key: str) -> None:
+		self._base_url = base_url.rstrip("/")
+		self._headers = {
+			"Authorization": f"Bearer {api_key}",
+			"Content-Type": "application/json",
+			"Accept": "application/json",
+		}
+
+	def _get(self, path: str) -> Any:
+		url = self._base_url + path
+		req = urllib.request.Request(url, headers=self._headers)
+		with urllib.request.urlopen(req) as resp:
+			return json.loads(resp.read().decode())
+
+	def _post(self, path: str, data: dict | None = None) -> Any:
+		url = self._base_url + path
+		body = json.dumps(data or {}).encode()
+		req = urllib.request.Request(url, data=body, headers=self._headers, method="POST")
+		try:
+			with urllib.request.urlopen(req) as resp:
+				raw = resp.read()
+				return json.loads(raw.decode()) if raw.strip() else None
+		except urllib.error.HTTPError as exc:
+			if exc.code in (200, 204):
+				return None
+			raise
+
+	def get_tick_info(self) -> dict:
+		"""GET /api/game/tick-info → TickInfoViewModel."""
+		return self._get("/api/game/tick-info")
+
+	def get_resources(self) -> dict:
+		"""GET /api/resources → PlayerResourcesViewModel."""
+		return self._get("/api/resources")
+
+	def get_units(self) -> dict:
+		"""GET /api/units → UnitsViewModel."""
+		return self._get("/api/units")
+
+	def get_attackable_players(self) -> dict:
+		"""GET /api/battle/attackableplayers → SelectEnemyViewModel."""
+		return self._get("/api/battle/attackableplayers")
+
+	def send_units(self, unit_id: str, enemy_player_id: str) -> None:
+		"""POST /api/battle/sendunits — send a unit to attack an enemy."""
+		eid = urllib.parse.quote(enemy_player_id, safe="")
+		self._post(f"/api/battle/sendunits?unitId={unit_id}&enemyPlayerId={eid}")
+
+	def build_units(self, unit_def_id: str, count: int) -> None:
+		"""POST /api/units/build — train units of the given type."""
+		self._post(f"/api/units/build?unitDefId={unit_def_id}&count={count}")
+
+	def build_asset(self, asset_def_id: str) -> None:
+		"""POST /api/assets/build — construct an asset."""
+		self._post(f"/api/assets/build?assetDefId={asset_def_id}")

--- a/agent1/main.py
+++ b/agent1/main.py
@@ -1,33 +1,95 @@
-"""Agent1 entry point — loads config and runs a single strategy tick (stub)."""
+"""Agent1 entry point — polling game loop wired to DecisionEngine."""
 from __future__ import annotations
+
 import argparse
-from .config import load_config
-from .strategy.context import StrategyContext
-from .strategy.military import should_attack
-from .strategy.resources import worker_target, should_expand
+import logging
+import time
+from collections import deque
+
+from .client import BgeClient
+from .config import AgentConfig, load_config
+from .state.tracker import GameStateTracker
+from .strategy.base import StrategyContext
+from .strategy.dispatcher import ActionDispatcher
+from .strategy.engine import DecisionEngine
+from .strategy.registry import load_strategy
 
 
-def run_tick(ctx: StrategyContext) -> dict[str, object]:
-    """Execute one decision tick and return a dict of recommended actions."""
-    return {
-        "attack": should_attack(ctx, enemy_units=0),
-        "worker_target": worker_target(ctx, max_workers=10),
-        "expand": should_expand(ctx),
-    }
+def run(config: AgentConfig) -> None:
+	"""Run the bot game loop until interrupted.
+
+	Each iteration polls ``/api/game/tick-info``.  When the server's
+	``nextTickAt`` value changes (indicating a new game tick has been
+	processed), state is fetched and ``DecisionEngine.run_tick`` is called
+	exactly once.  Errors are caught and logged; the loop never crashes.
+	"""
+	logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
+	logger = logging.getLogger(__name__)
+
+	client = BgeClient(config.base_url, config.api_key)
+	tracker = GameStateTracker()
+	dispatcher = ActionDispatcher(client)
+	strategy = load_strategy(config.strategy)
+	engine = DecisionEngine(strategy, dispatcher)
+	history: deque = deque(maxlen=20)
+
+	last_next_tick_at: str = ""
+
+	logger.info(
+		"Agent1 started — base_url=%s difficulty=%s strategy=%s poll=%ds",
+		config.base_url,
+		config.difficulty,
+		config.strategy,
+		config.poll_interval_seconds,
+	)
+
+	while True:
+		try:
+			tick_info = client.get_tick_info()
+			next_tick_at: str = tick_info.get("nextTickAt", "")
+
+			if next_tick_at != last_next_tick_at:
+				last_next_tick_at = next_tick_at
+				current_tick = hash(next_tick_at)
+
+				resources = client.get_resources()
+				units = client.get_units()
+				attackable = client.get_attackable_players()
+
+				tracker.update(tick_info, resources, units, attackable)
+
+				ctx = StrategyContext(
+					state=tracker,
+					tick=current_tick,
+					config=config,
+					history=history,
+				)
+				engine.run_tick(ctx)
+				history.append(tracker)
+
+				logger.debug(
+					"Tick processed — minerals=%d units=%d enemies=%d",
+					tracker.minerals,
+					tracker.units,
+					len(tracker.attackable_players),
+				)
+		except Exception:
+			logger.exception("Error in tick loop, continuing...")
+
+		time.sleep(config.poll_interval_seconds)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Agent1 bot")
-    parser.add_argument("config_path", nargs="?", default=None, help="Path to YAML config file")
-    args = parser.parse_args()
-
-    cfg = load_config(args.config_path)
-    ctx = StrategyContext(
-        difficulty_profile=cfg.difficulty_profile,
-        overrides=cfg.strategy_overrides,
-    )
-    print(run_tick(ctx))
+	parser = argparse.ArgumentParser(description="Agent1 bot")
+	parser.add_argument(
+		"config_path",
+		nargs="?",
+		default=None,
+		help="Path to YAML config file (default: config/config.yaml)",
+	)
+	args = parser.parse_args()
+	run(load_config(args.config_path))
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/agent1/state/tracker.py
+++ b/agent1/state/tracker.py
@@ -1,0 +1,59 @@
+"""GameStateTracker — mutable accumulator updated once per tick.
+
+Parses raw API response dicts (ViewModels serialized as JSON) into typed
+fields that strategy code can read without touching HTTP concerns.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GameStateTracker:
+	"""Holds the latest snapshot of game state for the current bot."""
+
+	# Resources
+	minerals: int = 0
+	gas: int = 0
+	land: int = 0
+	max_land: int = 0
+
+	# Units (total count of all home units)
+	units: int = 0
+	# Raw unit list for dispatch (each entry has unitId, count, positionPlayerId)
+	unit_list: list[dict] = field(default_factory=list)
+
+	# Attackable enemies returned by /api/battle/attackableplayers
+	attackable_players: list[dict] = field(default_factory=list)
+
+	def update(
+		self,
+		tick_info: dict[str, Any],
+		resources: dict[str, Any],
+		units: dict[str, Any],
+		attackable_players: dict[str, Any],
+	) -> None:
+		"""Refresh state from raw API response dicts.
+
+		Only the fields used by strategy modules are extracted; everything
+		else is discarded to keep the footprint minimal.
+		"""
+		# Resources: primaryResource.cost may contain {"minerals": N}
+		primary_cost: dict = (resources.get("primaryResource") or {}).get("cost") or {}
+		secondary_cost: dict = (resources.get("secondaryResources") or {}).get("cost") or {}
+
+		self.minerals = int(primary_cost.get("minerals", 0))
+		self.gas = int(secondary_cost.get("gas", 0))
+		self.land = int(secondary_cost.get("land", 0))
+		self.max_land = int(secondary_cost.get("maxLand", self.land))
+
+		# Units
+		raw_units: list[dict] = (units.get("units") or [])
+		# Home units only (positionPlayerId is None/empty when at home)
+		home_units = [u for u in raw_units if not u.get("positionPlayerId")]
+		self.units = sum(u.get("count", 0) for u in home_units)
+		self.unit_list = raw_units
+
+		# Attackable players
+		self.attackable_players = attackable_players.get("attackablePlayers") or []

--- a/agent1/strategy/balanced.py
+++ b/agent1/strategy/balanced.py
@@ -1,0 +1,56 @@
+"""BalancedStrategy — default strategy using existing military/resource modules.
+
+Bridges the game-loop ``StrategyContext`` (state + config) to the flat
+per-strategy ``StrategyContext`` expected by ``military`` and ``resources``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .context import StrategyContext as _LegacyCtx
+from .military import should_attack
+from .resources import worker_target
+
+if TYPE_CHECKING:
+	from agent1.strategy.base import StrategyContext
+	from agent1.strategy.dispatcher import ActionDispatcher
+
+logger = logging.getLogger(__name__)
+
+# Default unit type to train when workers are needed
+_WORKER_UNIT_DEF = "worker"
+
+
+class BalancedStrategy:
+	"""Balances attacking enemies and growing the economy."""
+
+	def run_tick(self, ctx: StrategyContext, dispatcher: ActionDispatcher) -> None:
+		state = ctx.state
+		cfg = ctx.config
+
+		legacy = _LegacyCtx(
+			minerals=state.minerals,
+			land=state.land,
+			max_land=state.max_land,
+			units=state.units,
+			difficulty_profile=cfg.difficulty_profile,
+			overrides=cfg.strategy_overrides,
+		)
+
+		# Attack decision: check each attackable enemy
+		for enemy in state.attackable_players:
+			enemy_units = int(enemy.get("approxHomeUnitCount") or 0)
+			if should_attack(legacy, enemy_units=enemy_units):
+				# Send the first available home unit group
+				home_units = [u for u in state.unit_list if not u.get("positionPlayerId") and u.get("count", 0) > 0]
+				if home_units:
+					unit = home_units[0]
+					dispatcher.attack(unit["unitId"], enemy["playerId"])
+				break  # one attack per tick
+
+		# Worker / economy decision
+		target = worker_target(legacy, max_workers=20)
+		if target > state.units:
+			needed = target - state.units
+			dispatcher.build_units(_WORKER_UNIT_DEF, needed)

--- a/agent1/strategy/base.py
+++ b/agent1/strategy/base.py
@@ -1,0 +1,26 @@
+"""StrategyContext — the context object passed to DecisionEngine.run_tick().
+
+This is the *game-loop* context.  It wraps a ``GameStateTracker`` snapshot
+plus loop-level metadata (current tick counter, full config, tick history).
+It is distinct from the per-strategy ``StrategyContext`` in ``context.py``
+which holds flat scalar fields used by individual strategy functions.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from agent1.config import AgentConfig
+	from agent1.state.tracker import GameStateTracker
+
+
+@dataclass
+class StrategyContext:
+	"""Immutable-ish snapshot fed to the engine once per tick."""
+
+	state: GameStateTracker
+	tick: int
+	config: AgentConfig
+	history: deque = field(default_factory=deque)

--- a/agent1/strategy/dispatcher.py
+++ b/agent1/strategy/dispatcher.py
@@ -1,0 +1,32 @@
+"""ActionDispatcher — translates strategy decisions into BGE API calls."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from agent1.client import BgeClient
+
+logger = logging.getLogger(__name__)
+
+
+class ActionDispatcher:
+	"""Wraps ``BgeClient`` and provides intent-level dispatch methods."""
+
+	def __init__(self, client: BgeClient) -> None:
+		self._client = client
+
+	def attack(self, unit_id: str, enemy_player_id: str) -> None:
+		"""Send *unit_id* to attack *enemy_player_id*."""
+		logger.info("Dispatching attack: unit=%s → enemy=%s", unit_id, enemy_player_id)
+		self._client.send_units(unit_id, enemy_player_id)
+
+	def build_units(self, unit_def_id: str, count: int) -> None:
+		"""Train *count* units of *unit_def_id*."""
+		logger.info("Dispatching build_units: %s × %d", unit_def_id, count)
+		self._client.build_units(unit_def_id, count)
+
+	def build_asset(self, asset_def_id: str) -> None:
+		"""Construct asset *asset_def_id*."""
+		logger.info("Dispatching build_asset: %s", asset_def_id)
+		self._client.build_asset(asset_def_id)

--- a/agent1/strategy/engine.py
+++ b/agent1/strategy/engine.py
@@ -1,0 +1,35 @@
+"""DecisionEngine — drives one strategy module per tick."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from agent1.strategy.base import StrategyContext
+	from agent1.strategy.dispatcher import ActionDispatcher
+
+logger = logging.getLogger(__name__)
+
+
+class DecisionEngine:
+	"""Orchestrates strategy evaluation and action dispatch for one tick.
+
+	Args:
+		strategy: Any object implementing ``run_tick(ctx, dispatcher)``.
+		dispatcher: ``ActionDispatcher`` instance used for all API calls.
+	"""
+
+	def __init__(self, strategy: object, dispatcher: ActionDispatcher) -> None:
+		self._strategy = strategy
+		self._dispatcher = dispatcher
+
+	def run_tick(self, ctx: StrategyContext) -> None:
+		"""Evaluate the strategy and dispatch resulting actions.
+
+		Errors from the strategy or dispatcher are logged and swallowed so
+		the main loop continues running even on transient API failures.
+		"""
+		try:
+			self._strategy.run_tick(ctx, self._dispatcher)
+		except Exception:
+			logger.exception("Strategy tick failed — skipping dispatch for this tick")

--- a/agent1/strategy/registry.py
+++ b/agent1/strategy/registry.py
@@ -1,0 +1,21 @@
+"""Strategy registry — maps strategy names to strategy instances."""
+from __future__ import annotations
+
+from .balanced import BalancedStrategy
+
+_REGISTRY: dict[str, type] = {
+	"balanced": BalancedStrategy,
+}
+
+
+def load_strategy(name: str) -> object:
+	"""Return a new strategy instance for *name*.
+
+	Raises:
+		ValueError: if *name* is not a registered strategy.
+	"""
+	if name not in _REGISTRY:
+		raise ValueError(
+			f"Unknown strategy {name!r}. Available strategies: {sorted(_REGISTRY)}"
+		)
+	return _REGISTRY[name]()

--- a/agent1/tests/test_main_wiring.py
+++ b/agent1/tests/test_main_wiring.py
@@ -1,0 +1,118 @@
+"""Unit tests for the main.py game loop wiring.
+
+Verifies that DecisionEngine.run_tick is called exactly once per new game
+tick, and is NOT called again when the server returns the same tick.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent1.config import AgentConfig
+from agent1.main import run
+
+
+def _make_tick(next_tick_at: str) -> dict:
+	return {
+		"serverTime": "2026-01-01T00:00:00Z",
+		"nextTickAt": next_tick_at,
+		"unreadMessageCount": 0,
+	}
+
+
+def _make_resources() -> dict:
+	return {
+		"primaryResource": {"cost": {"minerals": 500}},
+		"secondaryResources": {"cost": {"gas": 100, "land": 10}},
+		"colonizationCostPerLand": 0,
+	}
+
+
+def _make_units() -> dict:
+	return {"units": []}
+
+
+def _make_attackable() -> dict:
+	return {"attackablePlayers": []}
+
+
+def _run_loop_for_n_polls(config: AgentConfig, tick_info_sequence: list[dict], mock_engine: MagicMock) -> None:
+	"""Patch run() internals and drive *n* poll iterations, then stop."""
+	poll_count = 0
+
+	def fake_sleep(_secs: float) -> None:
+		nonlocal poll_count
+		poll_count += 1
+		if poll_count >= len(tick_info_sequence):
+			raise StopIteration
+
+	mock_client = MagicMock()
+	mock_client.get_tick_info.side_effect = tick_info_sequence
+	mock_client.get_resources.return_value = _make_resources()
+	mock_client.get_units.return_value = _make_units()
+	mock_client.get_attackable_players.return_value = _make_attackable()
+
+	with (
+		patch("agent1.main.BgeClient", return_value=mock_client),
+		patch("agent1.main.DecisionEngine", return_value=mock_engine),
+		patch("agent1.main.load_strategy"),
+		patch("agent1.main.ActionDispatcher"),
+		patch("agent1.main.time.sleep", side_effect=fake_sleep),
+	):
+		with pytest.raises(StopIteration):
+			run(config)
+
+
+def test_run_tick_called_once_per_new_tick() -> None:
+	"""engine.run_tick is called exactly once when the tick advances."""
+	config = AgentConfig(api_key="bge_k_test", game_id="g1")
+	mock_engine = MagicMock()
+
+	# Poll 1: tick A (new → run_tick called)
+	# Poll 2: tick A again (same → no call)
+	# Poll 3: tick B (new → run_tick called again) — drives StopIteration
+	ticks = [
+		_make_tick("2026-01-01T00:01:00Z"),
+		_make_tick("2026-01-01T00:01:00Z"),
+		_make_tick("2026-01-01T00:02:00Z"),
+	]
+	_run_loop_for_n_polls(config, ticks, mock_engine)
+
+	assert mock_engine.run_tick.call_count == 2
+
+
+def test_run_tick_not_called_on_repeated_same_tick() -> None:
+	"""engine.run_tick is NOT called when the same nextTickAt is returned twice."""
+	config = AgentConfig(api_key="bge_k_test", game_id="g1")
+	mock_engine = MagicMock()
+
+	# All three polls return the same tick
+	ticks = [
+		_make_tick("2026-01-01T00:01:00Z"),
+		_make_tick("2026-01-01T00:01:00Z"),
+		_make_tick("2026-01-01T00:01:00Z"),
+	]
+	_run_loop_for_n_polls(config, ticks, mock_engine)
+
+	# First poll is always "new" (last_next_tick_at starts empty), second and
+	# third are duplicates — only 1 call total.
+	assert mock_engine.run_tick.call_count == 1
+
+
+def test_loop_continues_after_engine_exception() -> None:
+	"""A crash inside run_tick does not kill the loop."""
+	config = AgentConfig(api_key="bge_k_test", game_id="g1")
+	mock_engine = MagicMock()
+	mock_engine.run_tick.side_effect = RuntimeError("strategy exploded")
+
+	ticks = [
+		_make_tick("2026-01-01T00:01:00Z"),
+		_make_tick("2026-01-01T00:02:00Z"),
+		_make_tick("2026-01-01T00:03:00Z"),
+	]
+	# Should not raise — the loop catches exceptions
+	_run_loop_for_n_polls(config, ticks, mock_engine)
+
+	# run_tick was attempted 3 times despite crashing each time
+	assert mock_engine.run_tick.call_count == 3


### PR DESCRIPTION
## Summary

- Rewrites the `agent1/main.py` stub into a real polling game loop that actively makes decisions each tick
- Detects new ticks via `nextTickAt` changes from `/api/game/tick-info` (calls `run_tick` exactly once per tick, skipped on repeated polls)
- Adds full wiring infrastructure: `BgeClient`, `GameStateTracker`, `DecisionEngine`, `ActionDispatcher`, `BalancedStrategy`, and `load_strategy` registry
- Errors in the tick loop are caught and logged — the loop never crashes on API failure
- 3 new unit tests verify tick-dedup logic and crash-recovery behaviour

## New files

| File | Purpose |
|---|---|
| `agent1/client.py` | stdlib urllib HTTP client for BGE REST API |
| `agent1/state/tracker.py` | `GameStateTracker` — parses API responses into typed fields |
| `agent1/strategy/base.py` | `StrategyContext` for the game loop (state, tick, config, history) |
| `agent1/strategy/engine.py` | `DecisionEngine(strategy, dispatcher)` — orchestrates one tick |
| `agent1/strategy/dispatcher.py` | `ActionDispatcher(client)` — intent-level API dispatch |
| `agent1/strategy/balanced.py` | `BalancedStrategy` — bridges to existing military/resources modules |
| `agent1/strategy/registry.py` | `load_strategy(name)` factory |
| `agent1/tests/test_main_wiring.py` | 3 unit tests for the main loop wiring |

## Test plan

- [x] `python -m pytest agent1/ -v` — 51/51 tests pass (48 existing + 3 new)
- [x] `dotnet build` passes
- [ ] Run against a live game: bot should log actual API calls (attacks, builds) rather than just state summaries

Closes BGE-792