### PR TITLE
feat: BGE-797 Alliance-Aware Play for Agent1

### DIFF
--- a/agent1/client.py
+++ b/agent1/client.py
@@ -75,3 +75,37 @@ class BgeClient:
 		"""GET /api/games/{gameId} → GameDetailViewModel (status, winnerId, …)."""
 		gid = urllib.parse.quote(game_id, safe="")
 		return self._get(f"/api/games/{gid}")
+
+	# --- Alliance API ---
+
+	def get_my_alliance_status(self) -> dict:
+		"""GET /api/alliances/my-status → MyAllianceStatusViewModel."""
+		return self._get("/api/alliances/my-status")
+
+	def get_all_alliances(self) -> list:
+		"""GET /api/alliances → list[AllianceViewModel]."""
+		return self._get("/api/alliances")
+
+	def get_alliance_detail(self, alliance_id: str) -> dict:
+		"""GET /api/alliances/{id} → AllianceDetailViewModel (includes member list)."""
+		aid = urllib.parse.quote(alliance_id, safe="")
+		return self._get(f"/api/alliances/{aid}")
+
+	def get_alliance_wars(self, alliance_id: str) -> list:
+		"""GET /api/alliances/{id}/wars → list[AllianceWarViewModel]."""
+		aid = urllib.parse.quote(alliance_id, safe="")
+		return self._get(f"/api/alliances/{aid}/wars")
+
+	def create_alliance(self, name: str, password: str) -> str:
+		"""POST /api/alliances — create a new alliance; returns the new alliance ID."""
+		return self._post("/api/alliances", {"allianceName": name, "password": password})
+
+	def join_alliance(self, alliance_id: str, password: str) -> None:
+		"""POST /api/alliances/{id}/join — join an existing alliance."""
+		aid = urllib.parse.quote(alliance_id, safe="")
+		self._post(f"/api/alliances/{aid}/join", {"password": password})
+
+	def declare_war(self, my_alliance_id: str, target_alliance_id: str) -> None:
+		"""POST /api/alliances/{id}/declare-war — declare war on another alliance."""
+		aid = urllib.parse.quote(my_alliance_id, safe="")
+		self._post(f"/api/alliances/{aid}/declare-war", {"targetAllianceId": target_alliance_id})

--- a/agent1/config.py
+++ b/agent1/config.py
@@ -47,6 +47,11 @@ class AgentConfig:
     # Fine-grained per-bot overrides; arbitrary key/value dict
     strategy_overrides: dict = field(default_factory=dict)
 
+    # Alliance mode: "passive" (default) avoids attacking allies but takes no
+    # proactive alliance actions.  "active" enables creating/joining alliances
+    # and declaring war per configured thresholds.
+    alliance_mode: str = "passive"
+
     # Resolved profile — kept in sync with difficulty
     difficulty_profile: DifficultyProfile = field(init=False)
 
@@ -98,6 +103,7 @@ def load_config(config_path: str | Path | None = None) -> AgentConfig:
     )
 
     strategy_overrides = dict(agent_raw.get("strategy_overrides") or {})
+    alliance_mode = str(agent_raw.get("alliance_mode", "passive")).lower()
 
     return AgentConfig(
         poll_interval_seconds=int(agent_raw.get("poll_interval_seconds", 5)),
@@ -108,6 +114,7 @@ def load_config(config_path: str | Path | None = None) -> AgentConfig:
         strategy=strategy,
         difficulty=difficulty,
         strategy_overrides=strategy_overrides,
+        alliance_mode=alliance_mode,
     )
 
 

--- a/agent1/main.py
+++ b/agent1/main.py
@@ -9,13 +9,14 @@ from collections import deque
 from .client import BgeClient
 from .config import AgentConfig, load_config
 from .server import start_server
+from .state.alliance_tracker import AllianceTracker
 from .state.tracker import GameStateTracker
 from .strategy.adaptive_difficulty import INSUFFICIENT_DATA, AdaptiveDifficultyAdvisor
 from .strategy.base import StrategyContext
 from .strategy.difficulty import PROFILES
 from .strategy.dispatcher import ActionDispatcher
 from .strategy.engine import DecisionEngine
-from .strategy.registry import load_strategy
+from .strategy.registry import load_alliance_module, load_strategy
 
 # Confidence threshold to trigger an automatic difficulty adjustment.
 _AUTO_ADJUST_CONFIDENCE = 0.5
@@ -64,9 +65,11 @@ def run(config: AgentConfig) -> None:
 
 	client = BgeClient(config.base_url, config.api_key)
 	tracker = GameStateTracker()
+	alliance_tracker = AllianceTracker()
 	dispatcher = ActionDispatcher(client)
 	strategy = load_strategy(config.strategy)
-	engine = DecisionEngine(strategy, dispatcher)
+	alliance_module = load_alliance_module()
+	engine = DecisionEngine(strategy, dispatcher, alliance_module=alliance_module)
 	history: deque = deque(maxlen=20)
 	advisor = AdaptiveDifficultyAdvisor()
 
@@ -76,10 +79,11 @@ def run(config: AgentConfig) -> None:
 	last_game_status: str = ""
 
 	logger.info(
-		"Agent1 started — base_url=%s difficulty=%s strategy=%s poll=%ds",
+		"Agent1 started — base_url=%s difficulty=%s strategy=%s alliance_mode=%s poll=%ds",
 		config.base_url,
 		config.difficulty,
 		config.strategy,
+		config.alliance_mode,
 		config.poll_interval_seconds,
 	)
 
@@ -92,6 +96,9 @@ def run(config: AgentConfig) -> None:
 				last_next_tick_at = next_tick_at
 				current_tick = hash(next_tick_at)
 
+				# Refresh alliance state before strategy decisions.
+				alliance_tracker.update(client)
+
 				resources = client.get_resources()
 				units = client.get_units()
 				attackable = client.get_attackable_players()
@@ -103,15 +110,18 @@ def run(config: AgentConfig) -> None:
 					tick=current_tick,
 					config=config,
 					history=history,
+					alliance_tracker=alliance_tracker,
 				)
 				engine.run_tick(ctx)
 				history.append(tracker)
 
 				logger.debug(
-					"Tick processed — minerals=%d units=%d enemies=%d",
+					"Tick processed — minerals=%d units=%d enemies=%d ally_count=%d war_enemies=%d",
 					tracker.minerals,
 					tracker.units,
 					len(tracker.attackable_players),
+					len(alliance_tracker.allied_player_ids),
+					len(alliance_tracker.war_enemy_player_ids),
 				)
 
 				# Detect game end and trigger adaptive difficulty adjustment.

--- a/agent1/state/alliance_tracker.py
+++ b/agent1/state/alliance_tracker.py
@@ -1,0 +1,118 @@
+"""AllianceTracker — refreshed once per tick from the BGE alliance API.
+
+Maintains a lightweight view of the bot's alliance membership, allied player
+IDs, and war-enemy player IDs so strategy modules can make alliance-aware
+decisions without duplicating API logic.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from agent1.client import BgeClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AllianceTracker:
+	"""Mutable alliance state updated once per game tick.
+
+	Attributes:
+		my_alliance_id: ID of the alliance the bot belongs to, or ``None``
+			if the bot is not currently a member of any alliance.
+		allied_player_ids: Set of player IDs who are active (non-pending)
+			members of the bot's alliance.  Empty when not in an alliance.
+		war_enemy_player_ids: Set of player IDs who belong to alliances that
+			are actively at war with the bot's alliance.  Empty when not at war.
+		known_alliances: Mapping from alliance ID to its ``AllianceViewModel``
+			dict as returned by ``GET /api/alliances``.
+	"""
+
+	my_alliance_id: str | None = None
+	allied_player_ids: set = field(default_factory=set)
+	war_enemy_player_ids: set = field(default_factory=set)
+	known_alliances: dict = field(default_factory=dict)
+
+	def update(self, client: BgeClient) -> None:
+		"""Refresh alliance state from the API.
+
+		All HTTP errors are caught and logged so a transient failure never
+		crashes the game loop.
+		"""
+		try:
+			status = client.get_my_alliance_status()
+		except Exception:
+			logger.exception("AllianceTracker: failed to fetch my-status")
+			return
+
+		if not status.get("isMember"):
+			self.my_alliance_id = None
+			self.allied_player_ids = set()
+			self.war_enemy_player_ids = set()
+			return
+
+		self.my_alliance_id = status.get("allianceId")
+
+		# Populate known_alliances index from the public alliance list.
+		try:
+			all_alliances = client.get_all_alliances()
+			self.known_alliances = {a["allianceId"]: a for a in all_alliances}
+		except Exception:
+			logger.exception("AllianceTracker: failed to fetch alliance list")
+
+		if not self.my_alliance_id:
+			return
+
+		# Resolve allied player IDs from the detailed member list.
+		try:
+			detail = client.get_alliance_detail(self.my_alliance_id)
+			self.allied_player_ids = {
+				m["playerId"]
+				for m in detail.get("members", [])
+				if not m.get("isPending")
+			}
+		except Exception:
+			logger.exception(
+				"AllianceTracker: failed to fetch detail for alliance %s",
+				self.my_alliance_id,
+			)
+
+		# Resolve war-enemy player IDs.
+		try:
+			wars = client.get_alliance_wars(self.my_alliance_id)
+			enemy_alliance_ids: set[str] = set()
+			for war in wars:
+				if war.get("status") == "Active":
+					if war["attackerAllianceId"] == self.my_alliance_id:
+						enemy_alliance_ids.add(war["defenderAllianceId"])
+					else:
+						enemy_alliance_ids.add(war["attackerAllianceId"])
+
+			war_enemy_ids: set[str] = set()
+			for enemy_aid in enemy_alliance_ids:
+				try:
+					enemy_detail = client.get_alliance_detail(enemy_aid)
+					war_enemy_ids.update(
+						m["playerId"]
+						for m in enemy_detail.get("members", [])
+						if not m.get("isPending")
+					)
+				except Exception:
+					logger.exception(
+						"AllianceTracker: failed to fetch detail for enemy alliance %s",
+						enemy_aid,
+					)
+			self.war_enemy_player_ids = war_enemy_ids
+		except Exception:
+			logger.exception("AllianceTracker: failed to fetch wars for alliance %s", self.my_alliance_id)
+
+	def is_ally(self, player_id: str) -> bool:
+		"""Return ``True`` if *player_id* is an active member of the bot's alliance."""
+		return player_id in self.allied_player_ids
+
+	def is_war_target(self, player_id: str) -> bool:
+		"""Return ``True`` if *player_id* belongs to an alliance at war with us."""
+		return player_id in self.war_enemy_player_ids

--- a/agent1/strategy/alliance_module.py
+++ b/agent1/strategy/alliance_module.py
@@ -1,0 +1,119 @@
+"""AllianceStrategyModule — alliance-aware target scoring and alliance actions.
+
+In *passive* mode (default) the module only prevents attacking allied players.
+In *active* mode (``config.alliance_mode = "active"``) it will also create or
+join alliances and declare war on isolated opponents, using thresholds from
+``config.strategy_overrides``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from agent1.strategy.base import StrategyContext
+	from agent1.strategy.dispatcher import ActionDispatcher
+
+logger = logging.getLogger(__name__)
+
+# Score multipliers
+_ALLY_SCORE: float = 0.0
+_WAR_ENEMY_BOOST: float = 2.0
+_DEFAULT_SCORE: float = 1.0
+
+
+@dataclass
+class AllianceAction:
+	"""A single pending alliance action to be dispatched this tick."""
+
+	kind: str  # "create", "join", "declare_war"
+	kwargs: dict = field(default_factory=dict)
+
+
+class AllianceStrategyModule:
+	"""Scores attack targets and decides alliance-management actions each tick.
+
+	This module is not a standalone strategy; it is wired into
+	``DecisionEngine`` so any active strategy benefits from alliance awareness
+	without duplicating logic.
+	"""
+
+	def score_attack_targets(self, ctx: StrategyContext) -> dict[str, float]:
+		"""Return a mapping of ``player_id → attack score`` for all attackable enemies.
+
+		Rules:
+		- Allied players → score ``0.0`` (never attack).
+		- War-enemy players → score ``2.0`` (prioritised attack).
+		- All others → score ``1.0`` (neutral).
+
+		Returns an empty dict when there is no alliance tracker or no
+		attackable players.
+		"""
+		tracker = ctx.alliance_tracker
+		scores: dict[str, float] = {}
+		for enemy in ctx.state.attackable_players:
+			pid = enemy.get("playerId", "")
+			if not pid:
+				continue
+			if tracker is not None and tracker.is_ally(pid):
+				scores[pid] = _ALLY_SCORE
+			elif tracker is not None and tracker.is_war_target(pid):
+				scores[pid] = _WAR_ENEMY_BOOST
+			else:
+				scores[pid] = _DEFAULT_SCORE
+		return scores
+
+	def decide_alliance_action(self, ctx: StrategyContext) -> list[AllianceAction]:
+		"""Return a list of alliance actions to execute this tick.
+
+		Always returns an empty list in passive mode.  In active mode, the
+		module may propose creating an alliance (when not yet a member) or
+		declaring war (when a lone powerful opponent is detected).
+		"""
+		if ctx.config.alliance_mode != "active":
+			return []
+
+		tracker = ctx.alliance_tracker
+		if tracker is None:
+			return []
+
+		actions: list[AllianceAction] = []
+
+		# Create an alliance when not already a member.
+		if tracker.my_alliance_id is None:
+			overrides = ctx.config.strategy_overrides
+			actions.append(AllianceAction(
+				kind="create",
+				kwargs={
+					"name": overrides.get("alliance_name", "BotAlliance"),
+					"password": overrides.get("alliance_password", ""),
+				},
+			))
+			return actions
+
+		# Declare war on the strongest enemy if above a unit threshold and not already at war.
+		if not tracker.war_enemy_player_ids:
+			overrides = ctx.config.strategy_overrides
+			war_unit_threshold = int(overrides.get("war_unit_threshold", 50))
+			if ctx.state.units >= war_unit_threshold:
+				# Find the most powerful enemy alliance (largest member count) to target.
+				best_target: str | None = None
+				best_members = 0
+				for aid, alliance in tracker.known_alliances.items():
+					if aid == tracker.my_alliance_id:
+						continue
+					mc = alliance.get("memberCount", 0)
+					if mc > best_members:
+						best_members = mc
+						best_target = aid
+				if best_target:
+					actions.append(AllianceAction(
+						kind="declare_war",
+						kwargs={
+							"my_alliance_id": tracker.my_alliance_id,
+							"target_alliance_id": best_target,
+						},
+					))
+
+		return actions

--- a/agent1/strategy/balanced.py
+++ b/agent1/strategy/balanced.py
@@ -38,15 +38,25 @@ class BalancedStrategy:
 			overrides=cfg.strategy_overrides,
 		)
 
-		# Attack decision: check each attackable enemy
-		for enemy in state.attackable_players:
+		# Attack decision: iterate enemies ordered by alliance score (highest first),
+		# skipping allied players (score 0.0).
+		scores = ctx.attack_target_scores
+		scored_enemies = sorted(
+			state.attackable_players,
+			key=lambda e: scores.get(e.get("playerId", ""), 1.0),
+			reverse=True,
+		)
+		for enemy in scored_enemies:
+			pid = enemy.get("playerId", "")
+			if scores.get(pid, 1.0) == 0.0:
+				# Allied player — never attack.
+				continue
 			enemy_units = int(enemy.get("approxHomeUnitCount") or 0)
 			if should_attack(legacy, enemy_units=enemy_units):
-				# Send the first available home unit group
 				home_units = [u for u in state.unit_list if not u.get("positionPlayerId") and u.get("count", 0) > 0]
 				if home_units:
 					unit = home_units[0]
-					dispatcher.attack(unit["unitId"], enemy["playerId"])
+					dispatcher.attack(unit["unitId"], pid)
 				break  # one attack per tick
 
 		# Worker / economy decision

--- a/agent1/strategy/base.py
+++ b/agent1/strategy/base.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
 	from agent1.config import AgentConfig
+	from agent1.state.alliance_tracker import AllianceTracker
 	from agent1.state.tracker import GameStateTracker
 
 
@@ -24,3 +25,7 @@ class StrategyContext:
 	tick: int
 	config: AgentConfig
 	history: deque = field(default_factory=deque)
+	alliance_tracker: AllianceTracker | None = None
+	# Populated by DecisionEngine from AllianceStrategyModule.score_attack_targets().
+	# Maps player_id → float score; 0.0 means do not attack, >1.0 means prioritise.
+	attack_target_scores: dict = field(default_factory=dict)

--- a/agent1/strategy/dispatcher.py
+++ b/agent1/strategy/dispatcher.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
 	from agent1.client import BgeClient
+	from agent1.strategy.alliance_module import AllianceAction
 
 logger = logging.getLogger(__name__)
 
@@ -30,3 +31,23 @@ class ActionDispatcher:
 		"""Construct asset *asset_def_id*."""
 		logger.info("Dispatching build_asset: %s", asset_def_id)
 		self._client.build_asset(asset_def_id)
+
+	def dispatch_alliance_action(self, action: AllianceAction) -> None:
+		"""Execute an ``AllianceAction`` returned by ``AllianceStrategyModule``."""
+		kind = action.kind
+		kw = action.kwargs
+		if kind == "create":
+			logger.info("Dispatching create_alliance: name=%s", kw.get("name"))
+			self._client.create_alliance(kw["name"], kw.get("password", ""))
+		elif kind == "join":
+			logger.info("Dispatching join_alliance: id=%s", kw.get("alliance_id"))
+			self._client.join_alliance(kw["alliance_id"], kw.get("password", ""))
+		elif kind == "declare_war":
+			logger.info(
+				"Dispatching declare_war: my_alliance=%s → target=%s",
+				kw.get("my_alliance_id"),
+				kw.get("target_alliance_id"),
+			)
+			self._client.declare_war(kw["my_alliance_id"], kw["target_alliance_id"])
+		else:
+			logger.warning("Unknown alliance action kind: %s", kind)

--- a/agent1/strategy/engine.py
+++ b/agent1/strategy/engine.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+	from agent1.strategy.alliance_module import AllianceStrategyModule
 	from agent1.strategy.base import StrategyContext
 	from agent1.strategy.dispatcher import ActionDispatcher
 
@@ -17,19 +18,38 @@ class DecisionEngine:
 	Args:
 		strategy: Any object implementing ``run_tick(ctx, dispatcher)``.
 		dispatcher: ``ActionDispatcher`` instance used for all API calls.
+		alliance_module: Optional ``AllianceStrategyModule``.  When supplied,
+			target scores are computed before the strategy runs (populating
+			``ctx.attack_target_scores``) and any active-mode alliance actions
+			are dispatched.
 	"""
 
-	def __init__(self, strategy: object, dispatcher: ActionDispatcher) -> None:
+	def __init__(
+		self,
+		strategy: object,
+		dispatcher: ActionDispatcher,
+		alliance_module: AllianceStrategyModule | None = None,
+	) -> None:
 		self._strategy = strategy
 		self._dispatcher = dispatcher
+		self._alliance_module = alliance_module
 
 	def run_tick(self, ctx: StrategyContext) -> None:
 		"""Evaluate the strategy and dispatch resulting actions.
 
-		Errors from the strategy or dispatcher are logged and swallowed so
-		the main loop continues running even on transient API failures.
+		If an ``alliance_module`` is configured, this method:
+		1. Scores all attack targets (populates ``ctx.attack_target_scores``).
+		2. Dispatches alliance-management actions (create/join/declare war).
+		3. Calls the main strategy's ``run_tick``.
+
+		Errors from any step are logged and swallowed so the main loop
+		continues running even on transient API failures.
 		"""
 		try:
+			if self._alliance_module is not None:
+				ctx.attack_target_scores = self._alliance_module.score_attack_targets(ctx)
+				for action in self._alliance_module.decide_alliance_action(ctx):
+					self._dispatcher.dispatch_alliance_action(action)
 			self._strategy.run_tick(ctx, self._dispatcher)
 		except Exception:
 			logger.exception("Strategy tick failed — skipping dispatch for this tick")

--- a/agent1/strategy/registry.py
+++ b/agent1/strategy/registry.py
@@ -1,6 +1,7 @@
 """Strategy registry — maps strategy names to strategy instances."""
 from __future__ import annotations
 
+from .alliance_module import AllianceStrategyModule
 from .balanced import BalancedStrategy
 
 _REGISTRY: dict[str, type] = {
@@ -19,3 +20,8 @@ def load_strategy(name: str) -> object:
 			f"Unknown strategy {name!r}. Available strategies: {sorted(_REGISTRY)}"
 		)
 	return _REGISTRY[name]()
+
+
+def load_alliance_module() -> AllianceStrategyModule:
+	"""Return a fresh ``AllianceStrategyModule`` instance."""
+	return AllianceStrategyModule()

--- a/agent1/tests/test_alliance_module.py
+++ b/agent1/tests/test_alliance_module.py
@@ -1,0 +1,252 @@
+"""Tests for AllianceStrategyModule."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+from agent1.state.alliance_tracker import AllianceTracker
+from agent1.strategy.alliance_module import AllianceAction, AllianceStrategyModule
+
+
+def _make_tracker(
+	*,
+	my_alliance_id: str | None = "a1",
+	allied_player_ids: set | None = None,
+	war_enemy_player_ids: set | None = None,
+	known_alliances: dict | None = None,
+) -> AllianceTracker:
+	return AllianceTracker(
+		my_alliance_id=my_alliance_id,
+		allied_player_ids=allied_player_ids or set(),
+		war_enemy_player_ids=war_enemy_player_ids or set(),
+		known_alliances=known_alliances or {},
+	)
+
+
+def _make_state(
+	*,
+	attackable_players: list[dict] | None = None,
+	units: int = 10,
+) -> MagicMock:
+	state = MagicMock()
+	state.attackable_players = attackable_players or []
+	state.units = units
+	return state
+
+
+def _make_config(*, alliance_mode: str = "passive", overrides: dict | None = None) -> MagicMock:
+	cfg = MagicMock()
+	cfg.alliance_mode = alliance_mode
+	cfg.strategy_overrides = overrides or {}
+	return cfg
+
+
+def _make_ctx(
+	*,
+	tracker: AllianceTracker | None = None,
+	attackable_players: list[dict] | None = None,
+	units: int = 10,
+	alliance_mode: str = "passive",
+	overrides: dict | None = None,
+) -> MagicMock:
+	ctx = MagicMock()
+	ctx.alliance_tracker = tracker
+	ctx.state = _make_state(attackable_players=attackable_players, units=units)
+	ctx.config = _make_config(alliance_mode=alliance_mode, overrides=overrides)
+	ctx.attack_target_scores = {}
+	return ctx
+
+
+class TestScoreAttackTargets:
+	def test_no_tracker_all_enemies_get_default_score(self) -> None:
+		# Without an alliance tracker every player is treated as neutral.
+		module = AllianceStrategyModule()
+		ctx = _make_ctx(tracker=None, attackable_players=[{"playerId": "p1"}])
+		scores = module.score_attack_targets(ctx)
+		assert scores == {"p1": 1.0}
+
+	def test_neutral_enemy_gets_default_score(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(allied_player_ids=set(), war_enemy_player_ids=set())
+		ctx = _make_ctx(tracker=tracker, attackable_players=[{"playerId": "neutral"}])
+		scores = module.score_attack_targets(ctx)
+		assert scores["neutral"] == 1.0
+
+	def test_allied_player_gets_zero_score(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(allied_player_ids={"ally1"})
+		ctx = _make_ctx(tracker=tracker, attackable_players=[{"playerId": "ally1"}])
+		scores = module.score_attack_targets(ctx)
+		assert scores["ally1"] == 0.0
+
+	def test_war_enemy_gets_boosted_score(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(war_enemy_player_ids={"enemy1"})
+		ctx = _make_ctx(tracker=tracker, attackable_players=[{"playerId": "enemy1"}])
+		scores = module.score_attack_targets(ctx)
+		assert scores["enemy1"] == 2.0
+
+	def test_war_enemy_scores_higher_than_neutral(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(war_enemy_player_ids={"enemy1"})
+		ctx = _make_ctx(
+			tracker=tracker,
+			attackable_players=[
+				{"playerId": "neutral"},
+				{"playerId": "enemy1"},
+			],
+		)
+		scores = module.score_attack_targets(ctx)
+		assert scores["enemy1"] > scores["neutral"]
+
+	def test_allied_score_lower_than_neutral(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(allied_player_ids={"ally1"})
+		ctx = _make_ctx(
+			tracker=tracker,
+			attackable_players=[
+				{"playerId": "neutral"},
+				{"playerId": "ally1"},
+			],
+		)
+		scores = module.score_attack_targets(ctx)
+		assert scores["ally1"] < scores["neutral"]
+
+	def test_missing_player_id_skipped(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker()
+		ctx = _make_ctx(tracker=tracker, attackable_players=[{}])
+		scores = module.score_attack_targets(ctx)
+		assert scores == {}
+
+	def test_mixed_targets(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(
+			allied_player_ids={"ally1"},
+			war_enemy_player_ids={"war_enemy"},
+		)
+		ctx = _make_ctx(
+			tracker=tracker,
+			attackable_players=[
+				{"playerId": "ally1"},
+				{"playerId": "neutral"},
+				{"playerId": "war_enemy"},
+			],
+		)
+		scores = module.score_attack_targets(ctx)
+		assert scores["ally1"] == 0.0
+		assert scores["neutral"] == 1.0
+		assert scores["war_enemy"] == 2.0
+
+
+class TestDecideAllianceActionPassiveMode:
+	def test_passive_mode_returns_empty(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(my_alliance_id=None)
+		ctx = _make_ctx(tracker=tracker, alliance_mode="passive")
+		actions = module.decide_alliance_action(ctx)
+		assert actions == []
+
+	def test_passive_mode_no_alliance_still_empty(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(my_alliance_id=None)
+		ctx = _make_ctx(tracker=tracker, alliance_mode="passive")
+		actions = module.decide_alliance_action(ctx)
+		assert actions == []
+
+	def test_none_tracker_returns_empty_in_any_mode(self) -> None:
+		module = AllianceStrategyModule()
+		ctx = _make_ctx(tracker=None, alliance_mode="active")
+		actions = module.decide_alliance_action(ctx)
+		assert actions == []
+
+
+class TestDecideAllianceActionActiveMode:
+	def test_creates_alliance_when_not_member(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(my_alliance_id=None)
+		ctx = _make_ctx(
+			tracker=tracker,
+			alliance_mode="active",
+			overrides={"alliance_name": "MyBot", "alliance_password": "secret"},
+		)
+		actions = module.decide_alliance_action(ctx)
+		assert len(actions) == 1
+		assert actions[0].kind == "create"
+		assert actions[0].kwargs["name"] == "MyBot"
+		assert actions[0].kwargs["password"] == "secret"
+
+	def test_create_uses_default_name_when_not_configured(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(my_alliance_id=None)
+		ctx = _make_ctx(tracker=tracker, alliance_mode="active")
+		actions = module.decide_alliance_action(ctx)
+		assert actions[0].kind == "create"
+		assert actions[0].kwargs["name"] == "BotAlliance"
+
+	def test_no_action_when_already_member_and_no_war(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(
+			my_alliance_id="a1",
+			war_enemy_player_ids=set(),
+			known_alliances={},
+		)
+		ctx = _make_ctx(tracker=tracker, alliance_mode="active", units=10)
+		actions = module.decide_alliance_action(ctx)
+		assert actions == []
+
+	def test_declares_war_when_above_threshold(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(
+			my_alliance_id="a1",
+			war_enemy_player_ids=set(),
+			known_alliances={
+				"a1": {"allianceId": "a1", "memberCount": 2},
+				"enemy-a": {"allianceId": "enemy-a", "memberCount": 5},
+			},
+		)
+		ctx = _make_ctx(
+			tracker=tracker,
+			alliance_mode="active",
+			units=100,
+			overrides={"war_unit_threshold": 50},
+		)
+		actions = module.decide_alliance_action(ctx)
+		assert len(actions) == 1
+		assert actions[0].kind == "declare_war"
+		assert actions[0].kwargs["my_alliance_id"] == "a1"
+		assert actions[0].kwargs["target_alliance_id"] == "enemy-a"
+
+	def test_no_war_when_below_threshold(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(
+			my_alliance_id="a1",
+			war_enemy_player_ids=set(),
+			known_alliances={"enemy-a": {"allianceId": "enemy-a", "memberCount": 5}},
+		)
+		ctx = _make_ctx(
+			tracker=tracker,
+			alliance_mode="active",
+			units=10,
+			overrides={"war_unit_threshold": 50},
+		)
+		actions = module.decide_alliance_action(ctx)
+		assert actions == []
+
+	def test_no_war_when_already_at_war(self) -> None:
+		module = AllianceStrategyModule()
+		tracker = _make_tracker(
+			my_alliance_id="a1",
+			war_enemy_player_ids={"e1"},  # already at war
+			known_alliances={"enemy-a": {"allianceId": "enemy-a", "memberCount": 5}},
+		)
+		ctx = _make_ctx(
+			tracker=tracker,
+			alliance_mode="active",
+			units=100,
+			overrides={"war_unit_threshold": 50},
+		)
+		actions = module.decide_alliance_action(ctx)
+		# war_enemy_player_ids is non-empty → skip war declaration
+		assert not any(a.kind == "declare_war" for a in actions)

--- a/agent1/tests/test_alliance_tracker.py
+++ b/agent1/tests/test_alliance_tracker.py
@@ -1,0 +1,200 @@
+"""Tests for AllianceTracker."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agent1.state.alliance_tracker import AllianceTracker
+
+
+def _make_client(
+	*,
+	is_member: bool = True,
+	alliance_id: str = "a1",
+	member_player_ids: list[str] | None = None,
+	all_alliances: list[dict] | None = None,
+	wars: list[dict] | None = None,
+	enemy_member_ids: list[str] | None = None,
+) -> MagicMock:
+	"""Return a mock BgeClient configured for the given scenario."""
+	client = MagicMock()
+
+	client.get_my_alliance_status.return_value = {
+		"isMember": is_member,
+		"allianceId": alliance_id if is_member else None,
+		"allianceName": "Test Alliance",
+	}
+
+	client.get_all_alliances.return_value = all_alliances or [
+		{"allianceId": "a1", "name": "Test Alliance", "memberCount": 2},
+	]
+
+	members = [{"playerId": pid, "isPending": False} for pid in (member_player_ids or ["p1", "p2"])]
+	enemy_members = [{"playerId": pid, "isPending": False} for pid in (enemy_member_ids or ["e1", "e2"])]
+
+	def get_alliance_detail(aid: str) -> dict:
+		if aid == alliance_id:
+			return {"allianceId": aid, "members": members}
+		return {"allianceId": aid, "members": enemy_members}
+
+	client.get_alliance_detail.side_effect = get_alliance_detail
+	client.get_alliance_wars.return_value = wars or []
+	return client
+
+
+class TestAllianceTrackerNotMember:
+	def test_not_member_clears_state(self) -> None:
+		tracker = AllianceTracker(
+			my_alliance_id="old",
+			allied_player_ids={"p1"},
+			war_enemy_player_ids={"e1"},
+		)
+		client = _make_client(is_member=False)
+		tracker.update(client)
+
+		assert tracker.my_alliance_id is None
+		assert tracker.allied_player_ids == set()
+		assert tracker.war_enemy_player_ids == set()
+
+	def test_not_member_does_not_call_alliance_apis(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client(is_member=False)
+		tracker.update(client)
+
+		client.get_alliance_detail.assert_not_called()
+		client.get_alliance_wars.assert_not_called()
+
+
+class TestAllianceTrackerMember:
+	def test_my_alliance_id_set(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client(alliance_id="alliance-42", member_player_ids=["p1"])
+		tracker.update(client)
+
+		assert tracker.my_alliance_id == "alliance-42"
+
+	def test_allied_player_ids_populated(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client(member_player_ids=["p1", "p2", "p3"])
+		tracker.update(client)
+
+		assert tracker.allied_player_ids == {"p1", "p2", "p3"}
+
+	def test_pending_members_excluded(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client()
+		client.get_alliance_detail.side_effect = None
+		client.get_alliance_detail.return_value = {
+			"allianceId": "a1",
+			"members": [
+				{"playerId": "p1", "isPending": False},
+				{"playerId": "p2", "isPending": True},
+			],
+		}
+		tracker.update(client)
+
+		assert "p1" in tracker.allied_player_ids
+		assert "p2" not in tracker.allied_player_ids
+
+	def test_is_ally_returns_true_for_member(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client(member_player_ids=["p1", "p2"])
+		tracker.update(client)
+
+		assert tracker.is_ally("p1") is True
+		assert tracker.is_ally("stranger") is False
+
+	def test_no_wars_means_empty_war_enemies(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client(wars=[])
+		tracker.update(client)
+
+		assert tracker.war_enemy_player_ids == set()
+
+
+class TestAllianceTrackerWars:
+	def _active_war(
+		self, *, attacker: str = "a1", defender: str = "enemy-alliance"
+	) -> dict:
+		return {
+			"warId": "w1",
+			"attackerAllianceId": attacker,
+			"defenderAllianceId": defender,
+			"status": "Active",
+		}
+
+	def test_war_enemy_player_ids_populated_when_attacker(self) -> None:
+		tracker = AllianceTracker()
+		war = self._active_war(attacker="a1", defender="enemy-alliance")
+		client = _make_client(
+			alliance_id="a1",
+			wars=[war],
+			enemy_member_ids=["e1", "e2"],
+		)
+		tracker.update(client)
+
+		assert tracker.war_enemy_player_ids == {"e1", "e2"}
+
+	def test_war_enemy_player_ids_populated_when_defender(self) -> None:
+		tracker = AllianceTracker()
+		war = self._active_war(attacker="enemy-alliance", defender="a1")
+		client = _make_client(
+			alliance_id="a1",
+			wars=[war],
+			enemy_member_ids=["e3"],
+		)
+		tracker.update(client)
+
+		assert tracker.war_enemy_player_ids == {"e3"}
+
+	def test_inactive_war_not_counted(self) -> None:
+		tracker = AllianceTracker()
+		war = {
+			"warId": "w1",
+			"attackerAllianceId": "a1",
+			"defenderAllianceId": "enemy",
+			"status": "PeaceProposed",
+		}
+		client = _make_client(wars=[war])
+		tracker.update(client)
+
+		assert tracker.war_enemy_player_ids == set()
+
+	def test_is_war_target(self) -> None:
+		tracker = AllianceTracker()
+		war = self._active_war(attacker="a1", defender="enemy-alliance")
+		client = _make_client(wars=[war], enemy_member_ids=["e1"])
+		tracker.update(client)
+
+		assert tracker.is_war_target("e1") is True
+		assert tracker.is_war_target("neutral") is False
+
+	def test_known_alliances_populated(self) -> None:
+		tracker = AllianceTracker()
+		all_alliances = [
+			{"allianceId": "a1", "name": "Test", "memberCount": 2},
+			{"allianceId": "a2", "name": "Other", "memberCount": 3},
+		]
+		client = _make_client(all_alliances=all_alliances)
+		tracker.update(client)
+
+		assert "a1" in tracker.known_alliances
+		assert "a2" in tracker.known_alliances
+
+
+class TestAllianceTrackerErrorTolerance:
+	def test_api_failure_does_not_raise(self) -> None:
+		tracker = AllianceTracker()
+		client = MagicMock()
+		client.get_my_alliance_status.side_effect = Exception("network error")
+
+		# Should not raise.
+		tracker.update(client)
+
+	def test_detail_failure_does_not_crash_update(self) -> None:
+		tracker = AllianceTracker()
+		client = _make_client()
+		client.get_alliance_detail.side_effect = Exception("timeout")
+
+		tracker.update(client)
+		# Still has the alliance ID from my-status.
+		assert tracker.my_alliance_id == "a1"


### PR DESCRIPTION
## Summary

- **AllianceTracker** (`agent1/state/alliance_tracker.py`): refreshed once per tick via the BGE alliance API; tracks `my_alliance_id`, `allied_player_ids`, `war_enemy_player_ids`, and `known_alliances`
- **BgeClient** alliance methods: `get_my_alliance_status`, `get_all_alliances`, `get_alliance_detail`, `get_alliance_wars`, `create_alliance`, `join_alliance`, `declare_war`
- **AllianceStrategyModule** (`agent1/strategy/alliance_module.py`): scores attack targets (0.0 = ally, 1.0 = neutral, 2.0 = war enemy) and decides alliance management actions in `active` mode
- **DecisionEngine** wired with optional `alliance_module`: populates `ctx.attack_target_scores` before calling the strategy, dispatches alliance actions via `ActionDispatcher`
- **BalancedStrategy** updated: skips allied players (score 0.0), prioritises war enemies (score 2.0)
- **Config**: new `alliance_mode` field (`passive` default / `active`) loaded from `agent.alliance_mode` in YAML
- **main.py**: `AllianceTracker.update(client)` called at the start of each tick; tracker passed into `StrategyContext`

## Test plan

- [x] `python -m pytest agent1/tests/` passes (82 tests, 31 new)
- [x] Alliance tracker: not-member clears state, member populates allies/war-enemies, inactive wars not counted, API failures are tolerated
- [x] Alliance module: scoring rules verified, passive mode returns no actions, active mode creates alliance when unaffiliated, declares war above unit threshold, skips war when already at war

Closes BGE-797