### PR TITLE
feat: BGE-849 Phase 6B — Live Spectator Mode

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpectatorController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpectatorController.cs
@@ -1,0 +1,85 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.FrontendServer.Controllers;
+
+[ApiController]
+[AllowAnonymous]
+[Route("api/games")]
+public class SpectatorController : ControllerBase
+{
+	private readonly GlobalState _globalState;
+	private readonly GameRegistry _gameRegistry;
+	private readonly PlayerRepository _playerRepository;
+	private readonly ScoreRepository _scoreRepository;
+	private readonly OnlineStatusRepository _onlineStatusRepository;
+
+	public SpectatorController(
+		GlobalState globalState,
+		GameRegistry gameRegistry,
+		PlayerRepository playerRepository,
+		ScoreRepository scoreRepository,
+		OnlineStatusRepository onlineStatusRepository)
+	{
+		_globalState = globalState;
+		_gameRegistry = gameRegistry;
+		_playerRepository = playerRepository;
+		_scoreRepository = scoreRepository;
+		_onlineStatusRepository = onlineStatusRepository;
+	}
+
+	/// <summary>Returns a live snapshot of the top 20 players for anonymous spectators.</summary>
+	[HttpGet("{gameId}/spectate")]
+	[ProducesResponseType(typeof(SpectatorSnapshotViewModel), StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status404NotFound)]
+	public ActionResult<SpectatorSnapshotViewModel> GetSpectatorSnapshot(string gameId)
+	{
+		var record = _globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId);
+		if (record == null) return NotFound();
+
+		var instance = _gameRegistry.TryGetInstance(record.GameId);
+		if (instance == null)
+		{
+			return Ok(new SpectatorSnapshotViewModel(
+				GameId: gameId,
+				GameName: record.Name,
+				GameStatus: record.Status.ToString(),
+				TopPlayers: Array.Empty<SpectatorPlayerEntryViewModel>(),
+				Tick: 0
+			));
+		}
+
+		var entries = _playerRepository.GetAll()
+			.Select(p => new {
+				Player = p,
+				Score = _scoreRepository.GetScore(p.PlayerId),
+			})
+			.OrderByDescending(x => x.Score)
+			.Take(20)
+			.Select((x, i) => new SpectatorPlayerEntryViewModel(
+				Rank: i + 1,
+				PlayerId: x.Player.PlayerId.Id,
+				PlayerName: x.Player.Name,
+				Score: x.Score,
+				IsOnline: _onlineStatusRepository.IsOnline(x.Player.PlayerId),
+				IsAgent: x.Player.ApiKeyHash != null
+			))
+			.ToList();
+
+		return Ok(new SpectatorSnapshotViewModel(
+			GameId: gameId,
+			GameName: record.Name,
+			GameStatus: record.Status.ToString(),
+			TopPlayers: entries,
+			Tick: 0
+		));
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Events/SignalRSpectatorEventPublisher.cs
+++ b/src/BrowserGameEngine.FrontendServer/Events/SignalRSpectatorEventPublisher.cs
@@ -1,0 +1,30 @@
+using BrowserGameEngine.FrontendServer.Hubs;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Events;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BrowserGameEngine.FrontendServer.Events;
+
+public class SignalRSpectatorEventPublisher : ISpectatorEventPublisher
+{
+	private const string SpectatorSnapshotEvent = "SpectatorSnapshot";
+
+	private readonly IHubContext<SpectatorHub> _hubContext;
+	private readonly ILogger<SignalRSpectatorEventPublisher> _logger;
+
+	public SignalRSpectatorEventPublisher(
+		IHubContext<SpectatorHub> hubContext,
+		ILogger<SignalRSpectatorEventPublisher> logger)
+	{
+		_hubContext = hubContext;
+		_logger = logger;
+	}
+
+	public void PublishSnapshot(GameId gameId, object snapshot)
+	{
+		var group = $"spectate:{gameId.Id}";
+		_hubContext.Clients.Group(group).SendAsync(SpectatorSnapshotEvent, snapshot)
+			.ConfigureAwait(false);
+		_logger.LogDebug("Published SpectatorSnapshot for game {GameId}", gameId.Id);
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Hubs/SpectatorHub.cs
+++ b/src/BrowserGameEngine.FrontendServer/Hubs/SpectatorHub.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BrowserGameEngine.FrontendServer.Hubs;
+
+/// <summary>
+/// SignalR hub for anonymous game spectators.
+/// Server-to-client only — spectators receive live snapshots but send no messages.
+/// Clients pass gameId as a query string parameter on connect.
+/// </summary>
+[AllowAnonymous]
+public class SpectatorHub : Hub
+{
+	private readonly ILogger<SpectatorHub> _logger;
+
+	public SpectatorHub(ILogger<SpectatorHub> logger)
+	{
+		_logger = logger;
+	}
+
+	public override async Task OnConnectedAsync()
+	{
+		var gameId = Context.GetHttpContext()?.Request.Query["gameId"].ToString();
+		if (!string.IsNullOrEmpty(gameId))
+		{
+			await Groups.AddToGroupAsync(Context.ConnectionId, $"spectate:{gameId}");
+			_logger.LogDebug("Spectator connected for game {GameId}: {ConnectionId}", gameId, Context.ConnectionId);
+		}
+		else
+		{
+			_logger.LogWarning("Spectator connected without gameId: {ConnectionId}", Context.ConnectionId);
+		}
+
+		await base.OnConnectedAsync();
+	}
+
+	public override async Task OnDisconnectedAsync(Exception? exception)
+	{
+		var gameId = Context.GetHttpContext()?.Request.Query["gameId"].ToString();
+		if (!string.IsNullOrEmpty(gameId))
+		{
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"spectate:{gameId}");
+		}
+
+		_logger.LogDebug("Spectator disconnected: {ConnectionId}", Context.ConnectionId);
+		await base.OnDisconnectedAsync(exception);
+	}
+}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddOpenApi();
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<PlayerConnectionTracker>();
 builder.Services.AddSingleton<IGameEventPublisher, SignalRGameEventPublisher>();
+builder.Services.AddSingleton<ISpectatorEventPublisher, SignalRSpectatorEventPublisher>();
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
@@ -242,6 +243,7 @@ app.MapDefaultControllerRoute();
 app.MapRazorPages();
 app.MapControllers();
 app.MapHub<GameHub>("/hubs/game");
+app.MapHub<SpectatorHub>("/hubs/spectator");
 app.MapMetrics();
 app.MapFallbackToFile("index.html", new StaticFileOptions {
 	OnPrepareResponse = ctx => {

--- a/src/BrowserGameEngine.Shared/SpectatorViewModels.cs
+++ b/src/BrowserGameEngine.Shared/SpectatorViewModels.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.Shared;
+
+public record SpectatorPlayerEntryViewModel(
+	int Rank,
+	string PlayerId,
+	string PlayerName,
+	decimal Score,
+	bool IsOnline,
+	bool IsAgent
+);
+
+public record SpectatorSnapshotViewModel(
+	string GameId,
+	string GameName,
+	string GameStatus,
+	IReadOnlyList<SpectatorPlayerEntryViewModel> TopPlayers,
+	long Tick
+);

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SpectatorTickModuleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SpectatorTickModuleTest.cs
@@ -1,0 +1,126 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test;
+
+public class SpectatorTickModuleTest
+{
+	private const string TestGameId = "default";
+
+	private sealed class RecordingSpectatorEventPublisher : ISpectatorEventPublisher
+	{
+		public List<(GameId GameId, object Snapshot)> Calls { get; } = new();
+
+		public void PublishSnapshot(GameId gameId, object snapshot)
+			=> Calls.Add((gameId, snapshot));
+	}
+
+	private static (TestGame game, SpectatorTickModule module, RecordingSpectatorEventPublisher publisher) Setup(int playerCount = 3)
+	{
+		var game = new TestGame(playerCount);
+
+		var record = new GameRecordImmutable(
+			new GameId(TestGameId), "Test Game", "sco", GameStatus.Active,
+			DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1), TimeSpan.FromSeconds(30));
+		game.GlobalState.AddGame(record);
+
+		var publisher = new RecordingSpectatorEventPublisher();
+		var module = new SpectatorTickModule(game.Accessor, game.GlobalState, game.GameDef, publisher);
+
+		return (game, module, publisher);
+	}
+
+	private static JsonElement ToJson(object obj)
+		=> JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(obj));
+
+	[Fact]
+	public void CalculateTick_PublishesSnapshotOnFirstCall()
+	{
+		var (game, module, publisher) = Setup();
+
+		module.CalculateTick(game.Player1);
+
+		Assert.Single(publisher.Calls);
+		var json = ToJson(publisher.Calls[0].Snapshot);
+		Assert.Equal(TestGameId, json.GetProperty("gameId").GetString());
+		Assert.Equal("Test Game", json.GetProperty("gameName").GetString());
+		Assert.Equal("Active", json.GetProperty("gameStatus").GetString());
+		Assert.True(json.GetProperty("topPlayers").GetArrayLength() > 0);
+	}
+
+	[Fact]
+	public void CalculateTick_DeduplicatesWithinSameTick()
+	{
+		var (game, module, publisher) = Setup(playerCount: 3);
+
+		// Call once per player — all on the same tick
+		module.CalculateTick(PlayerIdFactory.Create("player0"));
+		module.CalculateTick(PlayerIdFactory.Create("player1"));
+		module.CalculateTick(PlayerIdFactory.Create("player2"));
+
+		// Should only publish once regardless of how many players were ticked
+		Assert.Single(publisher.Calls);
+	}
+
+	[Fact]
+	public void CalculateTick_PublishesTopPlayersRankedByScore()
+	{
+		var (game, module, publisher) = Setup(playerCount: 3);
+
+		module.CalculateTick(game.Player1);
+
+		var json = ToJson(publisher.Calls[0].Snapshot);
+		var players = json.GetProperty("topPlayers");
+		Assert.True(players.GetArrayLength() > 0);
+
+		// Players should be ranked 1, 2, 3, ...
+		int i = 0;
+		decimal prevScore = decimal.MaxValue;
+		foreach (var p in players.EnumerateArray())
+		{
+			Assert.Equal(i + 1, p.GetProperty("rank").GetInt32());
+			var score = p.GetProperty("score").GetDecimal();
+			Assert.True(score <= prevScore);
+			prevScore = score;
+			i++;
+		}
+	}
+
+	[Fact]
+	public void BuildSnapshot_LimitsToTop20Players()
+	{
+		var game = new TestGame(25);
+		var record = new GameRecordImmutable(
+			new GameId(TestGameId), "Big Game", "sco", GameStatus.Active,
+			DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1), TimeSpan.FromSeconds(30));
+		game.GlobalState.AddGame(record);
+
+		var publisher = new RecordingSpectatorEventPublisher();
+		var module = new SpectatorTickModule(game.Accessor, game.GlobalState, game.GameDef, publisher);
+
+		var snapshot = module.BuildSnapshot(new GameId(TestGameId), record, tick: 1);
+		var json = ToJson(snapshot);
+
+		Assert.True(json.GetProperty("topPlayers").GetArrayLength() <= 20);
+	}
+
+	[Fact]
+	public void CalculateTick_DoesNotPublishIfNoGameRecord()
+	{
+		var game = new TestGame(1);
+		// Do NOT add any game record to GlobalState
+
+		var publisher = new RecordingSpectatorEventPublisher();
+		var module = new SpectatorTickModule(game.Accessor, game.GlobalState, game.GameDef, publisher);
+
+		module.CalculateTick(game.Player1);
+
+		Assert.Empty(publisher.Calls);
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/ISpectatorEventPublisher.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/ISpectatorEventPublisher.cs
@@ -1,0 +1,12 @@
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.Events;
+
+/// <summary>
+/// Publishes real-time spectator snapshots to anonymous viewers watching a game.
+/// Implementations may use SignalR, no-op (tests), or other transports.
+/// </summary>
+public interface ISpectatorEventPublisher
+{
+	void PublishSnapshot(GameId gameId, object snapshot);
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Events/NullSpectatorEventPublisher.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Events/NullSpectatorEventPublisher.cs
@@ -1,0 +1,11 @@
+using BrowserGameEngine.GameModel;
+
+namespace BrowserGameEngine.StatefulGameServer.Events;
+
+/// <summary>No-op implementation used in tests and when SignalR is not configured.</summary>
+public class NullSpectatorEventPublisher : ISpectatorEventPublisher
+{
+	public static readonly NullSpectatorEventPublisher Instance = new();
+
+	public void PublishSnapshot(GameId gameId, object snapshot) { }
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -27,6 +27,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton(defaultInstance.GameDef);
 			services.AddSingleton(TimeProvider.System);
 			services.AddSingleton<IGameEventPublisher, NullGameEventPublisher>();
+		services.AddSingleton<ISpectatorEventPublisher, NullSpectatorEventPublisher>();
 			services.AddSingleton<GameRepository>();
 
 			services.AddSingleton<UserRepository>();
@@ -95,6 +96,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<IGameTickModule, VictoryProgressNotificationModule>();
 			services.AddSingleton<IGameTickModule, VictoryConditionModule>();
 			services.AddSingleton<IGameTickModule, GameFinalizationModule>();
+			services.AddSingleton<IGameTickModule, SpectatorTickModule>();
 			services.AddSingleton<GameTickModuleRegistry>(); // Modules need to be registered before this
 			services.AddSingleton<GameTickEngine>();
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpectatorTickModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpectatorTickModule.cs
@@ -1,0 +1,82 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+
+public class SpectatorTickModule : IGameTickModule
+{
+	public string Name => "spectator:1";
+
+	private readonly IWorldStateAccessor _worldStateAccessor;
+	private readonly GlobalState _globalState;
+	private readonly GameDef _gameDef;
+	private readonly ISpectatorEventPublisher _spectatorEventPublisher;
+
+	private long _lastPublishedTick = -1;
+
+	public SpectatorTickModule(
+		IWorldStateAccessor worldStateAccessor,
+		GlobalState globalState,
+		GameDef gameDef,
+		ISpectatorEventPublisher spectatorEventPublisher)
+	{
+		_worldStateAccessor = worldStateAccessor;
+		_globalState = globalState;
+		_gameDef = gameDef;
+		_spectatorEventPublisher = spectatorEventPublisher;
+	}
+
+	public void SetProperty(string name, string value) { }
+
+	public void CalculateTick(PlayerId playerId)
+	{
+		var currentTick = _worldStateAccessor.WorldState.GameTickState.CurrentGameTick.Tick;
+		if (currentTick == _lastPublishedTick) return;
+		_lastPublishedTick = currentTick;
+
+		var gameId = _worldStateAccessor.WorldState.GameId;
+		var gameRecord = _globalState.GetGames().FirstOrDefault(g => g.GameId.Id == gameId.Id);
+		if (gameRecord == null) return;
+
+		var snapshot = BuildSnapshot(gameId, gameRecord, currentTick);
+		_spectatorEventPublisher.PublishSnapshot(gameId, snapshot);
+	}
+
+	public object BuildSnapshot(GameId gameId, GameRecordImmutable gameRecord, long tick)
+	{
+		var scoreResource = _gameDef.ScoreResource;
+		var world = _worldStateAccessor.WorldState;
+
+		var topPlayers = world.Players.Values
+			.Select(p => new {
+				playerId = p.PlayerId.Id,
+				playerName = p.Name,
+				score = p.State.Resources.TryGetValue(scoreResource, out var s) ? s : 0m,
+				isOnline = p.LastOnline.HasValue && DateTime.UtcNow - p.LastOnline.Value < TimeSpan.FromMinutes(8),
+				isAgent = p.ApiKeyHash != null,
+			})
+			.OrderByDescending(p => p.score)
+			.Take(20)
+			.Select((p, i) => new {
+				rank = i + 1,
+				p.playerId,
+				p.playerName,
+				p.score,
+				p.isOnline,
+				p.isAgent,
+			})
+			.ToList();
+
+		return new {
+			gameId = gameId.Id,
+			gameName = gameRecord.Name,
+			gameStatus = gameRecord.Status.ToString(),
+			topPlayers,
+			tick,
+		};
+	}
+}

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -62,6 +62,7 @@ const GameLiveView = lazy(() => import('@/pages/GameLiveView').then(m => ({ defa
 const PlayerStats = lazy(() => import('@/pages/PlayerStats').then(m => ({ default: m.PlayerStats })))
 const TournamentResults = lazy(() => import('@/pages/TournamentResults').then(m => ({ default: m.TournamentResults })))
 const Leaderboard = lazy(() => import('@/pages/Leaderboard').then(m => ({ default: m.Leaderboard })))
+const Spectator = lazy(() => import('@/pages/Spectator').then(m => ({ default: m.Spectator })))
 
 // Stub component for pages not yet implemented
 function TodoPage({ name }: { name: string }) {
@@ -162,6 +163,11 @@ function GameLiveViewPage() {
   if (!gameId) return null
   return <GameLiveView gameId={gameId} />
 }
+function SpectatorPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <Spectator gameId={gameId} />
+}
 
 const router = createBrowserRouter([
 	{
@@ -225,6 +231,7 @@ const router = createBrowserRouter([
 			{ path: '/stats', element: <RouteWithBoundary><PlayerStats /></RouteWithBoundary> },
 			{ path: '/tournaments/:tournamentId', element: <RouteWithBoundary><TournamentResults /></RouteWithBoundary> },
 			{ path: '/leaderboard', element: <RouteWithBoundary><Leaderboard /></RouteWithBoundary> },
+			{ path: '/games/:gameId/spectate', element: <RouteWithBoundary><SpectatorPage /></RouteWithBoundary> },
 			{ path: '/admin/games', element: <RouteWithBoundary><AdminGames /></RouteWithBoundary> },
 			{ path: '/admin/players', element: <RouteWithBoundary><AdminPlayers /></RouteWithBoundary> },
 			{ path: '/admin/ticks', element: <RouteWithBoundary><AdminTickControl /></RouteWithBoundary> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -1059,3 +1059,20 @@ export interface GameReplayViewModel {
   finalStandings: ReplayPlayerViewModel[]
   battleEvents: ReplayBattleEventViewModel[]
 }
+
+export interface SpectatorPlayerEntryViewModel {
+  rank: number
+  playerId: string
+  playerName: string
+  score: number
+  isOnline: boolean
+  isAgent: boolean
+}
+
+export interface SpectatorSnapshotViewModel {
+  gameId: string
+  gameName: string
+  gameStatus: string
+  topPlayers: SpectatorPlayerEntryViewModel[]
+  tick: number
+}

--- a/src/ReactClient/src/pages/Spectator.tsx
+++ b/src/ReactClient/src/pages/Spectator.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router'
+import apiClient from '@/api/client'
+import type { SpectatorSnapshotViewModel } from '@/api/types'
+import { ApiError } from '@/components/ApiError'
+import { SkeletonRow } from '@/components/Skeleton'
+import { cn } from '@/lib/utils'
+import { useSignalR } from '@/hooks/useSignalR'
+
+interface SpectatorProps {
+  gameId: string
+}
+
+const VICTORY_THRESHOLD = 500_000
+
+function progressBarColor(percent: number): string {
+  if (percent >= 90) return 'bg-red-500'
+  if (percent >= 75) return 'bg-orange-500'
+  return 'bg-yellow-500'
+}
+
+export function Spectator({ gameId }: SpectatorProps) {
+  const [liveSnapshot, setLiveSnapshot] = useState<SpectatorSnapshotViewModel | null>(null)
+
+  const hubUrl = useMemo(() => `/hubs/spectator?gameId=${encodeURIComponent(gameId)}`, [gameId])
+  const signalR = useSignalR(hubUrl)
+
+  useEffect(() => {
+    const handler = (...args: unknown[]) => {
+      setLiveSnapshot(args[0] as SpectatorSnapshotViewModel)
+    }
+    signalR.on('SpectatorSnapshot', handler)
+    return () => { signalR.off('SpectatorSnapshot', handler) }
+  }, [signalR])
+
+  const { data: initialSnapshot, isLoading, error, refetch } = useQuery({
+    queryKey: ['spectator', gameId],
+    queryFn: () =>
+      apiClient.get<SpectatorSnapshotViewModel>(`/api/games/${gameId}/spectate`).then((r) => r.data),
+    refetchOnWindowFocus: false,
+  })
+
+  const snapshot = liveSnapshot ?? initialSnapshot
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">
+            {snapshot ? snapshot.gameName : 'Live Spectator'}
+          </h1>
+          {snapshot && (
+            <p className="text-sm text-muted-foreground">
+              Status: <span className="font-medium">{snapshot.gameStatus}</span>
+              {' · '}Tick: <span className="font-mono">{snapshot.tick}</span>
+              {' · '}
+              <span className={cn(
+                'text-xs font-medium',
+                signalR.status === 'connected' ? 'text-green-600' : 'text-muted-foreground'
+              )}>
+                {signalR.status === 'connected' ? '● Live' : '○ Connecting…'}
+              </span>
+            </p>
+          )}
+        </div>
+        <Link to={`/lobby/${gameId}`} className="text-sm text-primary hover:underline">
+          Game Lobby →
+        </Link>
+      </div>
+
+      {error ? (
+        <ApiError message="Failed to load spectator data." onRetry={() => void refetch()} />
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
+                <th scope="col" className="px-4 py-2 text-left w-10">#</th>
+                <th scope="col" className="px-4 py-2 text-left">Player</th>
+                <th scope="col" className="px-4 py-2 text-right">Score</th>
+                <th scope="col" className="px-4 py-2 text-left hidden sm:table-cell w-32">Victory</th>
+                <th scope="col" className="px-4 py-2 text-center hidden sm:table-cell">Type</th>
+                <th scope="col" className="px-4 py-2 text-center">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {isLoading && !snapshot && Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} cols={6} />)}
+              {snapshot?.topPlayers.map((p) => {
+                const pct = Math.min(100, Math.round((p.score / VICTORY_THRESHOLD) * 100))
+                return (
+                  <tr key={p.playerId} className="hover:bg-secondary/20 transition-colors">
+                    <td className="px-4 py-2 font-mono text-muted-foreground">#{p.rank}</td>
+                    <td className="px-4 py-2 font-medium">{p.playerName}</td>
+                    <td className="px-4 py-2 text-right font-mono">{Math.floor(p.score).toLocaleString()}</td>
+                    <td className="px-4 py-2 hidden sm:table-cell">
+                      <div className="flex items-center gap-1.5">
+                        <div className="h-2 flex-1 rounded-full bg-secondary overflow-hidden">
+                          <div
+                            className={cn('h-full rounded-full transition-all', progressBarColor(pct))}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className="text-[10px] text-muted-foreground font-mono w-7 text-right">{pct}%</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 text-center hidden sm:table-cell">
+                      <span className={cn(
+                        'rounded px-1.5 py-0.5 text-[10px] font-medium',
+                        p.isAgent ? 'bg-accent text-accent-foreground' : 'bg-info/50 text-info-foreground'
+                      )}>
+                        {p.isAgent ? 'AI' : 'Human'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-center">
+                      <span
+                        className={cn(
+                          'inline-block h-2 w-2 rounded-full',
+                          p.isOnline ? 'bg-success' : 'bg-muted-foreground'
+                        )}
+                        title={p.isOnline ? 'Online' : 'Offline'}
+                      />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **SpectatorHub** — `[AllowAnonymous]` SignalR hub at `/hubs/spectator`. Clients connect with `?gameId=<id>` and are joined to a `spectate:{gameId}` group. Zero client-callable methods — server-to-client only.
- **ISpectatorEventPublisher / NullSpectatorEventPublisher** — publisher abstraction in `StatefulGameServer`; null impl used in tests and registered as default.
- **SignalRSpectatorEventPublisher** — real impl in `FrontendServer`; pushes `SpectatorSnapshot` events to the hub group via `IHubContext<SpectatorHub>`.
- **SpectatorTickModule** — `IGameTickModule` that builds a top-20 player snapshot once per game tick (deduplicates when `CalculateTick` is called once per player) and publishes it.
- **GET /api/games/{gameId}/spectate** — `[AllowAnonymous]` REST endpoint for the initial page-load snapshot.
- **Spectator.tsx** — React page at `/games/:gameId/spectate` (outside `GameLayout`, no auth required). Initial REST fetch + live `useSignalR('/hubs/spectator?gameId=…')` updates. Shows top-20 players, scores, victory progress, online status, and player type.
- **SpectatorTickModuleTest.cs** — 5 unit tests: publish on first call, dedup within same tick, ranked-by-score ordering, top-20 cap, no-record guard.

## Architecture notes

- `StatefulGameServer` cannot reference `BrowserGameEngine.Shared` (per dependency graph). `ISpectatorEventPublisher` uses `object` payload (matching `IGameEventPublisher` pattern). `SpectatorTickModule.BuildSnapshot` returns an anonymous object that serializes cleanly to camelCase JSON.
- The REST controller builds the snapshot via public repositories (`PlayerRepository`, `ScoreRepository`, `OnlineStatusRepository`) — no internal `WorldState` access from `FrontendServer`.

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (650 tests, 5 new)
- [ ] Navigate to `/games/default/spectate` without authentication — page should render
- [ ] Open two browser tabs; confirm SignalR snapshot updates arrive live on the spectator page
- [ ] Verify `GET /api/games/default/spectate` returns JSON with `topPlayers`, `gameName`, `gameStatus`

Closes BGE-849