### PR TITLE
fix: add GET /api/game/tick-info endpoint

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GameController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GameController.cs
@@ -1,0 +1,46 @@
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace BrowserGameEngine.FrontendServer.Controllers {
+	[ApiController]
+	[Authorize]
+	[Route("api/game")]
+	public class GameController : ControllerBase {
+		private readonly CurrentUserContext currentUserContext;
+		private readonly GameTickEngine gameTickEngine;
+		private readonly MessageRepository messageRepository;
+		private readonly TimeProvider timeProvider;
+
+		public GameController(
+			CurrentUserContext currentUserContext,
+			GameTickEngine gameTickEngine,
+			MessageRepository messageRepository,
+			TimeProvider timeProvider
+		) {
+			this.currentUserContext = currentUserContext;
+			this.gameTickEngine = gameTickEngine;
+			this.messageRepository = messageRepository;
+			this.timeProvider = timeProvider;
+		}
+
+		/// <summary>Returns the current server time, next tick timestamp, and unread message count.</summary>
+		[HttpGet("tick-info")]
+		[ProducesResponseType(typeof(TickInfoViewModel), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<TickInfoViewModel> GetTickInfo() {
+			if (!currentUserContext.IsValid) return Unauthorized();
+
+			var unread = messageRepository.GetUnreadCount(currentUserContext.PlayerId!);
+
+			return Ok(new TickInfoViewModel(
+				ServerTime: timeProvider.GetUtcNow().UtcDateTime,
+				NextTickAt: gameTickEngine.NextTickAt.ToUniversalTime(),
+				UnreadMessageCount: unread
+			));
+		}
+	}
+}

--- a/src/BrowserGameEngine.Shared/GameViewModels.cs
+++ b/src/BrowserGameEngine.Shared/GameViewModels.cs
@@ -77,6 +77,13 @@ namespace BrowserGameEngine.Shared {
 		string? TournamentId = null
 	);
 
+	/// <summary>Tick timing info returned by GET /api/game/tick-info.</summary>
+	public record TickInfoViewModel(
+		DateTime ServerTime,
+		DateTime NextTickAt,
+		int UnreadMessageCount
+	);
+
 	/// <summary>A game the current user is actively playing in, with their player info.</summary>
 	public record MyGameViewModel(
 		string GameId,


### PR DESCRIPTION
## Summary
- Adds `GET /api/game/tick-info` endpoint that returns `serverTime`, `nextTickAt`, and `unreadMessageCount` as JSON
- The route was documented in `docs/BOT-CLIENT.md` and used by the Agent1 bot client, but was never implemented on the server — requests fell through to the SPA HTML fallback
- Adds `TickInfoViewModel` record to `GameViewModels.cs` and a new `GameController` (route prefix `api/game`)

## Test plan
- [x] `dotnet build` succeeds
- [x] All 739 existing unit tests pass
- [ ] Deploy and verify `GET /api/game/tick-info` returns JSON with `serverTime`, `nextTickAt`, `unreadMessageCount`
- [ ] Verify Agent1 bot loop works end-to-end against the updated server

Closes #293