### PR TITLE
feat: BGE-855 touch zoom/pan in BattleReplay and GameLiveView

### DIFF
--- a/src/ReactClient/src/hooks/useTouchZoomPan.ts
+++ b/src/ReactClient/src/hooks/useTouchZoomPan.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef, useState } from 'react'
+
+interface TouchZoomPanState {
+	scale: number
+	translateX: number
+	translateY: number
+}
+
+interface UseTouchZoomPanResult {
+	containerProps: {
+		style: React.CSSProperties
+		onTouchStart: (e: React.TouchEvent) => void
+		onTouchMove: (e: React.TouchEvent) => void
+		onTouchEnd: () => void
+		onPointerMove: (e: React.PointerEvent) => void
+		onPointerDown: (e: React.PointerEvent) => void
+		onPointerUp: () => void
+	}
+	wrapperStyle: React.CSSProperties
+}
+
+const MIN_SCALE = 0.5
+const MAX_SCALE = 3.0
+
+function getDistance(t1: React.Touch, t2: React.Touch): number {
+	const dx = t1.clientX - t2.clientX
+	const dy = t1.clientY - t2.clientY
+	return Math.sqrt(dx * dx + dy * dy)
+}
+
+export function useTouchZoomPan(): UseTouchZoomPanResult {
+	const [state, setState] = useState<TouchZoomPanState>({ scale: 1, translateX: 0, translateY: 0 })
+	const lastDistanceRef = useRef<number | null>(null)
+	const lastPointerRef = useRef<{ x: number; y: number } | null>(null)
+	const isPanningRef = useRef(false)
+
+	const handleTouchStart = useCallback((e: React.TouchEvent) => {
+		if (e.touches.length === 2) {
+			lastDistanceRef.current = getDistance(e.touches[0], e.touches[1])
+		}
+	}, [])
+
+	const handleTouchMove = useCallback((e: React.TouchEvent) => {
+		if (e.touches.length === 2 && lastDistanceRef.current !== null) {
+			const newDistance = getDistance(e.touches[0], e.touches[1])
+			const delta = newDistance / lastDistanceRef.current
+			lastDistanceRef.current = newDistance
+			setState((prev) => ({
+				...prev,
+				scale: Math.min(MAX_SCALE, Math.max(MIN_SCALE, prev.scale * delta)),
+			}))
+		}
+	}, [])
+
+	const handleTouchEnd = useCallback(() => {
+		lastDistanceRef.current = null
+	}, [])
+
+	const handlePointerDown = useCallback((e: React.PointerEvent) => {
+		setState((prev) => {
+			if (prev.scale > 1) {
+				lastPointerRef.current = { x: e.clientX, y: e.clientY }
+				isPanningRef.current = true
+			}
+			return prev
+		})
+	}, [])
+
+	const handlePointerMove = useCallback((e: React.PointerEvent) => {
+		if (!isPanningRef.current || lastPointerRef.current === null) return
+		const dx = e.clientX - lastPointerRef.current.x
+		const dy = e.clientY - lastPointerRef.current.y
+		lastPointerRef.current = { x: e.clientX, y: e.clientY }
+		setState((prev) => ({
+			...prev,
+			translateX: prev.translateX + dx,
+			translateY: prev.translateY + dy,
+		}))
+	}, [])
+
+	const handlePointerUp = useCallback(() => {
+		isPanningRef.current = false
+		lastPointerRef.current = null
+	}, [])
+
+	const isZoomed = state.scale > 1
+
+	return {
+		containerProps: {
+			style: {
+				touchAction: isZoomed ? 'none' : 'pinch-zoom',
+				userSelect: 'none',
+				overflow: 'hidden',
+			},
+			onTouchStart: handleTouchStart,
+			onTouchMove: handleTouchMove,
+			onTouchEnd: handleTouchEnd,
+			onPointerDown: handlePointerDown,
+			onPointerMove: handlePointerMove,
+			onPointerUp: handlePointerUp,
+		},
+		wrapperStyle: {
+			transform: `scale(${state.scale}) translate(${state.translateX / state.scale}px, ${state.translateY / state.scale}px)`,
+			transformOrigin: 'top left',
+			willChange: 'transform',
+		},
+	}
+}

--- a/src/ReactClient/src/pages/BattleReplay.tsx
+++ b/src/ReactClient/src/pages/BattleReplay.tsx
@@ -4,6 +4,7 @@ import apiClient from '@/api/client'
 import type { BattleReportDetailViewModel, UnitCountViewModel } from '@/api/types'
 import { ApiError } from '@/components/ApiError'
 import { SkeletonLine } from '@/components/Skeleton'
+import { useTouchZoomPan } from '@/hooks/useTouchZoomPan'
 
 interface BattleReplayProps {
   gameId: string
@@ -41,6 +42,7 @@ function OutcomeBadge({ outcome }: { outcome: string }) {
 
 export function BattleReplay({ gameId }: BattleReplayProps) {
   const { reportId } = useParams<{ reportId: string }>()
+  const { containerProps, wrapperStyle } = useTouchZoomPan()
 
   const { data: report, isLoading, error, refetch } = useQuery<BattleReportDetailViewModel>({
     queryKey: ['battle-report', gameId, reportId],
@@ -91,7 +93,8 @@ export function BattleReplay({ gameId }: BattleReplayProps) {
   const date = new Date(report.createdAt)
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div {...containerProps}>
+    <div className="max-w-3xl space-y-6" style={wrapperStyle}>
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-3">
@@ -202,6 +205,7 @@ export function BattleReplay({ gameId }: BattleReplayProps) {
           </div>
         </div>
       )}
+    </div>
     </div>
   )
 }

--- a/src/ReactClient/src/pages/GameLiveView.tsx
+++ b/src/ReactClient/src/pages/GameLiveView.tsx
@@ -11,6 +11,7 @@ import type {
   PlayerNotificationViewModel,
 } from '@/api/types'
 import { relativeTime, cn } from '@/lib/utils'
+import { useTouchZoomPan } from '@/hooks/useTouchZoomPan'
 
 const POLL_MS = 10_000
 
@@ -61,6 +62,7 @@ export function GameLiveView({ gameId }: GameLiveViewProps) {
   const { currentGame } = useCurrentGame()
   const isFinished = currentGame?.status === 'Finished'
   const refetchInterval = isFinished ? false : POLL_MS
+  const { containerProps, wrapperStyle } = useTouchZoomPan()
 
   const { data: resources, dataUpdatedAt: resourcesUpdatedAt } = useQuery<PlayerResourcesViewModel>({
     queryKey: ['resources', gameId],
@@ -107,7 +109,8 @@ export function GameLiveView({ gameId }: GameLiveViewProps) {
   const homeUnits = unitsData?.units.filter((u) => u.positionPlayerId === null) ?? []
 
   return (
-    <div className="space-y-4">
+    <div {...containerProps}>
+    <div className="space-y-4" style={wrapperStyle}>
       {/* Page header */}
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Live View</h1>
@@ -312,6 +315,7 @@ export function GameLiveView({ gameId }: GameLiveViewProps) {
           </Section>
         </div>
       </div>
+    </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Added `useTouchZoomPan` hook (`src/ReactClient/src/hooks/useTouchZoomPan.ts`) implementing pinch-to-zoom and drag-to-pan via TouchEvent and Pointer events
- Wrapped the game board container in `BattleReplay` and `GameLiveView` with the hook's container props and wrapper style
- Pinch-to-zoom clamps scale between 0.5× and 3.0×; `touch-action` switches from `pinch-zoom` to `none` when scale > 1 to enable single-finger pan

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (645 tests)
- [ ] On a touch device (or Chrome DevTools touch emulation): verify two-finger pinch zooms the page content in BattleReplay and GameLiveView
- [ ] Verify single-finger drag pans when zoomed in (scale > 1)
- [ ] Verify scroll/pan is not broken when at default zoom (scale = 1)

Closes BGE-855