### PR TITLE
refactor: replace per-repo locks with per-player StateLock

### DIFF
--- a/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Notifications/NotificationService.cs
@@ -8,7 +8,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer.Notifications {
 	public class NotificationService : INotificationService {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly IGameEventPublisher eventPublisher;
@@ -29,10 +28,8 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 				ReadAt: null
 			);
 			var state = world.GetPlayer(playerId).State;
-			lock (_lock) {
-				lock (state.StateLock) {
-					state.Notifications.Add(notification);
-				}
+			lock (state.StateLock) {
+				state.Notifications.Add(notification);
 			}
 			eventPublisher.PublishToPlayer(playerId, GameEventTypes.ReceiveNotification, new {
 				type = type.ToString(),
@@ -43,38 +40,36 @@ namespace BrowserGameEngine.StatefulGameServer.Notifications {
 		}
 
 		public void MarkRead(PlayerId playerId, Guid notificationId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					var idx = state.Notifications.FindIndex(n => n.Id == notificationId);
-					if (idx >= 0) {
-						state.Notifications[idx] = state.Notifications[idx] with { ReadAt = DateTime.UtcNow };
-					}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				var idx = state.Notifications.FindIndex(n => n.Id == notificationId);
+				if (idx >= 0) {
+					state.Notifications[idx] = state.Notifications[idx] with { ReadAt = DateTime.UtcNow };
 				}
 			}
 		}
 
 		public void MarkAllRead(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					var now = DateTime.UtcNow;
-					for (int i = 0; i < state.Notifications.Count; i++) {
-						if (!state.Notifications[i].IsRead) {
-							state.Notifications[i] = state.Notifications[i] with { ReadAt = now };
-						}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				var now = DateTime.UtcNow;
+				for (int i = 0; i < state.Notifications.Count; i++) {
+					if (!state.Notifications[i].IsRead) {
+						state.Notifications[i] = state.Notifications[i] with { ReadAt = now };
 					}
 				}
 			}
 		}
 
 		public IReadOnlyList<GameNotification> GetNotifications(PlayerId playerId, bool unreadOnly = false) {
-			var notifications = world.GetPlayer(playerId).State.Notifications;
-			IEnumerable<GameNotification> result = notifications.OrderByDescending(n => n.CreatedAt);
-			if (unreadOnly) {
-				result = result.Where(n => !n.IsRead);
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				IEnumerable<GameNotification> result = state.Notifications.OrderByDescending(n => n.CreatedAt);
+				if (unreadOnly) {
+					result = result.Where(n => !n.IsRead);
+				}
+				return result.ToList();
 			}
-			return result.ToList();
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Asset/AssetRepositoryWrite.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -9,7 +9,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class AssetRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly ILogger<AssetRepositoryWrite> logger;
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
@@ -36,13 +35,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.gameDef = gameDef;
 		}
 
-		private ISet<Asset> Assets(PlayerId playerId) => world.GetPlayer(playerId).State.Assets;
-
 		/// <summary>
 		/// Building assets takes a number of gameticks until finished.
 		/// </summary>
 		public void BuildAsset(BuildAssetCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				var assetDef = gameDef.GetAssetDef(command.AssetDefId);
 				if (assetDef == null) throw new AssetNotFoundException(command.AssetDefId);
 				if (assetRepository.HasAsset(command.PlayerId, assetDef.Id)) throw new AssetAlreadyBuiltException(assetDef.Id);
@@ -71,7 +69,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void GrantBuilding(PlayerId playerId, AssetDefId assetDefId) {
-			lock (_lock) {
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				actionQueueRepository.RemoveActions(
 					playerId,
 					AssetBuildActionConstants.Name,
@@ -84,7 +83,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ExecuteGameActions(PlayerId playerId) {
-			lock (_lock) {
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				var actions = actionQueueRepository.GetAndRemoveDueActions(playerId, AssetBuildActionConstants.Name, world.GameTickState.CurrentGameTick);
 				foreach(var action in actions) {
 					AddAsset(action.PlayerId, Id.AssetDef(action.Properties[AssetBuildActionConstants.AssetDefId]));

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Battle/BattleReportRepositoryWrite.cs
@@ -1,12 +1,10 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
-using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class BattleReportRepositoryWrite {
 		public const int MaxReportsPerPlayer = 50;
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 
@@ -15,13 +13,11 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void AddBattleReport(PlayerId playerId, BattleReport report) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					state.BattleReports.Add(report);
-					while (state.BattleReports.Count > MaxReportsPerPlayer) {
-						state.BattleReports.RemoveAt(0);
-					}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.BattleReports.Add(report);
+				while (state.BattleReports.Count > MaxReportsPerPlayer) {
+					state.BattleReports.RemoveAt(0);
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
@@ -10,7 +10,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class BuildQueueRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly ILogger<BuildQueueRepositoryWrite> logger;
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
@@ -43,39 +42,34 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.gameDef = gameDef;
 		}
 
-		private List<BuildQueueEntry> Queue(PlayerId playerId) => world.GetPlayer(playerId).State.BuildQueue;
-
 		public void AddToQueue(AddToQueueCommand command) {
-			lock (_lock) {
-				var state = world.GetPlayer(command.PlayerId).State;
-				lock (state.StateLock) {
-					var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
-					state.BuildQueue.Add(new BuildQueueEntry {
-						Id = Guid.NewGuid(),
-						Type = command.Type,
-						DefId = command.DefId,
-						Count = command.Count,
-						Priority = priority
-					});
-				}
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
+				state.BuildQueue.Add(new BuildQueueEntry {
+					Id = Guid.NewGuid(),
+					Type = command.Type,
+					DefId = command.DefId,
+					Count = command.Count,
+					Priority = priority
+				});
 			}
 		}
 
 		public void RemoveFromQueue(RemoveFromQueueCommand command) {
-			lock (_lock) {
-				var state = world.GetPlayer(command.PlayerId).State;
-				lock (state.StateLock) {
-					var entry = state.BuildQueue.SingleOrDefault(x => x.Id == command.EntryId);
-					if (entry != null) {
-						state.BuildQueue.Remove(entry);
-					}
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				var entry = state.BuildQueue.SingleOrDefault(x => x.Id == command.EntryId);
+				if (entry != null) {
+					state.BuildQueue.Remove(entry);
 				}
 			}
 		}
 
 		public void ReorderQueue(ReorderQueueCommand command) {
-			lock (_lock) {
-				var entry = Queue(command.PlayerId).SingleOrDefault(x => x.Id == command.EntryId);
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				var entry = state.BuildQueue.SingleOrDefault(x => x.Id == command.EntryId);
 				if (entry == null) return;
 				entry.Priority = command.NewPriority;
 			}
@@ -86,24 +80,22 @@ namespace BrowserGameEngine.StatefulGameServer {
 		/// are met the entry is executed and dequeued. If not met, the entry stays.
 		/// </summary>
 		public void TryExecuteAndDequeueFirst(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					var front = state.BuildQueue.OrderBy(x => x.Priority).FirstOrDefault();
-					if (front == null) return;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				var front = state.BuildQueue.OrderBy(x => x.Priority).FirstOrDefault();
+				if (front == null) return;
 
-					bool executed = false;
-					if (front.Type == BuildQueueEntryConstants.TypeAsset) {
-						executed = TryExecuteAsset(playerId, front);
-					} else if (front.Type == BuildQueueEntryConstants.TypeUnit) {
-						executed = TryExecuteUnit(playerId, front);
-					}
+				bool executed = false;
+				if (front.Type == BuildQueueEntryConstants.TypeAsset) {
+					executed = TryExecuteAsset(playerId, front);
+				} else if (front.Type == BuildQueueEntryConstants.TypeUnit) {
+					executed = TryExecuteUnit(playerId, front);
+				}
 
-					if (executed) {
-						state.BuildQueue.Remove(front);
-						logger.LogDebug("Build queue: executed and dequeued entry {EntryId} ({Type} {DefId}) for player {PlayerId}",
-							front.Id, front.Type, front.DefId, playerId);
-					}
+				if (executed) {
+					state.BuildQueue.Remove(front);
+					logger.LogDebug("Build queue: executed and dequeued entry {EntryId} ({Type} {DefId}) for player {PlayerId}",
+						front.Id, front.Type, front.DefId, playerId);
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Messages/MessageRepositoryWrite.cs
@@ -7,7 +7,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class MessageRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly TimeProvider timeProvider;
@@ -21,38 +20,34 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		// Used by BattleReportGenerator for system messages (no sender)
 		public void SendMessage(PlayerId recipientId, string subject, string body) {
-			lock (_lock) {
-				var state = world.GetPlayer(recipientId).State;
-				lock (state.StateLock) {
-					state.Messages.Add(new Message {
-						Id = MessageIdFactory.NewMessageId(),
-						RecipientId = recipientId,
-						Subject = subject,
-						Body = body,
-						CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-						IsRead = false,
-						SenderId = null
-					});
-				}
+			var state = world.GetPlayer(recipientId).State;
+			lock (state.StateLock) {
+				state.Messages.Add(new Message {
+					Id = MessageIdFactory.NewMessageId(),
+					RecipientId = recipientId,
+					Subject = subject,
+					Body = body,
+					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+					IsRead = false,
+					SenderId = null
+				});
 			}
 		}
 
 		// Used for player-to-player messages
 		public MessageId Send(SendMessageCommand command) {
 			var id = MessageIdFactory.NewMessageId();
-			lock (_lock) {
-				var state = world.GetPlayer(command.RecipientId).State;
-				lock (state.StateLock) {
-					state.Messages.Add(new Message {
-						Id = id,
-						RecipientId = command.RecipientId,
-						SenderId = command.SenderId,
-						Subject = command.Subject,
-						Body = command.Body,
-						CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
-						IsRead = false
-					});
-				}
+			var state = world.GetPlayer(command.RecipientId).State;
+			lock (state.StateLock) {
+				state.Messages.Add(new Message {
+					Id = id,
+					RecipientId = command.RecipientId,
+					SenderId = command.SenderId,
+					Subject = command.Subject,
+					Body = command.Body,
+					CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+					IsRead = false
+				});
 			}
 			notificationService.Notify(command.RecipientId, GameNotificationType.MessageReceived,
 				$"New message: {command.Subject}");
@@ -60,9 +55,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void MarkRead(MarkMessageReadCommand command) {
-			lock (_lock) {
-				var message = world.GetPlayer(command.PlayerId).State.Messages
-					.Find(m => m.Id.Equals(command.MessageId));
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				var message = state.Messages.Find(m => m.Id.Equals(command.MessageId));
 				if (message != null) message.IsRead = true;
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -27,7 +27,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ChangePlayerName(ChangePlayerNameCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				Players[command.PlayerId].Name = command.NewName;
 			}
 		}
@@ -37,24 +38,24 @@ namespace BrowserGameEngine.StatefulGameServer {
 				throw new ArgumentOutOfRangeException("Worker counts cannot be negative.");
 			if (command.MineralWorkers + command.GasWorkers > totalWorkers)
 				throw new ArgumentOutOfRangeException($"Cannot assign {command.MineralWorkers + command.GasWorkers} workers: only {totalWorkers} available.");
-			lock (_lock) {
-				var state = world.GetPlayer(command.PlayerId).State;
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				state.MineralWorkers = command.MineralWorkers;
 				state.GasWorkers = command.GasWorkers;
 			}
 		}
 
 		public void GrantEmergencyWorkers(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				state.MineralWorkers = 1;
 				state.GasWorkers = 1;
 			}
 		}
 
 		public void CaptureWorkers(PlayerId playerId, int count) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				int mineralRemoved = Math.Min(count, state.MineralWorkers);
 				state.MineralWorkers -= mineralRemoved;
 				int remaining = count - mineralRemoved;
@@ -64,32 +65,30 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		internal GameTick IncrementTick(PlayerId playerId) {
-			lock (_lock) {
-				var player = world.GetPlayer(playerId);
-				player.State.CurrentGameTick = player.State.CurrentGameTick with { Tick = player.State.CurrentGameTick.Tick + 1 };
-				return player.State.CurrentGameTick;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.CurrentGameTick = state.CurrentGameTick with { Tick = state.CurrentGameTick.Tick + 1 };
+				return state.CurrentGameTick;
 			}
 		}
 
 		public void ResetPlayer(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					state.Resources = new Dictionary<ResourceDefId, decimal> {
-						{ Id.ResDef("land"), 50 },
-						{ Id.ResDef("minerals"), 5000 },
-						{ Id.ResDef("gas"), 3000 }
-					};
-					state.Assets = new HashSet<Asset> {
-						new Asset {
-							AssetDefId = Id.AssetDef("commandcenter"),
-							Level = 1
-						}
-					};
-					state.Units = new List<Unit>();
-					state.CurrentGameTick = world.GameTickState.CurrentGameTick;
-					state.LastGameTickUpdate = timeProvider.GetLocalNow().DateTime;
-				}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.Resources = new Dictionary<ResourceDefId, decimal> {
+					{ Id.ResDef("land"), 50 },
+					{ Id.ResDef("minerals"), 5000 },
+					{ Id.ResDef("gas"), 3000 }
+				};
+				state.Assets = new HashSet<Asset> {
+					new Asset {
+						AssetDefId = Id.AssetDef("commandcenter"),
+						Level = 1
+					}
+				};
+				state.Units = new List<Unit>();
+				state.CurrentGameTick = world.GameTickState.CurrentGameTick;
+				state.LastGameTickUpdate = timeProvider.GetLocalNow().DateTime;
 			}
 		}
 
@@ -148,21 +147,18 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void CompleteTutorial(PlayerId playerId) {
-			lock (_lock) {
-				world.GetPlayer(playerId).State.TutorialCompleted = true;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.TutorialCompleted = true;
 			}
 		}
 
 		public void BanPlayer(PlayerId playerId) {
-			lock (_lock) {
-				world.GetPlayer(playerId).IsBanned = true;
-			}
+			world.GetPlayer(playerId).IsBanned = true;
 		}
 
 		public void UnbanPlayer(PlayerId playerId) {
-			lock (_lock) {
-				world.GetPlayer(playerId).IsBanned = false;
-			}
+			world.GetPlayer(playerId).IsBanned = false;
 		}
 
 		public void DeletePlayer(PlayerId playerId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceHistoryRepositoryWrite.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
@@ -8,20 +7,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
-		private readonly Lock _lock = new();
 
 		public ResourceHistoryRepositoryWrite(IWorldStateAccessor worldStateAccessor) {
 			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public void AppendSnapshot(PlayerId playerId, ResourceSnapshot snapshot) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					state.ResourceHistory.Add(snapshot);
-					while (state.ResourceHistory.Count > MaxHistorySize) {
-						state.ResourceHistory.RemoveAt(0);
-					}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				state.ResourceHistory.Add(snapshot);
+				while (state.ResourceHistory.Count > MaxHistorySize) {
+					state.ResourceHistory.RemoveAt(0);
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ResourceRepositoryWrite.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -9,7 +9,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class ResourceRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ResourceRepository resourceRepository;
@@ -24,69 +23,57 @@ namespace BrowserGameEngine.StatefulGameServer {
 			this.gameDef = gameDef;
 		}
 
-		private IDictionary<ResourceDefId, decimal> Res(PlayerId playerId) => world.GetPlayer(playerId).State.Resources;
-
 		public void DeductCost(PlayerId playerId, ResourceDefId resourceDefId, decimal value) => DeductCost(playerId, Cost.FromSingle(resourceDefId, value));
 		public void DeductCost(PlayerId playerId, Cost cost) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					if (!resourceRepository.CanAfford(playerId, cost)) throw new CannotAffordException(cost);
-					foreach (var res in cost.Resources) {
-						DeductResourceUnchecked(playerId, res.Key, res.Value);
-					}
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				if (!resourceRepository.CanAfford(playerId, cost)) throw new CannotAffordException(cost);
+				foreach (var res in cost.Resources) {
+					DeductResourceUnchecked(state, res.Key, res.Value);
 				}
 			}
 		}
 
-		private void DeductResourceUnchecked(PlayerId playerId, ResourceDefId resourceDefId, decimal value) {
+		private void DeductResourceUnchecked(PlayerState state, ResourceDefId resourceDefId, decimal value) {
 			if (value < 0) throw new InvalidGameDefException("Resource cost cannot be negative.");
-			if (!Res(playerId).ContainsKey(resourceDefId)) throw new CannotAffordException(Cost.FromSingle(resourceDefId, value));
-
-			// deduct cost
-			Res(playerId)[resourceDefId] -= value;
+			if (!state.Resources.ContainsKey(resourceDefId)) throw new CannotAffordException(Cost.FromSingle(resourceDefId, value));
+			state.Resources[resourceDefId] -= value;
 		}
 
 		public decimal AddResources(PlayerId playerId, ResourceDefId resourceDefId, decimal value) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
-				lock (state.StateLock) {
-					var playerRes = state.Resources;
-					if (!playerRes.ContainsKey(resourceDefId)) {
-						playerRes.Add(resourceDefId, value);
-					} else {
-						playerRes[resourceDefId] += value;
-					}
-					return playerRes[resourceDefId];
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				if (!state.Resources.ContainsKey(resourceDefId)) {
+					state.Resources.Add(resourceDefId, value);
+				} else {
+					state.Resources[resourceDefId] += value;
 				}
+				return state.Resources[resourceDefId];
 			}
 		}
 
 		public void TradeResource(TradeResourceCommand cmd) {
-			lock (_lock) {
-				var tradeableResources = gameDef.Resources
-					.Where(r => r.Id != gameDef.ScoreResource)
-					.Select(r => r.Id)
-					.ToList();
+			var tradeableResources = gameDef.Resources
+				.Where(r => r.Id != gameDef.ScoreResource)
+				.Select(r => r.Id)
+				.ToList();
 
-				if (!tradeableResources.Contains(cmd.FromResource))
-					throw new InvalidOperationException($"Resource '{cmd.FromResource.Id}' is not tradeable.");
+			if (!tradeableResources.Contains(cmd.FromResource))
+				throw new InvalidOperationException($"Resource '{cmd.FromResource.Id}' is not tradeable.");
 
-				// NOTE: assumes exactly 2 tradeable resources; correct for SCO but would break if the game def ever adds a third
-				var toResource = tradeableResources.First(r => r != cmd.FromResource);
-				var cost = Cost.FromSingle(cmd.FromResource, 2m * cmd.Amount);
+			// NOTE: assumes exactly 2 tradeable resources; correct for SCO but would break if the game def ever adds a third
+			var toResource = tradeableResources.First(r => r != cmd.FromResource);
+			var cost = Cost.FromSingle(cmd.FromResource, 2m * cmd.Amount);
 
-				var state = world.GetPlayer(cmd.PlayerId).State;
-				lock (state.StateLock) {
-					if (!resourceRepository.CanAfford(cmd.PlayerId, cost)) throw new CannotAffordException(cost);
+			var state = world.GetPlayer(cmd.PlayerId).State;
+			lock (state.StateLock) {
+				if (!resourceRepository.CanAfford(cmd.PlayerId, cost)) throw new CannotAffordException(cost);
 
-					DeductResourceUnchecked(cmd.PlayerId, cmd.FromResource, 2m * cmd.Amount);
-					var playerRes = state.Resources;
-					if (!playerRes.ContainsKey(toResource)) {
-						playerRes.Add(toResource, cmd.Amount);
-					} else {
-						playerRes[toResource] += cmd.Amount;
-					}
+				DeductResourceUnchecked(state, cmd.FromResource, 2m * cmd.Amount);
+				if (!state.Resources.ContainsKey(toResource)) {
+					state.Resources.Add(toResource, cmd.Amount);
+				} else {
+					state.Resources[toResource] += cmd.Amount;
 				}
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyMissionRepositoryWrite.cs
@@ -9,7 +9,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class SpyMissionRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ResourceRepositoryWrite resourceRepositoryWrite;
@@ -41,46 +40,44 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public (Guid MissionId, DateTime EstimatedResolveAt) SendMission(SpyMissionCommand command) {
-			lock (_lock) {
-				world.ValidatePlayer(command.SpyingPlayerId);
-				world.ValidatePlayer(command.TargetPlayerId);
+			world.ValidatePlayer(command.SpyingPlayerId);
+			world.ValidatePlayer(command.TargetPlayerId);
 
-				var ineligibility = playerRepository.GetIneligibilityReason(command.SpyingPlayerId, command.TargetPlayerId);
-				if (ineligibility is AttackIneligibilityReason.DefenderProtected or
-					AttackIneligibilityReason.AttackerProtected or
-					AttackIneligibilityReason.SameAlliance) {
-					throw new PlayerNotAttackableException(command.TargetPlayerId, ineligibility.Value);
-				}
-
-				var cost = GetMissionCost(command.MissionType);
-				resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, cost);
-
-				var timerTicks = SpyMissionConstants.GetTimerTicks(command.MissionType);
-				var now = timeProvider.GetUtcNow().UtcDateTime;
-				var estimatedResolveAt = now + gameDef.TickDuration * timerTicks;
-
-				var mission = new SpyMission {
-					Id = Guid.NewGuid(),
-					TargetPlayerId = command.TargetPlayerId,
-					MissionType = command.MissionType,
-					Status = SpyMissionStatus.InTransit,
-					TimerTicks = timerTicks,
-					Result = null,
-					CreatedAt = now
-				};
-
-				var spyState = world.GetPlayer(command.SpyingPlayerId).State;
-				lock (spyState.StateLock) {
-					spyState.SpyMissions.Add(mission);
-				}
-
-				return (mission.Id, estimatedResolveAt);
+			var ineligibility = playerRepository.GetIneligibilityReason(command.SpyingPlayerId, command.TargetPlayerId);
+			if (ineligibility is AttackIneligibilityReason.DefenderProtected or
+				AttackIneligibilityReason.AttackerProtected or
+				AttackIneligibilityReason.SameAlliance) {
+				throw new PlayerNotAttackableException(command.TargetPlayerId, ineligibility.Value);
 			}
+
+			var cost = GetMissionCost(command.MissionType);
+			resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, cost);
+
+			var timerTicks = SpyMissionConstants.GetTimerTicks(command.MissionType);
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			var estimatedResolveAt = now + gameDef.TickDuration * timerTicks;
+
+			var mission = new SpyMission {
+				Id = Guid.NewGuid(),
+				TargetPlayerId = command.TargetPlayerId,
+				MissionType = command.MissionType,
+				Status = SpyMissionStatus.InTransit,
+				TimerTicks = timerTicks,
+				Result = null,
+				CreatedAt = now
+			};
+
+			var spyState = world.GetPlayer(command.SpyingPlayerId).State;
+			lock (spyState.StateLock) {
+				spyState.SpyMissions.Add(mission);
+			}
+
+			return (mission.Id, estimatedResolveAt);
 		}
 
 		public void ProcessMissions(PlayerId spyingPlayerId) {
-			lock (_lock) {
-				var playerState = world.GetPlayer(spyingPlayerId).State;
+			var playerState = world.GetPlayer(spyingPlayerId).State;
+			lock (playerState.StateLock) {
 				var activeMissions = playerState.SpyMissions
 					.Where(m => m.Status == SpyMissionStatus.InTransit)
 					.ToList();

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Spy/SpyRepositoryWrite.cs
@@ -9,7 +9,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class SpyRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly SpyRepository spyRepository;
@@ -48,70 +47,68 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public Cost GetSpyCost() => spyCost;
 
 		public SpyResult ExecuteSpy(SpyCommand command) {
-			lock (_lock) {
-				world.ValidatePlayer(command.SpyingPlayerId);
-				world.ValidatePlayer(command.TargetPlayerId);
+			world.ValidatePlayer(command.SpyingPlayerId);
+			world.ValidatePlayer(command.TargetPlayerId);
 
-				var cooldownExpiry = spyRepository.GetCooldownExpiry(command.SpyingPlayerId, command.TargetPlayerId);
-				if (cooldownExpiry != null) {
-					throw new SpyCooldownException(command.TargetPlayerId, cooldownExpiry.Value);
-				}
-
-				resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, spyCost);
-
-				var now = timeProvider.GetUtcNow().UtcDateTime;
-				var spyState = world.GetPlayer(command.SpyingPlayerId).State;
-				lock (spyState.StateLock) {
-					spyState.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
-				}
-
-				var targetState = world.GetPlayer(command.TargetPlayerId).State;
-				var rng = new Random();
-
-				var approxResources = new Dictionary<ResourceDefId, decimal>();
-				foreach (var kv in targetState.Resources) {
-					var noise = 1.0 + (rng.NextDouble() * 0.6 - 0.3); // ±30%
-					approxResources[kv.Key] = Math.Max(0, (decimal)((double)kv.Value * noise));
-				}
-
-				var unitGroups = targetState.Units
-					.Where(u => u.Position == null) // only home units
-					.GroupBy(u => u.UnitDefId)
-					.Select(g => {
-						var exactCount = g.Sum(u => u.Count);
-						var noise = 1.0 + (rng.NextDouble() * 0.4 - 0.2); // ±20%
-						return new SpyUnitEstimate(g.Key, Math.Max(0, (int)(exactCount * noise)));
-					})
-					.ToList();
-
-				// Detection roll: probability is the sum of CounterIntelDetection tech effect values for the target
-				var detectionProbability = techRepository.GetTotalEffectValue(command.TargetPlayerId, TechEffectType.CounterIntelDetection);
-				var detected = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
-
-				lock (targetState.StateLock) {
-					targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
-						Id: Guid.NewGuid(),
-						AttackerPlayerId: command.SpyingPlayerId,
-						ActionType: "Spy",
-						Detected: detected,
-						Timestamp: now
-					));
-				}
-
-				var result = new SpyResult(
-					TargetPlayerId: command.TargetPlayerId,
-					ApproximateResources: approxResources,
-					UnitEstimates: unitGroups,
-					ReportTime: now,
-					CooldownExpiresAt: now + SpyConstants.CooldownDuration
-				);
-
-				lock (spyState.StateLock) {
-					spyState.LastSpyResults[command.TargetPlayerId.ToString()] = result;
-				}
-
-				return result;
+			var cooldownExpiry = spyRepository.GetCooldownExpiry(command.SpyingPlayerId, command.TargetPlayerId);
+			if (cooldownExpiry != null) {
+				throw new SpyCooldownException(command.TargetPlayerId, cooldownExpiry.Value);
 			}
+
+			resourceRepositoryWrite.DeductCost(command.SpyingPlayerId, spyCost);
+
+			var now = timeProvider.GetUtcNow().UtcDateTime;
+			var spyState = world.GetPlayer(command.SpyingPlayerId).State;
+			lock (spyState.StateLock) {
+				spyState.SpyCooldowns[command.TargetPlayerId.ToString()] = now;
+			}
+
+			var targetState = world.GetPlayer(command.TargetPlayerId).State;
+			var rng = new Random();
+
+			var approxResources = new Dictionary<ResourceDefId, decimal>();
+			foreach (var kv in targetState.Resources) {
+				var noise = 1.0 + (rng.NextDouble() * 0.6 - 0.3); // ±30%
+				approxResources[kv.Key] = Math.Max(0, (decimal)((double)kv.Value * noise));
+			}
+
+			var unitGroups = targetState.Units
+				.Where(u => u.Position == null) // only home units
+				.GroupBy(u => u.UnitDefId)
+				.Select(g => {
+					var exactCount = g.Sum(u => u.Count);
+					var noise = 1.0 + (rng.NextDouble() * 0.4 - 0.2); // ±20%
+					return new SpyUnitEstimate(g.Key, Math.Max(0, (int)(exactCount * noise)));
+				})
+				.ToList();
+
+			// Detection roll: probability is the sum of CounterIntelDetection tech effect values for the target
+			var detectionProbability = techRepository.GetTotalEffectValue(command.TargetPlayerId, TechEffectType.CounterIntelDetection);
+			var detected = detectionProbability > 0 && (decimal)rng.NextDouble() < detectionProbability;
+
+			lock (targetState.StateLock) {
+				targetState.SpyAttemptLogs.Add(new SpyAttemptLog(
+					Id: Guid.NewGuid(),
+					AttackerPlayerId: command.SpyingPlayerId,
+					ActionType: "Spy",
+					Detected: detected,
+					Timestamp: now
+				));
+			}
+
+			var result = new SpyResult(
+				TargetPlayerId: command.TargetPlayerId,
+				ApproximateResources: approxResources,
+				UnitEstimates: unitGroups,
+				ReportTime: now,
+				CooldownExpiresAt: now + SpyConstants.CooldownDuration
+			);
+
+			lock (spyState.StateLock) {
+				spyState.LastSpyResults[command.TargetPlayerId.ToString()] = result;
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Tech/TechRepositoryWrite.cs
@@ -6,7 +6,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class TechRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly GameDef gameDef;
@@ -28,7 +27,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void StartResearch(ResearchTechCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				var techNodeDef = gameDef.GetTechNodeDef(command.TechNodeId);
 				if (techNodeDef == null) throw new System.Exception($"Tech node '{command.TechNodeId}' not found.");
 
@@ -52,24 +52,21 @@ namespace BrowserGameEngine.StatefulGameServer {
 				}
 
 				resourceRepositoryWrite.DeductCost(command.PlayerId, techNodeDef.Cost);
-				var state = world.GetPlayer(command.PlayerId).State;
 				state.TechBeingResearched = command.TechNodeId.Id;
 				state.TechResearchTimer = techNodeDef.ResearchTimeTicks;
 			}
 		}
 
 		public void ProcessResearchTimer(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				if (state.TechBeingResearched == null || state.TechResearchTimer <= 0) {
 					return;
 				}
 
 				state.TechResearchTimer--;
 				if (state.TechResearchTimer == 0) {
-					lock (state.StateLock) {
-						state.UnlockedTechs.Add(state.TechBeingResearched);
-					}
+					state.UnlockedTechs.Add(state.TechBeingResearched);
 					state.TechBeingResearched = null;
 				}
 			}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Units/UnitRepositoryWrite.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
@@ -10,7 +10,6 @@ using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class UnitRepositoryWrite {
-		private readonly Lock _lock = new();
 		private readonly ILogger<UnitRepositoryWrite> logger;
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
@@ -64,18 +63,17 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void GrantUnits(PlayerId playerId, UnitDefId unitDefId, int count) {
-			lock (_lock) {
-				var unitDef = gameDef.GetUnitDef(unitDefId);
-				if (unitDef == null) throw new UnitDefNotFoundException(unitDefId);
-				AddUnit(playerId, unitDefId, count);
-			}
+			var unitDef = gameDef.GetUnitDef(unitDefId);
+			if (unitDef == null) throw new UnitDefNotFoundException(unitDefId);
+			AddUnit(playerId, unitDefId, count);
 		}
 
 		/// <summary>
 		/// Building units happens immediately. Throws exceptions if prerequisites are not met.
 		/// </summary>
 		public void BuildUnit(BuildUnitCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				var unitDef = gameDef.GetUnitDef(command.UnitDefId);
 				if (unitDef == null) throw new UnitDefNotFoundException(command.UnitDefId);
 				if (!unitRepository.PrerequisitesMet(command.PlayerId, unitDef)) throw new PrerequisitesNotMetException($"Prerequisites not met for unit '{command.UnitDefId}'.");
@@ -86,32 +84,35 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void MergeUnits(MergeAllUnitsCommand command) {
-			lock (_lock) {
-				var unitDefIds = Units(command.PlayerId).Select(x => x.UnitDefId).Distinct().ToArray();
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				var unitDefIds = state.Units.Select(x => x.UnitDefId).Distinct().ToArray();
 				foreach (var unitDefId in unitDefIds) {
-					MergeUnitsInternal(new MergeUnitsCommand(command.PlayerId, unitDefId));
+					MergeUnitsInternal(command.PlayerId, unitDefId);
 				}
 			}
 		}
 
 		public void MergeUnits(MergeUnitsCommand command) {
-			lock (_lock) {
-				MergeUnitsInternal(command);
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
+				MergeUnitsInternal(command.PlayerId, command.UnitDefId);
 			}
 		}
 
-		private void MergeUnitsInternal(MergeUnitsCommand command) {
-			var unitDef = gameDef.GetUnitDef(command.UnitDefId);
-			if (unitDef == null) throw new UnitDefNotFoundException(command.UnitDefId);
-			int totalCount = Units(command.PlayerId).Where(x => x.UnitDefId.Equals(command.UnitDefId) && x.IsHome()).Sum(x => x.Count);
+		private void MergeUnitsInternal(PlayerId playerId, UnitDefId unitDefId) {
+			var unitDef = gameDef.GetUnitDef(unitDefId);
+			if (unitDef == null) throw new UnitDefNotFoundException(unitDefId);
+			int totalCount = Units(playerId).Where(x => x.UnitDefId.Equals(unitDefId) && x.IsHome()).Sum(x => x.Count);
 			if (totalCount == 0) return;
 
-			RemoveUnitsOfType(command.PlayerId, command.UnitDefId);
-			AddUnit(command.PlayerId, command.UnitDefId, totalCount);
+			RemoveUnitsOfType(playerId, unitDefId);
+			AddUnit(playerId, unitDefId, totalCount);
 		}
 
 		public void SplitUnit(SplitUnitCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				var unit = Unit(command.PlayerId, command.UnitId);
 				if (unit == null) throw new UnitNotFoundException(command.UnitId);
 				if (!unit.IsHome()) throw new UnitNotHomeException(command.UnitId, "Cannot split unit.");
@@ -125,7 +126,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void SendUnit(SendUnitCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				var unit = Unit(command.PlayerId, command.UnitId);
 				if (unit == null) throw new UnitNotFoundException(command.UnitId);
 				if (!gameDef.GetUnitDef(unit.UnitDefId)!.IsMobile) throw new UnitImmobileException(command.UnitId);
@@ -139,9 +141,10 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ReturnUnitsHome(ReturnUnitsHomeCommand command) {
-			lock (_lock) {
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				world.ValidatePlayer(command.EnemyPlayerId);
-				var units = Units(command.PlayerId).Where(x => x.Position == command.EnemyPlayerId);
+				var units = state.Units.Where(x => x.Position == command.EnemyPlayerId);
 				foreach (var unit in units) {
 					unit.Position = null;
 				}
@@ -149,8 +152,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		private void SetReturnTimers(PlayerId playerId, PlayerId enemyPlayerId) {
-			lock (_lock) {
-				var units = Units(playerId).Where(x => x.Position == enemyPlayerId).ToList();
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				var units = state.Units.Where(x => x.Position == enemyPlayerId).ToList();
 				foreach (var unit in units) {
 					unit.ReturnTimer = gameDef.GetUnitDef(unit.UnitDefId)!.Speed;
 				}
@@ -158,8 +162,9 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ProcessReturningUnits(PlayerId playerId) {
-			lock (_lock) {
-				var units = Units(playerId).Where(x => x.ReturnTimer > 0).ToList();
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
+				var units = state.Units.Where(x => x.ReturnTimer > 0).ToList();
 				foreach (var unit in units) {
 					unit.ReturnTimer--;
 					if (unit.ReturnTimer == 0) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Upgrades/UpgradeRepositoryWrite.cs
@@ -11,7 +11,6 @@ namespace BrowserGameEngine.StatefulGameServer {
 		private const int MaxUpgradeLevel = 3;
 		private const int ResearchTimerTicks = 10;
 
-		private readonly Lock _lock = new();
 		private readonly IWorldStateAccessor worldStateAccessor;
 		private WorldState world => worldStateAccessor.WorldState;
 		private readonly ResourceRepository resourceRepository;
@@ -35,9 +34,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public Cost GetUpgradeCost(int nextLevel) => UpgradeCosts[nextLevel - 1];
 
 		public void ResearchUpgrade(ResearchUpgradeCommand command) {
-			lock (_lock) {
-				var state = world.GetPlayer(command.PlayerId).State;
-
+			var state = world.GetPlayer(command.PlayerId).State;
+			lock (state.StateLock) {
 				if (state.UpgradeBeingResearched != UpgradeType.None) {
 					throw new UpgradeResearchInProgressException(state.UpgradeBeingResearched);
 				}
@@ -62,8 +60,8 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public void ProcessResearchTimer(PlayerId playerId) {
-			lock (_lock) {
-				var state = world.GetPlayer(playerId).State;
+			var state = world.GetPlayer(playerId).State;
+			lock (state.StateLock) {
 				if (state.UpgradeBeingResearched == UpgradeType.None || state.UpgradeResearchTimer <= 0) {
 					return;
 				}


### PR DESCRIPTION
## Summary
- Removes all repo-level `_lock` fields from write repositories, using `PlayerState.StateLock` as the single lock
- Eliminates nested locking which had a **deadlock risk** (e.g. `BuildQueueRepo._lock` → `StateLock` → `UnitRepo._lock` vs `UnitRepo._lock` → `StateLock`)
- Net -49 lines of code across 13 files
- `PlayerRepositoryWrite` retains `_lock` only for `CreatePlayer`/`DeletePlayer` which modify the `Players` dictionary (not PlayerState)

## Test plan
- [x] All 739 existing tests pass
- [ ] Monitor CloudWatch after deploy for absence of errors