### PR TITLE
fix: BGE-856 320px viewport overflow audit and fixes

### DIFF
--- a/src/ReactClient/src/components/BuildUnitsForm.tsx
+++ b/src/ReactClient/src/components/BuildUnitsForm.tsx
@@ -63,7 +63,7 @@ export function BuildUnitsForm({ availableUnits, gameId, onQueueChanged }: Build
         <select
           value={unitDefId}
           onChange={(e) => setUnitDefId(e.target.value)}
-          className="rounded border bg-input px-2 py-1 text-sm"
+          className="w-full sm:w-auto rounded border bg-input px-2 py-1 text-sm"
         >
           {availableUnits.map((u) => (
             <option key={u.id} value={u.id}>

--- a/src/ReactClient/src/index.css
+++ b/src/ReactClient/src/index.css
@@ -74,6 +74,7 @@ body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: system-ui, -apple-system, sans-serif;
+  overflow-x: hidden;
 }
 
 @keyframes page-fade-in {

--- a/src/ReactClient/src/pages/BattleReplay.tsx
+++ b/src/ReactClient/src/pages/BattleReplay.tsx
@@ -117,7 +117,7 @@ export function BattleReplay({ gameId }: BattleReplayProps) {
       {/* Initial Forces */}
       <div className="rounded-lg border p-4 space-y-3">
         <h2 className="font-semibold text-sm">Initial Forces</h2>
-        <div className="grid grid-cols-2 gap-4 text-sm">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
           <div>
             <div className="text-xs text-muted-foreground mb-1">Attacker (Strength: {report.totalAttackerStrengthBefore})</div>
             <UnitList units={report.attackerUnitsInitial} />
@@ -140,7 +140,7 @@ export function BattleReplay({ gameId }: BattleReplayProps) {
                   Round {round.roundNumber}
                 </span>
               </div>
-              <div className="grid grid-cols-2 gap-4 text-sm">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
                 <div className="space-y-1">
                   <div className="text-xs text-muted-foreground">Attacker</div>
                   {round.attackerCasualties.length > 0 && (

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -70,7 +70,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
       {error ? (
         <ApiError message="Failed to load ranking." onRetry={() => void refetch()} />
       ) : (
-        <div className="rounded-lg border overflow-hidden">
+        <div className="rounded-lg border overflow-x-auto max-w-full">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` to `body` in `index.css` to prevent the page-level horizontal scrollbar at narrow viewports
- Add `overflow-x-auto max-w-full` to the PlayerRanking table container so it scrolls horizontally rather than overflows on very narrow screens
- Change `grid-cols-2` to `grid-cols-1 sm:grid-cols-2` in BattleReplay initial forces and round-by-round sections so they stack on 320px screens
- Add `w-full sm:w-auto` to the BuildUnitsForm unit-type `<select>` so it uses full width on mobile instead of potentially overflowing

Note: WorkerAssignment inputs already use `w-full`. PlayerRanking extra columns already use `hidden sm:table-cell`. No canvas elements exist in BattleReplay/GameLiveView.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (645 tests)
- [ ] Verify at 320px viewport: no horizontal scrollbar on Base, PlayerRanking, or BattleReplay pages
- [ ] Verify BattleReplay force grids stack vertically on narrow screens
- [ ] Verify BuildUnitsForm select fills width on mobile

Closes BGE-856