### PR TITLE
fix: BGE-887 tournament race conditions — lock write repo and move player init before Register

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/TournamentEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/TournamentEngine.cs
@@ -208,8 +208,6 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			var wsImm = worldStateFactory.CreateDevWorldState(0) with { GameId = gameId };
 			var ws = wsImm.ToMutable();
 			var instance = new GameInstance(record, ws, gameDef);
-			gameRegistry.Register(instance);
-			globalState.AddGame(record);
 
 			var playerRepoWrite = new PlayerRepositoryWrite(instance.WorldStateAccessor, timeProvider);
 			var p1Name = globalState.GetUserDisplayName(match.Player1UserId!) ?? match.Player1UserId!;
@@ -220,9 +218,12 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 			playerRepoWrite.CreatePlayer(p1Id, match.Player1UserId, gameDef.PlayerTypes.First().Id.Id);
 			playerRepoWrite.CreatePlayer(p2Id, match.Player2UserId, gameDef.PlayerTypes.First().Id.Id);
 
-			// Set display names
+			// Set display names before registering — must happen before the tick engine can observe the instance
 			if (instance.WorldState.Players.TryGetValue(p1Id, out var p1)) p1.Name = p1Name;
 			if (instance.WorldState.Players.TryGetValue(p2Id, out var p2)) p2.Name = p2Name;
+
+			gameRegistry.Register(instance);
+			globalState.AddGame(record);
 
 			logger.LogInformation("Created tournament game {GameId} for match {MatchId}", gameId.Id, match.MatchId);
 			return gameId.Id;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tournament/TournamentRepositoryWrite.cs
@@ -7,6 +7,7 @@ using System.Linq;
 namespace BrowserGameEngine.StatefulGameServer.Repositories.Tournament {
 	public class TournamentRepositoryWrite {
 		private readonly GlobalState globalState;
+		private readonly object _lock = new();
 
 		public TournamentRepositoryWrite(GlobalState globalState) {
 			this.globalState = globalState;
@@ -17,39 +18,45 @@ namespace BrowserGameEngine.StatefulGameServer.Repositories.Tournament {
 		}
 
 		public void AddRegistration(string tournamentId, TournamentRegistrationImmutable registration) {
-			var tournament = globalState.GetTournamentById(tournamentId)
-				?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
+			lock (_lock) {
+				var tournament = globalState.GetTournamentById(tournamentId)
+					?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
 
-			if (tournament.Status != TournamentStatus.Registration)
-				throw new InvalidOperationException("Tournament is not in registration phase.");
+				if (tournament.Status != TournamentStatus.Registration)
+					throw new InvalidOperationException("Tournament is not in registration phase.");
 
-			if (tournament.Registrations.Any(r => r.UserId == registration.UserId))
-				throw new InvalidOperationException("User is already registered.");
+				if (tournament.Registrations.Any(r => r.UserId == registration.UserId))
+					throw new InvalidOperationException("User is already registered.");
 
-			if (tournament.MaxPlayers > 0 && tournament.Registrations.Count >= tournament.MaxPlayers)
-				throw new InvalidOperationException("Tournament is full.");
+				if (tournament.MaxPlayers > 0 && tournament.Registrations.Count >= tournament.MaxPlayers)
+					throw new InvalidOperationException("Tournament is full.");
 
-			var updatedRegistrations = new List<TournamentRegistrationImmutable>(tournament.Registrations) { registration };
-			var updated = tournament with { Registrations = updatedRegistrations };
-			globalState.UpdateTournament(tournament, updated);
+				var updatedRegistrations = new List<TournamentRegistrationImmutable>(tournament.Registrations) { registration };
+				var updated = tournament with { Registrations = updatedRegistrations };
+				globalState.UpdateTournament(tournament, updated);
+			}
 		}
 
 		public void RemoveRegistration(string tournamentId, string userId) {
-			var tournament = globalState.GetTournamentById(tournamentId)
-				?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
+			lock (_lock) {
+				var tournament = globalState.GetTournamentById(tournamentId)
+					?? throw new InvalidOperationException($"Tournament {tournamentId} not found.");
 
-			if (tournament.Status != TournamentStatus.Registration)
-				throw new InvalidOperationException("Tournament is not in registration phase.");
+				if (tournament.Status != TournamentStatus.Registration)
+					throw new InvalidOperationException("Tournament is not in registration phase.");
 
-			var updatedRegistrations = tournament.Registrations.Where(r => r.UserId != userId).ToList();
-			var updated = tournament with { Registrations = updatedRegistrations };
-			globalState.UpdateTournament(tournament, updated);
+				var updatedRegistrations = tournament.Registrations.Where(r => r.UserId != userId).ToList();
+				var updated = tournament with { Registrations = updatedRegistrations };
+				globalState.UpdateTournament(tournament, updated);
+			}
 		}
 
 		public void UpdateTournament(TournamentImmutable updated) {
-			var current = globalState.GetTournamentById(updated.TournamentId)
-				?? throw new InvalidOperationException($"Tournament {updated.TournamentId} not found.");
-			globalState.UpdateTournament(current, updated);
+			lock (_lock) {
+				var current = globalState.GetTournamentById(updated.TournamentId)
+					?? throw new InvalidOperationException($"Tournament {updated.TournamentId} not found.");
+				globalState.UpdateTournament(current, updated);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two race conditions found in the BGE-887 Tournament System (PR #278) by code review.

### Fix 1 — TournamentRepositoryWrite: missing lock on read-modify-write

All methods (`AddRegistration`, `RemoveRegistration`, `UpdateTournament`) did an unlocked read-modify-write via `GetTournamentById` → `UpdateTournament`. `GlobalState.UpdateTournament` uses `list.IndexOf(old)` for record equality — if a concurrent write changed the entry first, `IndexOf` returns `-1` and the update is **silently dropped**.

This is especially dangerous for round-robin tournaments where multiple match games can finalize concurrently, each calling `UpdateTournament` to record the result.

Fix: add `private readonly object _lock = new()` and wrap all three read-modify-write operations with `lock (_lock)`.

### Fix 2 — TournamentEngine.CreateMatchGame: player names set after game registered

`gameRegistry.Register(instance)` was called before player creation and name assignment. The tick engine starts observing the instance immediately on registration, so it could read unnamed players.

Fix: move `gameRegistry.Register(instance)` and `globalState.AddGame(record)` to after player creation and name assignment.

## Test plan
- [x] `dotnet build --configuration Release` passes
- [x] All 8 `TournamentEngineTest` tests pass