### PR TITLE
feat: BGE-853 EmptyState component

### DIFF
--- a/src/ReactClient/src/components/BuildQueue.tsx
+++ b/src/ReactClient/src/components/BuildQueue.tsx
@@ -1,6 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { HammerIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { BuildQueueViewModel } from '@/api/types'
+import { EmptyState } from '@/components/EmptyState'
 
 interface BuildQueueProps {
   gameId: string
@@ -31,7 +33,11 @@ export function BuildQueue({ gameId }: BuildQueueProps) {
     return (
       <div className="rounded-lg border bg-card p-4">
         <h3 className="font-semibold mb-2">Build Queue</h3>
-        <p className="text-muted-foreground text-sm">Queue is empty.</p>
+        <EmptyState
+          icon={<HammerIcon />}
+          title="Queue is empty"
+          description="Queue buildings or units to start constructing."
+        />
       </div>
     )
   }

--- a/src/ReactClient/src/components/EmptyState.tsx
+++ b/src/ReactClient/src/components/EmptyState.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router'
+
+type ActionProp =
+	| { label: string; onClick: () => void; to?: never }
+	| { label: string; to: string; onClick?: never }
+
+interface EmptyStateProps {
+	icon: ReactNode
+	title: string
+	description?: string
+	action?: ActionProp
+}
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+	return (
+		<div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+			<div className="text-muted-foreground [&>svg]:size-6">
+				{icon}
+			</div>
+			<p className="text-lg font-semibold">{title}</p>
+			{description && (
+				<p className="text-sm text-muted-foreground max-w-xs">{description}</p>
+			)}
+			{action && (
+				action.to ? (
+					<Link
+						to={action.to}
+						className="mt-1 rounded border px-4 py-1.5 text-sm hover:bg-secondary transition-colors"
+					>
+						{action.label}
+					</Link>
+				) : (
+					<button
+						onClick={action.onClick}
+						className="mt-1 rounded border px-4 py-1.5 text-sm hover:bg-secondary transition-colors"
+					>
+						{action.label}
+					</button>
+				)
+			)}
+		</div>
+	)
+}

--- a/src/ReactClient/src/components/NotificationBell.tsx
+++ b/src/ReactClient/src/components/NotificationBell.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
-import { BellIcon } from 'lucide-react'
+import { BellIcon, CheckCircleIcon } from 'lucide-react'
 import { useNotifications } from '@/hooks/useNotifications'
 import type { UseSignalRReturn } from '@/hooks/useSignalR'
 import { relativeTime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
+import { EmptyState } from '@/components/EmptyState'
 
 function notificationIcon(kind: string): string {
   switch (kind) {
@@ -71,7 +72,9 @@ export function NotificationBell({ signalR, onRealTimeNotification }: Notificati
           </div>
 
           {notifications.length === 0 ? (
-            <p className="text-sm text-muted-foreground p-3 text-center">No recent notifications.</p>
+            <div className="py-2">
+              <EmptyState icon={<CheckCircleIcon />} title="All caught up!" />
+            </div>
           ) : (
             <ul>
               {notifications.slice(0, 15).map((n) => (

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -5,7 +5,9 @@ import apiClient from '@/api/client'
 import type { PublicPlayerViewModel, PaginatedResponse } from '@/api/types'
 import { cn } from '@/lib/utils'
 import { ApiError } from '@/components/ApiError'
+import { EmptyState } from '@/components/EmptyState'
 import { SkeletonRow } from '@/components/Skeleton'
+import { UsersIcon } from 'lucide-react'
 
 const VICTORY_THRESHOLD = 500_000
 
@@ -85,6 +87,18 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
             </thead>
             <tbody className="divide-y">
               {isLoading && Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} cols={9} />)}
+              {!isLoading && filtered.length === 0 && (
+                <tr>
+                  <td colSpan={9}>
+                    <EmptyState
+                      icon={<UsersIcon />}
+                      title="No players yet"
+                      description="No players have joined this game yet."
+                      action={{ label: 'Browse games', to: '/games' }}
+                    />
+                  </td>
+                </tr>
+              )}
               {filtered.map((p, i) => (
                 <tr key={p.playerId} className={cn(
                   'transition-colors',


### PR DESCRIPTION
## Summary
- Add `EmptyState` component with `icon`, `title`, optional `description`, and optional `action` (inline button or React Router `Link`)
- Apply to `PlayerRanking` — no-players state with "Browse games" CTA
- Apply to `NotificationBell` — "All caught up!" empty state with CheckCircle icon
- Apply to `BuildQueue` — "Queue is empty" state with Hammer icon and helpful description

Closes BGE-853

## Test plan
- [ ] Open ranking page with no players — see EmptyState with link to /games
- [ ] Open notifications bell with no notifications — see "All caught up!" message
- [ ] Open Base page with empty build queue — see EmptyState instead of bare text