### PR TITLE
fix: API key Bearer auth returns 401 on all endpoints

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using BrowserGameEngine.StatefulGameServer;
@@ -7,6 +8,7 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 	/// <summary>
 	/// Middleware that authenticates API requests using a Bearer token in the format bge_k_...
 	/// Resolves the token to a Player and stores the PlayerId in HttpContext.Items for CurrentUserMiddleware.
+	/// Also sets HttpContext.User so that [Authorize] passes.
 	/// Must run after UseAuthentication() but before CurrentUserMiddleware.
 	/// </summary>
 	public class BearerTokenMiddleware {
@@ -27,6 +29,11 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 					var player = userRepository.GetPlayerByApiKeyHash(hash);
 					if (player != null) {
 						context.Items["BearerPlayerId"] = player.PlayerId.Id;
+						var claims = new[] {
+							new Claim(ClaimTypes.NameIdentifier, player.PlayerId.Id),
+							new Claim(ClaimTypes.AuthenticationMethod, "ApiKey"),
+						};
+						context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "ApiKey"));
 					}
 				}
 			}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
@@ -59,6 +59,39 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 		}
 
 		[Fact]
+		public async Task GenerateApiKey_ThenUseAsBearer_Authenticates() {
+			var userId = "user-pm-apikey-bearer-1";
+			var playerId = await CreatePlayerAsync(userId, "BearerPlayer1");
+
+			// Generate the API key via cookie-authenticated client
+			var authClient = CreateClient(userId);
+			var genResponse = await authClient.PostAsync($"/api/player-management/{playerId}/apikey", null);
+			Assert.Equal(HttpStatusCode.OK, genResponse.StatusCode);
+			var vm = await DeserializeAsync<ApiKeyViewModel>(genResponse);
+			Assert.NotNull(vm);
+			Assert.False(string.IsNullOrEmpty(vm!.ApiKey));
+
+			// Use the API key as a Bearer token on an unauthenticated client
+			var bearerClient = CreateClient(); // no cookie auth
+			bearerClient.DefaultRequestHeaders.Authorization =
+				new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", vm.ApiKey);
+
+			// Hit a protected endpoint — should succeed, not 401
+			var response = await bearerClient.GetAsync("/api/profile");
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task BearerToken_InvalidKey_Returns401() {
+			var bearerClient = CreateClient();
+			bearerClient.DefaultRequestHeaders.Authorization =
+				new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "bge_k_invalid_key_here");
+
+			var response = await bearerClient.GetAsync("/api/profile");
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[Fact]
 		public async Task DeletePlayer_Unauthenticated_Returns401() {
 			var client = CreateClient();
 			var response = await client.DeleteAsync("/api/player-management/some-player-id");


### PR DESCRIPTION
## Summary
- `BearerTokenMiddleware` stored the resolved player ID in `HttpContext.Items` but never set `HttpContext.User` to an authenticated `ClaimsPrincipal`
- Since every controller has `[Authorize]`, ASP.NET rejected all API-key-authenticated requests with 401 before they reached controller code
- Fix: set `context.User` to a `ClaimsPrincipal` with `"ApiKey"` auth type when a valid key resolves

## Test plan
- [x] `GenerateApiKey_ThenUseAsBearer_Authenticates` — full round-trip test
- [x] `BearerToken_InvalidKey_Returns401` — invalid keys still rejected
- [x] All 741 existing tests pass