### PR TITLE
fix: kill old Blazor service worker and remove stale CSS references

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Pages/Shared/_Layout.cshtml
+++ b/src/BrowserGameEngine.FrontendServer/Pages/Shared/_Layout.cshtml
@@ -5,8 +5,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>@ViewBag.Title</title>
-    <link href="~/css/bootstrap/bootstrap.min.css" rel="stylesheet" />
-    <link href="~/css/app.css" rel="stylesheet" />
 </head>
 
 <body>

--- a/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
+++ b/src/BrowserGameEngine.FrontendServer/Views/Authentication/Signin.cshtml
@@ -11,7 +11,6 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Log In — Browser Game Engine</title>
-	<link href="~/css/bootstrap/bootstrap.min.css" rel="stylesheet" />
 	<style>
 		* { box-sizing: border-box; }
 

--- a/src/ReactClient/public/service-worker.js
+++ b/src/ReactClient/public/service-worker.js
@@ -1,0 +1,9 @@
+// This no-op service worker replaces the old Blazor WASM service worker.
+// It immediately unregisters itself and clears all caches so that the
+// React SPA is served directly by the network.
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', async () => {
+  const keys = await caches.keys();
+  await Promise.all(keys.map(k => caches.delete(k)));
+  await self.registration.unregister();
+});


### PR DESCRIPTION
## Summary
- Add a self-unregistering `service-worker.js` that replaces the old Blazor WASM service worker cached in returning users' browsers. The old SW intercepted navigations and served the defunct Blazor app instead of the React SPA, causing pages to break.
- Remove the `bootstrap.min.css` reference from `Signin.cshtml` (styles are already inline) and stale CSS refs from `_Layout.cshtml` — both 404 since the Blazor assets were replaced by the Vite React build.

## Root cause
The old Blazor app registered a service worker that aggressively caches all assets. When users who previously visited the Blazor version return, their browser's cached service worker intercepts all navigations and serves the old Blazor app instead of the new React SPA. Only the root `/` URL works because it's the initial page load; subsequent navigations get hijacked by the SW.

## How the fix works
Vite copies `public/service-worker.js` verbatim into the build output. When a browser with the old Blazor SW checks for updates, it downloads this new version which:
1. Calls `skipWaiting()` on install to activate immediately
2. On activate, clears all caches and unregisters itself
3. After that, the browser loads the React SPA normally

## Test plan
- [x] `dotnet build --configuration Release` succeeds
- [x] `npm run build` succeeds and `dist/service-worker.js` is present
- [x] Verified via Chrome DevTools that after clearing the old SW and caches, `/leaderboard` correctly serves the React SPA
- [ ] Deploy and verify returning users see React on all routes