### PR TITLE
feat: BGE-823 Phase 5C Replay Viewer UI

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/ReplayController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ReplayController.cs
@@ -1,0 +1,84 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/replay")]
+	public class ReplayController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly GameReplayRepository gameReplayRepository;
+
+		public ReplayController(CurrentUserContext currentUserContext, GameReplayRepository gameReplayRepository) {
+			this.currentUserContext = currentUserContext;
+			this.gameReplayRepository = gameReplayRepository;
+		}
+
+		/// <summary>Returns the replay data for a specific game, including final standings and battle events for the current player.</summary>
+		/// <param name="gameId">The game identifier.</param>
+		[HttpGet("{gameId}")]
+		[ProducesResponseType(typeof(GameReplayViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public async Task<IActionResult> GetReplay(string gameId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var data = await gameReplayRepository.GetGameReplayData(new GameId(gameId), currentUserContext.UserId!);
+			if (data?.Record == null) return NotFound();
+
+			var raceMap = data.WorldState?.Players
+				.ToDictionary(kvp => kvp.Key.Id, kvp => kvp.Value.PlayerType.Id)
+				?? [];
+
+			var finalStandings = data.GameAchievements
+				.OrderBy(a => a.FinalRank)
+				.Select(a => new ReplayPlayerViewModel(
+					PlayerId: a.PlayerId.Id,
+					PlayerName: a.PlayerName,
+					Race: raceMap.GetValueOrDefault(a.PlayerId.Id, a.GameDefType),
+					FinalRank: a.FinalRank,
+					FinalScore: a.FinalScore
+				))
+				.ToList();
+
+			var battleEvents = new List<ReplayBattleEventViewModel>();
+			if (data.CurrentPlayerAchievement != null && data.WorldState != null) {
+				var currentPlayerId = data.CurrentPlayerAchievement.PlayerId;
+				if (data.WorldState.Players.TryGetValue(currentPlayerId, out var currentPlayer)) {
+					battleEvents = (currentPlayer.State.BattleReports ?? [])
+						.OrderBy(r => r.CreatedAt)
+						.Select(r => new ReplayBattleEventViewModel(
+							ReportId: r.Id,
+							OccurredAt: r.CreatedAt,
+							AttackerName: r.AttackerName,
+							DefenderName: r.DefenderName,
+							Outcome: r.Outcome,
+							IsCurrentPlayerAttacker: r.AttackerId == currentPlayerId,
+							IsCurrentPlayerDefender: r.DefenderId == currentPlayerId
+						))
+						.ToList();
+				}
+			}
+
+			var vm = new GameReplayViewModel(
+				GameId: data.Record.GameId.Id,
+				GameName: data.Record.Name,
+				GameDefType: data.Record.GameDefType,
+				StartTime: data.Record.StartTime,
+				ActualEndTime: data.Record.ActualEndTime,
+				Status: data.Record.Status.ToString(),
+				FinalStandings: finalStandings,
+				BattleEvents: battleEvents
+			);
+
+			return Ok(vm);
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/GameReplayViewModel.cs
+++ b/src/BrowserGameEngine.Shared/GameReplayViewModel.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared;
+
+public record GameReplayViewModel(
+	string GameId,
+	string GameName,
+	string GameDefType,
+	DateTime StartTime,
+	DateTime? ActualEndTime,
+	string Status,
+	List<ReplayPlayerViewModel> FinalStandings,
+	List<ReplayBattleEventViewModel> BattleEvents
+);
+
+public record ReplayPlayerViewModel(
+	string PlayerId,
+	string PlayerName,
+	string Race,
+	int FinalRank,
+	decimal FinalScore
+);
+
+public record ReplayBattleEventViewModel(
+	Guid ReportId,
+	DateTime OccurredAt,
+	string AttackerName,
+	string DefenderName,
+	string Outcome,
+	bool IsCurrentPlayerAttacker,
+	bool IsCurrentPlayerDefender
+);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameReplayRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameReplayRepositoryTest.cs
@@ -1,0 +1,317 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class GameReplayRepositoryTest {
+		private static readonly GameId TestGameId = new GameId("replay-test-game");
+		private static readonly PlayerId Player1Id = PlayerIdFactory.Create("replay-p1");
+		private static readonly PlayerId Player2Id = PlayerIdFactory.Create("replay-p2");
+		private const string UserId1 = "user-alice";
+		private const string UserId2 = "user-bob";
+
+		private static readonly GameDef TestGameDef = new TestGameDefFactory().CreateGameDef();
+
+		private static WorldStateImmutable MakeWorldState(
+			bool player1HasBattles = false,
+			bool includeBothPlayers = true
+		) {
+			var now = DateTime.UtcNow;
+			var gameTick = new GameTick(1);
+			var baseTick = new GameTickStateImmutable(gameTick, now);
+
+			var battles = player1HasBattles
+				? new List<BattleReportImmutable> {
+					new BattleReportImmutable(
+						Id: Guid.NewGuid(),
+						AttackerId: Player1Id,
+						DefenderId: Player2Id,
+						AttackerName: "Alice",
+						DefenderName: "Bob",
+						AttackerRace: "Terran",
+						DefenderRace: "Zerg",
+						Outcome: "AttackerWon",
+						TotalAttackerStrengthBefore: 100,
+						TotalDefenderStrengthBefore: 80,
+						AttackerUnitsInitial: [],
+						DefenderUnitsInitial: [],
+						Rounds: [],
+						LandTransferred: 0,
+						WorkersCaptured: 0,
+						ResourcesStolen: new Dictionary<string, decimal>(),
+						CreatedAt: now.AddHours(-2)
+					),
+					new BattleReportImmutable(
+						Id: Guid.NewGuid(),
+						AttackerId: Player2Id,
+						DefenderId: Player1Id,
+						AttackerName: "Bob",
+						DefenderName: "Alice",
+						AttackerRace: "Zerg",
+						DefenderRace: "Terran",
+						Outcome: "DefenderWon",
+						TotalAttackerStrengthBefore: 80,
+						TotalDefenderStrengthBefore: 100,
+						AttackerUnitsInitial: [],
+						DefenderUnitsInitial: [],
+						Rounds: [],
+						LandTransferred: 0,
+						WorkersCaptured: 0,
+						ResourcesStolen: new Dictionary<string, decimal>(),
+						CreatedAt: now.AddHours(-1)
+					)
+				}
+				: null;
+
+			var p1 = new PlayerImmutable(
+				PlayerId: Player1Id,
+				PlayerType: Id.PlayerType("type1"),
+				Name: "Alice",
+				Created: now,
+				State: new PlayerStateImmutable(
+					LastGameTickUpdate: now,
+					CurrentGameTick: gameTick,
+					Resources: new Dictionary<ResourceDefId, decimal>(),
+					Assets: new HashSet<AssetImmutable>(),
+					Units: new List<UnitImmutable>(),
+					BattleReports: battles
+				),
+				UserId: UserId1
+			);
+
+			var players = new Dictionary<PlayerId, PlayerImmutable> { [Player1Id] = p1 };
+
+			if (includeBothPlayers) {
+				var p2 = new PlayerImmutable(
+					PlayerId: Player2Id,
+					PlayerType: Id.PlayerType("type1"),
+					Name: "Bob",
+					Created: now,
+					State: new PlayerStateImmutable(
+						LastGameTickUpdate: now,
+						CurrentGameTick: gameTick,
+						Resources: new Dictionary<ResourceDefId, decimal>(),
+						Assets: new HashSet<AssetImmutable>(),
+						Units: new List<UnitImmutable>()
+					),
+					UserId: UserId2
+				);
+				players[Player2Id] = p2;
+			}
+
+			return new WorldStateImmutable(
+				Players: players,
+				GameTickState: baseTick,
+				GameActionQueue: new List<GameActionImmutable>(),
+				GameId: TestGameId
+			);
+		}
+
+		private static GlobalState MakeGlobalState(bool includeCurrentPlayer = true, bool includeBothAchievements = true) {
+			var state = new GlobalState();
+			state.AddGame(new GameRecordImmutable(
+				TestGameId, "Test Game", "sco", GameStatus.Finished,
+				new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+				new DateTime(2024, 1, 8, 0, 0, 0, DateTimeKind.Utc),
+				TimeSpan.FromSeconds(60),
+				ActualEndTime: new DateTime(2024, 1, 7, 12, 0, 0, DateTimeKind.Utc)
+			));
+			if (includeCurrentPlayer) {
+				state.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId1, GameId: TestGameId, PlayerId: Player1Id,
+					PlayerName: "Alice", FinalRank: 2, FinalScore: 1000m,
+					GameDefType: "sco", FinishedAt: DateTime.UtcNow
+				));
+			}
+			if (includeBothAchievements) {
+				state.AddAchievement(new PlayerAchievementImmutable(
+					UserId: UserId2, GameId: TestGameId, PlayerId: Player2Id,
+					PlayerName: "Bob", FinalRank: 1, FinalScore: 2000m,
+					GameDefType: "sco", FinishedAt: DateTime.UtcNow
+				));
+			}
+			return state;
+		}
+
+		private static GameReplayRepository CreateRepo(GlobalState globalState, GameRegistry.GameRegistry registry, IBlobStorage blobStorage) {
+			var serializer = new GameStateJsonSerializer();
+			var persistence = new PersistenceService(blobStorage, serializer);
+			return new GameReplayRepository(globalState, registry, persistence);
+		}
+
+		[Fact]
+		public async Task UnknownGameId_ReturnsNull() {
+			var globalState = new GlobalState();
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(new GameId("nonexistent"), UserId1);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ActiveGame_ReturnsBattleEventsForCurrentPlayer() {
+			var worldState = MakeWorldState(player1HasBattles: true);
+			var globalState = MakeGlobalState();
+			var gameRecord = new GameRecordImmutable(TestGameId, "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(6), TimeSpan.FromSeconds(60));
+			globalState.SetGames([..globalState.GetGames().Where(g => g.GameId.Id != TestGameId.Id), gameRecord]);
+
+			var instance = new GameInstance(gameRecord, worldState.ToMutable(), TestGameDef);
+			var registry = new GameRegistry.GameRegistry(globalState);
+			registry.Register(instance);
+
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(TestGameId, UserId1);
+
+			Assert.NotNull(result);
+			Assert.NotNull(result!.WorldState);
+			Assert.Equal(UserId1, result.CurrentPlayerAchievement?.UserId);
+			Assert.Equal(2, result.GameAchievements.Count);
+			var playerReports = result.WorldState.Players[Player1Id].State.BattleReports;
+			Assert.NotNull(playerReports);
+			Assert.Equal(2, playerReports!.Count);
+		}
+
+		[Fact]
+		public async Task ActiveGame_PlayerWithNoBattles_ReturnsEmptyBattleReports() {
+			var worldState = MakeWorldState(player1HasBattles: false);
+			var globalState = MakeGlobalState();
+			var gameRecord = new GameRecordImmutable(TestGameId, "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(6), TimeSpan.FromSeconds(60));
+			globalState.SetGames([..globalState.GetGames().Where(g => g.GameId.Id != TestGameId.Id), gameRecord]);
+
+			var instance = new GameInstance(gameRecord, worldState.ToMutable(), TestGameDef);
+			var registry = new GameRegistry.GameRegistry(globalState);
+			registry.Register(instance);
+
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(TestGameId, UserId1);
+
+			Assert.NotNull(result);
+			Assert.NotNull(result!.CurrentPlayerAchievement);
+			var playerReports = result.WorldState!.Players[Player1Id].State.BattleReports;
+			Assert.True(playerReports == null || playerReports.Count == 0);
+		}
+
+		[Fact]
+		public async Task CompletedGame_LoadsFromBlobStorage() {
+			var worldState = MakeWorldState(player1HasBattles: true);
+			var globalState = MakeGlobalState();
+
+			var blobStorage = new TestBlobStorage();
+			var serializer = new GameStateJsonSerializer();
+			var persistenceService = new PersistenceService(blobStorage, serializer);
+			await persistenceService.StoreGameState(TestGameId, worldState);
+
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var repo = new GameReplayRepository(globalState, registry, persistenceService);
+
+			var result = await repo.GetGameReplayData(TestGameId, UserId1);
+
+			Assert.NotNull(result);
+			Assert.Equal("Test Game", result!.Record!.Name);
+			Assert.NotNull(result.WorldState);
+			Assert.Equal(UserId1, result.CurrentPlayerAchievement?.UserId);
+			Assert.Equal(2, result.GameAchievements.Count);
+		}
+
+		[Fact]
+		public async Task BattleEvents_BothAttackerAndDefenderRolesPresent() {
+			var worldState = MakeWorldState(player1HasBattles: true);
+			var globalState = MakeGlobalState();
+			var gameRecord = new GameRecordImmutable(TestGameId, "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(6), TimeSpan.FromSeconds(60));
+			globalState.SetGames([..globalState.GetGames().Where(g => g.GameId.Id != TestGameId.Id), gameRecord]);
+
+			var instance = new GameInstance(gameRecord, worldState.ToMutable(), TestGameDef);
+			var registry = new GameRegistry.GameRegistry(globalState);
+			registry.Register(instance);
+
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(TestGameId, UserId1);
+
+			Assert.NotNull(result);
+			var reports = result!.WorldState!.Players[Player1Id].State.BattleReports!
+				.OrderBy(r => r.CreatedAt).ToList();
+
+			// First report: Player1 is attacker
+			Assert.Equal(Player1Id, reports[0].AttackerId);
+			Assert.Equal(Player2Id, reports[0].DefenderId);
+			// Second report: Player1 is defender
+			Assert.Equal(Player2Id, reports[1].AttackerId);
+			Assert.Equal(Player1Id, reports[1].DefenderId);
+		}
+
+		[Fact]
+		public async Task UserNotInGame_CurrentPlayerAchievementIsNull() {
+			var worldState = MakeWorldState();
+			var globalState = MakeGlobalState();
+			var gameRecord = new GameRecordImmutable(TestGameId, "Test Game", "sco", GameStatus.Active,
+				DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(6), TimeSpan.FromSeconds(60));
+			globalState.SetGames([..globalState.GetGames().Where(g => g.GameId.Id != TestGameId.Id), gameRecord]);
+
+			var instance = new GameInstance(gameRecord, worldState.ToMutable(), TestGameDef);
+			var registry = new GameRegistry.GameRegistry(globalState);
+			registry.Register(instance);
+
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(TestGameId, "user-unknown");
+
+			Assert.NotNull(result);
+			Assert.Null(result!.CurrentPlayerAchievement);
+		}
+
+		[Fact]
+		public async Task GameWithNoWorldState_ReturnsDataWithNullWorldState() {
+			var globalState = MakeGlobalState();
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var repo = CreateRepo(globalState, registry, new TestBlobStorage());
+
+			var result = await repo.GetGameReplayData(TestGameId, UserId1);
+
+			Assert.NotNull(result);
+			Assert.Null(result!.WorldState);
+			Assert.Equal("Test Game", result.Record!.Name);
+			Assert.Equal(2, result.GameAchievements.Count);
+		}
+
+		private class TestBlobStorage : IBlobStorage {
+			private readonly ConcurrentDictionary<string, byte[]> _blobs = new();
+
+			public Task Store(string name, byte[] blob) {
+				_blobs[name] = blob;
+				return Task.CompletedTask;
+			}
+
+			public Task<byte[]> Load(string name) {
+				if (_blobs.TryGetValue(name, out var blob)) return Task.FromResult(blob);
+				throw new KeyNotFoundException($"Blob '{name}' not found.");
+			}
+
+			public bool Exists(string name) => _blobs.ContainsKey(name);
+
+			public IEnumerable<string> List(string folderPrefix) =>
+				_blobs.Keys.Where(k => k.StartsWith(folderPrefix));
+
+			public Task Delete(string name) {
+				_blobs.TryRemove(name, out _);
+				return Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -77,6 +77,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<ResourceHistoryRepositoryWrite>();
 			services.AddSingleton<MilestoneRepository>();
 			services.AddSingleton<MilestoneRepositoryWrite>();
+			services.AddSingleton<GameReplayRepository>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameReplayRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Game/GameReplayRepository.cs
@@ -1,0 +1,59 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BrowserGameEngine.StatefulGameServer;
+
+public class GameReplayData {
+	public GameRecordImmutable? Record { get; init; }
+	public IReadOnlyList<PlayerAchievementImmutable> GameAchievements { get; init; } = [];
+	public PlayerAchievementImmutable? CurrentPlayerAchievement { get; init; }
+	public WorldStateImmutable? WorldState { get; init; }
+}
+
+public class GameReplayRepository {
+	private readonly GlobalState globalState;
+	private readonly GameRegistry.GameRegistry gameRegistry;
+	private readonly PersistenceService persistenceService;
+
+	public GameReplayRepository(GlobalState globalState, GameRegistry.GameRegistry gameRegistry, PersistenceService persistenceService) {
+		this.globalState = globalState;
+		this.gameRegistry = gameRegistry;
+		this.persistenceService = persistenceService;
+	}
+
+	public async Task<GameReplayData?> GetGameReplayData(GameId gameId, string userId) {
+		var record = null as GameRecordImmutable;
+		foreach (var g in globalState.GetGames()) {
+			if (g.GameId.Id == gameId.Id) { record = g; break; }
+		}
+		if (record == null) return null;
+
+		var allGameAchievements = new List<PlayerAchievementImmutable>();
+		PlayerAchievementImmutable? currentPlayerAchievement = null;
+		foreach (var a in globalState.GetAchievements()) {
+			if (a.GameId.Id == gameId.Id) {
+				allGameAchievements.Add(a);
+				if (a.UserId == userId) currentPlayerAchievement = a;
+			}
+		}
+
+		WorldStateImmutable? worldState = null;
+		var activeInstance = gameRegistry.TryGetInstance(gameId);
+		if (activeInstance != null) {
+			worldState = activeInstance.WorldState.ToImmutable();
+		} else if (persistenceService.GameStateExists(gameId)) {
+			worldState = await persistenceService.LoadGameState(gameId);
+		}
+
+		return new GameReplayData {
+			Record = record,
+			GameAchievements = allGameAchievements,
+			CurrentPlayerAchievement = currentPlayerAchievement,
+			WorldState = worldState
+		};
+	}
+}

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -44,6 +44,7 @@ const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ defaul
 const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
 const Help = lazy(() => import('@/pages/Help').then(m => ({ default: m.Help })))
 const BattleReplay = lazy(() => import('@/pages/BattleReplay').then(m => ({ default: m.BattleReplay })))
+const ReplayViewer = lazy(() => import('@/pages/ReplayViewer').then(m => ({ default: m.ReplayViewer })))
 const GameLiveView = lazy(() => import('@/pages/GameLiveView').then(m => ({ default: m.GameLiveView })))
 const PlayerStats = lazy(() => import('@/pages/PlayerStats').then(m => ({ default: m.PlayerStats })))
 const TournamentResults = lazy(() => import('@/pages/TournamentResults').then(m => ({ default: m.TournamentResults })))
@@ -206,6 +207,7 @@ const router = createBrowserRouter([
       { path: '/alliances/:allianceId', element: <AllianceDetail /> },
       { path: '/achievements', element: <Achievements /> },
       { path: '/history', element: <PlayerHistory /> },
+      { path: '/replays/:gameId', element: <ReplayViewer /> },
       { path: '/stats', element: <PlayerStats /> },
       { path: '/tournaments/:tournamentId', element: <TournamentResults /> },
       { path: '/admin/games', element: <AdminGames /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -985,3 +985,34 @@ export interface PaginatedResponse<T> {
   totalCount: number
   totalPages: number
 }
+
+// Replay Viewer
+
+export interface ReplayPlayerViewModel {
+  playerId: string
+  playerName: string
+  race: string
+  finalRank: number
+  finalScore: number
+}
+
+export interface ReplayBattleEventViewModel {
+  reportId: string
+  occurredAt: string
+  attackerName: string
+  defenderName: string
+  outcome: string
+  isCurrentPlayerAttacker: boolean
+  isCurrentPlayerDefender: boolean
+}
+
+export interface GameReplayViewModel {
+  gameId: string
+  gameName: string
+  gameDefType: string
+  startTime: string
+  actualEndTime: string | null
+  status: string
+  finalStandings: ReplayPlayerViewModel[]
+  battleEvents: ReplayBattleEventViewModel[]
+}

--- a/src/ReactClient/src/pages/PlayerHistory.tsx
+++ b/src/ReactClient/src/pages/PlayerHistory.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { PlayerHistoryViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
@@ -56,6 +57,7 @@ export function PlayerHistory() {
               <th scope="col" className="px-3 py-2 text-left font-medium">Rank</th>
               <th scope="col" className="px-3 py-2 text-right font-medium">Score</th>
               <th scope="col" className="px-3 py-2 text-right font-medium hidden sm:table-cell">Players</th>
+              <th scope="col" className="px-3 py-2 text-right font-medium hidden sm:table-cell"></th>
             </tr>
           </thead>
           <tbody>
@@ -93,6 +95,14 @@ export function PlayerHistory() {
                 </td>
                 <td className="px-3 py-2 text-right text-muted-foreground hidden sm:table-cell">
                   {entry.playersInGame}
+                </td>
+                <td className="px-3 py-2 text-right hidden sm:table-cell">
+                  <Link
+                    to={`/replays/${entry.gameId}`}
+                    className="text-xs text-primary hover:underline"
+                  >
+                    Replay
+                  </Link>
                 </td>
               </tr>
             ))}

--- a/src/ReactClient/src/pages/ReplayViewer.tsx
+++ b/src/ReactClient/src/pages/ReplayViewer.tsx
@@ -1,0 +1,313 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import apiClient from '@/api/client'
+import type { GameReplayViewModel, ReplayBattleEventViewModel } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { rankBadgeClass } from '@/lib/formatters'
+
+const SPEED_OPTIONS: { label: string; ms: number }[] = [
+  { label: '0.5x', ms: 4000 },
+  { label: '1x', ms: 2000 },
+  { label: '2x', ms: 1000 },
+  { label: '4x', ms: 500 },
+]
+
+function outcomeBadgeClass(outcome: string, isAttacker: boolean, isDefender: boolean): string {
+  if (!isAttacker && !isDefender) return 'bg-muted text-muted-foreground'
+  const won =
+    (isAttacker && outcome === 'AttackerWon') || (isDefender && outcome === 'DefenderWon')
+  if (won) return 'bg-success/20 text-success-foreground'
+  if (outcome === 'Draw') return 'bg-warning/20 text-warning-foreground'
+  return 'bg-destructive/20 text-destructive-foreground'
+}
+
+function outcomeLabel(
+  outcome: string,
+  isAttacker: boolean,
+  isDefender: boolean
+): string {
+  if (!isAttacker && !isDefender) return outcome
+  const won =
+    (isAttacker && outcome === 'AttackerWon') || (isDefender && outcome === 'DefenderWon')
+  if (outcome === 'Draw') return 'Draw'
+  return won ? 'Win' : 'Loss'
+}
+
+function EventCard({ event }: { event: ReplayBattleEventViewModel }) {
+  const { isCurrentPlayerAttacker: isAttacker, isCurrentPlayerDefender: isDefender } = event
+  const badgeClass = outcomeBadgeClass(event.outcome, isAttacker, isDefender)
+  const label = outcomeLabel(event.outcome, isAttacker, isDefender)
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 text-sm">
+          <span className={`font-semibold ${isAttacker ? 'text-primary' : ''}`}>
+            {event.attackerName}
+          </span>
+          <span className="text-muted-foreground">⚔️</span>
+          <span className={`font-semibold ${isDefender ? 'text-primary' : ''}`}>
+            {event.defenderName}
+          </span>
+        </div>
+        <span className={`text-xs px-2 py-0.5 rounded font-bold ${badgeClass}`}>{label}</span>
+      </div>
+      <div className="text-xs text-muted-foreground mt-2">
+        {new Date(event.occurredAt).toLocaleString(undefined, {
+          day: 'numeric',
+          month: 'short',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function ReplayViewer() {
+  const { gameId } = useParams<{ gameId: string }>()
+  const { data, isLoading, error, refetch } = useQuery<GameReplayViewModel>({
+    queryKey: ['replay', gameId],
+    queryFn: () => apiClient.get(`/api/replay/${gameId}`).then((r) => r.data),
+    enabled: !!gameId,
+  })
+
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [speedIndex, setSpeedIndex] = useState(1) // default 1x
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const events: ReplayBattleEventViewModel[] = data?.battleEvents ?? []
+  const total = events.length
+
+  const stopPlayback = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    setIsPlaying(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isPlaying || total === 0) return
+    intervalRef.current = setInterval(() => {
+      setCurrentIndex((prev) => {
+        if (prev >= total - 1) {
+          stopPlayback()
+          return prev
+        }
+        return prev + 1
+      })
+    }, SPEED_OPTIONS[speedIndex].ms)
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current)
+    }
+  }, [isPlaying, speedIndex, total, stopPlayback])
+
+  const handlePlay = () => {
+    if (currentIndex >= total - 1) setCurrentIndex(0)
+    setIsPlaying(true)
+  }
+
+  const handlePause = () => stopPlayback()
+
+  const handlePrev = () => {
+    stopPlayback()
+    setCurrentIndex((prev) => Math.max(0, prev - 1))
+  }
+
+  const handleNext = () => {
+    stopPlayback()
+    setCurrentIndex((prev) => Math.min(total - 1, prev + 1))
+  }
+
+  if (isLoading) return <PageLoader message="Loading replay..." />
+  if (error) return <ApiError message="Failed to load replay." onRetry={() => void refetch()} />
+  if (!data) return null
+
+  const currentEvent = total > 0 ? events[currentIndex] : null
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 flex-wrap">
+        <h1 className="text-2xl font-bold">{data.gameName}</h1>
+        <span
+          className={`text-xs px-2 py-0.5 rounded font-bold ${
+            data.status === 'Finished'
+              ? 'bg-muted text-muted-foreground'
+              : 'bg-success/20 text-success-foreground'
+          }`}
+        >
+          {data.status}
+        </span>
+        <span className="text-sm text-muted-foreground">
+          {new Date(data.startTime).toLocaleDateString(undefined, {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+          })}
+          {data.actualEndTime &&
+            ` – ${new Date(data.actualEndTime).toLocaleDateString(undefined, {
+              day: 'numeric',
+              month: 'short',
+              year: 'numeric',
+            })}`}
+        </span>
+        <span className="text-sm text-muted-foreground">
+          · {data.finalStandings.length} player{data.finalStandings.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Final Standings */}
+      {data.finalStandings.length > 0 && (
+        <div className="rounded-lg border border-border overflow-hidden mb-6">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th scope="col" className="px-3 py-2 text-left font-medium">Rank</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Player</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium hidden sm:table-cell">Race</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.finalStandings.map((p) => {
+                const isMe = currentEvent != null
+                  ? currentEvent.isCurrentPlayerAttacker
+                    ? currentEvent.attackerName === p.playerName
+                    : currentEvent.defenderName === p.playerName
+                  : false
+                return (
+                  <tr
+                    key={p.playerId}
+                    className={`border-b border-border/50 transition-colors ${
+                      isMe ? 'bg-primary/10' : 'hover:bg-muted/30'
+                    }`}
+                  >
+                    <td className="px-3 py-2">
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded font-bold ${rankBadgeClass(
+                          p.finalRank,
+                          data.finalStandings.length
+                        )}`}
+                      >
+                        #{p.finalRank}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-medium">{p.playerName}</td>
+                    <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">{p.race}</td>
+                    <td className="px-3 py-2 text-right font-mono">
+                      {Number(p.finalScore).toLocaleString()}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Battle Timeline */}
+      {total === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center border border-border rounded-lg">
+          <div className="text-4xl mb-3 opacity-30">⚔️</div>
+          <p className="text-muted-foreground">No battles recorded for this game.</p>
+        </div>
+      ) : (
+        <>
+          {/* Scrub bar */}
+          <div className="mb-4">
+            <input
+              type="range"
+              min={0}
+              max={total - 1}
+              value={currentIndex}
+              onChange={(e) => {
+                stopPlayback()
+                setCurrentIndex(Number(e.target.value))
+              }}
+              className="w-full accent-primary"
+              aria-label="Battle timeline"
+            />
+            <div className="flex justify-between text-xs text-muted-foreground mt-1">
+              <span>{total > 0 ? new Date(events[0].occurredAt).toLocaleDateString() : ''}</span>
+              <span>Event {currentIndex + 1} of {total}</span>
+              <span>{total > 0 ? new Date(events[total - 1].occurredAt).toLocaleDateString() : ''}</span>
+            </div>
+          </div>
+
+          {/* Current event card */}
+          {currentEvent && <EventCard event={currentEvent} />}
+
+          {/* Playback controls */}
+          <div className="flex items-center gap-3 mt-4 flex-wrap">
+            <button
+              onClick={() => { stopPlayback(); setCurrentIndex(0) }}
+              className="text-xs px-2 py-1 rounded border border-border hover:bg-muted/50 transition-colors"
+              title="Jump to first"
+            >
+              ⏮
+            </button>
+            <button
+              onClick={handlePrev}
+              className="text-xs px-2 py-1 rounded border border-border hover:bg-muted/50 transition-colors"
+              title="Previous"
+            >
+              ◀
+            </button>
+            {isPlaying ? (
+              <button
+                onClick={handlePause}
+                className="text-sm px-3 py-1 rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                ⏸ Pause
+              </button>
+            ) : (
+              <button
+                onClick={handlePlay}
+                className="text-sm px-3 py-1 rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                disabled={total === 0}
+              >
+                ▶ Play
+              </button>
+            )}
+            <button
+              onClick={handleNext}
+              className="text-xs px-2 py-1 rounded border border-border hover:bg-muted/50 transition-colors"
+              title="Next"
+            >
+              ▶
+            </button>
+            <button
+              onClick={() => { stopPlayback(); setCurrentIndex(total - 1) }}
+              className="text-xs px-2 py-1 rounded border border-border hover:bg-muted/50 transition-colors"
+              title="Jump to last"
+            >
+              ⏭
+            </button>
+
+            <div className="flex items-center gap-1 ml-auto">
+              <span className="text-xs text-muted-foreground">Speed:</span>
+              {SPEED_OPTIONS.map((opt, i) => (
+                <button
+                  key={opt.label}
+                  onClick={() => setSpeedIndex(i)}
+                  className={`text-xs px-2 py-0.5 rounded transition-colors ${
+                    speedIndex === i
+                      ? 'bg-primary text-primary-foreground'
+                      : 'border border-border hover:bg-muted/50'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Implements Phase 5C Replay Viewer at `/replays/{gameId}` using BGE-native persisted data (battle reports, achievements, game records) rather than Agent1 bot logs (deferred until BGE-817 merges and JSONL gains a `gameId` field)
- New `GET /api/replay/{gameId}` endpoint returns final standings + chronological battle events for the authenticated player
- React UI includes scrub bar, Prev/Next step, Play/Pause with 0.5x/1x/2x/4x speed, Jump to First/Last, outcome badge (Win/Loss/Draw from viewer's perspective)
- "Replay" link added to game history table in `PlayerHistory.tsx`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes — 626 tests (6 new in `GameReplayRepositoryTest.cs`)
- [ ] Navigate to `/history`, click "Replay" on a finished game — verify replay page loads
- [ ] Verify final standings table shows all players with ranks and scores
- [ ] Verify battle timeline scrubber advances through events
- [ ] Verify Play button auto-advances at selected speed; Pause stops it
- [ ] Verify outcome badge shows Win/Loss/Draw correctly for attacker and defender roles
- [ ] Verify empty state message when game has no battles
- [ ] Verify 404 response for unknown game ID

Closes BGE-823