### PR TITLE
feat: BGE-852 page fade transition on route change

### DIFF
--- a/src/ReactClient/src/index.css
+++ b/src/ReactClient/src/index.css
@@ -75,3 +75,18 @@ body {
   color: var(--color-foreground);
   font-family: system-ui, -apple-system, sans-serif;
 }
+
+@keyframes page-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.page-enter {
+  animation: page-fade-in 100ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-enter {
+    animation: none;
+  }
+}

--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -273,7 +273,9 @@ function GameLayoutInner() {
         {/* Page content */}
         <main className="flex-1 overflow-y-auto p-3 sm:p-4">
           <Suspense fallback={<PageLoader />}>
-            <Outlet />
+            <div key={location.pathname} className="page-enter">
+              <Outlet />
+            </div>
           </Suspense>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Add `@keyframes page-fade-in` (opacity 0→1, 100ms ease-out) and `.page-enter` class to `index.css`
- Wrap `<Outlet />` in `GameLayout.tsx` with `<div key={location.pathname} className="page-enter">` so React remounts the wrapper on every route change
- `@media (prefers-reduced-motion: reduce)` disables the animation for users who opt out

Closes BGE-852

## Test plan
- [ ] Navigate between game pages — each route change should fade in over 100ms
- [ ] Enable "Reduce motion" in OS settings — animation should not play
- [ ] No console errors, no layout shifts