### PR TITLE
feat: BGE-821 Phase 5A Achievement Engine (backend + frontend)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AchievementsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AchievementsController.cs
@@ -1,0 +1,67 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.Achievements;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Route("api")]
+	public class AchievementsController : ControllerBase {
+		private readonly GlobalState globalState;
+		private readonly PlayerRepository playerRepository;
+		private readonly MilestoneRepository milestoneRepository;
+		private readonly MilestoneRepositoryWrite milestoneRepositoryWrite;
+
+		public AchievementsController(
+			GlobalState globalState,
+			PlayerRepository playerRepository,
+			MilestoneRepository milestoneRepository,
+			MilestoneRepositoryWrite milestoneRepositoryWrite
+		) {
+			this.globalState = globalState;
+			this.playerRepository = playerRepository;
+			this.milestoneRepository = milestoneRepository;
+			this.milestoneRepositoryWrite = milestoneRepositoryWrite;
+		}
+
+		/// <summary>Returns game-completion trophies for the specified player.</summary>
+		/// <param name="playerId">The player identifier.</param>
+		[AllowAnonymous]
+		[HttpGet("players/{playerId}/achievements")]
+		[ProducesResponseType(typeof(PlayerAchievementsViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<PlayerAchievementsViewModel> GetPlayerAchievements(string playerId) {
+			PlayerImmutable player;
+			try {
+				player = playerRepository.Get(PlayerIdFactory.Create(playerId));
+			} catch {
+				return NotFound();
+			}
+			if (player.UserId == null) return Ok(new PlayerAchievementsViewModel([]));
+
+			var achievements = AchievementMapper.GetForUser(globalState, player.UserId);
+			return Ok(new PlayerAchievementsViewModel(achievements));
+		}
+
+		/// <summary>Manually awards a milestone to a user. Admin use only.</summary>
+		[Authorize(Policy = "Admin")]
+		[HttpPost("achievements/award")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		public ActionResult AwardAchievement([FromBody] AwardAchievementRequest request) {
+			if (string.IsNullOrWhiteSpace(request.UserId) || string.IsNullOrWhiteSpace(request.MilestoneId))
+				return BadRequest("UserId and MilestoneId are required.");
+
+			milestoneRepositoryWrite.UnlockIfNew(request.UserId, request.MilestoneId, DateTime.UtcNow);
+			return Ok();
+		}
+	}
+
+	public record AwardAchievementRequest(string UserId, string MilestoneId);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -98,6 +98,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(gameRegistry.GlobalState, gameRegistry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(gameRegistry.GlobalState),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}
@@ -238,6 +240,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepoWrite,
 				BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, registry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
@@ -65,6 +65,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(game.GlobalState, registry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(game.GlobalState),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -67,6 +67,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, gameRegistry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
 				NullLogger<GameRegistry.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
@@ -62,6 +62,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, gameRegistry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
 				NullLogger<GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneRepositoryTest.cs
@@ -527,13 +527,13 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		// ── MilestoneCatalogue completeness (verified via repository output) ─────
 
 		[Fact]
-		public void GetMilestonesForUser_Returns15Milestones() {
+		public void GetMilestonesForUser_Returns19Milestones() {
 			var globalState = new GlobalState();
 			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
 
 			var results = repo.GetMilestonesForUser(UserId);
 
-			Assert.Equal(15, results.Count);
+			Assert.Equal(19, results.Count);
 		}
 
 		[Fact]
@@ -564,12 +564,160 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				"games-first", "games-veteran", "games-commander", "games-legend",
 				"win-first", "win-champion", "win-legend", "top3-first",
 				"econ-minerals", "econ-gas", "econ-land-100", "econ-land-500",
-				"diplo-alliance", "market-first", "upgrade-first"
+				"diplo-alliance", "market-first", "upgrade-first",
+				"win-streak-5", "top3-leaderboard", "games-100", "difficulty-master"
 			};
 
 			var ids = repo.GetMilestonesForUser(UserId).Select(r => r.Definition.Id).ToHashSet();
 
 			Assert.All(expectedIds, id => Assert.Contains(id, ids));
+		}
+
+		// ── Phase 5A: new achievement types ─────────────────────────────────────
+
+		[Fact]
+		public void WinStreak_FiveConsecutiveWins_StreakIsAtTarget() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 5; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId, GameId: new GameId($"g{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow.AddMinutes(i)
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "win-streak-5");
+			Assert.Equal(5, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void WinStreak_LossBreaksStreak_ProgressResets() {
+			var globalState = new GlobalState();
+			// 3 wins, then a loss, then 2 wins → current streak is 2
+			for (int i = 0; i < 3; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId, GameId: new GameId($"win{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow.AddMinutes(i)
+				));
+			}
+			globalState.AddAchievement(new PlayerAchievementImmutable(
+				UserId: UserId, GameId: new GameId("loss"), PlayerId: Player1,
+				PlayerName: "p", FinalRank: 2, FinalScore: 50, GameDefType: "sco",
+				FinishedAt: DateTime.UtcNow.AddMinutes(3)
+			));
+			for (int i = 0; i < 2; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId, GameId: new GameId($"win2_{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow.AddMinutes(4 + i)
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "win-streak-5");
+			Assert.Equal(2, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void WinStreak_NoGames_ProgressIsZero() {
+			var globalState = new GlobalState();
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "win-streak-5");
+			Assert.Equal(0, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void Top3Leaderboard_UserIsTop3ByWins_ProgressIs1() {
+			var globalState = new GlobalState();
+			// User1 has 5 wins, User2 has 3 wins, UserId has 4 wins → UserId is rank 2
+			for (int i = 0; i < 5; i++)
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: "user-other1", GameId: new GameId($"o1g{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			for (int i = 0; i < 4; i++)
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId, GameId: new GameId($"ug{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			for (int i = 0; i < 3; i++)
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: "user-other2", GameId: new GameId($"o2g{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "top3-leaderboard");
+			Assert.Equal(1, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void Top3Leaderboard_UserIsRank4_ProgressIsZero() {
+			var globalState = new GlobalState();
+			// UserId has 1 win, 3 others have 5, 4, 3 wins respectively → UserId is rank 4
+			foreach (var (uid, wins) in new[] { ("u1", 5), ("u2", 4), ("u3", 3) }) {
+				for (int i = 0; i < wins; i++)
+					globalState.AddAchievement(new PlayerAchievementImmutable(
+						UserId: uid, GameId: new GameId($"{uid}g{i}"), PlayerId: Player1,
+						PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+						FinishedAt: DateTime.UtcNow
+					));
+			}
+			globalState.AddAchievement(new PlayerAchievementImmutable(
+				UserId: UserId, GameId: new GameId("mywin"), PlayerId: Player1,
+				PlayerName: "p", FinalRank: 1, FinalScore: 100, GameDefType: "sco",
+				FinishedAt: DateTime.UtcNow
+			));
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "top3-leaderboard");
+			Assert.Equal(0, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void Games100_ExactlyHundredGames_ProgressAtTarget() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 100; i++)
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId, GameId: new GameId($"g{i}"), PlayerId: Player1,
+					PlayerName: "p", FinalRank: i % 3 + 1, FinalScore: 100, GameDefType: "sco",
+					FinishedAt: DateTime.UtcNow
+				));
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "games-100");
+			Assert.Equal(100, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void DifficultyMaster_WinGameWith5Players_ProgressIs1() {
+			var globalState = new GlobalState();
+			// 5 players all finish the same game; UserId wins
+			for (int i = 0; i < 5; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: i == 0 ? UserId : $"other-{i}", GameId: new GameId("big-game"),
+					PlayerId: Player1, PlayerName: "p", FinalRank: i + 1, FinalScore: 100 - i * 10,
+					GameDefType: "sco", FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "difficulty-master");
+			Assert.Equal(1, m.CurrentProgress);
+		}
+
+		[Fact]
+		public void DifficultyMaster_WinGameWith4Players_ProgressIsZero() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 4; i++) {
+				globalState.AddAchievement(new PlayerAchievementImmutable(
+					UserId: i == 0 ? UserId : $"other-{i}", GameId: new GameId("small-game"),
+					PlayerId: Player1, PlayerName: "p", FinalRank: i + 1, FinalScore: 100 - i * 10,
+					GameDefType: "sco", FinishedAt: DateTime.UtcNow
+				));
+			}
+			var repo = new MilestoneRepository(globalState, EmptyGameRegistry(globalState));
+			var m = repo.GetMilestonesForUser(UserId).Single(r => r.Definition.Id == "difficulty-master");
+			Assert.Equal(0, m.CurrentProgress);
 		}
 
 		// ── GlobalState milestone storage ────────────────────────────────────────

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -60,6 +60,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				BrowserGameEngine.StatefulGameServer.Events.NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(registry.GlobalState, registry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(registry.GlobalState),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
@@ -44,6 +44,8 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				userRepositoryWrite,
 				NullGameEventPublisher.Instance,
 				TimeProvider.System,
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(game.GlobalState, registry),
+				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(game.GlobalState),
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneCatalogue.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneCatalogue.cs
@@ -41,6 +41,12 @@ namespace BrowserGameEngine.StatefulGameServer.Achievements {
 
 			// Exploration — in-game (tech)
 			new("upgrade-first",  "Tech Pioneer",   "Research first tech upgrade",   "exploration", "🔬", "bronze",     1),
+
+			// Phase 5A achievement types — cross-game
+			new("win-streak-5",      "On a Roll",         "Win 5 games in a row",                       "combat",      "🔥", "silver",    5),
+			new("top3-leaderboard",  "Hall of Fame",      "Reach top 3 on the all-time leaderboard",    "combat",      "🏅", "gold",      1),
+			new("games-100",         "Century Commander", "Complete 100 games",                          "exploration", "💯", "legendary",100),
+			new("difficulty-master", "Dominator",         "Win a game with 5 or more players",          "combat",      "👑", "gold",      1),
 		};
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Achievements/MilestoneRepository.cs
@@ -60,7 +60,7 @@ namespace BrowserGameEngine.StatefulGameServer.Achievements {
 			return value;
 		}
 
-		private static int ComputeProgress(
+		private int ComputeProgress(
 			MilestoneDefinition def,
 			IList<PlayerAchievementImmutable> achievements,
 			PlayerState? playerState,
@@ -72,11 +72,16 @@ namespace BrowserGameEngine.StatefulGameServer.Achievements {
 				"games-veteran"   => Math.Min(achievements.Count, def.TargetProgress),
 				"games-commander" => Math.Min(achievements.Count, def.TargetProgress),
 				"games-legend"    => Math.Min(achievements.Count, def.TargetProgress),
+				"games-100"       => Math.Min(achievements.Count, def.TargetProgress),
 
 				"win-first"    => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
 				"win-champion" => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
 				"win-legend"   => Math.Min(achievements.Count(a => a.FinalRank == 1), def.TargetProgress),
 				"top3-first"   => Math.Min(achievements.Count(a => a.FinalRank <= 3), def.TargetProgress),
+
+				"win-streak-5"      => Math.Min(GetCurrentWinStreak(achievements), def.TargetProgress),
+				"top3-leaderboard"  => GetLeaderboardRank(userId) <= 3 ? 1 : 0,
+				"difficulty-master" => HasWonLargeGame(achievements) ? 1 : 0,
 
 				"econ-minerals" => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "minerals"), def.TargetProgress),
 				"econ-gas"      => playerState == null ? 0 : Math.Min((int)GetResource(playerState, "gas"),      def.TargetProgress),
@@ -90,6 +95,44 @@ namespace BrowserGameEngine.StatefulGameServer.Achievements {
 
 				_ => 0
 			};
+		}
+
+		private static int GetCurrentWinStreak(IList<PlayerAchievementImmutable> achievements) {
+			var sorted = achievements.OrderBy(a => a.FinishedAt).ToList();
+			int streak = 0;
+			for (int i = sorted.Count - 1; i >= 0; i--) {
+				if (sorted[i].FinalRank == 1) {
+					streak++;
+				} else {
+					break;
+				}
+			}
+			return streak;
+		}
+
+		private int GetLeaderboardRank(string userId) {
+			var allAchievements = _globalState.GetAchievements();
+			var rankedUsers = allAchievements
+				.GroupBy(a => a.UserId)
+				.Select(g => (UserId: g.Key, Wins: g.Count(a => a.FinalRank == 1)))
+				.OrderByDescending(x => x.Wins)
+				.ToList();
+			var idx = rankedUsers.FindIndex(x => x.UserId == userId);
+			return idx == -1 ? int.MaxValue : idx + 1;
+		}
+
+		private bool HasWonLargeGame(IList<PlayerAchievementImmutable> achievements) {
+			var winningGameIds = achievements
+				.Where(a => a.FinalRank == 1)
+				.Select(a => a.GameId.Id)
+				.ToHashSet();
+			if (winningGameIds.Count == 0) return false;
+			var allAchievements = _globalState.GetAchievements();
+			foreach (var gameId in winningGameIds) {
+				var playerCount = allAchievements.Count(a => a.GameId.Id == gameId);
+				if (playerCount >= 5) return true;
+			}
+			return false;
 		}
 
 		private static int GetAllianceProgress(GameInstance instance, string userId) {

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -1,6 +1,7 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.Achievements;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
@@ -22,6 +23,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		private readonly UserRepositoryWrite userRepositoryWrite;
 		private readonly IGameEventPublisher eventPublisher;
 		private readonly TimeProvider timeProvider;
+		private readonly MilestoneRepository milestoneRepository;
+		private readonly MilestoneRepositoryWrite milestoneRepositoryWrite;
 		private readonly ILogger<GameLifecycleEngine> logger;
 
 		public GameLifecycleEngine(
@@ -34,6 +37,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			UserRepositoryWrite userRepositoryWrite,
 			IGameEventPublisher eventPublisher,
 			TimeProvider timeProvider,
+			MilestoneRepository milestoneRepository,
+			MilestoneRepositoryWrite milestoneRepositoryWrite,
 			ILogger<GameLifecycleEngine> logger
 		) {
 			this.gameRegistry = gameRegistry;
@@ -45,6 +50,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			this.userRepositoryWrite = userRepositoryWrite;
 			this.eventPublisher = eventPublisher;
 			this.timeProvider = timeProvider;
+			this.milestoneRepository = milestoneRepository;
+			this.milestoneRepositoryWrite = milestoneRepositoryWrite;
 			this.logger = logger;
 		}
 
@@ -162,6 +169,18 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				VictoryConditionType = victoryConditionType
 			};
 			globalState.UpdateGame(record, updated);
+
+			// Auto-unlock milestones and notify players of new achievements
+			foreach (var player in instance.WorldState.Players.Values) {
+				if (player.UserId == null) continue;
+				var evaluations = milestoneRepository.GetMilestonesForUser(player.UserId);
+				foreach (var eval in evaluations) {
+					if (!eval.IsUnlocked && eval.CurrentProgress >= eval.Definition.TargetProgress) {
+						milestoneRepositoryWrite.UnlockIfNew(player.UserId, eval.Definition.Id, utcNow);
+						playerNotificationService.Push(player.UserId, $"Achievement unlocked: {eval.Definition.Name}!", NotificationKind.GameEvent);
+					}
+				}
+			}
 
 			// Persist final world state before freeing memory
 			await persistenceService.StoreGameState(record.GameId, instance.WorldState.ToImmutable());


### PR DESCRIPTION
## Summary
- Add 4 new cross-game milestone/badge types: **Win Streak 5** (consecutive wins), **Hall of Fame** (top 3 all-time leaderboard), **Century Commander** (100 games played), **Dominator** (win with 5+ players)
- Auto-unlock milestones at game end in `GameLifecycleEngine.FinalizeGameAsync()` — previously milestones were only unlocked lazily when the player visited the Achievements page; now they unlock server-side and push a toast notification via the existing SignalR notification system
- New `GET /api/players/{playerId}/achievements` endpoint for public per-player trophy access
- New `POST /api/achievements/award` admin endpoint for manually awarding milestones
- Frontend: no changes needed — existing `Achievements.tsx` badge panel and `GameLayout` toast system already handle the new data; achievement notifications surface through the existing `ReceiveAlert` SignalR path

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (619 tests, 14 new milestone tests added)
- [ ] Create a game with 5+ human/bot players, finish it — verify badges auto-unlock and toast appears in-game
- [ ] Check `GET /api/players/{playerId}/achievements` returns trophies for that player
- [ ] Check `POST /api/achievements/award` (as admin) awards a milestone to a user
- [ ] Visit `/achievements` page and verify new milestone cards render in the grid

Closes BGE-821