### PR TITLE
feat: BGE-825/831 Player Profile page enhancements (stats, badges, game history)

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayersController.cs
@@ -75,7 +75,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 					GameEndTime: rec?.ActualEndTime ?? rec?.EndTime ?? System.DateTime.MinValue,
 					FinalRank: a.FinalRank,
 					FinalScore: a.FinalScore,
-					IsWinner: a.FinalRank == 1
+					IsWinner: a.FinalRank == 1,
+					GameDefType: a.GameDefType
 				);
 			}).ToArray();
 
@@ -86,7 +87,9 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				TotalWins: entries.Count(e => e.IsWinner),
 				BestRank: entries.Min(e => e.FinalRank),
 				TotalScore: entries.Sum(e => e.FinalScore),
-				Games: entries
+				Games: entries,
+				JoinedAt: globalState.GetUserCreated(userId),
+				TotalResourcesGathered: null
 			));
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
@@ -101,7 +101,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				GamesPlayed = gamesPlayed,
 				Wins = wins,
 				BestRank = bestRank,
-				CurrentGameId = currentGameId
+				CurrentGameId = currentGameId,
+				JoinedAt = currentUserContext.UserId != null
+					? globalState.GetUserCreated(currentUserContext.UserId)
+					: null
 			};
 		}
 	}

--- a/src/BrowserGameEngine.Shared/PlayerCrossGameStatsViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerCrossGameStatsViewModel.cs
@@ -8,7 +8,8 @@ namespace BrowserGameEngine.Shared {
 		DateTime GameEndTime,
 		int FinalRank,
 		decimal FinalScore,
-		bool IsWinner
+		bool IsWinner,
+		string GameDefType = ""
 	);
 
 	public record PlayerCrossGameStatsViewModel(
@@ -18,6 +19,8 @@ namespace BrowserGameEngine.Shared {
 		int TotalWins,
 		int BestRank,
 		decimal TotalScore,
-		PlayerCrossGameEntry[] Games
+		PlayerCrossGameEntry[] Games,
+		DateTime? JoinedAt = null,
+		decimal? TotalResourcesGathered = null
 	);
 }

--- a/src/BrowserGameEngine.Shared/ProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/ProfileViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace BrowserGameEngine.Shared {
 	public record ProfileViewModel {
 		public string? PlayerName { get; init; }
@@ -14,5 +16,6 @@ namespace BrowserGameEngine.Shared {
 		public int Wins { get; init; }
 		public int BestRank { get; init; }
 		public string? CurrentGameId { get; init; }
+		public DateTime? JoinedAt { get; init; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
@@ -21,6 +21,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			return user?.DisplayName;
 		}
 
+		public System.DateTime? GetUserCreated(string userId) {
+			var user = Users.Values.FirstOrDefault(u => u.UserId == userId);
+			return user?.Created;
+		}
+
 		public IReadOnlyList<GameRecordImmutable> GetGames() {
 			lock (_gamesLock) return _games.ToList();
 		}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -952,6 +952,7 @@ export interface ProfileViewModel {
   wins: number
   bestRank: number
   currentGameId: string | null
+  joinedAt?: string | null
 }
 
 // Public cross-game stats
@@ -964,6 +965,7 @@ export interface PlayerCrossGameEntry {
   finalRank: number
   finalScore: number
   isWinner: boolean
+  gameDefType?: string
 }
 
 export interface PlayerCrossGameStatsViewModel {
@@ -974,6 +976,23 @@ export interface PlayerCrossGameStatsViewModel {
   bestRank: number
   totalScore: number
   games: PlayerCrossGameEntry[]
+  joinedAt?: string | null
+  totalResourcesGathered?: number | null
+}
+
+// Public achievements (api/players/{userId}/achievements)
+
+export interface PublicAchievementEntry {
+  achievementType: string
+  achievementLabel: string
+  achievementIcon: string
+  gameId: string
+  gameName: string
+  earnedAt: string
+}
+
+export interface PublicPlayerAchievementsViewModel {
+  achievements: PublicAchievementEntry[]
 }
 
 // Pagination

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -2,9 +2,18 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
 import { TrophyIcon, SwordsIcon, StarIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ProfileViewModel, PlayerAchievementsViewModel } from '@/api/types'
+import type { ProfileViewModel, PlayerAchievementsViewModel, PlayerHistoryViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { relativeTime } from '@/lib/utils'
+
+function outcomeLabel(isWin: boolean, gameStatus: string): { label: string; className: string } {
+  if (isWin) return { label: 'Win', className: 'bg-green-700/30 text-green-300' }
+  if (gameStatus.toLowerCase() === 'active' || gameStatus.toLowerCase() === 'running') {
+    return { label: 'DNF', className: 'bg-secondary/40 text-muted-foreground' }
+  }
+  return { label: 'Loss', className: 'bg-red-900/30 text-red-300' }
+}
 
 export function PlayerProfile() {
   const { data: profile, isLoading, error, refetch } = useQuery({
@@ -17,18 +26,29 @@ export function PlayerProfile() {
     queryFn: () => apiClient.get('/api/player-management/me/achievements').then(r => r.data),
   })
 
+  const { data: historyData } = useQuery<PlayerHistoryViewModel>({
+    queryKey: ['player-history'],
+    queryFn: () => apiClient.get('/api/history').then(r => r.data),
+  })
+
   if (isLoading) return <PageLoader message="Loading profile..." />
   if (error) return <ApiError message="Failed to load profile." onRetry={() => void refetch()} />
   if (!profile) return <p className="text-destructive text-sm">Failed to load profile.</p>
 
   const displayName = profile.displayName ?? profile.playerName ?? 'Unknown'
+  const losses = profile.gamesPlayed - profile.wins
+  const winRate = profile.gamesPlayed > 0 ? (profile.wins / profile.gamesPlayed) * 100 : 0
+  const historyGames = historyData?.games ?? []
+  const avgScore = historyGames.length > 0
+    ? historyGames.reduce((sum, g) => sum + g.finalScore, 0) / historyGames.length
+    : 0
 
   return (
-    <div className="max-w-lg space-y-5">
+    <div className="max-w-2xl space-y-5">
       <h1 className="text-xl font-bold">My Profile</h1>
 
       <div className="rounded-lg border bg-card p-6 space-y-5">
-        {/* Avatar + name */}
+        {/* Avatar + name + join date */}
         <div className="flex items-center gap-4">
           {profile.avatarUrl ? (
             <img
@@ -45,6 +65,11 @@ export function PlayerProfile() {
             <div className="font-bold text-lg">{displayName}</div>
             {profile.playerName && profile.displayName && profile.playerName !== profile.displayName && (
               <div className="text-sm text-muted-foreground">Playing as {profile.playerName}</div>
+            )}
+            {profile.joinedAt && (
+              <div className="text-xs text-muted-foreground mt-0.5">
+                Member since {relativeTime(profile.joinedAt)}
+              </div>
             )}
           </div>
         </div>
@@ -102,14 +127,14 @@ export function PlayerProfile() {
         )}
       </div>
 
-      {/* Career stats */}
+      {/* Career stats — 6 cells */}
       {profile.gamesPlayed > 0 && (
         <div className="rounded-lg border bg-card p-5 space-y-3">
           <strong className="text-sm flex items-center gap-1.5">
             <TrophyIcon className="h-4 w-4 text-primary" />
             Career Stats
           </strong>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="rounded border bg-secondary/20 p-3 text-center">
               <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Games</div>
               <div className="text-xl font-bold">{profile.gamesPlayed}</div>
@@ -117,6 +142,18 @@ export function PlayerProfile() {
             <div className="rounded border bg-secondary/20 p-3 text-center">
               <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Wins</div>
               <div className="text-xl font-bold text-green-400">{profile.wins}</div>
+            </div>
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Losses</div>
+              <div className="text-xl font-bold text-red-400">{losses}</div>
+            </div>
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Win Rate</div>
+              <div className="text-xl font-bold">{winRate.toFixed(0)}%</div>
+            </div>
+            <div className="rounded border bg-secondary/20 p-3 text-center">
+              <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Avg Score</div>
+              <div className="text-xl font-bold">{avgScore > 0 ? Math.floor(avgScore).toLocaleString() : '—'}</div>
             </div>
             <div className="rounded border bg-secondary/20 p-3 text-center">
               <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Best Rank</div>
@@ -175,6 +212,51 @@ export function PlayerProfile() {
           </div>
         )
       })()}
+
+      {/* Game history — last 20 games */}
+      {historyGames.length > 0 && (
+        <div className="rounded-lg border bg-card">
+          <div className="border-b px-4 py-3">
+            <strong className="text-sm">Recent Games</strong>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" aria-label="Game history">
+              <thead className="border-b">
+                <tr>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Type</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Date</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Outcome</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Replay</th>
+                </tr>
+              </thead>
+              <tbody>
+                {historyGames.slice(0, 20).map((g) => {
+                  const outcome = outcomeLabel(g.isWin, '')
+                  return (
+                    <tr key={g.gameId} className="border-b border-border last:border-0">
+                      <td className="py-2 px-3 font-medium">{g.gameName}</td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground hidden sm:table-cell">{g.gameDefType || '—'}</td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground whitespace-nowrap">
+                        {relativeTime(g.finishedAt)}
+                      </td>
+                      <td className="py-2 px-3 font-mono">#{g.finalRank}</td>
+                      <td className="py-2 px-3">
+                        <span className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium ${outcome.className}`}>
+                          {g.isWin && <StarIcon className="h-3 w-3" />}
+                          {outcome.label}
+                        </span>
+                      </td>
+                      <td className="py-2 px-3 text-muted-foreground hidden sm:table-cell">—</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router'
 import { UserIcon, TrophyIcon, StarIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { PlayerCrossGameStatsViewModel } from '@/api/types'
+import type { PlayerCrossGameStatsViewModel, PublicPlayerAchievementsViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
@@ -23,6 +23,45 @@ function outcomeLabel(isWinner: boolean, gameStatus: string): { label: string; c
     return { label: 'DNF', className: 'bg-secondary/40 text-muted-foreground' }
   }
   return { label: 'Loss', className: 'bg-red-900/30 text-red-300' }
+}
+
+function PublicAchievementBadges({ userId }: { userId: string }) {
+  const { data } = useQuery<PublicPlayerAchievementsViewModel>({
+    queryKey: ['public-achievements', userId],
+    queryFn: () =>
+      apiClient.get(`/api/players/${encodeURIComponent(userId)}/achievements`).then(r => r.data),
+    retry: false,
+  })
+
+  const badges = data?.achievements ?? []
+  if (badges.length === 0) return null
+
+  const shown = badges.slice(0, 8)
+  const extra = badges.length - 8
+
+  return (
+    <div className="rounded-lg border bg-card p-5 space-y-3">
+      <strong className="text-sm flex items-center gap-1.5">
+        <TrophyIcon className="h-4 w-4 text-yellow-500" />
+        Achievements
+      </strong>
+      <div className="grid grid-cols-4 gap-2">
+        {shown.map((a, i) => (
+          <div
+            key={i}
+            className="flex flex-col items-center gap-1 rounded border bg-secondary/20 p-2 text-center"
+            title={`${a.achievementLabel} — ${a.gameName}`}
+          >
+            <span className="text-xl leading-none">{a.achievementIcon}</span>
+            <span className="text-xs font-medium leading-tight line-clamp-2">{a.achievementLabel}</span>
+          </div>
+        ))}
+      </div>
+      {extra > 0 && (
+        <p className="text-xs text-muted-foreground">+{extra} more achievement{extra !== 1 ? 's' : ''}</p>
+      )}
+    </div>
+  )
 }
 
 export function PublicProfile() {
@@ -74,6 +113,11 @@ export function PublicProfile() {
           <p className="text-sm text-muted-foreground mt-0.5">
             {stats.totalGames} {stats.totalGames === 1 ? 'game' : 'games'} played
           </p>
+          {stats.joinedAt && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Member since {relativeTime(stats.joinedAt)}
+            </p>
+          )}
         </div>
       </div>
 
@@ -112,8 +156,12 @@ export function PublicProfile() {
             <div className="text-xl font-bold">{avgRank > 0 ? `#${avgRank.toFixed(1)}` : '—'}</div>
           </div>
           <div className="rounded border bg-secondary/20 p-3 text-center">
-            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Total Score</div>
-            <div className="text-xl font-bold">{Math.floor(stats.totalScore).toLocaleString()}</div>
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Resources Gathered</div>
+            <div className="text-xl font-bold">
+              {stats.totalResourcesGathered != null
+                ? Math.floor(stats.totalResourcesGathered).toLocaleString()
+                : '—'}
+            </div>
           </div>
         </div>
       </div>
@@ -138,9 +186,11 @@ export function PublicProfile() {
               <thead className="border-b">
                 <tr>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Game</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Type</th>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Date</th>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rank</th>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Outcome</th>
+                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Replay</th>
                 </tr>
               </thead>
               <tbody>
@@ -149,6 +199,7 @@ export function PublicProfile() {
                   return (
                     <tr key={g.gameId} className="border-b border-border last:border-0">
                       <td className="py-2 px-3 font-medium">{g.gameName}</td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground hidden sm:table-cell">{g.gameDefType || '—'}</td>
                       <td className="py-2 px-3 text-xs text-muted-foreground whitespace-nowrap">
                         {relativeTime(g.gameEndTime)}
                       </td>
@@ -159,6 +210,7 @@ export function PublicProfile() {
                           {outcome.label}
                         </span>
                       </td>
+                      <td className="py-2 px-3 text-muted-foreground hidden sm:table-cell">—</td>
                     </tr>
                   )
                 })}
@@ -190,6 +242,9 @@ export function PublicProfile() {
           )}
         </div>
       )}
+
+      {/* Achievement badges — compact 2×4 grid, silent fail if unavailable */}
+      {userId && <PublicAchievementBadges userId={userId} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements [BGE-825](/BGE/issues/BGE-825) and [BGE-831](/BGE/issues/BGE-831) together to avoid merge conflicts on `PublicProfile.tsx`.

### Backend
- `GlobalState.GetUserCreated(userId)` — looks up user registration date from the Users dictionary
- `ProfileViewModel` — add `JoinedAt DateTime?`
- `PlayerCrossGameStatsViewModel` — add `JoinedAt DateTime?`, `TotalResourcesGathered decimal?` (null until tracked separately), `GameDefType` on `PlayerCrossGameEntry`
- `ProfileController` — populate `JoinedAt` from the current user's `Created` date
- `PlayersController` — populate `JoinedAt` and `GameDefType` per entry; `TotalResourcesGathered` set to null (field present for future use)

### Frontend types (`api/types.ts`)
- `ProfileViewModel` — add `joinedAt?: string | null`
- `PlayerCrossGameStatsViewModel` — add `joinedAt`, `totalResourcesGathered`, `gameDefType` on entry
- New: `PublicAchievementEntry`, `PublicPlayerAchievementsViewModel`

### PlayerProfile.tsx (own profile)
- Join date shown below display name in header
- Career stats expanded to 6 cells: Games · Wins · Losses · Win Rate · Avg Score · Best Rank
- New Recent Games table (last 20 from `GET /api/history`) with Type + Replay (placeholder) columns, hidden on mobile

### PublicProfile.tsx (public profile)
- Join date shown in profile header
- **Resources Gathered** stat cell replaces Total Score (shows `—` if null)
- Type column + Replay placeholder column added to game history table (hidden on mobile)
- `PublicAchievementBadges` component: 2×4 compact grid, up to 8 badges, `+N more` pill; fetches `GET /api/players/{userId}/achievements` with `retry: false` so missing data never breaks the page

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (611 tests)
- [x] TypeScript type-check passes (no errors)
- [ ] Own profile shows join date, 6-stat grid, game history with type/replay columns
- [ ] Public profile shows join date, Resources Gathered stat (—), type/replay columns, achievement badges
- [ ] Achievement badges hidden when player has no achievements (silent fail)

Closes BGE-825
Closes BGE-831