### PR TITLE
feat: BGE-795 adaptive difficulty advisor with HTTP management server

### DIFF
--- a/agent1/client.py
+++ b/agent1/client.py
@@ -70,3 +70,8 @@ class BgeClient:
 	def build_asset(self, asset_def_id: str) -> None:
 		"""POST /api/assets/build — construct an asset."""
 		self._post(f"/api/assets/build?assetDefId={asset_def_id}")
+
+	def get_game_detail(self, game_id: str) -> dict:
+		"""GET /api/games/{gameId} → GameDetailViewModel (status, winnerId, …)."""
+		gid = urllib.parse.quote(game_id, safe="")
+		return self._get(f"/api/games/{gid}")

--- a/agent1/main.py
+++ b/agent1/main.py
@@ -8,11 +8,42 @@ from collections import deque
 
 from .client import BgeClient
 from .config import AgentConfig, load_config
+from .server import start_server
 from .state.tracker import GameStateTracker
+from .strategy.adaptive_difficulty import INSUFFICIENT_DATA, AdaptiveDifficultyAdvisor
 from .strategy.base import StrategyContext
+from .strategy.difficulty import PROFILES
 from .strategy.dispatcher import ActionDispatcher
 from .strategy.engine import DecisionEngine
 from .strategy.registry import load_strategy
+
+# Confidence threshold to trigger an automatic difficulty adjustment.
+_AUTO_ADJUST_CONFIDENCE = 0.5
+
+
+def _apply_difficulty_recommendation(
+	advisor: AdaptiveDifficultyAdvisor,
+	config: AgentConfig,
+	logger: logging.Logger,
+) -> None:
+	"""Ask the advisor for a recommendation and apply it when confident enough."""
+	rec = advisor.recommend(config.difficulty)
+	if rec == INSUFFICIENT_DATA:
+		logger.info("Adaptive difficulty: insufficient data, keeping %s", config.difficulty)
+		return
+	if rec.suggested_difficulty != config.difficulty and rec.confidence >= _AUTO_ADJUST_CONFIDENCE:
+		old = config.difficulty
+		config.difficulty = rec.suggested_difficulty
+		config.difficulty_profile = PROFILES[rec.suggested_difficulty]
+		logger.info(
+			"Adaptive difficulty: %s -> %s (confidence=%.2f) — %s",
+			old,
+			rec.suggested_difficulty,
+			rec.confidence,
+			rec.reason,
+		)
+	else:
+		logger.info("Adaptive difficulty: keeping %s — %s", config.difficulty, rec.reason)
 
 
 def run(config: AgentConfig) -> None:
@@ -22,6 +53,11 @@ def run(config: AgentConfig) -> None:
 	``nextTickAt`` value changes (indicating a new game tick has been
 	processed), state is fetched and ``DecisionEngine.run_tick`` is called
 	exactly once.  Errors are caught and logged; the loop never crashes.
+
+	Phase 4B additions:
+	- Starts the HTTP management server (port 8081 by default).
+	- Checks game status each tick; when the game transitions to ``"Finished"``,
+	  calls ``AdaptiveDifficultyAdvisor`` and optionally updates difficulty.
 	"""
 	logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
 	logger = logging.getLogger(__name__)
@@ -32,8 +68,12 @@ def run(config: AgentConfig) -> None:
 	strategy = load_strategy(config.strategy)
 	engine = DecisionEngine(strategy, dispatcher)
 	history: deque = deque(maxlen=20)
+	advisor = AdaptiveDifficultyAdvisor()
+
+	start_server(advisor, config)
 
 	last_next_tick_at: str = ""
+	last_game_status: str = ""
 
 	logger.info(
 		"Agent1 started — base_url=%s difficulty=%s strategy=%s poll=%ds",
@@ -73,6 +113,18 @@ def run(config: AgentConfig) -> None:
 					tracker.units,
 					len(tracker.attackable_players),
 				)
+
+				# Detect game end and trigger adaptive difficulty adjustment.
+				if config.game_id:
+					try:
+						game_detail = client.get_game_detail(config.game_id)
+						status: str = game_detail.get("status", "")
+						if status == "Finished" and last_game_status != "Finished":
+							logger.info("Game %s finished — evaluating difficulty adjustment", config.game_id)
+							_apply_difficulty_recommendation(advisor, config, logger)
+						last_game_status = status
+					except Exception:
+						logger.debug("Could not fetch game status for %s", config.game_id, exc_info=True)
 		except Exception:
 			logger.exception("Error in tick loop, continuing...")
 

--- a/agent1/server.py
+++ b/agent1/server.py
@@ -1,0 +1,128 @@
+"""Agent1 HTTP management server.
+
+Exposes control and observability endpoints for the running bot.
+Intended to be started in a daemon background thread from ``main.py``.
+
+Current endpoints (Phase 4B — Adaptive Difficulty):
+  GET  /difficulty/recommendation  — current advisor output
+  POST /difficulty/apply           — apply recommendation immediately
+
+Phase 4A (Strategy Analytics & Replay) will add:
+  GET  /replay?limit=N    — last N decision log records
+  GET  /outcomes?limit=N  — last N outcome records
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
+
+if TYPE_CHECKING:
+	from agent1.config import AgentConfig
+	from agent1.strategy.adaptive_difficulty import AdaptiveDifficultyAdvisor
+
+logger = logging.getLogger(__name__)
+
+
+class _Handler(BaseHTTPRequestHandler):
+	"""Request handler bound to a shared advisor and config at class level."""
+
+	advisor: AdaptiveDifficultyAdvisor
+	config: AgentConfig
+
+	def log_message(self, fmt: str, *args: object) -> None:
+		logger.debug(fmt, *args)
+
+	def _send_json(self, data: object, status: int = 200) -> None:
+		body = json.dumps(data).encode()
+		self.send_response(status)
+		self.send_header("Content-Type", "application/json")
+		self.send_header("Content-Length", str(len(body)))
+		self.end_headers()
+		self.wfile.write(body)
+
+	def do_GET(self) -> None:  # noqa: N802
+		parsed = urlparse(self.path)
+		if parsed.path == "/difficulty/recommendation":
+			self._handle_recommendation()
+		else:
+			self._send_json({"error": "not found"}, 404)
+
+	def do_POST(self) -> None:  # noqa: N802
+		parsed = urlparse(self.path)
+		if parsed.path == "/difficulty/apply":
+			self._handle_apply()
+		else:
+			self._send_json({"error": "not found"}, 404)
+
+	def _handle_recommendation(self) -> None:
+		from agent1.strategy.adaptive_difficulty import INSUFFICIENT_DATA
+
+		rec = self.advisor.recommend(self.config.difficulty)
+		if rec == INSUFFICIENT_DATA:
+			self._send_json({"status": INSUFFICIENT_DATA})
+		else:
+			self._send_json({
+				"suggested_difficulty": rec.suggested_difficulty,
+				"confidence": rec.confidence,
+				"reason": rec.reason,
+				"current_difficulty": self.config.difficulty,
+			})
+
+	def _handle_apply(self) -> None:
+		from agent1.strategy.adaptive_difficulty import INSUFFICIENT_DATA
+		from agent1.strategy.difficulty import PROFILES
+
+		rec = self.advisor.recommend(self.config.difficulty)
+		if rec == INSUFFICIENT_DATA:
+			self._send_json({"status": INSUFFICIENT_DATA, "applied": False})
+		else:
+			old = self.config.difficulty
+			self.config.difficulty = rec.suggested_difficulty
+			self.config.difficulty_profile = PROFILES[rec.suggested_difficulty]
+			logger.info(
+				"Difficulty applied via HTTP: %s -> %s (reason: %s)",
+				old,
+				rec.suggested_difficulty,
+				rec.reason,
+			)
+			self._send_json({
+				"applied": True,
+				"previous_difficulty": old,
+				"new_difficulty": rec.suggested_difficulty,
+				"reason": rec.reason,
+			})
+
+
+def start_server(
+	advisor: AdaptiveDifficultyAdvisor,
+	config: AgentConfig,
+	host: str = "0.0.0.0",
+	port: int = 8081,
+) -> HTTPServer:
+	"""Start the management HTTP server in a daemon thread.
+
+	Args:
+		advisor: The :class:`AdaptiveDifficultyAdvisor` instance to expose.
+		config: The live :class:`AgentConfig` instance (mutated on apply).
+		host: Bind address.  Defaults to ``"0.0.0.0"``.
+		port: Listen port.  Defaults to ``8081``.
+
+	Returns:
+		The running :class:`HTTPServer` instance (useful in tests).
+	"""
+
+	class _BoundHandler(_Handler):
+		pass
+
+	_BoundHandler.advisor = advisor
+	_BoundHandler.config = config
+
+	server = HTTPServer((host, port), _BoundHandler)
+	thread = threading.Thread(target=server.serve_forever, name="agent1-server", daemon=True)
+	thread.start()
+	logger.info("Management server listening on http://%s:%d", host, port)
+	return server

--- a/agent1/strategy/adaptive_difficulty.py
+++ b/agent1/strategy/adaptive_difficulty.py
@@ -1,0 +1,128 @@
+"""AdaptiveDifficultyAdvisor — recommends difficulty based on outcome history.
+
+Reads *outcomes_path* (a JSONL file written by OutcomeTracker from Phase 4A)
+and computes a rolling win-rate over the last *window* games.  Returns a
+:class:`DifficultyRecommendation` when enough data exists, or the sentinel
+string ``"insufficient_data"`` when fewer than *window* records are available.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+DIFFICULTY_ORDER = ["easy", "medium", "hard", "expert"]
+
+# Sentinel returned when the outcome history is too short for a recommendation.
+INSUFFICIENT_DATA = "insufficient_data"
+
+
+@dataclass
+class DifficultyRecommendation:
+	"""Structured recommendation produced by :class:`AdaptiveDifficultyAdvisor`."""
+
+	suggested_difficulty: str
+	confidence: float
+	reason: str
+
+
+class AdaptiveDifficultyAdvisor:
+	"""Recommends difficulty adjustments from recent game outcome history.
+
+	Args:
+		outcomes_path: Path to the JSONL outcomes file (written by OutcomeTracker).
+			Each line must be a JSON object with at least an ``"outcome"`` field
+			whose value is ``"win"`` or ``"loss"``.
+		window: Number of recent games to consider.  Default 10.
+		promote_threshold: Win-rate at or above which difficulty is increased.
+			Default 0.7 (won 7 of last 10).
+		demote_threshold: Win-rate at or below which difficulty is decreased.
+			Default 0.3 (won 3 of last 10).
+	"""
+
+	def __init__(
+		self,
+		outcomes_path: Union[str, Path] = "./logs/outcomes.jsonl",
+		window: int = 10,
+		promote_threshold: float = 0.7,
+		demote_threshold: float = 0.3,
+	) -> None:
+		self._outcomes_path = Path(outcomes_path)
+		self._window = window
+		self._promote_threshold = promote_threshold
+		self._demote_threshold = demote_threshold
+
+	def recommend(self, current_difficulty: str) -> Union[DifficultyRecommendation, str]:
+		"""Return a :class:`DifficultyRecommendation`, or ``INSUFFICIENT_DATA``.
+
+		No auto-adjust is triggered until the outcomes window is filled.
+
+		Args:
+			current_difficulty: The bot's current difficulty name (e.g. ``"medium"``).
+
+		Returns:
+			:class:`DifficultyRecommendation` when enough history exists, or the
+			string ``"insufficient_data"`` when fewer than *window* records are
+			available.
+		"""
+		outcomes = self._load_outcomes()
+		if len(outcomes) < self._window:
+			return INSUFFICIENT_DATA
+
+		recent = outcomes[-self._window:]
+		wins = sum(1 for o in recent if o.get("outcome") == "win")
+		win_rate = wins / len(recent)
+
+		if current_difficulty in DIFFICULTY_ORDER:
+			current_idx = DIFFICULTY_ORDER.index(current_difficulty)
+		else:
+			current_idx = 1  # fall back to medium index
+
+		if win_rate >= self._promote_threshold:
+			new_idx = min(current_idx + 1, len(DIFFICULTY_ORDER) - 1)
+			suggested = DIFFICULTY_ORDER[new_idx]
+			confidence = (win_rate - self._promote_threshold) / (1.0 - self._promote_threshold)
+			reason = (
+				f"Win-rate {win_rate:.0%} >= {self._promote_threshold:.0%} "
+				f"over last {self._window} games — increasing difficulty"
+			)
+		elif win_rate <= self._demote_threshold:
+			new_idx = max(current_idx - 1, 0)
+			suggested = DIFFICULTY_ORDER[new_idx]
+			confidence = (self._demote_threshold - win_rate) / self._demote_threshold
+			reason = (
+				f"Win-rate {win_rate:.0%} <= {self._demote_threshold:.0%} "
+				f"over last {self._window} games — decreasing difficulty"
+			)
+		else:
+			suggested = current_difficulty
+			confidence = 0.5
+			reason = (
+				f"Win-rate {win_rate:.0%} in acceptable range "
+				f"over last {self._window} games — no change"
+			)
+
+		return DifficultyRecommendation(
+			suggested_difficulty=suggested,
+			confidence=round(confidence, 3),
+			reason=reason,
+		)
+
+	def _load_outcomes(self) -> list[dict]:
+		"""Read all records from the outcomes JSONL file."""
+		if not self._outcomes_path.exists():
+			return []
+		records: list[dict] = []
+		try:
+			with self._outcomes_path.open("r", encoding="utf-8") as fh:
+				for line in fh:
+					line = line.strip()
+					if line:
+						records.append(json.loads(line))
+		except (OSError, json.JSONDecodeError) as exc:
+			logger.warning("Failed to read outcomes file %s: %s", self._outcomes_path, exc)
+		return records

--- a/agent1/tests/test_adaptive_difficulty.py
+++ b/agent1/tests/test_adaptive_difficulty.py
@@ -1,0 +1,165 @@
+"""Tests for AdaptiveDifficultyAdvisor (Phase 4B)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent1.strategy.adaptive_difficulty import (
+	INSUFFICIENT_DATA,
+	AdaptiveDifficultyAdvisor,
+	DifficultyRecommendation,
+)
+
+
+def _write_outcomes(path: Path, outcomes: list[str]) -> None:
+	"""Write a list of outcome strings (``"win"``/``"loss"``) to a JSONL file."""
+	with path.open("w", encoding="utf-8") as fh:
+		for outcome in outcomes:
+			fh.write(json.dumps({"outcome": outcome}) + "\n")
+
+
+class TestAdaptiveDifficultyAdvisorInsufficientData:
+	def test_returns_insufficient_data_when_file_missing(self, tmp_path: Path) -> None:
+		advisor = AdaptiveDifficultyAdvisor(
+			outcomes_path=tmp_path / "outcomes.jsonl",
+			window=10,
+		)
+		assert advisor.recommend("medium") == INSUFFICIENT_DATA
+
+	def test_returns_insufficient_data_when_fewer_than_window(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 5)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		assert advisor.recommend("medium") == INSUFFICIENT_DATA
+
+	def test_returns_insufficient_data_when_exactly_window_minus_one(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 9)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		assert advisor.recommend("medium") == INSUFFICIENT_DATA
+
+	def test_proceeds_when_exactly_window(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 10)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		result = advisor.recommend("easy")
+		assert result != INSUFFICIENT_DATA
+
+
+class TestAdaptiveDifficultyAdvisorRecommendations:
+	def test_promotes_on_high_win_rate(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		# 8 wins out of 10 = 80% >= promote_threshold (0.7)
+		_write_outcomes(outcomes_file, ["win"] * 8 + ["loss"] * 2)
+		advisor = AdaptiveDifficultyAdvisor(
+			outcomes_path=outcomes_file,
+			window=10,
+			promote_threshold=0.7,
+			demote_threshold=0.3,
+		)
+		rec = advisor.recommend("easy")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "medium"
+		assert rec.confidence > 0.0
+		assert "increasing" in rec.reason
+
+	def test_demotes_on_low_win_rate(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		# 2 wins out of 10 = 20% <= demote_threshold (0.3)
+		_write_outcomes(outcomes_file, ["win"] * 2 + ["loss"] * 8)
+		advisor = AdaptiveDifficultyAdvisor(
+			outcomes_path=outcomes_file,
+			window=10,
+			promote_threshold=0.7,
+			demote_threshold=0.3,
+		)
+		rec = advisor.recommend("hard")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "medium"
+		assert rec.confidence > 0.0
+		assert "decreasing" in rec.reason
+
+	def test_no_change_on_acceptable_win_rate(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		# 5 wins out of 10 = 50% — in range [0.3, 0.7]
+		_write_outcomes(outcomes_file, ["win"] * 5 + ["loss"] * 5)
+		advisor = AdaptiveDifficultyAdvisor(
+			outcomes_path=outcomes_file,
+			window=10,
+			promote_threshold=0.7,
+			demote_threshold=0.3,
+		)
+		rec = advisor.recommend("medium")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "medium"
+		assert "no change" in rec.reason
+
+	def test_does_not_promote_beyond_expert(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 10)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		rec = advisor.recommend("expert")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "expert"
+
+	def test_does_not_demote_below_easy(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["loss"] * 10)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		rec = advisor.recommend("easy")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "easy"
+
+	def test_uses_only_last_window_records(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		# 90 losses followed by 10 wins — only recent window (wins) matters
+		_write_outcomes(outcomes_file, ["loss"] * 90 + ["win"] * 10)
+		advisor = AdaptiveDifficultyAdvisor(
+			outcomes_path=outcomes_file,
+			window=10,
+			promote_threshold=0.7,
+		)
+		rec = advisor.recommend("easy")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.suggested_difficulty == "medium"
+
+	def test_confidence_is_rounded_to_three_places(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 8 + ["loss"] * 2)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		rec = advisor.recommend("easy")
+		assert isinstance(rec, DifficultyRecommendation)
+		assert rec.confidence == round(rec.confidence, 3)
+
+	def test_unknown_current_difficulty_falls_back_to_medium_index(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		_write_outcomes(outcomes_file, ["win"] * 10)
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=10)
+		rec = advisor.recommend("unknown_level")
+		assert isinstance(rec, DifficultyRecommendation)
+		# Falls back to index 1 (medium), promote → hard
+		assert rec.suggested_difficulty == "hard"
+
+
+class TestAdaptiveDifficultyAdvisorEdgeCases:
+	def test_empty_file_returns_insufficient_data(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		outcomes_file.write_text("")
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=1)
+		assert advisor.recommend("medium") == INSUFFICIENT_DATA
+
+	def test_corrupt_file_returns_insufficient_data(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		outcomes_file.write_text("not valid json\n")
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=1)
+		assert advisor.recommend("medium") == INSUFFICIENT_DATA
+
+	def test_mixed_valid_and_blank_lines(self, tmp_path: Path) -> None:
+		outcomes_file = tmp_path / "outcomes.jsonl"
+		with outcomes_file.open("w") as fh:
+			fh.write('\n{"outcome": "win"}\n\n{"outcome": "win"}\n')
+		advisor = AdaptiveDifficultyAdvisor(outcomes_path=outcomes_file, window=2)
+		rec = advisor.recommend("easy")
+		assert rec != INSUFFICIENT_DATA

--- a/agent1/tests/test_main_wiring.py
+++ b/agent1/tests/test_main_wiring.py
@@ -58,6 +58,7 @@ def _run_loop_for_n_polls(config: AgentConfig, tick_info_sequence: list[dict], m
 		patch("agent1.main.DecisionEngine", return_value=mock_engine),
 		patch("agent1.main.load_strategy"),
 		patch("agent1.main.ActionDispatcher"),
+		patch("agent1.main.start_server"),
 		patch("agent1.main.time.sleep", side_effect=fake_sleep),
 	):
 		with pytest.raises(StopIteration):


### PR DESCRIPTION
## Summary

- Add `AdaptiveDifficultyAdvisor` (`agent1/strategy/adaptive_difficulty.py`): reads `outcomes.jsonl` written by Phase 4A's OutcomeTracker, computes rolling win-rate over last N games (configurable window, default 10), returns `DifficultyRecommendation` or `"insufficient_data"` sentinel when history is too short
- Add `agent1/server.py`: lightweight stdlib HTTP management server (port 8081, daemon thread); `GET /difficulty/recommendation` and `POST /difficulty/apply` endpoints
- Wire advisor into `agent1/main.py`: starts server at boot, detects game end via `GET /api/games/{gameId}`, auto-adjusts difficulty when recommendation confidence >= 0.5
- Add `BgeClient.get_game_detail(game_id)` for game-end detection
- 15 new tests in `agent1/tests/test_adaptive_difficulty.py`; update `test_main_wiring.py` to patch `start_server`

**Note:** branches from `feat/BGE-792-wire-main-loop` (PR #254) and must be merged after that PR. `outcomes.jsonl` is written at runtime by OutcomeTracker from BGE-796 (Phase 4A).

## Test plan

- [x] `python -m pytest agent1/tests/` passes (66 tests)
- [x] `AdaptiveDifficultyAdvisor` returns `insufficient_data` below window threshold
- [x] Recommends promotion at >=70% win-rate, demotion at <=30%
- [x] Does not promote beyond `expert` or demote below `easy`
- [x] HTTP server endpoints testable via `curl http://localhost:8081/difficulty/recommendation`

Closes BGE-795