### PR TITLE
fix: BGE-858 mobile responsive fixes for tables and worker grid

### DIFF
--- a/src/ReactClient/src/components/WorkerAssignment.tsx
+++ b/src/ReactClient/src/components/WorkerAssignment.tsx
@@ -41,7 +41,7 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
   return (
     <div className="rounded-lg border bg-card p-4">
       <h3 className="font-semibold mb-3">Worker Assignment</h3>
-      <div className="grid grid-cols-3 gap-4 text-sm mb-3">
+      <div className="grid grid-cols-3 gap-2 sm:gap-4 text-sm mb-3">
         <div className="text-center">
           <div className="text-2xl font-bold text-primary">{data.totalWorkers}</div>
           <div className="text-muted-foreground">Total</div>

--- a/src/ReactClient/src/pages/Alliances.tsx
+++ b/src/ReactClient/src/pages/Alliances.tsx
@@ -286,8 +286,8 @@ export function Alliances({ gameId }: AlliancesProps) {
 								<tr>
 									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Name</th>
 									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Members</th>
-									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
-									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Founded</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Status</th>
+									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Founded</th>
 									<th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
 								</tr>
 							</thead>
@@ -309,7 +309,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 												{a.memberCount}
 											</span>
 										</td>
-										<td className="py-2 px-3">
+										<td className="py-2 px-3 hidden sm:table-cell">
 											{a.isAtWar && (
 												<span className="inline-flex items-center gap-1 rounded bg-danger/30 px-2 py-0.5 text-xs text-danger-foreground">
 													<SwordsIcon className="h-3 w-3" />
@@ -317,7 +317,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 												</span>
 											)}
 										</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">
+										<td className="py-2 px-3 text-xs text-muted-foreground hidden sm:table-cell">
 											{relativeTime(a.created)}
 										</td>
 										<td className="py-2 px-3">

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -82,7 +82,7 @@ function UnitRow({
     <tr className="border-b border-border">
       <td className="py-2 px-3 font-medium">{unit.definition?.name}</td>
       <td className="py-2 px-3 text-right tabular-nums">{unit.count.toLocaleString()}</td>
-      <td className="py-2 px-3 text-xs text-muted-foreground">
+      <td className="py-2 px-3 text-xs text-muted-foreground hidden sm:table-cell">
         ⚔️{unit.definition?.attack} 🛡️{unit.definition?.defense} ❤️{unit.definition?.hitpoints}
       </td>
       {unit.positionPlayerId && (
@@ -227,7 +227,7 @@ export function Units({ gameId }: UnitsProps) {
                     <tr>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
                       <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Stats</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Location</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
@@ -270,7 +270,7 @@ export function Units({ gameId }: UnitsProps) {
                     <tr>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
                       <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Stats</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
                   </thead>


### PR DESCRIPTION
## Summary

Targeted mobile responsiveness fixes for the most-used in-game pages. Pure front-end changes — no API or logic changes.

- **Units.tsx**: Hide the Stats column (`⚔️/🛡️/❤️`) on xs screens (`hidden sm:table-cell`) in both Deployed and Home Base tables. Tables already had `overflow-x-auto` wrappers. On xs only Unit, Count, and Actions remain visible.
- **Alliances.tsx**: Hide Status and Founded columns on xs screens. The table already had `overflow-x-auto`. On xs only Name, Members, and Join action remain.
- **WorkerAssignment.tsx**: Reduced grid gap on xs screens (`gap-2 sm:gap-4`) so the 3-column worker stats display doesn't feel cramped on 320px.

Pages already responsive (no changes needed):
- `PlayerRanking.tsx` — already has `hidden sm:table-cell` / `hidden md:table-cell` on all secondary columns
- `GameLiveView.tsx` — already uses `grid-cols-1 lg:grid-cols-2`, sections stack correctly on mobile
- `Base.tsx` — assets grid uses `sm:grid-cols-2 lg:grid-cols-3`; Trade/Colonize use `flex flex-wrap`
- `GameLayout.tsx` — hamburger + overlay sidebar already in place

Note: `AllianceRanking.tsx` and `Assets.tsx` referenced in the task description do not exist. The equivalent pages are `Alliances.tsx` and `Base.tsx` (which already had correct responsive grids).

## Test plan

- [ ] View Units page on 320px viewport — Stats column should be hidden, table should not scroll horizontally
- [ ] View Alliances page on 320px viewport — Status/Founded columns hidden, table fits without scroll
- [ ] View Base page on 320px viewport — Worker Assignment 3-col grid has tighter spacing, no overflow
- [ ] At sm (640px+) verify all hidden columns become visible again