### PR TITLE
feat: BGE-843 Phase 6A — Global Leaderboard & Rankings

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/LeaderboardController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/LeaderboardController.cs
@@ -1,0 +1,63 @@
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Route("api/leaderboard")]
+	public class LeaderboardController : ControllerBase {
+		private readonly LeaderboardRepository leaderboardRepository;
+		private readonly CurrentUserContext currentUserContext;
+
+		public LeaderboardController(LeaderboardRepository leaderboardRepository, CurrentUserContext currentUserContext) {
+			this.leaderboardRepository = leaderboardRepository;
+			this.currentUserContext = currentUserContext;
+		}
+
+		/// <summary>Returns the global seasonal leaderboard, top players by weighted score.</summary>
+		/// <param name="limit">Maximum entries to return (default 100).</param>
+		[AllowAnonymous]
+		[HttpGet]
+		[ProducesResponseType(typeof(GlobalLeaderboardViewModel), StatusCodes.Status200OK)]
+		public ActionResult<GlobalLeaderboardViewModel> GetLeaderboard([FromQuery] int limit = 100) {
+			var currentUserId = currentUserContext.IsValid ? currentUserContext.UserId : null;
+			var result = leaderboardRepository.GetLeaderboard(limit);
+			return Ok(new GlobalLeaderboardViewModel(
+				Entries: result.Entries.Select(e => ToViewModel(e, currentUserId)).ToArray(),
+				SeasonStart: result.SeasonStart,
+				SeasonEnd: result.SeasonEnd
+			));
+		}
+
+		/// <summary>Returns the rank and nearby leaderboard entries (±5) for a specific player.</summary>
+		/// <param name="playerId">The player's OAuth user ID.</param>
+		[AllowAnonymous]
+		[HttpGet("player/{playerId}")]
+		[ProducesResponseType(typeof(PlayerLeaderboardContextViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<PlayerLeaderboardContextViewModel> GetPlayerContext(string playerId) {
+			var context = leaderboardRepository.GetPlayerContext(playerId);
+			if (context == null) return NotFound();
+			var currentUserId = currentUserContext.IsValid ? currentUserContext.UserId : null;
+			return Ok(new PlayerLeaderboardContextViewModel(
+				Rank: context.Rank,
+				NearbyEntries: context.NearbyEntries.Select(e => ToViewModel(e, currentUserId)).ToArray()
+			));
+		}
+
+		private static GlobalLeaderboardEntryViewModel ToViewModel(LeaderboardEntry e, string? currentUserId)
+			=> new GlobalLeaderboardEntryViewModel(
+				Rank: e.Rank,
+				UserId: e.UserId,
+				DisplayName: e.DisplayName,
+				Score: e.Score,
+				TournamentWins: e.TournamentWins,
+				GameWins: e.GameWins,
+				AchievementsUnlocked: e.AchievementsUnlocked,
+				IsCurrentPlayer: e.UserId == currentUserId
+			);
+	}
+}

--- a/src/BrowserGameEngine.Shared/GlobalLeaderboardViewModel.cs
+++ b/src/BrowserGameEngine.Shared/GlobalLeaderboardViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace BrowserGameEngine.Shared {
+	public record GlobalLeaderboardEntryViewModel(
+		int Rank,
+		string UserId,
+		string DisplayName,
+		double Score,
+		int TournamentWins,
+		int GameWins,
+		int AchievementsUnlocked,
+		bool IsCurrentPlayer
+	);
+
+	public record GlobalLeaderboardViewModel(
+		GlobalLeaderboardEntryViewModel[] Entries,
+		DateTime SeasonStart,
+		DateTime SeasonEnd
+	);
+
+	public record PlayerLeaderboardContextViewModel(
+		int Rank,
+		GlobalLeaderboardEntryViewModel[] NearbyEntries
+	);
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LeaderboardRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LeaderboardRepositoryTest.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Linq;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Repositories;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class LeaderboardRepositoryTest {
+		private const string UserId1 = "user-1";
+		private const string UserId2 = "user-2";
+		private const string UserId3 = "user-3";
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player1");
+		private static readonly PlayerId Player2 = PlayerIdFactory.Create("player2");
+		private static readonly PlayerId Player3 = PlayerIdFactory.Create("player3");
+
+		private static LeaderboardRepository Repo(GlobalState globalState)
+			=> new LeaderboardRepository(globalState, TimeProvider.System);
+
+		private static PlayerAchievementImmutable Achievement(string userId, PlayerId playerId, string playerName, string gameId, int finalRank, DateTime finishedAt)
+			=> new PlayerAchievementImmutable(userId, new GameId(gameId), playerId, playerName, finalRank, 100m, "sco", finishedAt);
+
+		private static GameRecordImmutable GameRecord(string gameId, string? tournamentId = null)
+			=> new GameRecordImmutable(
+				new GameId(gameId), gameId, "sco", GameStatus.Finished,
+				DateTime.UtcNow.AddDays(-10), DateTime.UtcNow.AddDays(-1), TimeSpan.FromSeconds(60),
+				TournamentId: tournamentId
+			);
+
+		// ── ComputeScore ─────────────────────────────────────────────────────────
+
+		[Fact]
+		public void ComputeScore_ZeroInputs_ReturnsZero() {
+			Assert.Equal(0.0, LeaderboardRepository.ComputeScore(0, 0, 0));
+		}
+
+		[Fact]
+		public void ComputeScore_TournamentWinCounts3x() {
+			Assert.Equal(3.0, LeaderboardRepository.ComputeScore(1, 0, 0));
+		}
+
+		[Fact]
+		public void ComputeScore_GameWinCounts1x() {
+			Assert.Equal(1.0, LeaderboardRepository.ComputeScore(0, 1, 0));
+		}
+
+		[Fact]
+		public void ComputeScore_AchievementCountsHalf() {
+			Assert.Equal(0.5, LeaderboardRepository.ComputeScore(0, 0, 1));
+		}
+
+		[Fact]
+		public void ComputeScore_MixedInputs_CombinesCorrectly() {
+			// 2 tournament wins (6) + 3 game wins (3) + 4 achievements (2) = 11
+			Assert.Equal(11.0, LeaderboardRepository.ComputeScore(2, 3, 4));
+		}
+
+		// ── GetLeaderboard ────────────────────────────────────────────────────────
+
+		[Fact]
+		public void GetLeaderboard_NoData_ReturnsEmptyEntries() {
+			var globalState = new GlobalState();
+			var result = Repo(globalState).GetLeaderboard();
+			Assert.Empty(result.Entries);
+		}
+
+		[Fact]
+		public void GetLeaderboard_AchievementsOutsideSeason_NotCounted() {
+			var globalState = new GlobalState();
+			// 40 days ago — outside the 30-day window
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-old", 1, DateTime.UtcNow.AddDays(-40)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			Assert.Empty(result.Entries);
+		}
+
+		[Fact]
+		public void GetLeaderboard_SingleGameWin_Rank1WithScore1() {
+			var globalState = new GlobalState();
+			globalState.AddGame(GameRecord("game-1"));
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-1", 1, DateTime.UtcNow.AddDays(-5)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			var entry = Assert.Single(result.Entries);
+			Assert.Equal(1, entry.Rank);
+			Assert.Equal(UserId1, entry.UserId);
+			Assert.Equal(1.0, entry.Score);
+			Assert.Equal(0, entry.TournamentWins);
+			Assert.Equal(1, entry.GameWins);
+		}
+
+		[Fact]
+		public void GetLeaderboard_TournamentWin_ScoreIs3() {
+			var globalState = new GlobalState();
+			globalState.AddGame(GameRecord("tourney-game-1", tournamentId: "t1"));
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "tourney-game-1", 1, DateTime.UtcNow.AddDays(-5)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			var entry = Assert.Single(result.Entries);
+			Assert.Equal(3.0, entry.Score);
+			Assert.Equal(1, entry.TournamentWins);
+			Assert.Equal(0, entry.GameWins);
+		}
+
+		[Fact]
+		public void GetLeaderboard_NonWinParticipation_NotCountedAsWin() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-1", 2, DateTime.UtcNow.AddDays(-5)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			// Still appears on leaderboard (played a game in season) but with 0 wins
+			var entry = Assert.Single(result.Entries);
+			Assert.Equal(0, entry.GameWins);
+			Assert.Equal(0.0, entry.Score);
+		}
+
+		[Fact]
+		public void GetLeaderboard_MilestoneUnlockedInSeason_CountsHalf() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-1", 2, DateTime.UtcNow.AddDays(-5)));
+			globalState.AddMilestone(new UserMilestoneImmutable(UserId1, "win-first", DateTime.UtcNow.AddDays(-3)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			var entry = Assert.Single(result.Entries);
+			Assert.Equal(0.5, entry.Score);
+			Assert.Equal(1, entry.AchievementsUnlocked);
+		}
+
+		[Fact]
+		public void GetLeaderboard_MilestoneOutsideSeason_NotCounted() {
+			var globalState = new GlobalState();
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-1", 1, DateTime.UtcNow.AddDays(-5)));
+			globalState.AddMilestone(new UserMilestoneImmutable(UserId1, "win-first", DateTime.UtcNow.AddDays(-45)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			var entry = Assert.Single(result.Entries);
+			Assert.Equal(1.0, entry.Score);
+			Assert.Equal(0, entry.AchievementsUnlocked);
+		}
+
+		[Fact]
+		public void GetLeaderboard_MultipleUsers_SortedByScoreDescending() {
+			var globalState = new GlobalState();
+			globalState.AddGame(GameRecord("tourney-g1", tournamentId: "t1"));
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "tourney-g1", 1, DateTime.UtcNow.AddDays(-5)));  // score 3
+			globalState.AddAchievement(Achievement(UserId2, Player2, "Bob", "game-1", 1, DateTime.UtcNow.AddDays(-3)));       // score 1
+			globalState.AddAchievement(Achievement(UserId3, Player3, "Charlie", "game-2", 1, DateTime.UtcNow.AddDays(-2)));   // score 1.5 (with milestone)
+			globalState.AddMilestone(new UserMilestoneImmutable(UserId3, "win-first", DateTime.UtcNow.AddDays(-1)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			Assert.Equal(3, result.Entries.Length);
+			Assert.Equal(UserId1, result.Entries[0].UserId); // 3.0
+			Assert.Equal(1, result.Entries[0].Rank);
+			Assert.Equal(UserId3, result.Entries[1].UserId); // 1.5
+			Assert.Equal(2, result.Entries[1].Rank);
+			Assert.Equal(UserId2, result.Entries[2].UserId); // 1.0
+			Assert.Equal(3, result.Entries[2].Rank);
+		}
+
+		[Fact]
+		public void GetLeaderboard_LimitApplied() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 5; i++) {
+				globalState.AddAchievement(Achievement($"user-{i}", PlayerIdFactory.Create($"p{i}"), $"Player{i}", $"game-{i}", 1, DateTime.UtcNow.AddDays(-1)));
+			}
+
+			var result = Repo(globalState).GetLeaderboard(limit: 3);
+
+			Assert.Equal(3, result.Entries.Length);
+		}
+
+		[Fact]
+		public void GetLeaderboard_EntriesDoNotHaveIsCurrentPlayer() {
+			// IsCurrentPlayer is computed by the controller, not the repository
+			var globalState = new GlobalState();
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "game-1", 1, DateTime.UtcNow.AddDays(-5)));
+
+			var result = Repo(globalState).GetLeaderboard();
+
+			Assert.Single(result.Entries);
+			Assert.Equal(UserId1, result.Entries[0].UserId);
+		}
+
+		[Fact]
+		public void GetLeaderboard_SeasonWindowIsReturned() {
+			var globalState = new GlobalState();
+			var repo = Repo(globalState);
+
+			var result = repo.GetLeaderboard();
+
+			Assert.True(result.SeasonEnd - result.SeasonStart == TimeSpan.FromDays(30));
+		}
+
+		// ── GetPlayerContext ──────────────────────────────────────────────────────
+
+		[Fact]
+		public void GetPlayerContext_UnknownPlayer_ReturnsNull() {
+			var globalState = new GlobalState();
+			Assert.Null(Repo(globalState).GetPlayerContext("unknown-user"));
+		}
+
+		[Fact]
+		public void GetPlayerContext_ReturnsCorrectRank() {
+			var globalState = new GlobalState();
+			globalState.AddGame(GameRecord("tourney-g1", tournamentId: "t1"));
+			globalState.AddAchievement(Achievement(UserId1, Player1, "Alice", "tourney-g1", 1, DateTime.UtcNow.AddDays(-5))); // rank 1 (score 3)
+			globalState.AddAchievement(Achievement(UserId2, Player2, "Bob", "game-1", 1, DateTime.UtcNow.AddDays(-3)));      // rank 2 (score 1)
+
+			var ctx = Repo(globalState).GetPlayerContext(UserId2);
+
+			Assert.NotNull(ctx);
+			Assert.Equal(2, ctx.Rank);
+		}
+
+		[Fact]
+		public void GetPlayerContext_NearbyEntriesIncludesPlayer() {
+			var globalState = new GlobalState();
+			for (int i = 0; i < 10; i++) {
+				globalState.AddAchievement(Achievement($"user-{i}", PlayerIdFactory.Create($"p{i}"), $"P{i}", $"game-{i}", 1, DateTime.UtcNow.AddDays(-1)));
+			}
+
+			var ctx = Repo(globalState).GetPlayerContext("user-7");
+
+			Assert.NotNull(ctx);
+			Assert.Contains(ctx.NearbyEntries, e => e.UserId == "user-7");
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -8,6 +8,7 @@ using BrowserGameEngine.StatefulGameServer.GameTicks;
 using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
 using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
+using BrowserGameEngine.StatefulGameServer.Repositories;
 using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -77,6 +78,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<ResourceHistoryRepositoryWrite>();
 			services.AddSingleton<MilestoneRepository>();
 			services.AddSingleton<MilestoneRepositoryWrite>();
+			services.AddSingleton<LeaderboardRepository>();
 			services.AddSingleton<GameReplayRepository>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/LeaderboardRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/LeaderboardRepository.cs
@@ -1,0 +1,108 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.Repositories {
+	public record LeaderboardEntry(
+		int Rank,
+		string UserId,
+		string DisplayName,
+		double Score,
+		int TournamentWins,
+		int GameWins,
+		int AchievementsUnlocked
+	);
+
+	public record LeaderboardResult(
+		LeaderboardEntry[] Entries,
+		DateTime SeasonStart,
+		DateTime SeasonEnd
+	);
+
+	public record PlayerLeaderboardContext(
+		int Rank,
+		LeaderboardEntry[] NearbyEntries
+	);
+
+	public class LeaderboardRepository {
+		private readonly GlobalState globalState;
+		private readonly TimeProvider timeProvider;
+
+		public LeaderboardRepository(GlobalState globalState, TimeProvider timeProvider) {
+			this.globalState = globalState;
+			this.timeProvider = timeProvider;
+		}
+
+		public (DateTime SeasonStart, DateTime SeasonEnd) GetCurrentSeason() {
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			return (now.AddDays(-30), now);
+		}
+
+		/// <summary>
+		/// Weighted leaderboard score: tournament wins (×3) + game wins (×1) + milestones unlocked (×0.5).
+		/// </summary>
+		public static double ComputeScore(int tournamentWins, int gameWins, int achievementsUnlocked)
+			=> tournamentWins * 3.0 + gameWins * 1.0 + achievementsUnlocked * 0.5;
+
+		public LeaderboardResult GetLeaderboard(int limit = 100) {
+			var (seasonStart, seasonEnd) = GetCurrentSeason();
+			var entries = BuildEntries(seasonStart, seasonEnd).Take(limit).ToArray();
+			return new LeaderboardResult(entries, seasonStart, seasonEnd);
+		}
+
+		public PlayerLeaderboardContext? GetPlayerContext(string userId) {
+			var (seasonStart, seasonEnd) = GetCurrentSeason();
+			var allEntries = BuildEntries(seasonStart, seasonEnd).ToList();
+			var playerEntry = allEntries.FirstOrDefault(e => e.UserId == userId);
+			if (playerEntry == null) return null;
+
+			var rank = playerEntry.Rank;
+			var startIdx = Math.Max(0, rank - 1 - 5);
+			var endIdx = Math.Min(allEntries.Count, rank + 5);
+			var nearby = allEntries.Skip(startIdx).Take(endIdx - startIdx).ToArray();
+			return new PlayerLeaderboardContext(rank, nearby);
+		}
+
+		private IEnumerable<LeaderboardEntry> BuildEntries(DateTime seasonStart, DateTime seasonEnd) {
+			var achievements = globalState.GetAchievements()
+				.Where(a => a.FinishedAt >= seasonStart && a.FinishedAt <= seasonEnd)
+				.ToList();
+
+			var milestones = globalState.GetAllMilestones()
+				.Where(m => m.UnlockedAt >= seasonStart && m.UnlockedAt <= seasonEnd)
+				.ToList();
+
+			var tournamentGameIds = new HashSet<string>(
+				globalState.GetGames()
+					.Where(g => g.TournamentId != null && g.Status == GameStatus.Finished)
+					.Select(g => g.GameId.Id)
+			);
+
+			return achievements
+				.GroupBy(a => a.UserId)
+				.Select(group => {
+					var userId = group.Key;
+					var list = group.ToList();
+					var tournamentWins = list.Count(a => a.FinalRank == 1 && tournamentGameIds.Contains(a.GameId.Id));
+					var gameWins = list.Count(a => a.FinalRank == 1 && !tournamentGameIds.Contains(a.GameId.Id));
+					var achievementsUnlocked = milestones.Count(m => m.UserId == userId);
+					var score = ComputeScore(tournamentWins, gameWins, achievementsUnlocked);
+					var displayName = globalState.GetUserDisplayName(userId) ?? list.First().PlayerName;
+					return (userId, displayName, score, tournamentWins, gameWins, achievementsUnlocked);
+				})
+				.OrderByDescending(x => x.score)
+				.ThenBy(x => x.displayName)
+				.Select((x, idx) => new LeaderboardEntry(
+					Rank: idx + 1,
+					UserId: x.userId,
+					DisplayName: x.displayName,
+					Score: x.score,
+					TournamentWins: x.tournamentWins,
+					GameWins: x.gameWins,
+					AchievementsUnlocked: x.achievementsUnlocked
+				));
+		}
+	}
+}

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -48,6 +48,7 @@ const ReplayViewer = lazy(() => import('@/pages/ReplayViewer').then(m => ({ defa
 const GameLiveView = lazy(() => import('@/pages/GameLiveView').then(m => ({ default: m.GameLiveView })))
 const PlayerStats = lazy(() => import('@/pages/PlayerStats').then(m => ({ default: m.PlayerStats })))
 const TournamentResults = lazy(() => import('@/pages/TournamentResults').then(m => ({ default: m.TournamentResults })))
+const Leaderboard = lazy(() => import('@/pages/Leaderboard').then(m => ({ default: m.Leaderboard })))
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -210,6 +211,7 @@ const router = createBrowserRouter([
       { path: '/replays/:gameId', element: <ReplayViewer /> },
       { path: '/stats', element: <PlayerStats /> },
       { path: '/tournaments/:tournamentId', element: <TournamentResults /> },
+      { path: '/leaderboard', element: <Leaderboard /> },
       { path: '/admin/games', element: <AdminGames /> },
       { path: '/admin/players', element: <AdminPlayers /> },
       { path: '/admin/ticks', element: <AdminTickControl /> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -995,6 +995,30 @@ export interface PublicPlayerAchievementsViewModel {
   achievements: PublicAchievementEntry[]
 }
 
+// Global Leaderboard
+
+export interface GlobalLeaderboardEntryViewModel {
+  rank: number
+  userId: string
+  displayName: string
+  score: number
+  tournamentWins: number
+  gameWins: number
+  achievementsUnlocked: number
+  isCurrentPlayer: boolean
+}
+
+export interface GlobalLeaderboardViewModel {
+  entries: GlobalLeaderboardEntryViewModel[]
+  seasonStart: string
+  seasonEnd: string
+}
+
+export interface PlayerLeaderboardContextViewModel {
+  rank: number
+  nearbyEntries: GlobalLeaderboardEntryViewModel[]
+}
+
 // Pagination
 
 export interface PaginatedResponse<T> {

--- a/src/ReactClient/src/pages/Leaderboard.tsx
+++ b/src/ReactClient/src/pages/Leaderboard.tsx
@@ -1,0 +1,201 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
+import { TrophyIcon } from 'lucide-react'
+import apiClient from '@/api/client'
+import type { GlobalLeaderboardViewModel } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+
+function medalClass(rank: number): string {
+  if (rank === 1) return 'text-yellow-400'
+  if (rank === 2) return 'text-slate-300'
+  if (rank === 3) return 'text-amber-600'
+  return 'text-muted-foreground'
+}
+
+function medalLabel(rank: number): string {
+  if (rank === 1) return '🥇'
+  if (rank === 2) return '🥈'
+  if (rank === 3) return '🥉'
+  return `#${rank}`
+}
+
+function SeasonCountdown({ seasonEnd }: { seasonEnd: string }) {
+  const end = new Date(seasonEnd)
+  const now = new Date()
+  const diffMs = end.getTime() - now.getTime()
+  const diffDays = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)))
+  const diffHours = Math.max(0, Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)))
+  return (
+    <span className="text-sm text-muted-foreground">
+      Season resets in <span className="font-semibold text-foreground">{diffDays}d {diffHours}h</span>
+    </span>
+  )
+}
+
+export function Leaderboard() {
+  const { data, isLoading, error, refetch } = useQuery<GlobalLeaderboardViewModel>({
+    queryKey: ['global-leaderboard'],
+    queryFn: () => apiClient.get<GlobalLeaderboardViewModel>('/api/leaderboard').then((r) => r.data),
+    refetchInterval: 60_000,
+  })
+
+  if (isLoading) return <PageLoader message="Loading leaderboard..." />
+  if (error) return <ApiError message="Failed to load leaderboard." onRetry={() => void refetch()} />
+  if (!data) return null
+
+  const entries = data.entries
+  const top10 = entries.slice(0, 10)
+  const rest = entries.slice(10)
+  const currentPlayerEntry = entries.find((e) => e.isCurrentPlayer)
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <TrophyIcon className="h-6 w-6 text-yellow-400" />
+            Global Leaderboard
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">Rolling 30-day season</p>
+        </div>
+        <SeasonCountdown seasonEnd={data.seasonEnd} />
+      </div>
+
+      {entries.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground text-sm">
+          No ranked players yet this season. Play a game to get on the board!
+        </div>
+      ) : (
+        <>
+          {/* Top 10 podium */}
+          <div className="rounded-lg border overflow-hidden">
+            <div className="px-4 py-2 bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide font-semibold">
+              Top Players
+            </div>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-secondary/10 text-xs text-muted-foreground uppercase tracking-wide">
+                  <th scope="col" className="px-4 py-2 text-left w-12">Rank</th>
+                  <th scope="col" className="px-4 py-2 text-left">Player</th>
+                  <th scope="col" className="px-4 py-2 text-right">Score</th>
+                  <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">T. Wins</th>
+                  <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Wins</th>
+                  <th scope="col" className="px-4 py-2 text-right hidden md:table-cell">Milestones</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {top10.map((entry) => (
+                  <tr
+                    key={entry.userId}
+                    className={`transition-colors ${entry.isCurrentPlayer ? 'bg-primary/10 border-l-2 border-l-primary' : 'hover:bg-secondary/20'}`}
+                  >
+                    <td className={`px-4 py-3 font-bold text-base ${medalClass(entry.rank)}`}>
+                      {medalLabel(entry.rank)}
+                    </td>
+                    <td className="px-4 py-3 font-medium">
+                      <Link
+                        to={`/profile/${encodeURIComponent(entry.userId)}`}
+                        className="hover:underline text-primary"
+                      >
+                        {entry.displayName}
+                      </Link>
+                      {entry.isCurrentPlayer && (
+                        <span className="ml-2 text-xs text-muted-foreground">(you)</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono font-semibold">
+                      {entry.score.toFixed(1)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden sm:table-cell">
+                      {entry.tournamentWins}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden sm:table-cell">
+                      {entry.gameWins}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden md:table-cell">
+                      {entry.achievementsUnlocked}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Current player sticky row if outside top 10 */}
+          {currentPlayerEntry && currentPlayerEntry.rank > 10 && (
+            <div className="rounded-lg border border-primary/40 bg-primary/5 overflow-hidden">
+              <div className="px-4 py-2 text-xs text-muted-foreground font-semibold uppercase tracking-wide">
+                Your Ranking
+              </div>
+              <table className="w-full text-sm">
+                <tbody>
+                  <tr>
+                    <td className="px-4 py-3 font-bold text-muted-foreground w-12">#{currentPlayerEntry.rank}</td>
+                    <td className="px-4 py-3 font-medium">
+                      {currentPlayerEntry.displayName}
+                      <span className="ml-2 text-xs text-muted-foreground">(you)</span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono font-semibold">
+                      {currentPlayerEntry.score.toFixed(1)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden sm:table-cell">
+                      {currentPlayerEntry.tournamentWins}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden sm:table-cell">
+                      {currentPlayerEntry.gameWins}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono hidden md:table-cell">
+                      {currentPlayerEntry.achievementsUnlocked}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Remaining players (11+) */}
+          {rest.length > 0 && (
+            <div className="rounded-lg border overflow-hidden">
+              <div className="px-4 py-2 bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide font-semibold">
+                Remaining Players
+              </div>
+              <table className="w-full text-sm">
+                <tbody className="divide-y">
+                  {rest.map((entry) => (
+                    <tr
+                      key={entry.userId}
+                      className={`transition-colors ${entry.isCurrentPlayer ? 'bg-primary/10' : 'hover:bg-secondary/20'}`}
+                    >
+                      <td className="px-4 py-2 font-mono text-muted-foreground w-12">#{entry.rank}</td>
+                      <td className="px-4 py-2 font-medium">
+                        <Link
+                          to={`/profile/${encodeURIComponent(entry.userId)}`}
+                          className="hover:underline text-primary"
+                        >
+                          {entry.displayName}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono">{entry.score.toFixed(1)}</td>
+                      <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">{entry.tournamentWins}</td>
+                      <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">{entry.gameWins}</td>
+                      <td className="px-4 py-2 text-right font-mono hidden md:table-cell">{entry.achievementsUnlocked}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Score formula legend */}
+      <div className="rounded-lg border bg-secondary/10 p-4 text-xs text-muted-foreground space-y-1">
+        <p className="font-semibold text-foreground text-sm">Score Formula</p>
+        <p>Tournament win = 3 pts &nbsp;·&nbsp; Game win = 1 pt &nbsp;·&nbsp; Milestone unlocked = 0.5 pts</p>
+        <p>Season window: rolling 30 days</p>
+      </div>
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router'
+import { Link } from 'react-router'
 import { UserIcon, TrophyIcon, StarIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { PlayerCrossGameStatsViewModel, PublicPlayerAchievementsViewModel } from '@/api/types'
+import type { PlayerCrossGameStatsViewModel, PublicPlayerAchievementsViewModel, PlayerLeaderboardContextViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
@@ -75,6 +76,13 @@ export function PublicProfile() {
     enabled: !!userId,
   })
 
+  const { data: leaderboardCtx } = useQuery<PlayerLeaderboardContextViewModel>({
+    queryKey: ['leaderboard-context', userId],
+    queryFn: () =>
+      apiClient.get(`/api/leaderboard/player/${encodeURIComponent(userId ?? '')}`).then((r) => r.data),
+    enabled: !!userId,
+  })
+
   if (isLoading) return <PageLoader message="Loading profile..." />
   if (error) return <ApiError message="Failed to load player profile." onRetry={() => void refetch()} />
   if (!stats) {
@@ -113,6 +121,13 @@ export function PublicProfile() {
           <p className="text-sm text-muted-foreground mt-0.5">
             {stats.totalGames} {stats.totalGames === 1 ? 'game' : 'games'} played
           </p>
+          {leaderboardCtx && (
+            <p className="text-xs mt-0.5">
+              <Link to={`/leaderboard?highlight=${encodeURIComponent(userId ?? '')}`} className="text-yellow-500 hover:underline font-medium">
+                🏆 Season rank #{leaderboardCtx.rank}
+              </Link>
+            </p>
+          )}
           {stats.joinedAt && (
             <p className="text-xs text-muted-foreground mt-0.5">
               Member since {relativeTime(stats.joinedAt)}


### PR DESCRIPTION
## Summary
- Add `LeaderboardRepository` computing weighted seasonal score: tournament wins ×3 + game wins ×1 + milestones unlocked ×0.5
- Season window = rolling 30-day window from current UTC time
- Add `GET /api/leaderboard?limit=100` — top players sorted by score, current user flagged when authenticated
- Add `GET /api/leaderboard/player/{playerId}` — player rank + ±5 nearby entries (404 when not on board)
- Add `GlobalLeaderboardViewModel`, `PlayerLeaderboardContextViewModel` to Shared project
- Add `/leaderboard` React page: medals for top 10, sticky current-player row if outside top 10, score formula legend, season countdown timer
- Add season rank badge to PublicProfile page with link to leaderboard highlighted on player

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (645 total, 19 new `LeaderboardRepositoryTest` tests)
- [ ] Visit `/leaderboard` — verify table renders, medals show for rank 1-3
- [ ] Log in and visit `/leaderboard` — verify your row is highlighted
- [ ] Visit a player's `/profile/{userId}` — verify season rank badge appears
- [ ] Call `GET /api/leaderboard/player/{unknownId}` — verify 404 response
- [ ] Call `GET /api/leaderboard?limit=5` — verify at most 5 entries returned

Closes BGE-843