### PR TITLE
feat: BGE-893 Phase 7D — Admin Dashboard & Moderation Tools

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -4,6 +4,7 @@ using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.ActionFeed;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using BrowserGameEngine.StatefulGameServer.GameTicks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -38,6 +39,10 @@ public class AdminController : ControllerBase
 	private readonly GameDef gameDef;
 	private readonly ScoreRepository scoreRepository;
 	private readonly MarketRepository marketRepository;
+	private readonly AdminAuditLog auditLog;
+	private readonly ReportStore reportStore;
+	private readonly GlobalState globalState;
+	private readonly CurrentUserContext currentUserContext;
 
 	public AdminController(
 		ILogger<AdminController> logger,
@@ -55,7 +60,11 @@ public class AdminController : ControllerBase
 		IActionLogger actionLogger,
 		GameDef gameDef,
 		ScoreRepository scoreRepository,
-		MarketRepository marketRepository
+		MarketRepository marketRepository,
+		AdminAuditLog auditLog,
+		ReportStore reportStore,
+		GlobalState globalState,
+		CurrentUserContext currentUserContext
 	)
 	{
 		this.logger = logger;
@@ -74,6 +83,10 @@ public class AdminController : ControllerBase
 		this.gameDef = gameDef;
 		this.scoreRepository = scoreRepository;
 		this.marketRepository = marketRepository;
+		this.auditLog = auditLog;
+		this.reportStore = reportStore;
+		this.globalState = globalState;
+		this.currentUserContext = currentUserContext;
 	}
 
 	// ── Existing cheat endpoints ──────────────────────────────────────────────
@@ -90,6 +103,8 @@ public class AdminController : ControllerBase
 		var resourceDefId = Id.ResDef(request.ResourceDefId);
 		var current = resourceRepository.GetAmount(playerId, resourceDefId);
 		resourceRepositoryWrite.AddResources(playerId, resourceDefId, request.Amount - current);
+		auditLog.Record("SetResources", currentUserContext.UserId,
+			$"Set {request.ResourceDefId}={request.Amount} for player {request.PlayerId}", request.PlayerId);
 		return Ok();
 	}
 
@@ -315,6 +330,7 @@ public class AdminController : ControllerBase
 		if (!playerRepository.Exists(playerId)) return NotFound($"Player '{request.PlayerId}' not found.");
 		playerRepositoryWrite.BanPlayer(playerId);
 		logger.LogWarning("Player {PlayerId} banned via admin endpoint", request.PlayerId);
+		auditLog.Record("BanPlayer", currentUserContext.UserId, $"Banned player {request.PlayerId}", request.PlayerId);
 		return Ok(new { playerId = request.PlayerId, isBanned = true });
 	}
 
@@ -326,6 +342,7 @@ public class AdminController : ControllerBase
 		if (!playerRepository.Exists(playerId)) return NotFound($"Player '{request.PlayerId}' not found.");
 		playerRepositoryWrite.UnbanPlayer(playerId);
 		logger.LogInformation("Player {PlayerId} unbanned via admin endpoint", request.PlayerId);
+		auditLog.Record("UnbanPlayer", currentUserContext.UserId, $"Unbanned player {request.PlayerId}", request.PlayerId);
 		return Ok(new { playerId = request.PlayerId, isBanned = false });
 	}
 
@@ -343,6 +360,30 @@ public class AdminController : ControllerBase
 		var openOrders = marketRepository.GetOpenOrders();
 		var recentlyOnline = players.Count(p => p.LastOnline.HasValue && p.LastOnline.Value > DateTime.UtcNow.AddMinutes(-15));
 		var snapshot = worldState.ToImmutable();
+
+		// Extended metrics
+		var now = DateTime.UtcNow;
+		var dayAgo = now.AddDays(-1);
+		var allGames = globalState.GetGames().ToList();
+		var allAchievements = globalState.GetAchievements().ToList();
+		var achievementUnlocksToday = allAchievements.Count(a => a.FinishedAt >= dayAgo);
+		var runningGames = allGames.Count(g => g.Status == GameStatus.Active);
+
+		// Daily active users: unique user IDs who have a player active in the last 24h
+		var dailyActiveUsers = players
+			.Where(p => p.UserId != null && p.LastOnline.HasValue && p.LastOnline.Value >= dayAgo)
+			.Select(p => p.UserId!)
+			.Distinct()
+			.Count();
+
+		// Top achievements by game def type
+		var topAchievements = allAchievements
+			.GroupBy(a => a.GameDefType)
+			.Select(g => new { gameDefType = g.Key, count = g.Count() })
+			.OrderByDescending(x => x.count)
+			.Take(5)
+			.ToList();
+
 		return Ok(new {
 			totalPlayers = players.Count,
 			activePlayers = recentlyOnline,
@@ -352,6 +393,11 @@ public class AdminController : ControllerBase
 			currentTick = snapshot.GameTickState.CurrentGameTick.Tick,
 			isPaused = gameTickEngine.IsPaused,
 			effectiveTickDurationSeconds = gameTickEngine.EffectiveTickDuration.TotalSeconds,
+			dailyActiveUsers,
+			runningGames,
+			totalGames = allGames.Count,
+			achievementUnlocksToday,
+			topAchievements,
 		});
 	}
 
@@ -369,6 +415,56 @@ public class AdminController : ControllerBase
 			defaultTickDurationSeconds = gameDef.TickDuration.TotalSeconds,
 		});
 	}
+
+	// ── Audit Log ─────────────────────────────────────────────────────────────
+
+	[HttpGet("audit-log")]
+	public ActionResult GetAuditLog([FromQuery] int page = 0, [FromQuery] int pageSize = 20, [FromQuery] string actionType = "all")
+	{
+		if (pageSize < 1 || pageSize > 100) return BadRequest("pageSize must be between 1 and 100.");
+		var entries = auditLog.GetPage(page, pageSize, actionType);
+		var total = auditLog.GetTotal(actionType);
+		return Ok(new { entries, total, page, pageSize });
+	}
+
+	// ── Reports ───────────────────────────────────────────────────────────────
+
+	[HttpGet("reports")]
+	public ActionResult GetReports()
+	{
+		var reports = reportStore.GetAll().Select(r => new {
+			id = r.Id,
+			createdAt = r.CreatedAt,
+			reporterUserId = r.ReporterUserId,
+			targetUserId = r.TargetUserId,
+			reason = r.Reason,
+			details = r.Details,
+			status = r.Status.ToString(),
+			resolvedByUserId = r.ResolvedByUserId,
+			resolutionNote = r.ResolutionNote,
+			resolvedAt = r.ResolvedAt,
+		});
+		return Ok(reports);
+	}
+
+	[HttpPost("reports/{id}/action")]
+	public ActionResult ResolveReport(string id, [FromBody] ReportActionRequest request)
+	{
+		var report = reportStore.GetById(id);
+		if (report == null) return NotFound();
+		if (!Enum.TryParse<ReportStatus>(request.Action, true, out var newStatus))
+			return BadRequest($"Invalid action. Valid values: Resolved, Dismissed.");
+		var updated = report with {
+			Status = newStatus,
+			ResolvedByUserId = currentUserContext.UserId,
+			ResolutionNote = request.Note,
+			ResolvedAt = DateTime.UtcNow,
+		};
+		reportStore.Update(report, updated);
+		auditLog.Record("ReportAction", currentUserContext.UserId,
+			$"Report {id}: {newStatus} — {request.Note}", report.TargetUserId);
+		return Ok();
+	}
 }
 
 public record SetResourcesRequest(string PlayerId, string ResourceDefId, decimal Amount);
@@ -377,3 +473,4 @@ public record GrantUnitsRequest(string PlayerId, string UnitDefId, int Count);
 public record ResetPlayerRequest(string PlayerId);
 public record BanPlayerRequest(string PlayerId);
 public record UnbanPlayerRequest(string PlayerId);
+public record ReportActionRequest(string Action, string? Note);

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -96,7 +96,8 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				IsOnline = onlineStatusRepository.IsOnline(pid),
 				LastOnline = player.LastOnline,
 				IsAgent = player.ApiKeyHash != null,
-				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining
+				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining,
+				UserId = player.UserId,
 			};
 		}
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ReportsController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ReportsController.cs
@@ -1,0 +1,50 @@
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace BrowserGameEngine.FrontendServer.Controllers;
+
+[ApiController]
+[Route("api/reports")]
+[Authorize]
+public class ReportsController : ControllerBase {
+	private readonly ReportStore reportStore;
+	private readonly CurrentUserContext currentUserContext;
+
+	public ReportsController(ReportStore reportStore, CurrentUserContext currentUserContext) {
+		this.reportStore = reportStore;
+		this.currentUserContext = currentUserContext;
+	}
+
+	/// <summary>Submit a report against another player/user.</summary>
+	[HttpPost]
+	[ProducesResponseType(StatusCodes.Status201Created)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
+	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+	public ActionResult SubmitReport([FromBody] SubmitReportRequest request) {
+		if (!currentUserContext.IsValid) return Unauthorized();
+		if (string.IsNullOrWhiteSpace(request.TargetUserId)) return BadRequest("TargetUserId is required.");
+		if (string.IsNullOrWhiteSpace(request.Reason)) return BadRequest("Reason is required.");
+		if (request.TargetUserId == currentUserContext.UserId) return BadRequest("Cannot report yourself.");
+
+		var report = new Report(
+			Id: Guid.NewGuid().ToString("N")[..12],
+			CreatedAt: DateTime.UtcNow,
+			ReporterUserId: currentUserContext.UserId!,
+			TargetUserId: request.TargetUserId,
+			Reason: request.Reason,
+			Details: request.Details?.Trim(),
+			Status: ReportStatus.Pending,
+			ResolvedByUserId: null,
+			ResolutionNote: null,
+			ResolvedAt: null
+		);
+		reportStore.Add(report);
+		return StatusCode(201, new { id = report.Id });
+	}
+}
+
+public record SubmitReportRequest(string TargetUserId, string Reason, string? Details);

--- a/src/BrowserGameEngine.Shared/InGamePlayerProfileViewModel.cs
+++ b/src/BrowserGameEngine.Shared/InGamePlayerProfileViewModel.cs
@@ -15,5 +15,6 @@ namespace BrowserGameEngine.Shared {
 		public DateTime? LastOnline { get; set; }
 		public bool IsAgent { get; set; }
 		public int ProtectionTicksRemaining { get; set; }
+		public string? UserId { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AdminAuditLog.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/AdminAuditLog.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	public record AuditLogEntry(
+		string Id,
+		DateTime Timestamp,
+		string ActionType,
+		string? ActorUserId,
+		string Description,
+		string? TargetPlayerId
+	);
+
+	public class AdminAuditLog {
+		private readonly object _lock = new();
+		private readonly List<AuditLogEntry> _entries = new();
+		private const int MaxEntries = 1000;
+
+		public void Record(string actionType, string? actorUserId, string description, string? targetPlayerId = null) {
+			var entry = new AuditLogEntry(
+				Id: Guid.NewGuid().ToString("N")[..12],
+				Timestamp: DateTime.UtcNow,
+				ActionType: actionType,
+				ActorUserId: actorUserId,
+				Description: description,
+				TargetPlayerId: targetPlayerId
+			);
+			lock (_lock) {
+				_entries.Add(entry);
+				if (_entries.Count > MaxEntries)
+					_entries.RemoveAt(0);
+			}
+		}
+
+		public IReadOnlyList<AuditLogEntry> GetPage(int page, int pageSize, string? actionType) {
+			lock (_lock) {
+				var query = _entries.AsEnumerable().Reverse();
+				if (!string.IsNullOrEmpty(actionType) && actionType != "all")
+					query = query.Where(e => string.Equals(e.ActionType, actionType, StringComparison.OrdinalIgnoreCase));
+				return query.Skip(page * pageSize).Take(pageSize).ToList();
+			}
+		}
+
+		public int GetTotal(string? actionType) {
+			lock (_lock) {
+				if (string.IsNullOrEmpty(actionType) || actionType == "all")
+					return _entries.Count;
+				return _entries.Count(e => string.Equals(e.ActionType, actionType, StringComparison.OrdinalIgnoreCase));
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/ReportStore.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/ReportStore.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	public enum ReportStatus { Pending, Resolved, Dismissed }
+
+	public record Report(
+		string Id,
+		DateTime CreatedAt,
+		string ReporterUserId,
+		string TargetUserId,
+		string Reason,
+		string? Details,
+		ReportStatus Status,
+		string? ResolvedByUserId,
+		string? ResolutionNote,
+		DateTime? ResolvedAt
+	);
+
+	public class ReportStore {
+		private readonly object _lock = new();
+		private readonly List<Report> _reports = new();
+
+		public void Add(Report report) {
+			lock (_lock) _reports.Add(report);
+		}
+
+		public IReadOnlyList<Report> GetAll() {
+			lock (_lock) return _reports.OrderByDescending(r => r.CreatedAt).ToList();
+		}
+
+		public Report? GetById(string id) {
+			lock (_lock) return _reports.FirstOrDefault(r => r.Id == id);
+		}
+
+		public void Update(Report old, Report updated) {
+			lock (_lock) {
+				var idx = _reports.IndexOf(old);
+				if (idx >= 0) _reports[idx] = updated;
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameServerExtensions.cs
@@ -86,6 +86,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 			services.AddSingleton<TournamentRepositoryWrite>();
 			services.AddSingleton<TournamentEngine>();
 			services.AddSingleton<CurrencyService>();
+			services.AddSingleton<AdminAuditLog>();
+			services.AddSingleton<ReportStore>();
 
 			services.AddSingleton<IActionLogger, ActionLogger>();
 			services.AddSingleton<IGameTickModule, ActionQueueExecutor>();

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -53,6 +53,9 @@ const AdminGames = lazy(() => import('@/pages/admin/AdminGames').then(m => ({ de
 const AdminPlayers = lazy(() => import('@/pages/admin/AdminPlayers').then(m => ({ default: m.AdminPlayers })))
 const AdminTickControl = lazy(() => import('@/pages/admin/AdminTickControl').then(m => ({ default: m.AdminTickControl })))
 const AdminStats = lazy(() => import('@/pages/admin/AdminStats').then(m => ({ default: m.AdminStats })))
+const AdminMetrics = lazy(() => import('@/pages/admin/AdminMetrics').then(m => ({ default: m.AdminMetrics })))
+const AdminAuditLog = lazy(() => import('@/pages/admin/AdminAuditLog').then(m => ({ default: m.AdminAuditLog })))
+const AdminReports = lazy(() => import('@/pages/admin/AdminReports').then(m => ({ default: m.AdminReports })))
 const PlayersList = lazy(() => import('@/pages/PlayersList').then(m => ({ default: m.PlayersList })))
 const Trade = lazy(() => import('@/pages/Trade').then(m => ({ default: m.Trade })))
 const Help = lazy(() => import('@/pages/Help').then(m => ({ default: m.Help })))
@@ -244,6 +247,9 @@ const router = createBrowserRouter([
 			{ path: '/admin/players', element: <RouteWithBoundary><AdminPlayers /></RouteWithBoundary> },
 			{ path: '/admin/ticks', element: <RouteWithBoundary><AdminTickControl /></RouteWithBoundary> },
 			{ path: '/admin/stats', element: <RouteWithBoundary><AdminStats /></RouteWithBoundary> },
+			{ path: '/admin/metrics', element: <RouteWithBoundary><AdminMetrics /></RouteWithBoundary> },
+			{ path: '/admin/audit', element: <RouteWithBoundary><AdminAuditLog /></RouteWithBoundary> },
+			{ path: '/admin/reports', element: <RouteWithBoundary><AdminReports /></RouteWithBoundary> },
 		],
 	},
 ])

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -474,6 +474,7 @@ export interface InGamePlayerProfileViewModel {
   lastOnline: string | null
   isAgent: boolean
   protectionTicksRemaining: number
+  userId: string | null
 }
 
 // Rankings
@@ -491,7 +492,6 @@ export interface LeaderboardEntryViewModel {
   playerName: string
   score: number
   isCurrentPlayer: boolean
-  level: number
 }
 
 // Alliance
@@ -851,7 +851,7 @@ export interface AchievementsViewModel {
 
 // Milestone achievements (progress-based, unlockable)
 
-export type MilestoneCategory = 'combat' | 'economy' | 'diplomacy' | 'exploration' | 'progression'
+export type MilestoneCategory = 'combat' | 'economy' | 'diplomacy' | 'exploration'
 export type MilestoneTier = 'bronze' | 'silver' | 'gold' | 'legendary'
 
 export interface MilestoneAchievementViewModel {
@@ -961,8 +961,6 @@ export interface AllTimePlayerEntryViewModel {
   totalWins: number
   bestRank: number
   totalScore: number
-  totalXp: number
-  level: number
 }
 
 export interface AllTimePlayerListViewModel {
@@ -1024,10 +1022,6 @@ export interface ProfileViewModel {
   bestRank: number
   currentGameId: string | null
   joinedAt?: string | null
-  totalXp: number
-  level: number
-  levelProgress: number
-  xpToNextLevel: number
 }
 
 // Public cross-game stats
@@ -1053,8 +1047,6 @@ export interface PlayerCrossGameStatsViewModel {
   games: PlayerCrossGameEntry[]
   joinedAt?: string | null
   totalResourcesGathered?: number | null
-  totalXp: number
-  level: number
 }
 
 // Public achievements (api/players/{userId}/achievements)
@@ -1083,7 +1075,6 @@ export interface GlobalLeaderboardEntryViewModel {
   gameWins: number
   achievementsUnlocked: number
   isCurrentPlayer: boolean
-  level: number
 }
 
 export interface GlobalLeaderboardViewModel {

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -492,6 +492,7 @@ export interface LeaderboardEntryViewModel {
   playerName: string
   score: number
   isCurrentPlayer: boolean
+  level: number
 }
 
 // Alliance
@@ -851,7 +852,7 @@ export interface AchievementsViewModel {
 
 // Milestone achievements (progress-based, unlockable)
 
-export type MilestoneCategory = 'combat' | 'economy' | 'diplomacy' | 'exploration'
+export type MilestoneCategory = 'combat' | 'economy' | 'diplomacy' | 'exploration' | 'progression'
 export type MilestoneTier = 'bronze' | 'silver' | 'gold' | 'legendary'
 
 export interface MilestoneAchievementViewModel {
@@ -961,6 +962,8 @@ export interface AllTimePlayerEntryViewModel {
   totalWins: number
   bestRank: number
   totalScore: number
+  totalXp: number
+  level: number
 }
 
 export interface AllTimePlayerListViewModel {
@@ -1022,6 +1025,10 @@ export interface ProfileViewModel {
   bestRank: number
   currentGameId: string | null
   joinedAt?: string | null
+  totalXp: number
+  level: number
+  levelProgress: number
+  xpToNextLevel: number
 }
 
 // Public cross-game stats
@@ -1047,6 +1054,8 @@ export interface PlayerCrossGameStatsViewModel {
   games: PlayerCrossGameEntry[]
   joinedAt?: string | null
   totalResourcesGathered?: number | null
+  totalXp: number
+  level: number
 }
 
 // Public achievements (api/players/{userId}/achievements)
@@ -1075,6 +1084,7 @@ export interface GlobalLeaderboardEntryViewModel {
   gameWins: number
   achievementsUnlocked: number
   isCurrentPlayer: boolean
+  level: number
 }
 
 export interface GlobalLeaderboardViewModel {

--- a/src/ReactClient/src/pages/InGamePlayerProfile.tsx
+++ b/src/ReactClient/src/pages/InGamePlayerProfile.tsx
@@ -1,5 +1,8 @@
-import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router'
+import { FlagIcon } from 'lucide-react'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import type { InGamePlayerProfileViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
@@ -10,8 +13,82 @@ interface InGamePlayerProfileProps {
   gameId: string
 }
 
+const REPORT_REASONS = ['Cheating', 'Harassment', 'Spam', 'Inappropriate name', 'Other']
+
+function ReportModal({ targetUserId, onClose }: { targetUserId: string; onClose: () => void }) {
+  const [reason, setReason] = useState(REPORT_REASONS[0])
+  const [details, setDetails] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  const mutation = useMutation({
+    mutationFn: () => apiClient.post('/api/reports', { targetUserId, reason, details: details.trim() || null }),
+    onSuccess: () => setSubmitted(true),
+  })
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="bg-card border border-border rounded-lg p-6 w-full max-w-sm space-y-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold">Report Player</h2>
+        {submitted ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">Your report has been submitted. Thank you.</p>
+            <button onClick={onClose} className="w-full rounded bg-primary text-primary-foreground px-3 py-2 text-sm">
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">Reason</label>
+              <select
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                className="w-full border border-border rounded px-2 py-1.5 text-sm bg-background"
+              >
+                {REPORT_REASONS.map((r) => <option key={r}>{r}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">Details (optional)</label>
+              <textarea
+                value={details}
+                onChange={(e) => setDetails(e.target.value)}
+                rows={3}
+                maxLength={500}
+                className="w-full border border-border rounded px-2 py-1.5 text-sm bg-background resize-none"
+                placeholder="Provide any additional context..."
+              />
+            </div>
+            {mutation.isError && (
+              <p className="text-xs text-destructive">
+                {axios.isAxiosError(mutation.error) ? (mutation.error.response?.data as string ?? mutation.error.message) : 'Failed to submit report.'}
+              </p>
+            )}
+            <div className="flex gap-2 justify-end">
+              <button onClick={onClose} className="px-3 py-1.5 rounded border border-border text-sm hover:bg-muted">
+                Cancel
+              </button>
+              <button
+                onClick={() => mutation.mutate()}
+                disabled={mutation.isPending}
+                className="px-3 py-1.5 rounded bg-destructive text-destructive-foreground text-sm hover:bg-destructive/90 disabled:opacity-50"
+              >
+                {mutation.isPending ? 'Submitting…' : 'Submit Report'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
   const { playerId } = useParams<{ playerId: string }>()
+  const [showReport, setShowReport] = useState(false)
 
   const { data: player, isLoading, error, refetch } = useQuery({
     queryKey: ['ingame-player', gameId, playerId],
@@ -59,7 +136,7 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
           <div className="h-14 w-14 rounded-full bg-secondary flex items-center justify-center text-xl border border-primary/40">
             {player.playerName?.[0]?.toUpperCase() ?? '?'}
           </div>
-          <div>
+          <div className="flex-1">
             <div className="font-bold text-lg">{player.playerName}</div>
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
               <span
@@ -72,6 +149,16 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
                   : 'Offline'}
             </div>
           </div>
+          {player.userId && (
+            <button
+              onClick={() => setShowReport(true)}
+              className="flex-shrink-0 flex items-center gap-1 px-2 py-1 rounded border border-border text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              title="Report this player"
+            >
+              <FlagIcon className="h-3 w-3" />
+              Report
+            </button>
+          )}
         </div>
 
         {/* Stats grid */}
@@ -114,6 +201,10 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
           </div>
         )}
       </div>
+
+      {showReport && player.userId && (
+        <ReportModal targetUserId={player.userId} onClose={() => setShowReport(false)} />
+      )}
     </div>
   )
 }

--- a/src/ReactClient/src/pages/PublicProfile.tsx
+++ b/src/ReactClient/src/pages/PublicProfile.tsx
@@ -1,13 +1,87 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation } from '@tanstack/react-query'
 import { useParams } from 'react-router'
 import { Link } from 'react-router'
-import { UserIcon, TrophyIcon, StarIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { UserIcon, TrophyIcon, StarIcon, ChevronLeftIcon, ChevronRightIcon, FlagIcon } from 'lucide-react'
+import axios from 'axios'
 import apiClient from '@/api/client'
 import type { PlayerCrossGameStatsViewModel, PublicPlayerAchievementsViewModel, PlayerLeaderboardContextViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+
+const REPORT_REASONS = ['Cheating', 'Harassment', 'Spam', 'Inappropriate name', 'Other']
+
+function ReportModal({ targetUserId, onClose }: { targetUserId: string; onClose: () => void }) {
+  const [reason, setReason] = useState(REPORT_REASONS[0])
+  const [details, setDetails] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  const mutation = useMutation({
+    mutationFn: () => apiClient.post('/api/reports', { targetUserId, reason, details: details.trim() || null }),
+    onSuccess: () => setSubmitted(true),
+  })
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="bg-card border border-border rounded-lg p-6 w-full max-w-sm space-y-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold">Report Player</h2>
+        {submitted ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">Your report has been submitted. Thank you.</p>
+            <button onClick={onClose} className="w-full rounded bg-primary text-primary-foreground px-3 py-2 text-sm">
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">Reason</label>
+              <select
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                className="w-full border border-border rounded px-2 py-1.5 text-sm bg-background"
+              >
+                {REPORT_REASONS.map((r) => <option key={r}>{r}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">Details (optional)</label>
+              <textarea
+                value={details}
+                onChange={(e) => setDetails(e.target.value)}
+                rows={3}
+                maxLength={500}
+                className="w-full border border-border rounded px-2 py-1.5 text-sm bg-background resize-none"
+                placeholder="Provide any additional context..."
+              />
+            </div>
+            {mutation.isError && (
+              <p className="text-xs text-destructive">
+                {axios.isAxiosError(mutation.error) ? (mutation.error.response?.data as string ?? mutation.error.message) : 'Failed to submit report.'}
+              </p>
+            )}
+            <div className="flex gap-2 justify-end">
+              <button onClick={onClose} className="px-3 py-1.5 rounded border border-border text-sm hover:bg-muted">
+                Cancel
+              </button>
+              <button
+                onClick={() => mutation.mutate()}
+                disabled={mutation.isPending}
+                className="px-3 py-1.5 rounded bg-destructive text-destructive-foreground text-sm hover:bg-destructive/90 disabled:opacity-50"
+              >
+                {mutation.isPending ? 'Submitting…' : 'Submit Report'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
 
 const PAGE_SIZE = 10
 
@@ -68,6 +142,7 @@ function PublicAchievementBadges({ userId }: { userId: string }) {
 export function PublicProfile() {
   const { userId } = useParams<{ userId: string }>()
   const [page, setPage] = useState(0)
+  const [showReport, setShowReport] = useState(false)
 
   const { data: stats, isLoading, error, refetch } = useQuery<PlayerCrossGameStatsViewModel>({
     queryKey: ['public-profile', userId],
@@ -116,7 +191,7 @@ export function PublicProfile() {
         >
           {avatarInitials(stats.playerName)}
         </div>
-        <div>
+        <div className="flex-1">
           <h1 className="text-xl font-bold">{stats.playerName ?? 'Unknown Player'}</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
             {stats.totalGames} {stats.totalGames === 1 ? 'game' : 'games'} played
@@ -134,7 +209,18 @@ export function PublicProfile() {
             </p>
           )}
         </div>
+        {userId && (
+          <button
+            onClick={() => setShowReport(true)}
+            className="flex-shrink-0 flex items-center gap-1 px-2 py-1 rounded border border-border text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="Report this player"
+          >
+            <FlagIcon className="h-3 w-3" />
+            Report
+          </button>
+        )}
       </div>
+      {showReport && userId && <ReportModal targetUserId={userId} onClose={() => setShowReport(false)} />}
 
       {/* Statistics panel */}
       <div className="rounded-lg border bg-card p-5 space-y-3">

--- a/src/ReactClient/src/pages/admin/AdminAuditLog.tsx
+++ b/src/ReactClient/src/pages/admin/AdminAuditLog.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface AuditLogEntry {
+  id: string
+  timestamp: string
+  actionType: string
+  actorUserId: string | null
+  description: string
+  targetPlayerId: string | null
+}
+
+interface AuditLogPage {
+  entries: AuditLogEntry[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+const ACTION_TYPES = ['all', 'BanPlayer', 'UnbanPlayer', 'SetResources', 'ReportAction']
+
+export function AdminAuditLog() {
+  const [page, setPage] = useState(0)
+  const [actionType, setActionType] = useState('all')
+
+  const { data, isLoading, error, refetch } = useQuery<AuditLogPage>({
+    queryKey: ['admin-audit-log', page, actionType],
+    queryFn: () =>
+      apiClient
+        .get('/api/admin/audit-log', { params: { page, pageSize: 20, actionType } })
+        .then((r) => r.data),
+  })
+
+  const totalPages = data ? Math.ceil(data.total / 20) : 0
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Audit Log</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Audit Log</h1>
+        <ApiError message="Failed to load audit log." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <AdminNav />
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Audit Log</h1>
+        <select
+          value={actionType}
+          onChange={(e) => { setActionType(e.target.value); setPage(0) }}
+          className="border border-border rounded px-2 py-1 text-sm bg-background"
+        >
+          {ACTION_TYPES.map((t) => (
+            <option key={t} value={t}>{t === 'all' ? 'All actions' : t}</option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading ? (
+        <PageLoader message="Loading audit log..." />
+      ) : !data || data.entries.length === 0 ? (
+        <p className="text-muted-foreground">No audit entries found.</p>
+      ) : (
+        <>
+          <div className="rounded-lg border border-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/40">
+                  <th scope="col" className="px-3 py-2 text-left font-medium">Time</th>
+                  <th scope="col" className="px-3 py-2 text-left font-medium">Action</th>
+                  <th scope="col" className="px-3 py-2 text-left font-medium">Description</th>
+                  <th scope="col" className="px-3 py-2 text-left font-medium hidden md:table-cell">Actor</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.entries.map((entry) => (
+                  <tr key={entry.id} className="border-b border-border/50">
+                    <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
+                      {new Date(entry.timestamp).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className="text-xs px-2 py-0.5 rounded bg-secondary font-mono">
+                        {entry.actionType}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">{entry.description}</td>
+                    <td className="px-3 py-2 text-xs text-muted-foreground font-mono hidden md:table-cell">
+                      {entry.actorUserId ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="px-3 py-1 rounded border border-border text-sm hover:bg-muted disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-muted-foreground">
+                Page {page + 1} of {totalPages} ({data.total} entries)
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+                className="px-3 py-1 rounded border border-border text-sm hover:bg-muted disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminMetrics.tsx
+++ b/src/ReactClient/src/pages/admin/AdminMetrics.tsx
@@ -1,0 +1,162 @@
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface LiveStats {
+  totalPlayers: number
+  activePlayers: number
+  bannedPlayers: number
+  totalResources: Record<string, number>
+  openMarketOrders: number
+  currentTick: number
+  isPaused: boolean
+  effectiveTickDurationSeconds: number
+  dailyActiveUsers: number
+  runningGames: number
+  totalGames: number
+  achievementUnlocksToday: number
+  topAchievements: { gameDefType: string; count: number }[]
+}
+
+export function AdminMetrics() {
+  const { data: stats, isLoading, error, refetch } = useQuery<LiveStats>({
+    queryKey: ['admin-live-stats'],
+    queryFn: () => apiClient.get('/api/admin/live-stats').then((r) => r.data),
+    refetchInterval: 10000,
+  })
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Metrics</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Metrics</h1>
+        <ApiError message="Failed to load metrics." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-6">Metrics</h1>
+
+      {isLoading || !stats ? (
+        <PageLoader message="Loading metrics..." />
+      ) : (
+        <div className="space-y-6">
+          {/* Player Stats */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Players</h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.totalPlayers}</div>
+                <div className="text-xs text-muted-foreground">Total</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-success-foreground">{stats.activePlayers}</div>
+                <div className="text-xs text-muted-foreground">Active (15m)</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-primary">{stats.dailyActiveUsers}</div>
+                <div className="text-xs text-muted-foreground">DAU (24h)</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-destructive">{stats.bannedPlayers}</div>
+                <div className="text-xs text-muted-foreground">Banned</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Games */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Games</h2>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.totalGames}</div>
+                <div className="text-xs text-muted-foreground">Total</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-success-foreground">{stats.runningGames}</div>
+                <div className="text-xs text-muted-foreground">Running</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-yellow-500">{stats.achievementUnlocksToday}</div>
+                <div className="text-xs text-muted-foreground">Achievements Today</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Top Achievement Types */}
+          {stats.topAchievements.length > 0 && (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h2 className="text-lg font-semibold mb-3">Achievements by Game Type</h2>
+              <div className="space-y-2">
+                {stats.topAchievements.map((a) => (
+                  <div key={a.gameDefType} className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground font-mono">{a.gameDefType}</span>
+                    <span className="font-bold">{a.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Tick Info */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Tick Engine</h2>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.currentTick}</div>
+                <div className="text-xs text-muted-foreground">Current Tick</div>
+              </div>
+              <div className="text-center">
+                <div className={`text-3xl font-bold ${stats.isPaused ? 'text-warning' : 'text-success-foreground'}`}>
+                  {stats.isPaused ? 'Paused' : 'Running'}
+                </div>
+                <div className="text-xs text-muted-foreground">Status</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.effectiveTickDurationSeconds}s</div>
+                <div className="text-xs text-muted-foreground">Tick Duration</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Economy */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Economy</h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {Object.entries(stats.totalResources).map(([key, val]) => (
+                <div key={key} className="text-center">
+                  <div className="text-2xl font-bold">{Number(val).toLocaleString()}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{key}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Market */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Market</h2>
+            <div className="text-center">
+              <div className="text-3xl font-bold">{stats.openMarketOrders}</div>
+              <div className="text-xs text-muted-foreground">Open Market Orders</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminNav.tsx
+++ b/src/ReactClient/src/pages/admin/AdminNav.tsx
@@ -4,13 +4,15 @@ const links = [
   { path: '/admin/games', label: 'Games' },
   { path: '/admin/players', label: 'Players' },
   { path: '/admin/ticks', label: 'Tick Control' },
-  { path: '/admin/stats', label: 'Live Stats' },
+  { path: '/admin/metrics', label: 'Metrics' },
+  { path: '/admin/audit', label: 'Audit Log' },
+  { path: '/admin/reports', label: 'Reports' },
 ]
 
 export function AdminNav() {
   const location = useLocation()
   return (
-    <nav className="flex gap-1 mb-6 border-b border-border pb-2">
+    <nav className="flex gap-1 mb-6 border-b border-border pb-2 flex-wrap">
       {links.map(({ path, label }) => (
         <a
           key={path}

--- a/src/ReactClient/src/pages/admin/AdminPlayers.tsx
+++ b/src/ReactClient/src/pages/admin/AdminPlayers.tsx
@@ -31,6 +31,7 @@ export function AdminPlayers() {
   const queryClient = useQueryClient()
   const [selectedPlayer, setSelectedPlayer] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const { data: players, isLoading, error, refetch } = useQuery<AdminPlayerEntry[]>({
     queryKey: ['admin-players'],
@@ -103,6 +104,16 @@ export function AdminPlayers() {
       <AdminNav />
       <h1 className="text-2xl font-bold mb-6">Player Moderation</h1>
 
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search players by name..."
+          className="w-full max-w-sm border border-border rounded px-3 py-2 text-sm bg-background"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
+
       {actionError && (
         <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">
           {actionError}
@@ -113,7 +124,13 @@ export function AdminPlayers() {
         <PageLoader message="Loading players..." />
       ) : !players || players.length === 0 ? (
         <p className="text-muted-foreground">No players found.</p>
-      ) : (
+      ) : (() => {
+        const filtered = players.filter(p =>
+          !searchQuery || p.name.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+        return filtered.length === 0 ? (
+          <p className="text-muted-foreground">No players match your search.</p>
+        ) : (
         <div className="rounded-lg border border-border overflow-hidden">
           <table className="w-full text-sm">
             <thead>
@@ -128,7 +145,7 @@ export function AdminPlayers() {
               </tr>
             </thead>
             <tbody>
-              {players.map((player) => (
+              {filtered.map((player) => (
                 <>
                   <tr key={player.playerId} className="border-b border-border/50">
                     <td className="px-3 py-2 font-medium">{player.name}</td>
@@ -246,7 +263,8 @@ export function AdminPlayers() {
             </tbody>
           </table>
         </div>
-      )}
+        )
+      })()}
     </div>
   )
 }

--- a/src/ReactClient/src/pages/admin/AdminReports.tsx
+++ b/src/ReactClient/src/pages/admin/AdminReports.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import apiClient from '@/api/client'
+import { PageLoader } from '@/components/PageLoader'
+import { ApiError } from '@/components/ApiError'
+import { AdminNav } from './AdminNav'
+
+interface Report {
+  id: string
+  createdAt: string
+  reporterUserId: string
+  targetUserId: string
+  reason: string
+  details: string | null
+  status: 'Pending' | 'Resolved' | 'Dismissed'
+  resolvedByUserId: string | null
+  resolutionNote: string | null
+  resolvedAt: string | null
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  Pending: 'bg-warning/20 text-warning-foreground',
+  Resolved: 'bg-success/20 text-success-foreground',
+  Dismissed: 'bg-muted text-muted-foreground',
+}
+
+export function AdminReports() {
+  const queryClient = useQueryClient()
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [noteInputs, setNoteInputs] = useState<Record<string, string>>({})
+
+  const { data: reports, isLoading, error, refetch } = useQuery<Report[]>({
+    queryKey: ['admin-reports'],
+    queryFn: () => apiClient.get('/api/admin/reports').then((r) => r.data),
+  })
+
+  const actionMutation = useMutation({
+    mutationFn: ({ id, action, note }: { id: string; action: string; note: string }) =>
+      apiClient.post(`/api/admin/reports/${id}/action`, { action, note }),
+    onSuccess: () => {
+      setActionError(null)
+      void queryClient.invalidateQueries({ queryKey: ['admin-reports'] })
+    },
+    onError: (err) => {
+      setActionError(axios.isAxiosError(err) ? `Action failed: ${err.response?.data ?? err.message}` : 'Unknown error.')
+    },
+  })
+
+  if (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      return (
+        <div className="p-6 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Reports</h1>
+          <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
+            You are not authorized to view the admin panel.
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Reports</h1>
+        <ApiError message="Failed to load reports." onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  const pendingCount = reports?.filter((r) => r.status === 'Pending').length ?? 0
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <AdminNav />
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-2xl font-bold">Reports</h1>
+        {pendingCount > 0 && (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-destructive text-destructive-foreground font-bold">
+            {pendingCount} pending
+          </span>
+        )}
+      </div>
+
+      {actionError && (
+        <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">
+          {actionError}
+        </div>
+      )}
+
+      {isLoading ? (
+        <PageLoader message="Loading reports..." />
+      ) : !reports || reports.length === 0 ? (
+        <p className="text-muted-foreground">No reports submitted yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {reports.map((report) => (
+            <div key={report.id} className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-start justify-between gap-4 mb-2">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`text-xs px-2 py-0.5 rounded font-medium ${STATUS_COLORS[report.status] ?? ''}`}>
+                      {report.status}
+                    </span>
+                    <span className="text-xs text-muted-foreground font-mono">{report.id}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(report.createdAt).toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Reporter:</span>{' '}
+                    <span className="font-mono text-xs">{report.reporterUserId}</span>
+                    {' → '}
+                    <span className="text-muted-foreground">Target:</span>{' '}
+                    <span className="font-mono text-xs">{report.targetUserId}</span>
+                  </div>
+                  <div className="text-sm font-medium">{report.reason}</div>
+                  {report.details && (
+                    <div className="text-sm text-muted-foreground">{report.details}</div>
+                  )}
+                  {report.resolutionNote && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      Resolution: {report.resolutionNote}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {report.status === 'Pending' && (
+                <div className="flex items-center gap-2 mt-3 pt-3 border-t border-border/50">
+                  <input
+                    type="text"
+                    placeholder="Resolution note (optional)"
+                    className="flex-1 border border-border rounded px-2 py-1 text-xs bg-background"
+                    value={noteInputs[report.id] ?? ''}
+                    onChange={(e) => setNoteInputs((prev) => ({ ...prev, [report.id]: e.target.value }))}
+                  />
+                  <button
+                    onClick={() => actionMutation.mutate({ id: report.id, action: 'Resolved', note: noteInputs[report.id] ?? '' })}
+                    disabled={actionMutation.isPending}
+                    className="px-3 py-1 rounded bg-success text-success-foreground text-xs hover:bg-success/90 disabled:opacity-50"
+                  >
+                    Resolve
+                  </button>
+                  <button
+                    onClick={() => actionMutation.mutate({ id: report.id, action: 'Dismissed', note: noteInputs[report.id] ?? '' })}
+                    disabled={actionMutation.isPending}
+                    className="px-3 py-1 rounded border border-border text-xs hover:bg-muted disabled:opacity-50"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **Player search**: client-side text filter in AdminPlayers page
- **AdminNav**: added Metrics, Audit Log, and Reports tabs; removed old \"Live Stats\" in favour of `/admin/metrics`
- **Enhanced Metrics** (`/admin/metrics`): extends `GET /api/admin/live-stats` with `dailyActiveUsers`, `runningGames`, `totalGames`, `achievementUnlocksToday`, `topAchievements[]`; new `AdminMetrics.tsx` page
- **Audit Log** (backend + frontend): in-memory `AdminAuditLog` singleton records every admin mutation (ban/unban/set-resources/report action); `GET /api/admin/audit-log?page&pageSize&actionType`; `AdminAuditLog.tsx` with pagination and action-type filter
- **Report System** (backend + frontend): `ReportStore` singleton; `POST /api/reports` (authenticated, player-facing); `GET /api/admin/reports`; `POST /api/admin/reports/{id}/action` (Resolve/Dismissed); `AdminReports.tsx` with pending count badge and resolution form
- **Report buttons**: flag modal added to `PublicProfile` and `InGamePlayerProfile`; `InGamePlayerProfileViewModel` gains `UserId` field so report targets the user, not the game-specific player ID

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (663 tests)
- [ ] Navigate to `/admin/metrics` — see new DAU / games / achievement stats
- [ ] Navigate to `/admin/audit` — after ban/unban an entry appears
- [ ] Navigate to `/admin/reports` — submit a report from a public profile and see it appear; resolve/dismiss works
- [ ] Player search in `/admin/players` filters by name

Closes BGE-893