### PR TITLE
feat: BGE-851 skeleton loading screens

### DIFF
--- a/src/ReactClient/src/components/Skeleton.tsx
+++ b/src/ReactClient/src/components/Skeleton.tsx
@@ -1,0 +1,31 @@
+/** Skeleton loading primitives — use aria-hidden=true on the container. */
+
+/** A single skeleton row for use inside a <tbody>. Mimics a table row with N cells. */
+export function SkeletonRow({ cols = 5 }: { cols?: number }) {
+	return (
+		<tr aria-hidden="true" className="animate-pulse">
+			{Array.from({ length: cols }).map((_, i) => (
+				<td key={i} className="px-4 py-3">
+					<div className="h-3.5 rounded bg-muted" />
+				</td>
+			))}
+		</tr>
+	)
+}
+
+/** A skeleton card block — mimics a stat card with label + value. */
+export function SkeletonCard({ className = '' }: { className?: string }) {
+	return (
+		<div aria-hidden="true" className={`animate-pulse rounded border bg-secondary/20 p-3 ${className}`}>
+			<div className="h-2.5 w-16 rounded bg-muted mb-2" />
+			<div className="h-6 w-24 rounded bg-muted" />
+		</div>
+	)
+}
+
+/** A generic skeleton line — for headings, text, etc. */
+export function SkeletonLine({ className = '' }: { className?: string }) {
+	return (
+		<div aria-hidden="true" className={`animate-pulse h-3 rounded bg-muted ${className}`} />
+	)
+}

--- a/src/ReactClient/src/pages/BattleReplay.tsx
+++ b/src/ReactClient/src/pages/BattleReplay.tsx
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { BattleReportDetailViewModel, UnitCountViewModel } from '@/api/types'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonLine } from '@/components/Skeleton'
 
 interface BattleReplayProps {
   gameId: string
@@ -51,7 +51,40 @@ export function BattleReplay({ gameId }: BattleReplayProps) {
     enabled: !!reportId,
   })
 
-  if (isLoading) return <PageLoader message="Loading battle report..." />
+  if (isLoading) return (
+    <div className="max-w-3xl space-y-6 animate-pulse" aria-hidden="true">
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <SkeletonLine className="h-6 w-36" />
+          <div className="h-6 w-16 rounded bg-muted" />
+        </div>
+        <SkeletonLine className="h-3.5 w-40" />
+        <SkeletonLine className="h-3.5 w-64" />
+      </div>
+      <div className="rounded-lg border p-4 space-y-3">
+        <SkeletonLine className="h-4 w-28" />
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <SkeletonLine className="h-3 w-32" />
+            <SkeletonLine className="h-3 w-full" />
+          </div>
+          <div className="space-y-2">
+            <SkeletonLine className="h-3 w-32" />
+            <SkeletonLine className="h-3 w-full" />
+          </div>
+        </div>
+      </div>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="rounded-lg border p-3 space-y-2">
+          <div className="h-5 w-16 rounded bg-muted" />
+          <div className="grid grid-cols-2 gap-4">
+            <SkeletonLine className="h-3 w-full" />
+            <SkeletonLine className="h-3 w-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
   if (error) return <ApiError message="Battle report not found." onRetry={() => void refetch()} />
   if (!report) return null
 

--- a/src/ReactClient/src/pages/InGamePlayerProfile.tsx
+++ b/src/ReactClient/src/pages/InGamePlayerProfile.tsx
@@ -3,8 +3,8 @@ import { useParams, Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { InGamePlayerProfileViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 
 interface InGamePlayerProfileProps {
   gameId: string
@@ -22,7 +22,26 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
     enabled: !!playerId,
   })
 
-  if (isLoading) return <PageLoader message="Loading player..." />
+  if (isLoading) return (
+    <div className="max-w-md space-y-4" aria-hidden="true">
+      <SkeletonLine className="h-4 w-20" />
+      <div className="rounded-lg border bg-card p-6 space-y-4">
+        <div className="flex items-center gap-4 animate-pulse">
+          <div className="h-14 w-14 rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-32 rounded bg-muted" />
+            <div className="h-3.5 w-24 rounded bg-muted" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </div>
+  )
   if (error) return <ApiError message="Failed to load player profile." onRetry={() => void refetch()} />
   if (!player) return <p className="text-destructive text-sm">Player not found.</p>
 

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router'
 import { TrophyIcon, SwordsIcon, StarIcon, ChevronRightIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { ProfileViewModel, PlayerAchievementsViewModel, PlayerHistoryViewModel } from '@/api/types'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { relativeTime } from '@/lib/utils'
 
 function outcomeLabel(isWin: boolean, gameStatus: string): { label: string; className: string } {
@@ -31,7 +31,29 @@ export function PlayerProfile() {
     queryFn: () => apiClient.get('/api/history').then(r => r.data),
   })
 
-  if (isLoading) return <PageLoader message="Loading profile..." />
+  if (isLoading) return (
+    <div className="max-w-lg space-y-5" aria-hidden="true">
+      <SkeletonLine className="h-6 w-40" />
+      <div className="rounded-lg border bg-card p-6 space-y-5">
+        <div className="flex items-center gap-4 animate-pulse">
+          <div className="h-16 w-16 rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-32 rounded bg-muted" />
+            <div className="h-3.5 w-24 rounded bg-muted" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="grid grid-cols-3 gap-3">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </div>
+  )
   if (error) return <ApiError message="Failed to load profile." onRetry={() => void refetch()} />
   if (!profile) return <p className="text-destructive text-sm">Failed to load profile.</p>
 

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { PublicPlayerViewModel, PaginatedResponse } from '@/api/types'
 import { cn } from '@/lib/utils'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonRow } from '@/components/Skeleton'
 
 const VICTORY_THRESHOLD = 500_000
 
@@ -65,9 +65,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
         {filterBtn('agent', 'Agent')}
       </div>
 
-      {isLoading ? (
-        <PageLoader message="Loading ranking..." />
-      ) : error ? (
+      {error ? (
         <ApiError message="Failed to load ranking." onRetry={() => void refetch()} />
       ) : (
         <div className="rounded-lg border overflow-hidden">
@@ -86,6 +84,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
               </tr>
             </thead>
             <tbody className="divide-y">
+              {isLoading && Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} cols={9} />)}
               {filtered.map((p, i) => (
                 <tr key={p.playerId} className={cn(
                   'transition-colors',


### PR DESCRIPTION
## Summary
- Add `SkeletonRow`, `SkeletonCard`, and `SkeletonLine` components in `Skeleton.tsx` using Tailwind `animate-pulse` + `bg-muted`
- Replace `PageLoader` spinner on `PlayerRanking` (8 skeleton table rows), `PlayerProfile` (avatar + 2×2 + 3×3 card grid), `InGamePlayerProfile` (avatar + 2×2 card grid), and `BattleReplay` (header + sections)
- All skeleton elements use `aria-hidden="true"` to avoid announcing placeholder content to screen readers

Closes BGE-851

## Test plan
- [ ] Navigate to `/games/{id}/ranking` — see 8 pulsing rows before data loads
- [ ] Navigate to `/profile` — see pulsing avatar + stat cards before data loads
- [ ] Navigate to `/games/{id}/player/{id}` — see pulsing avatar + stat cards
- [ ] Navigate to `/games/{id}/battles/{id}` — see pulsing report skeleton
- [ ] Confirm no console type errors