### PR TITLE
fix: persist game state to per-game path instead of legacy latest.json

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Services/PersistenceHostedService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/PersistenceHostedService.cs
@@ -1,14 +1,7 @@
 using BrowserGameEngine.Persistence;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
-using BrowserGameEngine.GameModel;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer {
 	public class PersistenceHostedService : IHostedService, IDisposable {
@@ -17,15 +10,15 @@ namespace BrowserGameEngine.FrontendServer {
 		private Timer? timer;
 		private readonly ILogger<PersistenceHostedService> logger;
 		private readonly PersistenceService persistenceService;
-		private readonly WorldState worldState;
+		private readonly GameRegistry gameRegistry;
 
 		public PersistenceHostedService(ILogger<PersistenceHostedService> logger
 				, PersistenceService persistenceService
-				, WorldState worldState
+				, GameRegistry gameRegistry
 			) {
 			this.logger = logger;
 			this.persistenceService = persistenceService;
-			this.worldState = worldState;
+			this.gameRegistry = gameRegistry;
 		}
 
 		public Task StartAsync(CancellationToken cancellationToken) {
@@ -36,7 +29,7 @@ namespace BrowserGameEngine.FrontendServer {
 		private void DoWork(object? state) {
 			if (Interlocked.CompareExchange(ref isactive, 1, 0) != 0) return;
 			try {
-				StoreGameState().GetAwaiter().GetResult();
+				StoreAllGameStates().GetAwaiter().GetResult();
 			} catch (Exception ex) {
 				logger.LogError(ex, "Failed to store game state");
 			} finally {
@@ -44,16 +37,23 @@ namespace BrowserGameEngine.FrontendServer {
 			}
 		}
 
-		private async Task StoreGameState() {
+		private async Task StoreAllGameStates() {
 			var sw = Stopwatch.StartNew();
 			var count = Interlocked.Increment(ref executionCount);
-			await persistenceService.StoreWorldSate(worldState.ToImmutable());
-			logger.LogInformation("Storing gamestate #{Count} took {Elapsed}", count, sw.Elapsed);
+			foreach (var instance in gameRegistry.GetAllInstances()) {
+				var gameId = instance.Record.GameId;
+				try {
+					await persistenceService.StoreGameState(gameId, instance.WorldState.ToImmutable());
+				} catch (Exception ex) {
+					logger.LogError(ex, "Failed to store game state for {GameId}", gameId.Id);
+				}
+			}
+			logger.LogInformation("Storing gamestate #{Count} ({GameCount} games) took {Elapsed}", count, gameRegistry.GetAllInstances().Count, sw.Elapsed);
 		}
 
 		public async Task StopAsync(CancellationToken cancellationToken) {
 			// store state on shutdown
-			await StoreGameState();
+			await StoreAllGameStates();
 		}
 
 		public void Dispose() {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/PersistenceHostedServiceTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/PersistenceHostedServiceTest.cs
@@ -1,0 +1,100 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Persistence;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class PersistenceHostedServiceTest {
+		private static GameRegistryNs.GameInstance MakeInstance(string gameId, TestGame game) {
+			var record = new GameRecordImmutable(new GameId(gameId), "Test", "sco", GameStatus.Active,
+				DateTime.UtcNow, DateTime.UtcNow.AddDays(1), TimeSpan.FromSeconds(10));
+			return new GameRegistryNs.GameInstance(record, game.World, game.GameDef);
+		}
+
+		/// <summary>
+		/// Verifies that game state is persisted to the per-game path (games/{gameId}/state.json)
+		/// rather than the legacy single-game path (latest.json).
+		/// Regression test: previously PersistenceHostedService wrote to latest.json,
+		/// but on startup games were loaded from games/{gameId}/state.json, causing
+		/// all progress to be lost on every server restart.
+		/// </summary>
+		[Fact]
+		public async Task StopAsync_PersistsToPerGamePath_NotLegacyPath() {
+			var storage = new InMemoryBlobStorage();
+			var serializer = new GameStateJsonSerializer();
+			var persistenceService = new PersistenceService(storage, serializer);
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+
+			var game = new TestGame();
+			var instance = MakeInstance("league-round-1", game);
+			registry.Register(instance);
+
+			var service = new PersistenceHostedService(
+				NullLogger<PersistenceHostedService>.Instance,
+				persistenceService,
+				registry);
+
+			await service.StopAsync(CancellationToken.None);
+
+			Assert.True(storage.Exists("games/league-round-1/state.json"),
+				"Game state must be persisted to games/{gameId}/state.json");
+			Assert.False(storage.Exists("latest.json"),
+				"Game state must NOT be written to the legacy latest.json path");
+		}
+
+		[Fact]
+		public async Task StopAsync_PersistsAllGameInstances() {
+			var storage = new InMemoryBlobStorage();
+			var serializer = new GameStateJsonSerializer();
+			var persistenceService = new PersistenceService(storage, serializer);
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+
+			var game1 = new TestGame();
+			var game2 = new TestGame();
+			registry.Register(MakeInstance("game-alpha", game1));
+			registry.Register(MakeInstance("game-beta", game2));
+
+			var service = new PersistenceHostedService(
+				NullLogger<PersistenceHostedService>.Instance,
+				persistenceService,
+				registry);
+
+			await service.StopAsync(CancellationToken.None);
+
+			Assert.True(storage.Exists("games/game-alpha/state.json"),
+				"game-alpha state must be persisted");
+			Assert.True(storage.Exists("games/game-beta/state.json"),
+				"game-beta state must be persisted");
+		}
+
+		[Fact]
+		public async Task StopAsync_PersistedStateCanBeReloaded() {
+			var storage = new InMemoryBlobStorage();
+			var serializer = new GameStateJsonSerializer();
+			var persistenceService = new PersistenceService(storage, serializer);
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+
+			var game = new TestGame(playerCount: 2);
+			var instance = MakeInstance("round-1", game);
+			registry.Register(instance);
+
+			var service = new PersistenceHostedService(
+				NullLogger<PersistenceHostedService>.Instance,
+				persistenceService,
+				registry);
+
+			await service.StopAsync(CancellationToken.None);
+
+			// Simulate server restart: load state from per-game path
+			var reloaded = await persistenceService.LoadGameState(new GameId("round-1"));
+			Assert.Equal(2, reloaded.Players.Count);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `PersistenceHostedService` saved game state to `latest.json` (legacy single-game path), but on startup games are loaded from `games/{gameId}/state.json`. Every server restart reverted all player progress to the migration snapshot.
- **Fix**: Changed `PersistenceHostedService` to iterate all `GameRegistry` instances and save each to `games/{gameId}/state.json` via `PersistenceService.StoreGameState()`.
- **Tests**: Added `PersistenceHostedServiceTest` with 3 regression tests ensuring state is written to the correct per-game path, all instances are persisted, and persisted state can be reloaded.

## Test plan
- [x] All 693 tests pass (690 existing + 3 new)
- [x] `StopAsync_PersistsToPerGamePath_NotLegacyPath` — verifies correct path and no legacy path
- [x] `StopAsync_PersistsAllGameInstances` — verifies multi-game persistence
- [x] `StopAsync_PersistedStateCanBeReloaded` — verifies round-trip integrity