### PR TITLE
feat: BGE-850 Phase 6C — Milestone Achievement Unlock Notifications

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/NotificationsController.cs
@@ -93,6 +93,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 					GameNotificationType.SpyAttempted => GameNotificationTypeViewModel.SpyAttempted,
 					GameNotificationType.AllianceRequest => GameNotificationTypeViewModel.AllianceRequest,
 					GameNotificationType.MessageReceived => GameNotificationTypeViewModel.MessageReceived,
+					GameNotificationType.MilestoneUnlocked => GameNotificationTypeViewModel.MilestoneUnlocked,
 					_ => GameNotificationTypeViewModel.AttackReceived
 				},
 				Title = n.Title,

--- a/src/BrowserGameEngine.GameModel/GameNotification.cs
+++ b/src/BrowserGameEngine.GameModel/GameNotification.cs
@@ -5,7 +5,8 @@ namespace BrowserGameEngine.GameModel {
 		AttackReceived,
 		SpyAttempted,
 		AllianceRequest,
-		MessageReceived
+		MessageReceived,
+		MilestoneUnlocked
 	}
 
 	public record GameNotification(

--- a/src/BrowserGameEngine.Shared/GameNotificationViewModel.cs
+++ b/src/BrowserGameEngine.Shared/GameNotificationViewModel.cs
@@ -5,7 +5,8 @@ namespace BrowserGameEngine.Shared {
 		AttackReceived,
 		SpyAttempted,
 		AllianceRequest,
-		MessageReceived
+		MessageReceived,
+		MilestoneUnlocked
 	}
 
 	public class GameNotificationViewModel {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneNotificationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MilestoneNotificationTest.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Linq;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Achievements;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Test.Events;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class MilestoneNotificationTest {
+		private const string UserId = "notify-user-1";
+		private static readonly PlayerId Player1 = PlayerIdFactory.Create("player0");
+		private const string MilestoneId = "games-first";
+
+		private static GlobalState CreateGlobalStateWithAchievement() {
+			var gs = new GlobalState();
+			gs.AddAchievement(new PlayerAchievementImmutable(
+				UserId: UserId,
+				GameId: new GameId(Guid.NewGuid().ToString()),
+				PlayerId: Player1,
+				PlayerName: "Notify Player",
+				FinalRank: 1,
+				FinalScore: 100,
+				GameDefType: "SCO",
+				FinishedAt: DateTime.UtcNow
+			));
+			return gs;
+		}
+
+		[Fact]
+		public void UnlockIfNew_FirstUnlock_AddsMilestoneToGlobalState() {
+			var gs = new GlobalState();
+			var repo = new MilestoneRepositoryWrite(gs);
+
+			repo.UnlockIfNew(UserId, MilestoneId, DateTime.UtcNow);
+
+			var milestones = gs.GetMilestonesForUser(UserId);
+			Assert.Single(milestones);
+			Assert.Equal(MilestoneId, milestones[0].MilestoneId);
+		}
+
+		[Fact]
+		public void UnlockIfNew_CalledTwice_DoesNotDuplicate() {
+			var gs = new GlobalState();
+			var repo = new MilestoneRepositoryWrite(gs);
+
+			repo.UnlockIfNew(UserId, MilestoneId, DateTime.UtcNow);
+			repo.UnlockIfNew(UserId, MilestoneId, DateTime.UtcNow);
+
+			var milestones = gs.GetMilestonesForUser(UserId);
+			Assert.Single(milestones);
+		}
+
+		[Fact]
+		public void MilestoneUnlocked_EventPublishedOnce_ForNewUnlock() {
+			var gs = CreateGlobalStateWithAchievement();
+			var gameRegistry = new GameRegistry.GameRegistry(gs);
+			var milestoneRepo = new MilestoneRepository(gs, gameRegistry);
+			var milestoneRepoWrite = new MilestoneRepositoryWrite(gs);
+			var recorder = new RecordingGameEventPublisher();
+			var utcNow = DateTime.UtcNow;
+
+			// Simulate the unlock loop from GameLifecycleEngine
+			var evaluations = milestoneRepo.GetMilestonesForUser(UserId);
+			foreach (var eval in evaluations) {
+				if (!eval.IsUnlocked && eval.CurrentProgress >= eval.Definition.TargetProgress) {
+					milestoneRepoWrite.UnlockIfNew(UserId, eval.Definition.Id, utcNow);
+					recorder.PublishToPlayer(Player1, GameEventTypes.MilestoneUnlocked, new {
+						milestoneId = eval.Definition.Id,
+						name = eval.Definition.Name,
+						icon = eval.Definition.Icon
+					});
+				}
+			}
+
+			// "games-first" requires 1 completed game; user has 1 achievement
+			var milestoneEvents = recorder.PlayerEvents
+				.Where(e => e.EventType == GameEventTypes.MilestoneUnlocked)
+				.ToList();
+			Assert.NotEmpty(milestoneEvents);
+			Assert.All(milestoneEvents, e => Assert.Equal(Player1, e.PlayerId));
+		}
+
+		[Fact]
+		public void MilestoneUnlocked_NoEventOnRecheck_WhenAlreadyUnlocked() {
+			var gs = CreateGlobalStateWithAchievement();
+			var gameRegistry = new GameRegistry.GameRegistry(gs);
+			var milestoneRepo = new MilestoneRepository(gs, gameRegistry);
+			var milestoneRepoWrite = new MilestoneRepositoryWrite(gs);
+			var recorder = new RecordingGameEventPublisher();
+			var utcNow = DateTime.UtcNow;
+
+			// First pass: unlock and publish
+			var evaluations = milestoneRepo.GetMilestonesForUser(UserId);
+			foreach (var eval in evaluations) {
+				if (!eval.IsUnlocked && eval.CurrentProgress >= eval.Definition.TargetProgress) {
+					milestoneRepoWrite.UnlockIfNew(UserId, eval.Definition.Id, utcNow);
+					recorder.PublishToPlayer(Player1, GameEventTypes.MilestoneUnlocked, new {
+						milestoneId = eval.Definition.Id,
+						name = eval.Definition.Name,
+						icon = eval.Definition.Icon
+					});
+				}
+			}
+			int firstPassCount = recorder.PlayerEvents.Count(e => e.EventType == GameEventTypes.MilestoneUnlocked);
+
+			// Second pass: re-evaluate — already-unlocked milestones should not fire again
+			var evaluations2 = milestoneRepo.GetMilestonesForUser(UserId);
+			foreach (var eval in evaluations2) {
+				if (!eval.IsUnlocked && eval.CurrentProgress >= eval.Definition.TargetProgress) {
+					milestoneRepoWrite.UnlockIfNew(UserId, eval.Definition.Id, utcNow);
+					recorder.PublishToPlayer(Player1, GameEventTypes.MilestoneUnlocked, new {
+						milestoneId = eval.Definition.Id,
+						name = eval.Definition.Name,
+						icon = eval.Definition.Icon
+					});
+				}
+			}
+			int secondPassCount = recorder.PlayerEvents.Count(e => e.EventType == GameEventTypes.MilestoneUnlocked);
+
+			Assert.Equal(firstPassCount, secondPassCount);
+		}
+
+		[Fact]
+		public void NotificationsController_MapToViewModel_MilestoneUnlocked_MapsCorrectly() {
+			var notification = new GameNotification(
+				Id: Guid.NewGuid(),
+				Type: GameNotificationType.MilestoneUnlocked,
+				Title: "Achievement Unlocked: First Commander",
+				Body: null,
+				CreatedAt: DateTime.UtcNow,
+				ReadAt: null
+			);
+
+			// Verify the enum value exists and is distinct
+			Assert.Equal(GameNotificationType.MilestoneUnlocked, notification.Type);
+			Assert.NotEqual(GameNotificationType.AttackReceived, notification.Type);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/GameEventTypes.cs
@@ -11,4 +11,5 @@ public static class GameEventTypes
 	public const string MarketOrderFilled = "MarketOrderFilled";
 	public const string GameFinalized = "GameFinalized";
 	public const string LobbyUpdated = "LobbyUpdated";
+	public const string MilestoneUnlocked = "MilestoneUnlocked";
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -178,6 +178,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 					if (!eval.IsUnlocked && eval.CurrentProgress >= eval.Definition.TargetProgress) {
 						milestoneRepositoryWrite.UnlockIfNew(player.UserId, eval.Definition.Id, utcNow);
 						playerNotificationService.Push(player.UserId, $"Achievement unlocked: {eval.Definition.Name}!", NotificationKind.GameEvent);
+						eventPublisher.PublishToPlayer(player.PlayerId, GameEventTypes.MilestoneUnlocked, new {
+							milestoneId = eval.Definition.Id,
+							name = eval.Definition.Name,
+							icon = eval.Definition.Icon
+						});
 					}
 				}
 			}

--- a/src/ReactClient/src/components/NotificationToast.tsx
+++ b/src/ReactClient/src/components/NotificationToast.tsx
@@ -23,6 +23,7 @@ function toastIcon(type: string): string {
     case 'TradeComplete':
     case 'MarketOrderFilled': return '💰'
     case 'MessageReceived': return '📩'
+    case 'MilestoneUnlocked': return '🏆'
     case 'GameEvent': return '⚡'
     case 'Warning': return '⚠️'
     default: return 'ℹ️'
@@ -38,6 +39,7 @@ function toastRoute(type: string): string | null {
     case 'TradeComplete':
     case 'MarketOrderFilled': return 'market'
     case 'MessageReceived': return 'messages'
+    case 'MilestoneUnlocked': return 'achievements'
     default: return null
   }
 }

--- a/src/ReactClient/src/hooks/useNotifications.ts
+++ b/src/ReactClient/src/hooks/useNotifications.ts
@@ -42,15 +42,31 @@ export function useNotifications(options?: UseNotificationsOptions) {
     [queryClient, options?.onRealTimeNotification]
   )
 
+  const milestoneHandler = useCallback(
+    (...args: unknown[]) => {
+      const payload = args[0] as { milestoneId?: string; name?: string; icon?: string }
+      if (!payload?.name) return
+
+      options?.onRealTimeNotification?.({
+        type: 'MilestoneUnlocked',
+        title: `${payload.icon ?? '🏆'} Achievement Unlocked: ${payload.name}`,
+        createdAt: new Date().toISOString(),
+      })
+    },
+    [options?.onRealTimeNotification]
+  )
+
   useEffect(() => {
     if (!options?.signalR) return
     options.signalR.on('ReceiveNotification', handler)
     options.signalR.on('ReceiveAlert', handler)
+    options.signalR.on('MilestoneUnlocked', milestoneHandler)
     return () => {
       options.signalR?.off('ReceiveNotification', handler)
       options.signalR?.off('ReceiveAlert', handler)
+      options.signalR?.off('MilestoneUnlocked', milestoneHandler)
     }
-  }, [options?.signalR, handler])
+  }, [options?.signalR, handler, milestoneHandler])
 
   const dismissAll = useMutation({
     mutationFn: () => apiClient.delete('/api/notifications/recent'),


### PR DESCRIPTION
## Summary
- Add `MilestoneUnlocked` to `GameNotificationType` enum and `GameNotificationTypeViewModel`
- Add `GameEventTypes.MilestoneUnlocked` event type constant
- `GameLifecycleEngine.FinalizeGameAsync()` publishes a `MilestoneUnlocked` player event (via `IGameEventPublisher`) with `{ milestoneId, name, icon }` when a milestone is unlocked at game end
- `NotificationsController.MapToViewModel()` handles the `MilestoneUnlocked` case
- Frontend `NotificationToast.tsx`: renders 🏆 icon, navigates to achievements page on click
- Frontend `useNotifications.ts`: listens for `MilestoneUnlocked` SignalR event

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (631 total, 5 new `MilestoneNotificationTest` tests)
- [ ] Trigger a milestone unlock in a game — verify toast notification appears with 🏆 icon
- [ ] Click toast — verify navigation to achievements page
- [ ] Verify other notification types are unaffected

Closes BGE-850