### PR TITLE
feat: BGE-887 Phase 7A — Tournament System

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/TournamentController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/TournamentController.cs
@@ -3,9 +3,11 @@ using BrowserGameEngine.Shared;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer.Repositories.Tournament;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,14 +17,28 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 	public class TournamentController : ControllerBase {
 		private readonly GlobalState globalState;
 		private readonly GameRegistry gameRegistry;
+		private readonly TournamentRepository tournamentRepository;
+		private readonly TournamentRepositoryWrite tournamentRepositoryWrite;
+		private readonly TournamentEngine tournamentEngine;
+		private readonly CurrentUserContext currentUserContext;
 
-		public TournamentController(GlobalState globalState, GameRegistry gameRegistry) {
+		public TournamentController(
+			GlobalState globalState,
+			GameRegistry gameRegistry,
+			TournamentRepository tournamentRepository,
+			TournamentRepositoryWrite tournamentRepositoryWrite,
+			TournamentEngine tournamentEngine,
+			CurrentUserContext currentUserContext
+		) {
 			this.globalState = globalState;
 			this.gameRegistry = gameRegistry;
+			this.tournamentRepository = tournamentRepository;
+			this.tournamentRepositoryWrite = tournamentRepositoryWrite;
+			this.tournamentEngine = tournamentEngine;
+			this.currentUserContext = currentUserContext;
 		}
 
 		/// <summary>Returns aggregated tournament standings ranked by total score.</summary>
-		/// <param name="tournamentId">The tournament identifier.</param>
 		[AllowAnonymous]
 		[HttpGet("{tournamentId}/results")]
 		[ProducesResponseType(typeof(TournamentResultsViewModel), StatusCodes.Status200OK)]
@@ -65,7 +81,6 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		}
 
 		/// <summary>Returns all games in the tournament.</summary>
-		/// <param name="tournamentId">The tournament identifier.</param>
 		[AllowAnonymous]
 		[HttpGet("{tournamentId}/games")]
 		[ProducesResponseType(typeof(GameListViewModel), StatusCodes.Status200OK)]
@@ -110,6 +125,224 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}).ToList();
 
 			return Ok(new GameListViewModel(summaries));
+		}
+
+		/// <summary>Returns all tournaments.</summary>
+		[AllowAnonymous]
+		[HttpGet]
+		[ProducesResponseType(typeof(List<TournamentSummaryViewModel>), StatusCodes.Status200OK)]
+		public ActionResult<List<TournamentSummaryViewModel>> GetAll() {
+			var summaries = tournamentRepository.GetAll()
+				.Select(ToSummary)
+				.ToList();
+			return Ok(summaries);
+		}
+
+		/// <summary>Creates a new tournament.</summary>
+		[Authorize]
+		[HttpPost]
+		[ProducesResponseType(typeof(TournamentSummaryViewModel), StatusCodes.Status201Created)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<TournamentSummaryViewModel> Create([FromBody] CreateTournamentRequest request) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (string.IsNullOrWhiteSpace(request.Name)) return BadRequest("Name is required.");
+			if (string.IsNullOrWhiteSpace(request.Format)) return BadRequest("Format is required.");
+			if (!Enum.TryParse<TournamentFormat>(request.Format, true, out var format))
+				return BadRequest($"Invalid format. Valid values: {string.Join(", ", Enum.GetNames<TournamentFormat>())}");
+			if (request.RegistrationDeadline <= DateTime.UtcNow) return BadRequest("RegistrationDeadline must be in the future.");
+			if (request.MaxPlayers < 0) return BadRequest("MaxPlayers cannot be negative.");
+			if (string.IsNullOrWhiteSpace(request.GameDefType)) return BadRequest("GameDefType is required.");
+			if (!TimeSpan.TryParse(request.TickDuration, out var tickDuration) || tickDuration <= TimeSpan.Zero)
+				return BadRequest("TickDuration must be a valid positive timespan (HH:MM:SS).");
+			if (request.MatchDurationHours <= 0) return BadRequest("MatchDurationHours must be positive.");
+
+			var tournament = new TournamentImmutable(
+				TournamentId: Guid.NewGuid().ToString("N")[..12],
+				Name: request.Name,
+				CreatedByUserId: currentUserContext.UserId!,
+				Format: format,
+				Status: TournamentStatus.Registration,
+				RegistrationDeadline: request.RegistrationDeadline.ToUniversalTime(),
+				MaxPlayers: request.MaxPlayers,
+				Registrations: new List<TournamentRegistrationImmutable>(),
+				GameDefType: request.GameDefType,
+				TickDuration: request.TickDuration,
+				MatchDurationHours: request.MatchDurationHours
+			);
+
+			tournamentRepositoryWrite.Create(tournament);
+			return CreatedAtAction(nameof(GetDetail), new { tournamentId = tournament.TournamentId }, ToSummary(tournament));
+		}
+
+		/// <summary>Returns tournament detail including registrations and bracket.</summary>
+		[AllowAnonymous]
+		[HttpGet("{tournamentId}")]
+		[ProducesResponseType(typeof(TournamentDetailViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<TournamentDetailViewModel> GetDetail(string tournamentId) {
+			var tournament = tournamentRepository.GetById(tournamentId);
+			if (tournament == null) return NotFound();
+
+			var registrations = tournament.Registrations
+				.Select(r => new TournamentRegistrationViewModel(r.UserId, r.DisplayName, r.RegisteredAt))
+				.ToList();
+
+			bool isRegistered = currentUserContext.IsValid
+				&& tournament.Registrations.Any(r => r.UserId == currentUserContext.UserId);
+
+			bool isCreator = currentUserContext.IsValid
+				&& tournament.CreatedByUserId == currentUserContext.UserId;
+
+			TournamentBracketViewModel? bracket = null;
+			if (tournament.Matches != null && tournament.Matches.Count > 0)
+				bracket = BuildBracketViewModel(tournament);
+
+			return Ok(new TournamentDetailViewModel(
+				TournamentId: tournament.TournamentId,
+				Name: tournament.Name,
+				Format: tournament.Format.ToString(),
+				Status: tournament.Status.ToString(),
+				RegistrationDeadline: tournament.RegistrationDeadline,
+				MaxPlayers: tournament.MaxPlayers,
+				Registrations: registrations,
+				IsRegistered: isRegistered,
+				IsCreator: isCreator,
+				Bracket: bracket
+			));
+		}
+
+		/// <summary>Returns the bracket for an in-progress or finished tournament.</summary>
+		[AllowAnonymous]
+		[HttpGet("{tournamentId}/bracket")]
+		[ProducesResponseType(typeof(TournamentBracketViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult<TournamentBracketViewModel> GetBracket(string tournamentId) {
+			var tournament = tournamentRepository.GetById(tournamentId);
+			if (tournament == null || tournament.Matches == null || tournament.Matches.Count == 0)
+				return NotFound();
+
+			return Ok(BuildBracketViewModel(tournament));
+		}
+
+		/// <summary>Registers the current user for a tournament.</summary>
+		[Authorize]
+		[HttpPost("{tournamentId}/register")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult Register(string tournamentId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var tournament = tournamentRepository.GetById(tournamentId);
+			if (tournament == null) return NotFound();
+			if (tournament.Status != TournamentStatus.Registration)
+				return BadRequest("Tournament is not accepting registrations.");
+			if (tournament.RegistrationDeadline < DateTime.UtcNow)
+				return BadRequest("Registration deadline has passed.");
+
+			var displayName = globalState.GetUserDisplayName(currentUserContext.UserId!) ?? currentUserContext.UserId!;
+			var registration = new TournamentRegistrationImmutable(
+				UserId: currentUserContext.UserId!,
+				DisplayName: displayName,
+				RegisteredAt: DateTime.UtcNow
+			);
+
+			try {
+				tournamentRepositoryWrite.AddRegistration(tournamentId, registration);
+			} catch (InvalidOperationException ex) {
+				return BadRequest(ex.Message);
+			}
+
+			return Ok();
+		}
+
+		/// <summary>Unregisters the current user from a tournament.</summary>
+		[Authorize]
+		[HttpDelete("{tournamentId}/register")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult Unregister(string tournamentId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var tournament = tournamentRepository.GetById(tournamentId);
+			if (tournament == null) return NotFound();
+
+			try {
+				tournamentRepositoryWrite.RemoveRegistration(tournamentId, currentUserContext.UserId!);
+			} catch (InvalidOperationException ex) {
+				return BadRequest(ex.Message);
+			}
+
+			return Ok();
+		}
+
+		/// <summary>Starts a tournament (creator only).</summary>
+		[Authorize]
+		[HttpPost("{tournamentId}/start")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult Start(string tournamentId) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			var tournament = tournamentRepository.GetById(tournamentId);
+			if (tournament == null) return NotFound();
+			if (tournament.CreatedByUserId != currentUserContext.UserId) return Forbid();
+
+			try {
+				tournamentEngine.StartTournament(tournamentId);
+			} catch (InvalidOperationException ex) {
+				return BadRequest(ex.Message);
+			}
+
+			return Ok();
+		}
+
+		private static TournamentSummaryViewModel ToSummary(TournamentImmutable t) =>
+			new(
+				TournamentId: t.TournamentId,
+				Name: t.Name,
+				Format: t.Format.ToString(),
+				Status: t.Status.ToString(),
+				RegistrationDeadline: t.RegistrationDeadline,
+				MaxPlayers: t.MaxPlayers,
+				RegistrationCount: t.Registrations.Count
+			);
+
+		private TournamentBracketViewModel BuildBracketViewModel(TournamentImmutable tournament) {
+			var rounds = (tournament.Matches ?? Enumerable.Empty<TournamentMatchImmutable>())
+				.GroupBy(m => m.Round)
+				.OrderBy(g => g.Key)
+				.Select(g => new RoundViewModel(
+					Round: g.Key,
+					Matches: g.OrderBy(m => m.MatchNumber).Select(m => new MatchViewModel(
+						MatchId: m.MatchId,
+						Round: m.Round,
+						MatchNumber: m.MatchNumber,
+						Player1: m.Player1UserId != null ? new PlayerRefViewModel(
+							m.Player1UserId,
+							globalState.GetUserDisplayName(m.Player1UserId) ?? m.Player1UserId
+						) : null,
+						Player2: m.Player2UserId != null ? new PlayerRefViewModel(
+							m.Player2UserId,
+							globalState.GetUserDisplayName(m.Player2UserId) ?? m.Player2UserId
+						) : null,
+						WinnerId: m.WinnerUserId,
+						GameId: m.GameId,
+						Status: m.Status.ToString()
+					)).ToList()
+				)).ToList();
+
+			return new TournamentBracketViewModel(
+				TournamentId: tournament.TournamentId,
+				Name: tournament.Name,
+				Format: tournament.Format.ToString(),
+				Status: tournament.Status.ToString(),
+				Rounds: rounds
+			);
 		}
 	}
 }

--- a/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GameRecordImmutable.cs
@@ -20,6 +20,7 @@ namespace BrowserGameEngine.GameModel {
 		string? DiscordWebhookUrl = null,
 		int MaxPlayers = 0,
 		GameSettings? Settings = null,
-		string? TournamentId = null
+		string? TournamentId = null,
+		string? TournamentMatchId = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/GlobalStateImmutable.cs
@@ -5,6 +5,7 @@ namespace BrowserGameEngine.GameModel {
 		IDictionary<string, UserImmutable> Users,
 		IList<GameRecordImmutable> Games,
 		IList<PlayerAchievementImmutable> Achievements,
-		IList<UserMilestoneImmutable>? Milestones = null
+		IList<UserMilestoneImmutable>? Milestones = null,
+		IList<TournamentImmutable>? Tournaments = null
 	);
 }

--- a/src/BrowserGameEngine.GameModel/TournamentImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/TournamentImmutable.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrowserGameEngine.GameModel {
+	public enum TournamentFormat { RoundRobin, SingleElimination }
+	public enum TournamentStatus { Registration, InProgress, Finished, Cancelled }
+	public enum MatchStatus { Pending, InProgress, Completed, Bye }
+
+	public record TournamentRegistrationImmutable(
+		string UserId,
+		string DisplayName,
+		DateTime RegisteredAt
+	);
+
+	public record TournamentMatchImmutable(
+		string MatchId,
+		string TournamentId,
+		int Round,
+		int MatchNumber,
+		string? Player1UserId,
+		string? Player2UserId,
+		string? GameId,
+		string? WinnerUserId,
+		MatchStatus Status
+	);
+
+	public record TournamentImmutable(
+		string TournamentId,
+		string Name,
+		string CreatedByUserId,
+		TournamentFormat Format,
+		TournamentStatus Status,
+		DateTime RegistrationDeadline,
+		int MaxPlayers,
+		IList<TournamentRegistrationImmutable> Registrations,
+		IList<TournamentMatchImmutable>? Matches = null,
+		string? GameDefType = null,
+		string? TickDuration = null,
+		int MatchDurationHours = 24
+	);
+}

--- a/src/BrowserGameEngine.Shared/TournamentViewModels.cs
+++ b/src/BrowserGameEngine.Shared/TournamentViewModels.cs
@@ -1,6 +1,75 @@
+using System;
 using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
+	public record CreateTournamentRequest(
+		string Name,
+		string Format,
+		DateTime RegistrationDeadline,
+		int MaxPlayers,
+		string GameDefType,
+		string TickDuration,
+		int MatchDurationHours
+	);
+
+	public record TournamentSummaryViewModel(
+		string TournamentId,
+		string Name,
+		string Format,
+		string Status,
+		DateTime RegistrationDeadline,
+		int MaxPlayers,
+		int RegistrationCount
+	);
+
+	public record TournamentRegistrationViewModel(
+		string UserId,
+		string DisplayName,
+		DateTime RegisteredAt
+	);
+
+	public record PlayerRefViewModel(
+		string UserId,
+		string DisplayName
+	);
+
+	public record MatchViewModel(
+		string MatchId,
+		int Round,
+		int MatchNumber,
+		PlayerRefViewModel? Player1,
+		PlayerRefViewModel? Player2,
+		string? WinnerId,
+		string? GameId,
+		string Status
+	);
+
+	public record RoundViewModel(
+		int Round,
+		List<MatchViewModel> Matches
+	);
+
+	public record TournamentBracketViewModel(
+		string TournamentId,
+		string Name,
+		string Format,
+		string Status,
+		List<RoundViewModel> Rounds
+	);
+
+	public record TournamentDetailViewModel(
+		string TournamentId,
+		string Name,
+		string Format,
+		string Status,
+		DateTime RegistrationDeadline,
+		int MaxPlayers,
+		List<TournamentRegistrationViewModel> Registrations,
+		bool IsRegistered,
+		bool IsCreator,
+		TournamentBracketViewModel? Bracket
+	);
+
 	public record TournamentPlayerResultViewModel(
 		int Rank,
 		string? UserId,

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameLifecycleEngineTest.cs
@@ -88,6 +88,16 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
 			var defaultInstance = gameRegistry.GetDefaultInstance();
 			var userRepositoryWrite = new UserRepositoryWrite(gameRegistry.GlobalState, defaultInstance.WorldState, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(gameRegistry.GlobalState);
+			var tournamentEngine = new GameRegistryNs.TournamentEngine(
+				gameRegistry.GlobalState,
+				gameRegistry,
+				new TestWorldStateFactory(),
+				TestGameDef,
+				TimeProvider.System,
+				tournamentRepositoryWrite,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance
+			);
 			return new GameRegistryNs.GameLifecycleEngine(
 				gameRegistry,
 				gameRegistry.GlobalState,
@@ -100,6 +110,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(gameRegistry.GlobalState, gameRegistry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(gameRegistry.GlobalState),
+				tournamentEngine,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}
@@ -230,6 +241,16 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, serializer);
 			var globalSerializer = new GlobalStateJsonSerializer();
 			var globalPersistenceService = new GlobalPersistenceService(storage, globalSerializer);
+			var tournamentRepositoryWrite2 = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(globalState);
+			var tournamentEngine2 = new GameRegistryNs.TournamentEngine(
+				globalState,
+				registry,
+				new TestWorldStateFactory(),
+				TestGameDef,
+				TimeProvider.System,
+				tournamentRepositoryWrite2,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance
+			);
 			var engine = new GameRegistryNs.GameLifecycleEngine(
 				registry,
 				globalState,
@@ -242,6 +263,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, registry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
+				tournamentEngine2,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameSettingsTest.cs
@@ -55,6 +55,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
 			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
 			var userRepositoryWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(game.GlobalState);
+			var tournamentEngine = new GameRegistryNs.TournamentEngine(
+				game.GlobalState, registry, game.WorldStateFactory, game.GameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance);
 			var lifecycleEngine = new GameRegistryNs.GameLifecycleEngine(
 				registry,
 				game.GlobalState,
@@ -67,6 +72,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(game.GlobalState, registry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(game.GlobalState),
+				tournamentEngine,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GamesControllerTest.cs
@@ -57,6 +57,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
 			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
 			var userRepositoryWrite = new UserRepositoryWrite(globalState, game.World, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(globalState);
+			var tournamentEngine = new GameRegistry.TournamentEngine(
+				globalState, gameRegistry, game.WorldStateFactory, game.GameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<GameRegistry.TournamentEngine>.Instance);
 			var lifecycleEngine = new GameRegistry.GameLifecycleEngine(
 				gameRegistry,
 				globalState,
@@ -69,6 +74,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, gameRegistry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
+				tournamentEngine,
 				NullLogger<GameRegistry.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/LobbyTest.cs
@@ -52,6 +52,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
 			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
 			var userRepositoryWrite = new UserRepositoryWrite(globalState, game.World, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(globalState);
+			var tournamentEngine = new TournamentEngine(
+				globalState, gameRegistry, game.WorldStateFactory, game.GameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<TournamentEngine>.Instance);
 			var lifecycleEngine = new GameLifecycleEngine(
 				gameRegistry,
 				globalState,
@@ -64,6 +69,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(globalState, gameRegistry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(globalState),
+				tournamentEngine,
 				NullLogger<GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/MultiGameLifecycleTest.cs
@@ -50,6 +50,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var globalSerializer = new GlobalStateJsonSerializer();
 			var defaultInstance = registry.GetDefaultInstance();
 			var userRepositoryWrite = new UserRepositoryWrite(registry.GlobalState, defaultInstance.WorldState, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(registry.GlobalState);
+			var tournamentEngine = new GameRegistryNs.TournamentEngine(
+				registry.GlobalState, registry, new TestWorldStateFactory(), TestGameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance);
 			return new GameRegistryNs.GameLifecycleEngine(
 				registry,
 				registry.GlobalState,
@@ -62,6 +67,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(registry.GlobalState, registry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(registry.GlobalState),
+				tournamentEngine,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/TournamentEngineTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/TournamentEngineTest.cs
@@ -1,0 +1,247 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Repositories.Tournament;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class TournamentEngineTest {
+		private static readonly GameDef TestGameDef = new TestGameDefFactory().CreateGameDef();
+
+		private static (GameRegistryNs.TournamentEngine engine, GlobalState globalState, GameRegistryNs.GameRegistry registry) MakeEngine() {
+			var globalState = new GlobalState();
+			var registry = new GameRegistryNs.GameRegistry(globalState);
+
+			var worldStateFactory = new TestWorldStateFactory();
+			var wsImm = worldStateFactory.CreateDevWorldState(0) with { GameId = new GameId("default") };
+			var ws = wsImm.ToMutable();
+			var record = new GameRecordImmutable(
+				new GameId("default"), "Default", "sco", GameStatus.Active,
+				DateTime.UtcNow, DateTime.UtcNow.AddHours(24), TimeSpan.FromMinutes(1));
+			globalState.AddGame(record);
+			registry.Register(new GameRegistryNs.GameInstance(record, ws, TestGameDef));
+
+			var tournamentRepositoryWrite = new TournamentRepositoryWrite(globalState);
+			var engine = new GameRegistryNs.TournamentEngine(
+				globalState, registry, worldStateFactory, TestGameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance);
+
+			return (engine, globalState, registry);
+		}
+
+		private static TournamentImmutable MakeTournament(
+			GlobalState globalState,
+			int playerCount,
+			TournamentFormat format = TournamentFormat.SingleElimination
+		) {
+			var registrations = Enumerable.Range(1, playerCount)
+				.Select(i => new TournamentRegistrationImmutable($"user{i}", $"Player {i}", DateTime.UtcNow))
+				.ToList();
+
+			var tournament = new TournamentImmutable(
+				TournamentId: $"t-{format}-{playerCount}",
+				Name: "Test Tournament",
+				CreatedByUserId: "creator",
+				Format: format,
+				Status: TournamentStatus.Registration,
+				RegistrationDeadline: DateTime.UtcNow.AddHours(1),
+				MaxPlayers: 0,
+				Registrations: registrations,
+				GameDefType: "sco",
+				TickDuration: "00:01:00",
+				MatchDurationHours: 1
+			);
+			globalState.AddTournament(tournament);
+			return tournament;
+		}
+
+		[Fact]
+		public void GenerateBracket_RoundRobin_4Players_Produces6Matches() {
+			var (engine, globalState, _) = MakeEngine();
+			var tournament = MakeTournament(globalState, 4, TournamentFormat.RoundRobin);
+
+			engine.StartTournament(tournament.TournamentId);
+
+			var updated = globalState.GetTournamentById(tournament.TournamentId)!;
+			Assert.Equal(TournamentStatus.InProgress, updated.Status);
+			Assert.NotNull(updated.Matches);
+			Assert.Equal(6, updated.Matches!.Count); // n*(n-1)/2 = 4*3/2 = 6
+			Assert.All(updated.Matches, m => Assert.Equal(1, m.Round));
+
+			// All player pairs must be unique
+			var pairs = updated.Matches.Select(m => (m.Player1UserId!, m.Player2UserId!)).ToList();
+			var uniquePairs = pairs.Select(p => (
+				string.CompareOrdinal(p.Item1, p.Item2) < 0 ? p.Item1 : p.Item2,
+				string.CompareOrdinal(p.Item1, p.Item2) < 0 ? p.Item2 : p.Item1
+			)).ToHashSet();
+			Assert.Equal(6, uniquePairs.Count);
+		}
+
+		[Fact]
+		public void GenerateBracket_SingleElim_4Players_ProducesCorrectRounds() {
+			var (engine, globalState, _) = MakeEngine();
+			var tournament = MakeTournament(globalState, 4, TournamentFormat.SingleElimination);
+
+			engine.StartTournament(tournament.TournamentId);
+
+			var updated = globalState.GetTournamentById(tournament.TournamentId)!;
+			Assert.Equal(TournamentStatus.InProgress, updated.Status);
+			Assert.NotNull(updated.Matches);
+
+			// 4 players, bracket=4 → 2 round-1 real matches, 0 byes, 1 round-2 slot
+			var round1 = updated.Matches!.Where(m => m.Round == 1).ToList();
+			var round2 = updated.Matches.Where(m => m.Round == 2).ToList();
+
+			Assert.Equal(2, round1.Count);
+			Assert.Single(round2);
+			Assert.All(round1, m => Assert.NotNull(m.Player1UserId));
+			Assert.All(round1, m => Assert.NotNull(m.Player2UserId));
+			// Round 2 starts with null players (waiting for winners)
+			Assert.Null(round2[0].Player1UserId);
+			Assert.Null(round2[0].Player2UserId);
+		}
+
+		[Fact]
+		public void GenerateBracket_SingleElim_5Players_GeneratesByesCorrectly() {
+			var (engine, globalState, _) = MakeEngine();
+			var tournament = MakeTournament(globalState, 5, TournamentFormat.SingleElimination);
+
+			engine.StartTournament(tournament.TournamentId);
+
+			var updated = globalState.GetTournamentById(tournament.TournamentId)!;
+			Assert.NotNull(updated.Matches);
+
+			// 5 players, bracket=8 → realMatches=5-(8/2)=5-4=1... wait let me recalculate
+			// bracketSize=8, realMatches = n - bracketSize/2 = 5 - 4 = 1? No that's wrong
+			// Actually: realMatches = n - (bracketSize/2)? No.
+			// With 5 players and bracket=8:
+			// We want all 8 "slots" filled. 5 real players + 3 byes = 8.
+			// Round 1 has 4 matches: some real, some byes.
+			// realMatches = n - bracketSize/2 ... this should be:
+			// To have bracketSize/2 matches in round 1, we need bracketSize/2 pairs.
+			// byes = bracketSize - n = 8 - 5 = 3
+			// real matches in round 1 = (n - byes) / 2 = ... actually let me re-check my code
+			// n=5, bracketSize=8
+			// realMatches = n - bracketSize/2 = 5 - 4 = 1
+			// byes = bracketSize/2 - realMatches = 4 - 1 = 3
+			// So round 1 has 1 real match + 3 byes = 4 matches
+			var round1 = updated.Matches!.Where(m => m.Round == 1).ToList();
+			Assert.Equal(4, round1.Count);
+
+			var byeMatches = round1.Where(m => m.Status == MatchStatus.Bye).ToList();
+			var realMatches = round1.Where(m => m.Status != MatchStatus.Bye).ToList();
+			Assert.Equal(3, byeMatches.Count);
+			Assert.Single(realMatches);
+		}
+
+		[Fact]
+		public void AddRegistration_AtMaxPlayers_ThrowsInvalidOperationException() {
+			var (_, globalState, _) = MakeEngine();
+			var tournament = new TournamentImmutable(
+				TournamentId: "t-maxtest",
+				Name: "Max Test",
+				CreatedByUserId: "creator",
+				Format: TournamentFormat.SingleElimination,
+				Status: TournamentStatus.Registration,
+				RegistrationDeadline: DateTime.UtcNow.AddHours(1),
+				MaxPlayers: 2,
+				Registrations: new List<TournamentRegistrationImmutable> {
+					new("user1", "Player 1", DateTime.UtcNow),
+					new("user2", "Player 2", DateTime.UtcNow),
+				}
+			);
+			globalState.AddTournament(tournament);
+
+			var write = new TournamentRepositoryWrite(globalState);
+			var ex = Assert.Throws<InvalidOperationException>(() =>
+				write.AddRegistration("t-maxtest", new TournamentRegistrationImmutable("user3", "Player 3", DateTime.UtcNow)));
+			Assert.Contains("full", ex.Message);
+		}
+
+		[Fact]
+		public void AddRegistration_DuplicateUser_ThrowsInvalidOperationException() {
+			var (_, globalState, _) = MakeEngine();
+			var tournament = new TournamentImmutable(
+				TournamentId: "t-duptest",
+				Name: "Dup Test",
+				CreatedByUserId: "creator",
+				Format: TournamentFormat.SingleElimination,
+				Status: TournamentStatus.Registration,
+				RegistrationDeadline: DateTime.UtcNow.AddHours(1),
+				MaxPlayers: 0,
+				Registrations: new List<TournamentRegistrationImmutable> {
+					new("user1", "Player 1", DateTime.UtcNow),
+				}
+			);
+			globalState.AddTournament(tournament);
+
+			var write = new TournamentRepositoryWrite(globalState);
+			var ex = Assert.Throws<InvalidOperationException>(() =>
+				write.AddRegistration("t-duptest", new TournamentRegistrationImmutable("user1", "Player 1", DateTime.UtcNow)));
+			Assert.Contains("already registered", ex.Message);
+		}
+
+		[Fact]
+		public void StartTournament_WithLessThan2Players_ThrowsInvalidOperationException() {
+			var (engine, globalState, _) = MakeEngine();
+			var tournament = MakeTournament(globalState, 1);
+
+			Assert.Throws<InvalidOperationException>(() => engine.StartTournament(tournament.TournamentId));
+		}
+
+		[Fact]
+		public void ProcessGameFinalized_NonTournamentGame_IsNoOp() {
+			var (engine, globalState, _) = MakeEngine();
+			var record = new GameRecordImmutable(
+				new GameId("nontournament"), "Normal", "sco", GameStatus.Finished,
+				DateTime.UtcNow, DateTime.UtcNow, TimeSpan.FromMinutes(1));
+
+			// Should not throw, tournaments list remains empty
+			engine.ProcessGameFinalized(record);
+			Assert.Empty(globalState.GetTournaments());
+		}
+
+		[Fact]
+		public void ProcessGameFinalized_SingleElim_LastMatch_FinishesTournament() {
+			var (engine, globalState, _) = MakeEngine();
+			var tournament = MakeTournament(globalState, 2, TournamentFormat.SingleElimination);
+
+			engine.StartTournament(tournament.TournamentId);
+
+			var updated = globalState.GetTournamentById(tournament.TournamentId)!;
+			var match = updated.Matches!.First(m => m.Round == 1 && m.Status == MatchStatus.InProgress);
+
+			// Add achievement for the match game so ProcessGameFinalized can find a winner
+			globalState.AddAchievement(new PlayerAchievementImmutable(
+				UserId: match.Player1UserId!,
+				GameId: new GameId(match.GameId!),
+				PlayerId: PlayerIdFactory.Create("p1"),
+				PlayerName: "Player 1",
+				FinalRank: 1,
+				FinalScore: 100m,
+				GameDefType: "sco",
+				FinishedAt: DateTime.UtcNow
+			));
+
+			var gameRecord = new GameRecordImmutable(
+				new GameId(match.GameId!), match.MatchId, "sco", GameStatus.Finished,
+				DateTime.UtcNow, DateTime.UtcNow, TimeSpan.FromMinutes(1),
+				TournamentId: tournament.TournamentId,
+				TournamentMatchId: match.MatchId
+			);
+
+			engine.ProcessGameFinalized(gameRecord);
+
+			var finalized = globalState.GetTournamentById(tournament.TournamentId)!;
+			Assert.Equal(TournamentStatus.Finished, finalized.Status);
+			Assert.Equal(match.Player1UserId, finalized.Matches!.First(m => m.MatchId == match.MatchId).WinnerUserId);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/VictoryConditionModuleTest.cs
@@ -34,6 +34,11 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var persistenceService = new PersistenceService(storage, new GameStateJsonSerializer());
 			var globalPersistenceService = new GlobalPersistenceService(storage, new GlobalStateJsonSerializer());
 			var userRepositoryWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+			var tournamentRepositoryWrite = new BrowserGameEngine.StatefulGameServer.Repositories.Tournament.TournamentRepositoryWrite(game.GlobalState);
+			var tournamentEngine = new GameRegistryNs.TournamentEngine(
+				game.GlobalState, registry, game.WorldStateFactory, game.GameDef,
+				TimeProvider.System, tournamentRepositoryWrite,
+				NullLogger<GameRegistryNs.TournamentEngine>.Instance);
 			var lifecycleEngine = new GameRegistryNs.GameLifecycleEngine(
 				registry,
 				game.GlobalState,
@@ -46,6 +51,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 				TimeProvider.System,
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepository(game.GlobalState, registry),
 				new BrowserGameEngine.StatefulGameServer.Achievements.MilestoneRepositoryWrite(game.GlobalState),
+				tournamentEngine,
 				NullLogger<GameRegistryNs.GameLifecycleEngine>.Instance
 			);
 

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
@@ -16,6 +16,9 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		private readonly object _milestonesLock = new();
 		private List<UserMilestoneImmutable> _milestones = new();
 
+		private readonly object _tournamentsLock = new();
+		private List<TournamentImmutable> _tournaments = new();
+
 		public string? GetUserDisplayName(string userId) {
 			var user = Users.Values.FirstOrDefault(u => u.UserId == userId);
 			return user?.DisplayName;
@@ -90,6 +93,29 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				addValueFactory: _ => throw new System.InvalidOperationException($"User {userId} not found when awarding XP"),
 				updateValueFactory: (_, existing) => { existing.TotalXp += xp; return existing; });
 		}
+
+		public IReadOnlyList<TournamentImmutable> GetTournaments() {
+			lock (_tournamentsLock) return _tournaments.ToList();
+		}
+
+		public TournamentImmutable? GetTournamentById(string tournamentId) {
+			lock (_tournamentsLock) return _tournaments.FirstOrDefault(t => t.TournamentId == tournamentId);
+		}
+
+		public void AddTournament(TournamentImmutable tournament) {
+			lock (_tournamentsLock) _tournaments.Add(tournament);
+		}
+
+		public void UpdateTournament(TournamentImmutable old, TournamentImmutable updated) {
+			lock (_tournamentsLock) {
+				var idx = _tournaments.IndexOf(old);
+				if (idx >= 0) _tournaments[idx] = updated;
+			}
+		}
+
+		public void SetTournaments(IEnumerable<TournamentImmutable> tournaments) {
+			lock (_tournamentsLock) _tournaments = tournaments.ToList();
+		}
 	}
 
 	public static class GlobalStateExtensions {
@@ -98,7 +124,8 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Users: globalState.Users.ToDictionary(x => x.Key, y => y.Value.ToImmutable()),
 				Games: globalState.GetGames().ToList(),
 				Achievements: globalState.GetAchievements().ToList(),
-				Milestones: globalState.GetAllMilestones().ToList()
+				Milestones: globalState.GetAllMilestones().ToList(),
+				Tournaments: globalState.GetTournaments().ToList()
 			);
 		}
 
@@ -110,6 +137,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			state.SetGames(globalStateImmutable.Games);
 			state.SetAchievements(globalStateImmutable.Achievements);
 			state.SetMilestones(globalStateImmutable.Milestones ?? Enumerable.Empty<UserMilestoneImmutable>());
+			state.SetTournaments(globalStateImmutable.Tournaments ?? Enumerable.Empty<TournamentImmutable>());
 			return state;
 		}
 	}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -25,6 +25,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		private readonly TimeProvider timeProvider;
 		private readonly MilestoneRepository milestoneRepository;
 		private readonly MilestoneRepositoryWrite milestoneRepositoryWrite;
+		private readonly TournamentEngine tournamentEngine;
 		private readonly ILogger<GameLifecycleEngine> logger;
 
 		public GameLifecycleEngine(
@@ -39,6 +40,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			TimeProvider timeProvider,
 			MilestoneRepository milestoneRepository,
 			MilestoneRepositoryWrite milestoneRepositoryWrite,
+			TournamentEngine tournamentEngine,
 			ILogger<GameLifecycleEngine> logger
 		) {
 			this.gameRegistry = gameRegistry;
@@ -52,6 +54,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			this.timeProvider = timeProvider;
 			this.milestoneRepository = milestoneRepository;
 			this.milestoneRepositoryWrite = milestoneRepositoryWrite;
+			this.tournamentEngine = tournamentEngine;
 			this.logger = logger;
 		}
 
@@ -240,6 +243,13 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 
 			logger.LogInformation("Game {GameId} finalized. Winner: {WinnerId}, Players: {PlayerCount}",
 				record.GameId.Id, winnerId?.Id ?? "(none)", rankings.Count);
+
+			// Process tournament progression (no-op for non-tournament games)
+			try {
+				tournamentEngine.ProcessGameFinalized(updated);
+			} catch (Exception ex) {
+				logger.LogError(ex, "Tournament progression failed for game {GameId}", record.GameId.Id);
+			}
 
 			var victoryLabel = GetVictoryConditionLabel(victoryConditionType);
 			await notificationService.NotifyGameFinishedAsync(updated, winnerId, winnerName, rankings.Count, victoryLabel);

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/TournamentEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/TournamentEngine.cs
@@ -1,0 +1,309 @@
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.Repositories.Tournament;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
+	public class TournamentEngine {
+		private readonly GlobalState globalState;
+		private readonly GameRegistry gameRegistry;
+		private readonly IWorldStateFactory worldStateFactory;
+		private readonly GameDef gameDef;
+		private readonly TimeProvider timeProvider;
+		private readonly TournamentRepositoryWrite tournamentRepositoryWrite;
+		private readonly ILogger<TournamentEngine> logger;
+
+		public TournamentEngine(
+			GlobalState globalState,
+			GameRegistry gameRegistry,
+			IWorldStateFactory worldStateFactory,
+			GameDef gameDef,
+			TimeProvider timeProvider,
+			TournamentRepositoryWrite tournamentRepositoryWrite,
+			ILogger<TournamentEngine> logger
+		) {
+			this.globalState = globalState;
+			this.gameRegistry = gameRegistry;
+			this.worldStateFactory = worldStateFactory;
+			this.gameDef = gameDef;
+			this.timeProvider = timeProvider;
+			this.tournamentRepositoryWrite = tournamentRepositoryWrite;
+			this.logger = logger;
+		}
+
+		public void StartTournament(string tournamentId) {
+			var tournament = globalState.GetTournamentById(tournamentId)
+				?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
+
+			if (tournament.Status != TournamentStatus.Registration)
+				throw new InvalidOperationException("Tournament is not in registration phase.");
+
+			if (tournament.Registrations.Count < 2)
+				throw new InvalidOperationException("At least 2 players are required to start a tournament.");
+
+			var matches = GenerateBracket(tournament);
+			var matchesWithGames = CreateGamesForRound(tournament, matches, 1);
+
+			var updated = tournament with {
+				Status = TournamentStatus.InProgress,
+				Matches = matchesWithGames
+			};
+			tournamentRepositoryWrite.UpdateTournament(updated);
+
+			logger.LogInformation("Tournament {TournamentId} started with {MatchCount} matches", tournamentId, matchesWithGames.Count);
+		}
+
+		private List<TournamentMatchImmutable> GenerateBracket(TournamentImmutable tournament) {
+			var registrations = tournament.Registrations.ToList();
+			int n = registrations.Count;
+
+			if (tournament.Format == TournamentFormat.RoundRobin) {
+				return GenerateRoundRobinBracket(tournament.TournamentId, registrations);
+			} else {
+				return GenerateSingleEliminationBracket(tournament.TournamentId, registrations);
+			}
+		}
+
+		private static List<TournamentMatchImmutable> GenerateRoundRobinBracket(
+			string tournamentId,
+			List<TournamentRegistrationImmutable> registrations
+		) {
+			var matches = new List<TournamentMatchImmutable>();
+			int matchNumber = 1;
+			for (int i = 0; i < registrations.Count; i++) {
+				for (int j = i + 1; j < registrations.Count; j++) {
+					matches.Add(new TournamentMatchImmutable(
+						MatchId: $"{tournamentId}-r1-m{matchNumber}",
+						TournamentId: tournamentId,
+						Round: 1,
+						MatchNumber: matchNumber,
+						Player1UserId: registrations[i].UserId,
+						Player2UserId: registrations[j].UserId,
+						GameId: null,
+						WinnerUserId: null,
+						Status: MatchStatus.Pending
+					));
+					matchNumber++;
+				}
+			}
+			return matches;
+		}
+
+		private static List<TournamentMatchImmutable> GenerateSingleEliminationBracket(
+			string tournamentId,
+			List<TournamentRegistrationImmutable> registrations
+		) {
+			int n = registrations.Count;
+			int bracketSize = NextPowerOfTwo(n);
+			var shuffled = registrations.OrderBy(_ => Guid.NewGuid()).ToList();
+			var matches = new List<TournamentMatchImmutable>();
+
+			// Determine how many Round 1 real matches we need
+			// Players beyond power-of-2 need to play in, rest get byes
+			int realMatches = n - (bracketSize / 2); // players who must play in round 1
+			int byes = bracketSize / 2 - realMatches;
+
+			int matchNumber = 1;
+			// Real matches: first 2*realMatches players
+			for (int i = 0; i < realMatches; i++) {
+				matches.Add(new TournamentMatchImmutable(
+					MatchId: $"{tournamentId}-r1-m{matchNumber}",
+					TournamentId: tournamentId,
+					Round: 1,
+					MatchNumber: matchNumber,
+					Player1UserId: shuffled[i * 2].UserId,
+					Player2UserId: shuffled[i * 2 + 1].UserId,
+					GameId: null,
+					WinnerUserId: null,
+					Status: MatchStatus.Pending
+				));
+				matchNumber++;
+			}
+
+			// Bye matches: remaining players get automatic wins
+			for (int i = 0; i < byes; i++) {
+				int playerIndex = realMatches * 2 + i;
+				matches.Add(new TournamentMatchImmutable(
+					MatchId: $"{tournamentId}-r1-m{matchNumber}",
+					TournamentId: tournamentId,
+					Round: 1,
+					MatchNumber: matchNumber,
+					Player1UserId: shuffled[playerIndex].UserId,
+					Player2UserId: null,
+					GameId: null,
+					WinnerUserId: shuffled[playerIndex].UserId,
+					Status: MatchStatus.Bye
+				));
+				matchNumber++;
+			}
+
+			// Create subsequent rounds with null player slots (filled during progression)
+			int prevRoundMatchCount = bracketSize / 2;
+			for (int round = 2; prevRoundMatchCount > 1; round++) {
+				int currentRoundMatchCount = prevRoundMatchCount / 2;
+				for (int i = 1; i <= currentRoundMatchCount; i++) {
+					matches.Add(new TournamentMatchImmutable(
+						MatchId: $"{tournamentId}-r{round}-m{i}",
+						TournamentId: tournamentId,
+						Round: round,
+						MatchNumber: i,
+						Player1UserId: null,
+						Player2UserId: null,
+						GameId: null,
+						WinnerUserId: null,
+						Status: MatchStatus.Pending
+					));
+				}
+				prevRoundMatchCount = currentRoundMatchCount;
+			}
+
+			return matches;
+		}
+
+		private List<TournamentMatchImmutable> CreateGamesForRound(
+			TournamentImmutable tournament,
+			List<TournamentMatchImmutable> allMatches,
+			int round
+		) {
+			var result = new List<TournamentMatchImmutable>(allMatches);
+			var roundMatches = allMatches.Where(m => m.Round == round && m.Status == MatchStatus.Pending).ToList();
+
+			foreach (var match in roundMatches) {
+				if (match.Player1UserId == null || match.Player2UserId == null) continue;
+
+				var gameId = CreateMatchGame(tournament, match);
+				var idx = result.IndexOf(match);
+				result[idx] = match with { GameId = gameId, Status = MatchStatus.InProgress };
+			}
+
+			return result;
+		}
+
+		private string CreateMatchGame(TournamentImmutable tournament, TournamentMatchImmutable match) {
+			var gameId = new GameId(Guid.NewGuid().ToString("N")[..12]);
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			var startTime = now.AddMinutes(2);
+			var endTime = startTime.AddHours(tournament.MatchDurationHours);
+
+			if (!TimeSpan.TryParse(tournament.TickDuration ?? "00:01:00", out var tickDuration))
+				tickDuration = TimeSpan.FromMinutes(1);
+
+			var gameDefType = tournament.GameDefType ?? "sco";
+			var record = new GameRecordImmutable(
+				GameId: gameId,
+				Name: $"{tournament.Name} — {match.MatchId}",
+				GameDefType: gameDefType,
+				Status: GameStatus.Upcoming,
+				StartTime: startTime,
+				EndTime: endTime,
+				TickDuration: tickDuration,
+				TournamentId: tournament.TournamentId,
+				TournamentMatchId: match.MatchId
+			);
+
+			var wsImm = worldStateFactory.CreateDevWorldState(0) with { GameId = gameId };
+			var ws = wsImm.ToMutable();
+			var instance = new GameInstance(record, ws, gameDef);
+			gameRegistry.Register(instance);
+			globalState.AddGame(record);
+
+			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
+			var p1Name = globalState.GetUserDisplayName(match.Player1UserId!) ?? match.Player1UserId!;
+			var p2Name = globalState.GetUserDisplayName(match.Player2UserId!) ?? match.Player2UserId!;
+
+			var p1Id = PlayerIdFactory.Create(Guid.NewGuid().ToString("N")[..12]);
+			var p2Id = PlayerIdFactory.Create(Guid.NewGuid().ToString("N")[..12]);
+			playerRepoWrite.CreatePlayer(p1Id, match.Player1UserId, gameDef.PlayerTypes.First().Id.Id);
+			playerRepoWrite.CreatePlayer(p2Id, match.Player2UserId, gameDef.PlayerTypes.First().Id.Id);
+
+			// Set display names
+			if (instance.WorldState.Players.TryGetValue(p1Id, out var p1)) p1.Name = p1Name;
+			if (instance.WorldState.Players.TryGetValue(p2Id, out var p2)) p2.Name = p2Name;
+
+			logger.LogInformation("Created tournament game {GameId} for match {MatchId}", gameId.Id, match.MatchId);
+			return gameId.Id;
+		}
+
+		public void ProcessGameFinalized(GameRecordImmutable record) {
+			if (record.TournamentMatchId == null) return;
+
+			var tournament = globalState.GetTournaments()
+				.FirstOrDefault(t => t.TournamentId == record.TournamentId);
+
+			if (tournament == null) {
+				logger.LogWarning("Tournament {TournamentId} not found when processing game {GameId}",
+					record.TournamentId, record.GameId.Id);
+				return;
+			}
+
+			var matches = tournament.Matches?.ToList();
+			if (matches == null) return;
+
+			var match = matches.FirstOrDefault(m => m.MatchId == record.TournamentMatchId);
+			if (match == null) {
+				logger.LogWarning("Match {MatchId} not found in tournament {TournamentId}",
+					record.TournamentMatchId, record.TournamentId);
+				return;
+			}
+
+			// Find winner from achievements
+			var winnerUserId = globalState.GetAchievements()
+				.FirstOrDefault(a => a.GameId == record.GameId && a.FinalRank == 1)
+				?.UserId;
+
+			var idx = matches.IndexOf(match);
+			matches[idx] = match with { Status = MatchStatus.Completed, WinnerUserId = winnerUserId };
+
+			int currentRound = match.Round;
+			var currentRoundMatches = matches.Where(m => m.Round == currentRound).ToList();
+			bool roundComplete = currentRoundMatches.All(m => m.Status == MatchStatus.Completed || m.Status == MatchStatus.Bye);
+
+			TournamentStatus newStatus = tournament.Status;
+
+			if (roundComplete) {
+				if (tournament.Format == TournamentFormat.RoundRobin) {
+					newStatus = TournamentStatus.Finished;
+				} else {
+					// Single elimination — check if there's a next round
+					var winners = currentRoundMatches.Select(m => m.WinnerUserId).Where(w => w != null).ToList();
+
+					if (winners.Count <= 1) {
+						newStatus = TournamentStatus.Finished;
+					} else {
+						// Populate next round matches with winners
+						int nextRound = currentRound + 1;
+						var nextRoundMatches = matches.Where(m => m.Round == nextRound).ToList();
+						for (int i = 0; i < nextRoundMatches.Count && i * 2 + 1 < winners.Count; i++) {
+							var nextMatch = nextRoundMatches[i];
+							var nextMatchIdx = matches.IndexOf(nextMatch);
+							matches[nextMatchIdx] = nextMatch with {
+								Player1UserId = winners[i * 2],
+								Player2UserId = winners[i * 2 + 1]
+							};
+						}
+
+						// Create games for the next round
+						var updatedTournament = tournament with { Matches = matches };
+						matches = CreateGamesForRound(updatedTournament, matches, nextRound);
+					}
+				}
+			}
+
+			var finalUpdated = tournament with { Status = newStatus, Matches = matches };
+			tournamentRepositoryWrite.UpdateTournament(finalUpdated);
+
+			logger.LogInformation("Tournament {TournamentId} match {MatchId} processed. Winner: {WinnerId}. Status: {Status}",
+				tournament.TournamentId, record.TournamentMatchId, winnerUserId ?? "(none)", newStatus);
+		}
+
+		private static int NextPowerOfTwo(int n) {
+			int p = 1;
+			while (p < n) p <<= 1;
+			return p;
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -10,6 +10,7 @@ using BrowserGameEngine.StatefulGameServer.Events;
 using BrowserGameEngine.StatefulGameServer.Notifications;
 using BrowserGameEngine.StatefulGameServer.Repositories;
 using BrowserGameEngine.StatefulGameServer.Repositories.Chat;
+using BrowserGameEngine.StatefulGameServer.Repositories.Tournament;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -81,6 +82,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<MilestoneRepositoryWrite>();
 			services.AddSingleton<LeaderboardRepository>();
 			services.AddSingleton<GameReplayRepository>();
+			services.AddSingleton<TournamentRepository>();
+			services.AddSingleton<TournamentRepositoryWrite>();
+			services.AddSingleton<TournamentEngine>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepository.cs
@@ -1,0 +1,21 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.Repositories.Tournament {
+	public class TournamentRepository {
+		private readonly GlobalState globalState;
+
+		public TournamentRepository(GlobalState globalState) {
+			this.globalState = globalState;
+		}
+
+		public IReadOnlyList<TournamentImmutable> GetAll() => globalState.GetTournaments();
+
+		public TournamentImmutable? GetById(string tournamentId) => globalState.GetTournamentById(tournamentId);
+
+		public IReadOnlyList<TournamentImmutable> GetByStatus(TournamentStatus status) =>
+			globalState.GetTournaments().Where(t => t.Status == status).ToList();
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepositoryWrite.cs
@@ -1,0 +1,55 @@
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.Repositories.Tournament {
+	public class TournamentRepositoryWrite {
+		private readonly GlobalState globalState;
+
+		public TournamentRepositoryWrite(GlobalState globalState) {
+			this.globalState = globalState;
+		}
+
+		public void Create(TournamentImmutable tournament) {
+			globalState.AddTournament(tournament);
+		}
+
+		public void AddRegistration(string tournamentId, TournamentRegistrationImmutable registration) {
+			var tournament = globalState.GetTournamentById(tournamentId)
+				?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
+
+			if (tournament.Status != TournamentStatus.Registration)
+				throw new InvalidOperationException("Tournament is not in registration phase.");
+
+			if (tournament.Registrations.Any(r => r.UserId == registration.UserId))
+				throw new InvalidOperationException("User is already registered.");
+
+			if (tournament.MaxPlayers > 0 && tournament.Registrations.Count >= tournament.MaxPlayers)
+				throw new InvalidOperationException("Tournament is full.");
+
+			var updatedRegistrations = new List<TournamentRegistrationImmutable>(tournament.Registrations) { registration };
+			var updated = tournament with { Registrations = updatedRegistrations };
+			globalState.UpdateTournament(tournament, updated);
+		}
+
+		public void RemoveRegistration(string tournamentId, string userId) {
+			var tournament = globalState.GetTournamentById(tournamentId)
+				?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
+
+			if (tournament.Status != TournamentStatus.Registration)
+				throw new InvalidOperationException("Tournament is not in registration phase.");
+
+			var updatedRegistrations = tournament.Registrations.Where(r => r.UserId != userId).ToList();
+			var updated = tournament with { Registrations = updatedRegistrations };
+			globalState.UpdateTournament(tournament, updated);
+		}
+
+		public void UpdateTournament(TournamentImmutable updated) {
+			var current = globalState.GetTournamentById(updated.TournamentId)
+				?? throw new InvalidOperationException($"Tournament {updated.TournamentId} not found.");
+			globalState.UpdateTournament(current, updated);
+		}
+	}
+}

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -61,6 +61,8 @@ const ReplayViewer = lazy(() => import('@/pages/ReplayViewer').then(m => ({ defa
 const GameLiveView = lazy(() => import('@/pages/GameLiveView').then(m => ({ default: m.GameLiveView })))
 const PlayerStats = lazy(() => import('@/pages/PlayerStats').then(m => ({ default: m.PlayerStats })))
 const TournamentResults = lazy(() => import('@/pages/TournamentResults').then(m => ({ default: m.TournamentResults })))
+const TournamentList = lazy(() => import('@/pages/TournamentList').then(m => ({ default: m.TournamentList })))
+const TournamentDetail = lazy(() => import('@/pages/TournamentDetail').then(m => ({ default: m.TournamentDetail })))
 const Leaderboard = lazy(() => import('@/pages/Leaderboard').then(m => ({ default: m.Leaderboard })))
 const Spectator = lazy(() => import('@/pages/Spectator').then(m => ({ default: m.Spectator })))
 
@@ -229,7 +231,9 @@ const router = createBrowserRouter([
 			{ path: '/history', element: <RouteWithBoundary><PlayerHistory /></RouteWithBoundary> },
 			{ path: '/replays/:gameId', element: <RouteWithBoundary><ReplayViewer /></RouteWithBoundary> },
 			{ path: '/stats', element: <RouteWithBoundary><PlayerStats /></RouteWithBoundary> },
-			{ path: '/tournaments/:tournamentId', element: <RouteWithBoundary><TournamentResults /></RouteWithBoundary> },
+			{ path: '/tournaments', element: <RouteWithBoundary><TournamentList /></RouteWithBoundary> },
+			{ path: '/tournaments/:tournamentId', element: <RouteWithBoundary><TournamentDetail /></RouteWithBoundary> },
+			{ path: '/tournaments/:tournamentId/results', element: <RouteWithBoundary><TournamentResults /></RouteWithBoundary> },
 			{ path: '/leaderboard', element: <RouteWithBoundary><Leaderboard /></RouteWithBoundary> },
 			{ path: '/games/:gameId/spectate', element: <RouteWithBoundary><SpectatorPage /></RouteWithBoundary> },
 			{ path: '/admin/games', element: <RouteWithBoundary><AdminGames /></RouteWithBoundary> },

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -350,6 +350,74 @@ export interface CreateGameRequest {
   tournamentId?: string | null
 }
 
+export interface CreateTournamentRequest {
+  name: string
+  format: string
+  registrationDeadline: string
+  maxPlayers: number
+  gameDefType: string
+  tickDuration: string
+  matchDurationHours: number
+}
+
+export interface TournamentSummaryViewModel {
+  tournamentId: string
+  name: string
+  format: string
+  status: string
+  registrationDeadline: string
+  maxPlayers: number
+  registrationCount: number
+}
+
+export interface TournamentRegistrationViewModel {
+  userId: string
+  displayName: string
+  registeredAt: string
+}
+
+export interface PlayerRefViewModel {
+  userId: string
+  displayName: string
+}
+
+export interface MatchViewModel {
+  matchId: string
+  round: number
+  matchNumber: number
+  player1: PlayerRefViewModel | null
+  player2: PlayerRefViewModel | null
+  winnerId: string | null
+  gameId: string | null
+  status: string
+}
+
+export interface RoundViewModel {
+  round: number
+  matches: MatchViewModel[]
+}
+
+export interface TournamentBracketViewModel {
+  tournamentId: string
+  name: string
+  format: string
+  status: string
+  rounds: RoundViewModel[]
+}
+
+export interface TournamentDetailViewModel {
+  tournamentId: string
+  name: string
+  format: string
+  status: string
+  registrationDeadline: string
+  maxPlayers: number
+  registrations: TournamentRegistrationViewModel[]
+  isRegistered: boolean
+  isCreator: boolean
+  bracket: TournamentBracketViewModel | null
+}
+
 export interface TournamentPlayerResultViewModel {
   rank: number
   userId: string | null

--- a/src/ReactClient/src/pages/TournamentDetail.tsx
+++ b/src/ReactClient/src/pages/TournamentDetail.tsx
@@ -1,0 +1,292 @@
+import { Link, useParams } from 'react-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { TournamentDetailViewModel, MatchViewModel, RoundViewModel } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+
+export function TournamentDetail() {
+  const { tournamentId } = useParams<{ tournamentId: string }>()
+  const queryClient = useQueryClient()
+
+  const { data: tournament, error, isLoading, refetch } = useQuery<TournamentDetailViewModel>({
+    queryKey: ['tournament', tournamentId],
+    queryFn: () => apiClient.get(`/api/tournaments/${tournamentId}`).then((r) => r.data),
+    enabled: !!tournamentId,
+  })
+
+  const registerMutation = useMutation({
+    mutationFn: () => apiClient.post(`/api/tournaments/${tournamentId}/register`),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] }),
+  })
+
+  const unregisterMutation = useMutation({
+    mutationFn: () => apiClient.delete(`/api/tournaments/${tournamentId}/register`),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] }),
+  })
+
+  const startMutation = useMutation({
+    mutationFn: () => apiClient.post(`/api/tournaments/${tournamentId}/start`),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] }),
+  })
+
+  if (isLoading) return <PageLoader message="Loading tournament..." />
+  if (error) return <ApiError message="Failed to load tournament." onRetry={() => void refetch()} />
+  if (!tournament) return null
+
+  const isRegistration = tournament.status === 'Registration'
+  const isInProgress = tournament.status === 'InProgress'
+  const isFinished = tournament.status === 'Finished'
+  const deadlinePassed = new Date(tournament.registrationDeadline) < new Date()
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{tournament.name}</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            {tournament.format} · <StatusBadge status={tournament.status} />
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {isRegistration && !deadlinePassed && (
+            tournament.isRegistered ? (
+              <button
+                className="px-4 py-2 text-sm rounded border border-border hover:bg-muted disabled:opacity-50"
+                onClick={() => unregisterMutation.mutate()}
+                disabled={unregisterMutation.isPending}
+              >
+                {unregisterMutation.isPending ? 'Withdrawing...' : 'Withdraw'}
+              </button>
+            ) : (
+              <button
+                className="px-4 py-2 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                onClick={() => registerMutation.mutate()}
+                disabled={registerMutation.isPending}
+              >
+                {registerMutation.isPending ? 'Registering...' : 'Register'}
+              </button>
+            )
+          )}
+
+          {isRegistration && tournament.isCreator && tournament.registrations.length >= 2 && (
+            <button
+              className="px-4 py-2 text-sm rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+              onClick={() => startMutation.mutate()}
+              disabled={startMutation.isPending}
+            >
+              {startMutation.isPending ? 'Starting...' : 'Start Tournament'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {registerMutation.error && (
+        <p className="text-destructive text-sm">{String(registerMutation.error)}</p>
+      )}
+      {startMutation.error && (
+        <p className="text-destructive text-sm">{String(startMutation.error)}</p>
+      )}
+
+      {/* Details row */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">Deadline</p>
+          <p className="font-medium">{new Date(tournament.registrationDeadline).toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Players</p>
+          <p className="font-medium">
+            {tournament.registrations.length}
+            {tournament.maxPlayers > 0 ? ` / ${tournament.maxPlayers}` : ''}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Format</p>
+          <p className="font-medium">{tournament.format}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Results</p>
+          <p className="font-medium">
+            <Link to={`/tournaments/${tournament.tournamentId}/results`} className="text-primary hover:underline">
+              View standings
+            </Link>
+          </p>
+        </div>
+      </div>
+
+      {/* Bracket or registrations */}
+      {(isInProgress || isFinished) && tournament.bracket ? (
+        <BracketView bracket={tournament.bracket} format={tournament.format} />
+      ) : (
+        <RegistrationsList registrations={tournament.registrations} />
+      )}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    Registration: 'bg-blue-100 text-blue-800',
+    InProgress: 'bg-green-100 text-green-800',
+    Finished: 'bg-gray-100 text-gray-700',
+    Cancelled: 'bg-red-100 text-red-700',
+  }
+  return (
+    <span className={`px-2 py-0.5 rounded text-xs font-medium ${colors[status] ?? 'bg-muted'}`}>
+      {status}
+    </span>
+  )
+}
+
+function RegistrationsList({ registrations }: { registrations: TournamentDetailViewModel['registrations'] }) {
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-3">
+        Registrations ({registrations.length})
+      </h2>
+      {registrations.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No players registered yet.</p>
+      ) : (
+        <ul className="space-y-1">
+          {registrations.map((r) => (
+            <li key={r.userId} className="text-sm flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-primary inline-block" />
+              {r.displayName}
+              <span className="text-muted-foreground text-xs">
+                {new Date(r.registeredAt).toLocaleDateString()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function BracketView({ bracket, format }: { bracket: NonNullable<TournamentDetailViewModel['bracket']>, format: string }) {
+  if (format === 'RoundRobin') {
+    return <RoundRobinBracket rounds={bracket.rounds} />
+  }
+  return <EliminationBracket rounds={bracket.rounds} />
+}
+
+function RoundRobinBracket({ rounds }: { rounds: RoundViewModel[] }) {
+  const allMatches = rounds.flatMap((r) => r.matches)
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-3">Match Schedule</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-muted-foreground">
+              <th className="pb-2 pr-4">Match</th>
+              <th className="pb-2 pr-4">Player 1</th>
+              <th className="pb-2 pr-4">Player 2</th>
+              <th className="pb-2 pr-4">Winner</th>
+              <th className="pb-2">Game</th>
+            </tr>
+          </thead>
+          <tbody>
+            {allMatches.map((m) => (
+              <MatchRow key={m.matchId} match={m} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function EliminationBracket({ rounds }: { rounds: RoundViewModel[] }) {
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-3">Bracket</h2>
+      <div className="flex gap-6 overflow-x-auto pb-4">
+        {rounds.map((round) => (
+          <div key={round.round} className="flex flex-col gap-4 min-w-[200px]">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              {round.round === rounds.length ? 'Final' : `Round ${round.round}`}
+            </p>
+            {round.matches.map((match) => (
+              <MatchCard key={match.matchId} match={match} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MatchCard({ match }: { match: MatchViewModel }) {
+  const isBye = match.status === 'Bye'
+  const isCompleted = match.status === 'Completed'
+
+  return (
+    <div className={`border border-border rounded-lg p-3 text-sm space-y-1 ${isCompleted ? 'bg-muted/30' : 'bg-card'}`}>
+      {isBye ? (
+        <p className="text-muted-foreground italic">Bye</p>
+      ) : (
+        <>
+          <PlayerLine
+            name={match.player1?.displayName ?? '—'}
+            isWinner={match.winnerId === match.player1?.userId}
+          />
+          <div className="border-t border-border/50" />
+          <PlayerLine
+            name={match.player2?.displayName ?? 'TBD'}
+            isWinner={match.winnerId === match.player2?.userId}
+          />
+        </>
+      )}
+      {match.gameId && (
+        <div className="pt-1">
+          <Link
+            to={`/games/${match.gameId}`}
+            className="text-xs text-primary hover:underline"
+          >
+            View game →
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PlayerLine({ name, isWinner }: { name: string; isWinner: boolean }) {
+  return (
+    <p className={`truncate ${isWinner ? 'font-bold text-green-600' : 'text-foreground'}`}>
+      {isWinner && '🏆 '}
+      {name}
+    </p>
+  )
+}
+
+function MatchRow({ match }: { match: MatchViewModel }) {
+  return (
+    <tr className="border-b border-border">
+      <td className="py-2 pr-4 text-muted-foreground">{match.matchNumber}</td>
+      <td className={`py-2 pr-4 ${match.winnerId === match.player1?.userId ? 'font-bold text-green-600' : ''}`}>
+        {match.player1?.displayName ?? '—'}
+      </td>
+      <td className={`py-2 pr-4 ${match.winnerId === match.player2?.userId ? 'font-bold text-green-600' : ''}`}>
+        {match.player2?.displayName ?? '—'}
+      </td>
+      <td className="py-2 pr-4 text-muted-foreground">
+        {match.winnerId
+          ? (match.player1?.userId === match.winnerId ? match.player1?.displayName : match.player2?.displayName)
+          : match.status}
+      </td>
+      <td className="py-2">
+        {match.gameId && (
+          <Link to={`/games/${match.gameId}`} className="text-primary hover:underline text-xs">
+            Game →
+          </Link>
+        )}
+      </td>
+    </tr>
+  )
+}

--- a/src/ReactClient/src/pages/TournamentList.tsx
+++ b/src/ReactClient/src/pages/TournamentList.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react'
+import { Link } from 'react-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import apiClient from '@/api/client'
+import type { TournamentSummaryViewModel, CreateTournamentRequest } from '@/api/types'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { useCurrentUser } from '@/contexts/CurrentUserContext'
+
+export function TournamentList() {
+  const [showCreate, setShowCreate] = useState(false)
+  const { user } = useCurrentUser()
+  const queryClient = useQueryClient()
+
+  const { data: tournaments, error, isLoading, refetch } = useQuery<TournamentSummaryViewModel[]>({
+    queryKey: ['tournaments'],
+    queryFn: () => apiClient.get('/api/tournaments').then((r) => r.data),
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreateTournamentRequest) =>
+      apiClient.post('/api/tournaments', req).then((r) => r.data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['tournaments'] })
+      setShowCreate(false)
+    },
+  })
+
+  if (isLoading) return <PageLoader message="Loading tournaments..." />
+  if (error) return <ApiError message="Failed to load tournaments." onRetry={() => void refetch()} />
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Tournaments</h1>
+          <p className="text-muted-foreground text-sm mt-1">Competitive brackets and round-robin events</p>
+        </div>
+        {user && (
+          <button
+            className="px-4 py-2 bg-primary text-primary-foreground rounded text-sm font-medium hover:bg-primary/90"
+            onClick={() => setShowCreate(true)}
+          >
+            Create Tournament
+          </button>
+        )}
+      </div>
+
+      {showCreate && (
+        <CreateTournamentForm
+          onSubmit={(req) => createMutation.mutate(req)}
+          onCancel={() => setShowCreate(false)}
+          error={createMutation.error?.message}
+          isSubmitting={createMutation.isPending}
+        />
+      )}
+
+      {!tournaments || tournaments.length === 0 ? (
+        <p className="text-muted-foreground">No tournaments yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="pb-2 pr-4">Name</th>
+                <th className="pb-2 pr-4">Format</th>
+                <th className="pb-2 pr-4">Status</th>
+                <th className="pb-2 pr-4">Players</th>
+                <th className="pb-2">Deadline</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tournaments.map((t) => (
+                <tr key={t.tournamentId} className="border-b border-border hover:bg-muted/30">
+                  <td className="py-2 pr-4">
+                    <Link
+                      to={`/tournaments/${t.tournamentId}`}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      {t.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-4 text-muted-foreground">{t.format}</td>
+                  <td className="py-2 pr-4">
+                    <StatusBadge status={t.status} />
+                  </td>
+                  <td className="py-2 pr-4">
+                    {t.registrationCount}
+                    {t.maxPlayers > 0 ? ` / ${t.maxPlayers}` : ''}
+                  </td>
+                  <td className="py-2 text-muted-foreground">
+                    {new Date(t.registrationDeadline).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    Registration: 'bg-blue-100 text-blue-800',
+    InProgress: 'bg-green-100 text-green-800',
+    Finished: 'bg-gray-100 text-gray-700',
+    Cancelled: 'bg-red-100 text-red-700',
+  }
+  return (
+    <span className={`px-2 py-0.5 rounded text-xs font-medium ${colors[status] ?? 'bg-muted'}`}>
+      {status}
+    </span>
+  )
+}
+
+interface CreateTournamentFormProps {
+  onSubmit: (req: CreateTournamentRequest) => void
+  onCancel: () => void
+  error?: string
+  isSubmitting: boolean
+}
+
+function CreateTournamentForm({ onSubmit, onCancel, error, isSubmitting }: CreateTournamentFormProps) {
+  const [name, setName] = useState('')
+  const [format, setFormat] = useState('SingleElimination')
+  const [deadline, setDeadline] = useState('')
+  const [maxPlayers, setMaxPlayers] = useState(0)
+  const [gameDefType, setGameDefType] = useState('sco')
+  const [tickDuration, setTickDuration] = useState('00:20:00')
+  const [matchDurationHours, setMatchDurationHours] = useState(24)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({
+      name,
+      format,
+      registrationDeadline: new Date(deadline).toISOString(),
+      maxPlayers,
+      gameDefType,
+      tickDuration,
+      matchDurationHours,
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border border-border rounded-lg p-4 space-y-4 bg-card">
+      <h2 className="font-semibold text-lg">Create Tournament</h2>
+
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium mb-1">Name</label>
+          <input
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Format</label>
+          <select
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={format}
+            onChange={(e) => setFormat(e.target.value)}
+          >
+            <option value="SingleElimination">Single Elimination</option>
+            <option value="RoundRobin">Round Robin</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Registration Deadline</label>
+          <input
+            type="datetime-local"
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={deadline}
+            onChange={(e) => setDeadline(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Max Players (0 = unlimited)</label>
+          <input
+            type="number"
+            min={0}
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={maxPlayers}
+            onChange={(e) => setMaxPlayers(Number(e.target.value))}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Game Type</label>
+          <input
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={gameDefType}
+            onChange={(e) => setGameDefType(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Tick Duration (HH:MM:SS)</label>
+          <input
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={tickDuration}
+            onChange={(e) => setTickDuration(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Match Duration (hours)</label>
+          <input
+            type="number"
+            min={1}
+            className="w-full border border-border rounded px-3 py-2 text-sm bg-background"
+            value={matchDurationHours}
+            onChange={(e) => setMatchDurationHours(Number(e.target.value))}
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          className="px-4 py-2 text-sm rounded border border-border hover:bg-muted"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="px-4 py-2 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSubmitting ? 'Creating...' : 'Create'}
+        </button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary

- **New `TournamentImmutable` data model** in `GameModel` with enums for format (RoundRobin/SingleElimination), status, and match status; `GlobalStateImmutable` and `GameRecordImmutable` extended backward-compatibly
- **`TournamentEngine`** handles bracket generation (round-robin + single-elimination with bye support for non-power-of-2 player counts), per-match game auto-creation, and auto-progression when games finalize
- **`GameLifecycleEngine`** hooks `TournamentEngine.ProcessGameFinalized` after each finalization (no-op for non-tournament games, exceptions caught so tournament bugs never crash finalization)
- **7 new REST endpoints** on `TournamentController`: `GET /api/tournaments`, `POST /api/tournaments`, `GET /api/tournaments/{id}`, `GET /api/tournaments/{id}/bracket`, `POST /api/tournaments/{id}/register`, `DELETE /api/tournaments/{id}/register`, `POST /api/tournaments/{id}/start`
- **React UI**: `TournamentList` page with create-tournament form, `TournamentDetail` page with registration list, bracket visualization for single-elimination (card tree) and round-robin (match table), plus game links; routes `/tournaments` and `/tournaments/:id` added to `App.tsx`
- **8 new `TournamentEngineTest` cases** covering bracket shapes (RR 4-player, SE power-of-2, SE non-power-of-2), registration boundary validation, no-op finalization, and tournament completion

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (663 tests)
- [ ] Create a tournament, register 2+ players, start it, verify bracket games are created as `Upcoming`
- [ ] Finalize a tournament match game, verify winner advances (SE) or tournament finishes (RR/final match)
- [ ] Verify `/tournaments` list page loads and create form works
- [ ] Verify `/tournaments/:id` shows registrations, bracket, register/unregister buttons

Closes BGE-887