### PR TITLE
fix: keep sidebar visible on Account pages and add API key UI

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -208,6 +208,12 @@ const router = createBrowserRouter([
 					{ path: 'join', element: <RouteWithBoundary><JoinGame /></RouteWithBoundary> },
 					{ path: 'summary', element: <RouteWithBoundary><GameSummary /></RouteWithBoundary> },
 					{ path: 'results', element: <RouteWithBoundary><GameResults /></RouteWithBoundary> },
+
+					// Account pages (also available at top-level, but rendered inside game layout when accessed from nav)
+					{ path: 'history', element: <RouteWithBoundary><PlayerHistory /></RouteWithBoundary> },
+					{ path: 'stats', element: <RouteWithBoundary><PlayerStats /></RouteWithBoundary> },
+					{ path: 'profile', element: <RouteWithBoundary><PlayerProfile /></RouteWithBoundary> },
+					{ path: 'achievements', element: <RouteWithBoundary><Achievements /></RouteWithBoundary> },
 				],
 			},
 

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -969,6 +969,22 @@ export interface AllTimePlayerListViewModel {
   players: AllTimePlayerEntryViewModel[]
 }
 
+// Player Management
+
+export interface PlayerSummaryViewModel {
+  playerId: string
+  playerName: string
+  hasApiKey: boolean
+}
+
+export interface PlayerListViewModel {
+  players: PlayerSummaryViewModel[]
+}
+
+export interface ApiKeyViewModel {
+  apiKey: string
+}
+
 // Create Player
 
 export interface CreatePlayerRequest {

--- a/src/ReactClient/src/components/NavMenu.tsx
+++ b/src/ReactClient/src/components/NavMenu.tsx
@@ -98,10 +98,10 @@ export function NavMenu() {
       <div className="mt-6 px-3">
         <ul className="space-y-0.5">
           <SectionLabel>Account</SectionLabel>
-          <NavItem to="/history" icon={HistoryIcon} label="History" />
-          <NavItem to="/stats" icon={LineChartIcon} label="My Stats" />
-          <NavItem to="/profile" icon={UserIcon} label="Profile" />
-          <NavItem to="/achievements" icon={TrophyIcon} label="Achievements" />
+          <NavItem to={g('history')} icon={HistoryIcon} label="History" />
+          <NavItem to={g('stats')} icon={LineChartIcon} label="My Stats" />
+          <NavItem to={g('profile')} icon={UserIcon} label="Profile" />
+          <NavItem to={g('achievements')} icon={TrophyIcon} label="Achievements" />
         </ul>
       </div>
     </nav>

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -1,11 +1,120 @@
-import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
-import { TrophyIcon, SwordsIcon, StarIcon, ChevronRightIcon } from 'lucide-react'
+import { TrophyIcon, SwordsIcon, StarIcon, ChevronRightIcon, KeyIcon, CopyIcon, CheckIcon, Trash2Icon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ProfileViewModel, PlayerAchievementsViewModel, PlayerHistoryViewModel } from '@/api/types'
+import type { ProfileViewModel, PlayerAchievementsViewModel, PlayerHistoryViewModel, PlayerListViewModel, ApiKeyViewModel } from '@/api/types'
 import { ApiError } from '@/components/ApiError'
 import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { relativeTime } from '@/lib/utils'
+
+function ApiKeySection() {
+  const queryClient = useQueryClient()
+  const [newKey, setNewKey] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const { data: playerList, isLoading } = useQuery({
+    queryKey: ['my-players'],
+    queryFn: () => apiClient.get<PlayerListViewModel>('/api/player-management').then(r => r.data),
+  })
+
+  const generateMutation = useMutation({
+    mutationFn: (playerId: string) =>
+      apiClient.post<ApiKeyViewModel>(`/api/player-management/${playerId}/apikey`).then(r => r.data),
+    onSuccess: (data) => {
+      setNewKey(data.apiKey)
+      void queryClient.invalidateQueries({ queryKey: ['my-players'] })
+    },
+  })
+
+  const revokeMutation = useMutation({
+    mutationFn: (playerId: string) =>
+      apiClient.delete(`/api/player-management/${playerId}/apikey`),
+    onSuccess: () => {
+      setNewKey(null)
+      void queryClient.invalidateQueries({ queryKey: ['my-players'] })
+    },
+  })
+
+  const handleCopy = async () => {
+    if (!newKey) return
+    await navigator.clipboard.writeText(newKey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  if (isLoading) return null
+
+  const player = playerList?.players?.[0]
+  if (!player) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-5 space-y-3">
+      <strong className="text-sm flex items-center gap-1.5">
+        <KeyIcon className="h-4 w-4 text-primary" />
+        Bot API Key
+      </strong>
+      <p className="text-xs text-muted-foreground">
+        Use an API key to control your player programmatically via the REST API.
+      </p>
+
+      {newKey && (
+        <div className="rounded border bg-secondary/30 p-3 space-y-2">
+          <div className="text-xs font-medium text-warning-foreground">
+            Copy this key now — it won't be shown again.
+          </div>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs bg-background rounded px-2 py-1.5 break-all select-all border">
+              {newKey}
+            </code>
+            <button
+              onClick={() => void handleCopy()}
+              className="shrink-0 p-1.5 rounded hover:bg-secondary"
+              aria-label="Copy API key"
+            >
+              {copied ? <CheckIcon className="h-4 w-4 text-green-500" /> : <CopyIcon className="h-4 w-4" />}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        {player.hasApiKey ? (
+          <>
+            <span className="text-xs text-muted-foreground">Active key configured</span>
+            <button
+              onClick={() => generateMutation.mutate(player.playerId)}
+              disabled={generateMutation.isPending}
+              className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {generateMutation.isPending ? 'Regenerating...' : 'Regenerate'}
+            </button>
+            <button
+              onClick={() => revokeMutation.mutate(player.playerId)}
+              disabled={revokeMutation.isPending}
+              className="rounded border border-destructive/50 px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50 flex items-center gap-1"
+            >
+              <Trash2Icon className="h-3 w-3" />
+              {revokeMutation.isPending ? 'Revoking...' : 'Revoke'}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => generateMutation.mutate(player.playerId)}
+            disabled={generateMutation.isPending}
+            className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {generateMutation.isPending ? 'Generating...' : 'Generate API Key'}
+          </button>
+        )}
+      </div>
+
+      {(generateMutation.isError || revokeMutation.isError) && (
+        <p className="text-xs text-destructive">Something went wrong. Please try again.</p>
+      )}
+    </div>
+  )
+}
 
 function outcomeLabel(isWin: boolean, gameStatus: string): { label: string; className: string } {
   if (isWin) return { label: 'Win', className: 'bg-green-700/30 text-green-300' }
@@ -215,6 +324,9 @@ export function PlayerProfile() {
           </div>
         </div>
       )}
+
+      {/* API Key management */}
+      <ApiKeySection />
 
       {/* Achievement badges */}
       {(() => {


### PR DESCRIPTION
## Summary
- **Menu fix**: Account nav links (History, Stats, Profile, Achievements) now use game-scoped routes so the sidebar stays visible when navigating to them from within a game
- **API key UI**: Added a Bot API Key section to the Profile page — players can generate, regenerate, copy, and revoke API keys through the UI (backend endpoints already existed)

## Test plan
- [ ] Navigate to a game, click History/Stats/Profile/Achievements in sidebar — sidebar should remain visible
- [ ] Top-level routes (/history, /profile, etc.) still work for direct navigation
- [ ] On Profile page, generate an API key — key is displayed with copy button
- [ ] Regenerate key — old key is replaced
- [ ] Revoke key — key is removed