### PR TITLE
fix: prevent concurrent modification crash in PlayerState.ToImmutable()

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/PlayerState.cs
@@ -3,9 +3,11 @@ using BrowserGameEngine.GameModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 	internal class PlayerState {
+		internal readonly Lock StateLock = new();
 		public DateTime? LastGameTickUpdate { get; set; }
 		public GameTick CurrentGameTick { get; set; } = new GameTick(0);
 		public IDictionary<ResourceDefId, decimal> Resources { get; set; } = new Dictionary<ResourceDefId, decimal>();
@@ -35,33 +37,35 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 
 	internal static class PlayerStateExtensions {
 		internal static PlayerStateImmutable ToImmutable(this PlayerState playerState) {
-			return new PlayerStateImmutable(
-				LastGameTickUpdate: playerState.LastGameTickUpdate,
-				CurrentGameTick: playerState.CurrentGameTick,
-				Resources: new Dictionary<ResourceDefId, decimal>(playerState.Resources),
-				Assets: playerState.Assets.Select(x => x.ToImmutable()).ToHashSet(),
-				Units: playerState.Units.Select(x => x.ToImmutable()).ToList(),
-				MineralWorkers: playerState.MineralWorkers,
-				GasWorkers: playerState.GasWorkers,
-				ProtectionTicksRemaining: playerState.ProtectionTicksRemaining,
-				Messages: playerState.Messages.Select(x => x.ToImmutable()).ToList(),
-				AttackUpgradeLevel: playerState.AttackUpgradeLevel,
-				DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
-				UpgradeResearchTimer: playerState.UpgradeResearchTimer,
-				UpgradeBeingResearched: playerState.UpgradeBeingResearched,
-				BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList(),
-				SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns),
-				UnlockedTechs: new List<string>(playerState.UnlockedTechs),
-				TechBeingResearched: playerState.TechBeingResearched,
-				TechResearchTimer: playerState.TechResearchTimer,
-				LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
-				SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
-				Notifications: new List<GameNotification>(playerState.Notifications),
-				SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList(),
-				TutorialCompleted: playerState.TutorialCompleted,
-				ResourceHistory: new List<ResourceSnapshot>(playerState.ResourceHistory),
-				BattleReports: playerState.BattleReports.Select(x => x.ToImmutable()).ToList()
-			);
+			lock (playerState.StateLock) {
+				return new PlayerStateImmutable(
+					LastGameTickUpdate: playerState.LastGameTickUpdate,
+					CurrentGameTick: playerState.CurrentGameTick,
+					Resources: new Dictionary<ResourceDefId, decimal>(playerState.Resources),
+					Assets: playerState.Assets.Select(x => x.ToImmutable()).ToHashSet(),
+					Units: playerState.Units.Select(x => x.ToImmutable()).ToList(),
+					MineralWorkers: playerState.MineralWorkers,
+					GasWorkers: playerState.GasWorkers,
+					ProtectionTicksRemaining: playerState.ProtectionTicksRemaining,
+					Messages: playerState.Messages.Select(x => x.ToImmutable()).ToList(),
+					AttackUpgradeLevel: playerState.AttackUpgradeLevel,
+					DefenseUpgradeLevel: playerState.DefenseUpgradeLevel,
+					UpgradeResearchTimer: playerState.UpgradeResearchTimer,
+					UpgradeBeingResearched: playerState.UpgradeBeingResearched,
+					BuildQueue: playerState.BuildQueue.Select(x => x.ToImmutable()).ToList(),
+					SpyCooldowns: new Dictionary<string, DateTime>(playerState.SpyCooldowns),
+					UnlockedTechs: new List<string>(playerState.UnlockedTechs),
+					TechBeingResearched: playerState.TechBeingResearched,
+					TechResearchTimer: playerState.TechResearchTimer,
+					LastSpyResults: new Dictionary<string, SpyResult>(playerState.LastSpyResults),
+					SpyAttemptLogs: new List<SpyAttemptLog>(playerState.SpyAttemptLogs),
+					Notifications: new List<GameNotification>(playerState.Notifications),
+					SpyMissions: playerState.SpyMissions.Select(x => x.ToImmutable()).ToList(),
+					TutorialCompleted: playerState.TutorialCompleted,
+					ResourceHistory: new List<ResourceSnapshot>(playerState.ResourceHistory),
+					BattleReports: playerState.BattleReports.Select(x => x.ToImmutable()).ToList()
+				);
+			}
 		}
 
 		internal static PlayerState ToMutable(this PlayerStateImmutable playerStateImmutable) {

--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
@@ -28,8 +28,11 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 				CreatedAt: DateTime.UtcNow,
 				ReadAt: null
 			);
+			var state = world.GetPlayer(playerId).State;
 			lock (_lock) {
-				world.GetPlayer(playerId).State.Notifications.Add(notification);
+				lock (state.StateLock) {
+					state.Notifications.Add(notification);
+				}
 			}
 			eventPublisher.PublishToPlayer(playerId, GameEventTypes.ReceiveNotification, new {
 				type = type.ToString(),
@@ -42,9 +45,11 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 		public void MarkRead(PlayerId playerId, Guid notificationId) {
 			lock (_lock) {
 				var state = world.GetPlayer(playerId).State;
-				var idx = state.Notifications.FindIndex(n => n.Id == notificationId);
-				if (idx >= 0) {
-					state.Notifications[idx] = state.Notifications[idx] with { ReadAt = DateTime.UtcNow };
+				lock (state.StateLock) {
+					var idx = state.Notifications.FindIndex(n => n.Id == notificationId);
+					if (idx >= 0) {
+						state.Notifications[idx] = state.Notifications[idx] with { ReadAt = DateTime.UtcNow };
+					}
 				}
 			}
 		}
@@ -52,10 +57,12 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 		public void MarkAllRead(PlayerId playerId) {
 			lock (_lock) {
 				var state = world.GetPlayer(playerId).State;
-				var now = DateTime.UtcNow;
-				for (int i = 0; i < state.Notifications.Count; i++) {
-					if (!state.Notifications[i].IsRead) {
-						state.Notifications[i] = state.Notifications[i] with { ReadAt = now };
+				lock (state.StateLock) {
+					var now = DateTime.UtcNow;
+					for (int i = 0; i < state.Notifications.Count; i++) {
+						if (!state.Notifications[i].IsRead) {
+							state.Notifications[i] = state.Notifications[i] with { ReadAt = now };
+						}
 					}
 				}
 			}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
@@ -61,10 +61,13 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		private void AddAsset(PlayerId playerId, AssetDefId assetDefId) {
 			logger.LogDebug("Adding asset '{assetDefId}' to player '{playerId}'", assetDefId, playerId);
-			Assets(playerId).Add(new Asset {
-				AssetDefId = assetDefId,
-				Level = 1
-			});
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.Assets.Add(new Asset {
+					AssetDefId = assetDefId,
+					Level = 1
+				});
+			}
 		}
 
 		public void GrantBuilding(PlayerId playerId, AssetDefId assetDefId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
@@ -16,10 +16,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public void AddBattleReport(PlayerId playerId, BattleReport report) {
 			lock (_lock) {
-				var reports = world.GetPlayer(playerId).State.BattleReports;
-				reports.Add(report);
-				while (reports.Count > MaxReportsPerPlayer) {
-					reports.RemoveAt(0);
+				var state = world.GetPlayer(playerId).State;
+				lock (state.StateLock) {
+					state.BattleReports.Add(report);
+					while (state.BattleReports.Count > MaxReportsPerPlayer) {
+						state.BattleReports.RemoveAt(0);
+					}
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
@@ -47,23 +47,28 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public void AddToQueue(AddToQueueCommand command) {
 			lock (_lock) {
-				var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
-				Queue(command.PlayerId).Add(new BuildQueueEntry {
-					Id = Guid.NewGuid(),
-					Type = command.Type,
-					DefId = command.DefId,
-					Count = command.Count,
-					Priority = priority
-				});
+				var state = world.GetPlayer(command.PlayerId).State;
+				lock (state.StateLock) {
+					var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
+					state.BuildQueue.Add(new BuildQueueEntry {
+						Id = Guid.NewGuid(),
+						Type = command.Type,
+						DefId = command.DefId,
+						Count = command.Count,
+						Priority = priority
+					});
+				}
 			}
 		}
 
 		public void RemoveFromQueue(RemoveFromQueueCommand command) {
 			lock (_lock) {
-				var queue = Queue(command.PlayerId);
-				var entry = queue.SingleOrDefault(x => x.Id == command.EntryId);
-				if (entry != null) {
-					queue.Remove(entry);
+				var state = world.GetPlayer(command.PlayerId).State;
+				lock (state.StateLock) {
+					var entry = state.BuildQueue.SingleOrDefault(x => x.Id == command.EntryId);
+					if (entry != null) {
+						state.BuildQueue.Remove(entry);
+					}
 				}
 			}
 		}
@@ -82,21 +87,23 @@ namespace BrowserGameEngine.StatefulGameServer {
 		/// </summary>
 		public void TryExecuteAndDequeueFirst(PlayerId playerId) {
 			lock (_lock) {
-				var queue = Queue(playerId);
-				var front = queue.OrderBy(x => x.Priority).FirstOrDefault();
-				if (front == null) return;
+				var state = world.GetPlayer(playerId).State;
+				lock (state.StateLock) {
+					var front = state.BuildQueue.OrderBy(x => x.Priority).FirstOrDefault();
+					if (front == null) return;
 
-				bool executed = false;
-				if (front.Type == BuildQueueEntryConstants.TypeAsset) {
-					executed = TryExecuteAsset(playerId, front);
-				} else if (front.Type == BuildQueueEntryConstants.TypeUnit) {
-					executed = TryExecuteUnit(playerId, front);
-				}
+					bool executed = false;
+					if (front.Type == BuildQueueEntryConstants.TypeAsset) {
+						executed = TryExecuteAsset(playerId, front);
+					} else if (front.Type == BuildQueueEntryConstants.TypeUnit) {
+						executed = TryExecuteUnit(playerId, front);
+					}
 
-				if (executed) {
-					queue.Remove(front);
-					logger.LogDebug("Build queue: executed and dequeued entry {EntryId} ({Type} {DefId}) for player {PlayerId}",
-						front.Id, front.Type, front.DefId, playerId);
+					if (executed) {
+						state.BuildQueue.Remove(front);
+						logger.LogDebug("Build queue: executed and dequeued entry {EntryId} ({Type} {DefId}) for player {PlayerId}",
+							front.Id, front.Type, front.DefId, playerId);
+					}
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
@@ -22,15 +22,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 		// Used by BattleReportGenerator for system messages (no sender)
 		public void SendMessage(PlayerId recipientId, string subject, string body) {
 			lock (_lock) {
-				world.GetPlayer(recipientId).State.Messages.Add(new Message {
-					Id = MessageIdFactory.NewMessageId(),
-					RecipientId = recipientId,
-					Subject = subject,
-					Body = body,
-					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-					IsRead = false,
-					SenderId = null
-				});
+				var state = world.GetPlayer(recipientId).State;
+				lock (state.StateLock) {
+					state.Messages.Add(new Message {
+						Id = MessageIdFactory.NewMessageId(),
+						RecipientId = recipientId,
+						Subject = subject,
+						Body = body,
+						CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+						IsRead = false,
+						SenderId = null
+					});
+				}
 			}
 		}
 
@@ -38,15 +41,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public MessageId Send(SendMessageCommand command) {
 			var id = MessageIdFactory.NewMessageId();
 			lock (_lock) {
-				world.GetPlayer(command.RecipientId).State.Messages.Add(new Message {
-					Id = id,
-					RecipientId = command.RecipientId,
-					SenderId = command.SenderId,
-					Subject = command.Subject,
-					Body = command.Body,
-					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-					IsRead = false
-				});
+				var state = world.GetPlayer(command.RecipientId).State;
+				lock (state.StateLock) {
+					state.Messages.Add(new Message {
+						Id = id,
+						RecipientId = command.RecipientId,
+						SenderId = command.SenderId,
+						Subject = command.Subject,
+						Body = command.Body,
+						CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+						IsRead = false
+					});
+				}
 			}
 			notificationService.Notify(command.RecipientId, GameNotificationType.MessageReceived,
 				$"New message: {command.Subject}");

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -74,20 +74,22 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public void ResetPlayer(PlayerId playerId) {
 			lock (_lock) {
 				var state = world.GetPlayer(playerId).State;
-				state.Resources = new Dictionary<ResourceDefId, decimal> {
-					{ Id.ResDef("land"), 50 },
-					{ Id.ResDef("minerals"), 5000 },
-					{ Id.ResDef("gas"), 3000 }
-				};
-				state.Assets = new HashSet<Asset> {
-					new Asset {
-						AssetDefId = Id.AssetDef("commandcenter"),
-						Level = 1
-					}
-				};
-				state.Units = new List<Unit>();
-				state.CurrentGameTick = world.GameTickState.CurrentGameTick;
-				state.LastGameTickUpdate = timeProvider.GetLocalNow().DateTime;
+				lock (state.StateLock) {
+					state.Resources = new Dictionary<ResourceDefId, decimal> {
+						{ Id.ResDef("land"), 50 },
+						{ Id.ResDef("minerals"), 5000 },
+						{ Id.ResDef("gas"), 3000 }
+					};
+					state.Assets = new HashSet<Asset> {
+						new Asset {
+							AssetDefId = Id.AssetDef("commandcenter"),
+							Level = 1
+						}
+					};
+					state.Units = new List<Unit>();
+					state.CurrentGameTick = world.GameTickState.CurrentGameTick;
+					state.LastGameTickUpdate = timeProvider.GetLocalNow().DateTime;
+				}
 			}
 		}
 

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
@@ -16,10 +16,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public void AppendSnapshot(PlayerId playerId, ResourceSnapshot snapshot) {
 			lock (_lock) {
-				var history = world.GetPlayer(playerId).State.ResourceHistory;
-				history.Add(snapshot);
-				while (history.Count > MaxHistorySize) {
-					history.RemoveAt(0);
+				var state = world.GetPlayer(playerId).State;
+				lock (state.StateLock) {
+					state.ResourceHistory.Add(snapshot);
+					while (state.ResourceHistory.Count > MaxHistorySize) {
+						state.ResourceHistory.RemoveAt(0);
+					}
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -29,10 +29,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public void DeductCost(PlayerId playerId, ResourceDefId resourceDefId, decimal value) => DeductCost(playerId, Cost.FromSingle(resourceDefId, value));
 		public void DeductCost(PlayerId playerId, Cost cost) {
 			lock (_lock) {
-				if (!resourceRepository.CanAfford(playerId, cost)) throw new CannotAffordException(cost);
-				var playerRes = Res(playerId);
-				foreach (var res in cost.Resources) {
-					DeductResourceUnchecked(playerId, res.Key, res.Value);
+				var state = world.GetPlayer(playerId).State;
+				lock (state.StateLock) {
+					if (!resourceRepository.CanAfford(playerId, cost)) throw new CannotAffordException(cost);
+					foreach (var res in cost.Resources) {
+						DeductResourceUnchecked(playerId, res.Key, res.Value);
+					}
 				}
 			}
 		}
@@ -47,13 +49,16 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		public decimal AddResources(PlayerId playerId, ResourceDefId resourceDefId, decimal value) {
 			lock (_lock) {
-				var playerRes = Res(playerId);
-				if (!playerRes.ContainsKey(resourceDefId)) {
-					playerRes.Add(resourceDefId, value);
-				} else {
-					playerRes[resourceDefId] += value;
+				var state = world.GetPlayer(playerId).State;
+				lock (state.StateLock) {
+					var playerRes = state.Resources;
+					if (!playerRes.ContainsKey(resourceDefId)) {
+						playerRes.Add(resourceDefId, value);
+					} else {
+						playerRes[resourceDefId] += value;
+					}
+					return playerRes[resourceDefId];
 				}
-				return playerRes[resourceDefId];
 			}
 		}
 
@@ -71,14 +76,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 				var toResource = tradeableResources.First(r => r != cmd.FromResource);
 				var cost = Cost.FromSingle(cmd.FromResource, 2m * cmd.Amount);
 
-				if (!resourceRepository.CanAfford(cmd.PlayerId, cost)) throw new CannotAffordException(cost);
+				var state = world.GetPlayer(cmd.PlayerId).State;
+				lock (state.StateLock) {
+					if (!resourceRepository.CanAfford(cmd.PlayerId, cost)) throw new CannotAffordException(cost);
 
-				DeductResourceUnchecked(cmd.PlayerId, cmd.FromResource, 2m * cmd.Amount);
-				var playerRes = Res(cmd.PlayerId);
-				if (!playerRes.ContainsKey(toResource)) {
-					playerRes.Add(toResource, cmd.Amount);
-				} else {
-					playerRes[toResource] += cmd.Amount;
+					DeductResourceUnchecked(cmd.PlayerId, cmd.FromResource, 2m * cmd.Amount);
+					var playerRes = state.Resources;
+					if (!playerRes.ContainsKey(toResource)) {
+						playerRes.Add(toResource, cmd.Amount);
+					} else {
+						playerRes[toResource] += cmd.Amount;
+					}
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
@@ -69,7 +69,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 					CreatedAt = now
 				};
 
-				world.GetPlayer(command.SpyingPlayerId).State.SpyMissions.Add(mission);
+				var spyState = world.GetPlayer(command.SpyingPlayerId).State;
+				lock (spyState.StateLock) {
+					spyState.SpyMissions.Add(mission);
+				}
 
 				return (mission.Id, estimatedResolveAt);
 			}
@@ -98,13 +101,15 @@ namespace BrowserGameEngine.StatefulGameServer {
 			var detectionProbability = techRepository.GetTotalEffectValue(mission.TargetPlayerId, TechEffectType.CounterIntelDetection);
 			var intercepted = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
 
-			targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
-				Id: Guid.NewGuid(),
-				AttackerPlayerId: spyingPlayerId,
-				ActionType: mission.MissionType.ToString(),
-				Detected: intercepted,
-				Timestamp: timeProvider.GetUtcNow().UtcDateTime
-			));
+			lock (targetState.StateLock) {
+				targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
+					Id: Guid.NewGuid(),
+					AttackerPlayerId: spyingPlayerId,
+					ActionType: mission.MissionType.ToString(),
+					Detected: intercepted,
+					Timestamp: timeProvider.GetUtcNow().UtcDateTime
+				));
+			}
 
 			if (intercepted) {
 				mission.Status = SpyMissionStatus.Intercepted;

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -60,8 +60,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 				resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, spyCost);
 
 				var now = timeProvider.GetUtcNow().UtcDateTime;
-				world.GetPlayer(command.SpyingPlayerId).State.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
-
+				var spyState = world.GetPlayer(command.SpyingPlayerId).State;
+				lock (spyState.StateLock) {
+					spyState.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
+				}
 
 				var targetState = world.GetPlayer(command.TargetPlayerId).State;
 				var rng = new Random();
@@ -86,13 +88,15 @@ namespace BrowserGameEngine.StatefulGameServer {
 				var detectionProbability = techRepository.GetTotalEffectValue(command.TargetPlayerId, TechEffectType.CounterIntelDetection);
 				var detected = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
 
-				targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
-					Id: Guid.NewGuid(),
-					AttackerPlayerId: command.SpyingPlayerId,
-					ActionType: "Spy",
-					Detected: detected,
-					Timestamp: now
-				));
+				lock (targetState.StateLock) {
+					targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
+						Id: Guid.NewGuid(),
+						AttackerPlayerId: command.SpyingPlayerId,
+						ActionType: "Spy",
+						Detected: detected,
+						Timestamp: now
+					));
+				}
 
 				var result = new SpyResult(
 					TargetPlayerId: command.TargetPlayerId,
@@ -102,7 +106,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 					CooldownExpiresAt: now + SpyConstants.CooldownDuration
 				);
 
-				world.GetPlayer(command.SpyingPlayerId).State.LastSpyResults[command.TargetPlayerId.ToString()] = result;
+				lock (spyState.StateLock) {
+					spyState.LastSpyResults[command.TargetPlayerId.ToString()] = result;
+				}
 
 				return result;
 			}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
@@ -67,7 +67,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 				state.TechResearchTimer--;
 				if (state.TechResearchTimer == 0) {
-					state.UnlockedTechs.Add(state.TechBeingResearched);
+					lock (state.StateLock) {
+						state.UnlockedTechs.Add(state.TechBeingResearched);
+					}
 					state.TechBeingResearched = null;
 				}
 			}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -53,11 +53,14 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private Unit? Unit(PlayerId playerId, UnitId unitId) => Units(playerId).SingleOrDefault(x => x.UnitId.Equals(unitId));
 
 		private void AddUnit(PlayerId playerId, UnitDefId unitDefId, int count) {
-			Units(playerId).Add(new Unit {
-				UnitId = Id.NewUnitId(),
-				UnitDefId = unitDefId,
-				Count = count
-			});
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.Units.Add(new Unit {
+					UnitId = Id.NewUnitId(),
+					UnitDefId = unitDefId,
+					Count = count
+				});
+			}
 		}
 
 		public void GrantUnits(PlayerId playerId, UnitDefId unitDefId, int count) {
@@ -209,11 +212,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		private void RemoveUnitsOfType(PlayerId playerId, UnitDefId unitDefId) {
-			Units(playerId).RemoveAll(x => x.UnitDefId == unitDefId);
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.Units.RemoveAll(x => x.UnitDefId == unitDefId);
+			}
 		}
 
 		private void RemoveUnit(PlayerId playerId, UnitId unitId) {
-			Units(playerId).RemoveAll(x => x.UnitId == unitId);
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.Units.RemoveAll(x => x.UnitId == unitId);
+			}
 		}
 
 		private int TryRemoveUnitCount(PlayerId playerId, UnitId unitId, int count) {


### PR DESCRIPTION
## Summary
- Fixes recurring `System.ArgumentException: Destination array was not long enough` errors (~7/day in CloudWatch) caused by `PlayerState.ToImmutable()` racing with write repositories when serializing game state every 10 seconds
- Adds a `StateLock` to `PlayerState`, acquired by `ToImmutable()` and by all write repositories around collection mutations (Lists, Dictionaries, HashSets)
- Lock nesting order is always `repo._lock` → `StateLock`, preventing deadlocks

## Test plan
- [x] All 739 existing tests pass
- [ ] Monitor CloudWatch `/ecs/bge` logs for absence of "Failed to store game state" errors after deploy