### PR TITLE
UI/UX Phase 1: design doc + confirmations + skeletons + icons

### DIFF
--- a/docs/UI-UX-DESIGN.md
+++ b/docs/UI-UX-DESIGN.md
@@ -1,0 +1,356 @@
+# BGE UI/UX Design Reference
+
+Reverse-engineered from the React client at `src/ReactClient`. Describes the current state of the UI: what it is, how it looks, how it behaves, and the conventions it has settled on. Intended as the shared mental model for anyone touching frontend code or designing new screens.
+
+---
+
+## 1. Product Shape
+
+BGE is a **browser-based multiplayer strategy game** (StarCraft Online / SCO being the first concrete ruleset). The UI has three high-level modes:
+
+1. **Meta-game**: sign in, browse seasons, join/create games, manage account.
+2. **In-game**: per-game scoped pages for base management, units, research, diplomacy, trade, chat, intel.
+3. **Spectator / post-game**: live view, results, replays, rankings.
+
+The entire client is a single SPA; mode is expressed through the route, not through separate apps.
+
+---
+
+## 2. Tech Stack
+
+| Concern | Choice |
+|---|---|
+| Framework | React 19 + TypeScript (strict) |
+| Build | Vite 6 |
+| Routing | React Router v7 (lazy routes + Suspense) |
+| Server state | TanStack Query v5 (5s staleTime, retry=1, per-query `refetchInterval`) |
+| HTTP | Axios instance with 401 → `/signin` interceptor |
+| Real-time | SignalR (`/gamehub`) with WS → long-poll fallback, auto-reconnect |
+| Styling | Tailwind CSS v4 (via `@tailwindcss/vite`) + CSS custom properties for tokens |
+| Primitives | Radix UI (dialog, dropdown, select, toast, label, separator, slot) |
+| Icons | Lucide React (+ sparing emoji) |
+| Charts | Recharts v3 (resource history) |
+| Utility | `clsx` + `tailwind-merge` via a `cn()` helper, `class-variance-authority` for variants |
+| Monitoring | Sentry (opt-in, 10% trace sample) |
+| E2E | Playwright |
+
+Routes are split aggressively: `/signin` and `/` are eager, **every game page is `React.lazy()`** wrapped in a `RouteWithBoundary`. Suspense fallback is a shared `PageLoader`.
+
+---
+
+## 3. Design Tokens
+
+Tokens live in `index.css` as CSS custom properties, consumed by Tailwind's theme. Dark is the default; a `.light` class on `<html>` switches palette.
+
+### Color (HSL)
+
+| Token | Dark | Light | Usage |
+|---|---|---|---|
+| `--background` | `222 84% 5%` | white | page background |
+| `--foreground` | `210 40% 98%` | dark gray | body text |
+| `--card` | = background | white | card surfaces |
+| `--primary` | `217 91% 60%` | desaturated blue | CTAs, active nav, links |
+| `--primary-foreground` | `222 47% 11%` | — | text on primary |
+| `--secondary` / `--muted` / `--border` / `--input` | `217 33% 18%` | light gray | chrome |
+| `--muted-foreground` | `215 20% 65%` | — | helper/label text |
+| `--ring` | `224 76% 48%` | — | focus outline |
+| `--destructive` | `0 63% 31%` | — | danger buttons/messages |
+
+**Semantic status colors** (custom, outside the shadcn-style token set):
+
+- `success` `142 71% 35%` — green
+- `warning` `38 92% 45%` — amber
+- `danger` `0 72% 45%` — red
+- `info` `217 91% 55%` — blue
+
+Theme preference persists in `localStorage` under `bge-theme`; initial value reads `prefers-color-scheme`.
+
+### Typography
+
+- Font: OS stack (`system-ui, -apple-system, sans-serif`). No custom webfont.
+- Scale: `text-4xl` hero → `text-2xl` page title → `text-lg` section → `text-sm` body → `text-xs` labels.
+- Weights: 400 / 500 / 600 / 700.
+- **`font-mono` for all numeric game data** (resources, costs, timers, counts). This is a deliberate and consistent choice.
+
+### Spacing & Radii
+
+- Tailwind 4px grid. Common rhythms: `gap-2`, `gap-3`, `p-3`/`p-4`, `py-2 px-3`.
+- Responsive padding pattern: `p-3 sm:p-4` (tighter on mobile).
+- Radius token: `--radius: 0.5rem` (8px) applied uniformly.
+- Fixed sidebar width `w-52` (208px), header `h-12` (48px).
+- Touch targets: interactive controls target ≥36px, primary/nav ≥44px.
+
+---
+
+## 4. App Shell & Layout
+
+### Provider stack
+
+```
+ErrorBoundary
+└── ThemeProvider
+    └── CurrentUserProvider        (loads /me on mount)
+        └── <Outlet />              (route tree)
+```
+
+### `GameLayout` (the in-game shell)
+
+A persistent three-region layout once you're inside a game:
+
+```
+┌────────────┬──────────────────────────────────────────┐
+│            │  Header (h-12, sticky)                   │
+│  Sidebar   │  [☰] ……………… PlayerResources · 📶 · 🔔 · ☀ │
+│  (w-52)    ├──────────────────────────────────────────┤
+│  • game    │  [GameEndedBanner] · [TimeRemainingBanner]│
+│    title   ├──────────────────────────────────────────┤
+│  • NavMenu │                                          │
+│  • sign    │          <Outlet />  (main, scroll-y)    │
+│    out     │                                          │
+└────────────┴──────────────────────────────────────────┘
+```
+
+- **Sidebar**: `hidden md:flex`, scrollable. On mobile it becomes a fixed drawer (`-translate-x-full` ↔ `translate-x-0`) with a z-40 backdrop.
+- **Header**: sticky, carries global controls. `PlayerResources` collapses gaps (`gap-2 sm:gap-4`) and uses `whitespace-nowrap` to survive narrow screens.
+- **Banners**: `GameEndedBanner` (winner + victory condition + results link) and `TimeRemainingBanner` (countdown, turns red when <1h) appear above main content when relevant.
+- **Main**: `flex-1 overflow-y-auto`, `p-3 sm:p-4`, page-fade-in animation on route change (respects `prefers-reduced-motion`).
+
+### Overlay z-index ladder
+
+| Layer | z-index | Example |
+|---|---|---|
+| Toasts | 50 | `NotificationToasts` top-right |
+| Tutorial overlay | 60 | first-run tutorial dialog |
+| Game-over modal | 100 | finalized game w/ 8s countdown to results |
+
+### Navigation menu
+
+Five labeled groups, uppercase section headers, active state is `bg-primary/20 text-primary font-medium`:
+
+- **Play** — Base, Units, Research, Market, Trade
+- **Info** — Live View, Unit Types, Ranking, Help
+- **Social** — Diplomacy, Alliances, Alliance Ranking, Chat, Messages
+- **Account** — History, Stats, Profile
+- **Economy** — Shop, My Economy, Currency badge
+
+Each entry is a `NavLink` with icon + label, min-height 44px. Bare routes like `/base` exist and redirect via `BareRouteRedirect` to the current game's scoped route.
+
+---
+
+## 5. Page Inventory
+
+### Meta / onboarding
+- **SignIn** *(eager)* — GitHub OAuth button, optional dev-login form gated on `VITE_DEV_AUTH`.
+- **Index** *(eager)* — landing/redirect.
+- **CreatePlayer** — first-time profile creation.
+
+### Game selection
+- **Games** — season schedule split into Active / Upcoming / Finished card grids with status badges.
+- **GameLobby**, **GameLobbyDetail** — admin-facing game management and detail.
+- **JoinGame** — registration for a specific game.
+
+### Core gameplay (under `/games/:gameId/`)
+- **Base** — the hub. Victory progress → worker assignment → trade/colonize → asset grid → build queue → resource history chart → recent activity.
+- **Units** — home-base and deployed stacks, with merge / split / attack actions.
+- **Research** — Attack & Defense upgrade tracks rendered as connected node rows.
+- **Market** — post/accept/cancel trade orders, tabbed (mine vs open).
+- **Trade** — direct player-to-player offers with incoming/sent/history tabs.
+
+### Social & multiplayer
+- **Diplomacy** — Non-Aggression Pacts and Resource Agreements: active, incoming, outgoing.
+- **Alliances**, **AllianceDetail**, **AllianceRanking**.
+- **Chat** — global game chat via SignalR with 5s polling fallback.
+- **Messages** — DM inbox, threads, compose.
+- **PlayerRanking**, **InGamePlayerProfile**, **EnemyBase** (intel view).
+
+### Spectator & analysis
+- **GameLiveView** — real-time scoreboard and notification feed, with pinch-zoom/pan on mobile.
+- **GameSummary**, **GameResults**, **BattleReplay**, **ReplayViewer**, **Spectator**.
+
+### Account & meta
+- **PlayerProfile** — API keys, win/loss, stats cards.
+- **PublicProfile**, **PlayerHistory**, **PlayerStats**, **PlayersList**, **UnitDefinitions** (codex).
+
+### Economy & tournaments
+- **Shop**, **Economy**.
+- **TournamentList**, **TournamentDetail**, **TournamentResults**.
+
+### Admin (role-gated)
+- **AdminGames**, **AdminPlayers**, **AdminTickControl**, **AdminStats**, **AdminMetrics**, **AdminAuditLog**, **AdminReports**.
+
+### Misc
+- **Help** — mechanics reference.
+
+---
+
+## 6. Component Patterns
+
+### Containers
+- **Card**: `rounded-lg border bg-card p-4`. The universal surface.
+- **Section**: card + `border-b px-4 py-2.5` header strip.
+- **Modal**: full-screen `inset-0 bg-black/60` backdrop + centered `max-w-md` card, `role="dialog"`.
+- **Table**: wrap in `overflow-x-auto`; `thead` uses `font-medium text-muted-foreground`; rows `border-b`; some columns `hidden sm:table-cell` on mobile.
+
+### Forms
+- Inputs / selects / textareas share `rounded border bg-input px-2 py-1.5 text-sm`.
+- Labels: `text-xs text-muted-foreground mb-1 block` above the control.
+- Validation is mostly server-side; errors render inline in `text-destructive` or as an alert box `border border-destructive/50 bg-destructive/10 px-3 py-2`.
+
+### Buttons
+| Variant | Classes |
+|---|---|
+| Primary | `bg-primary text-primary-foreground hover:opacity-90` |
+| Secondary | `bg-secondary text-secondary-foreground` |
+| Destructive | `bg-destructive text-destructive-foreground` |
+| Ghost / outline | `border text-sm hover:bg-muted` |
+| Icon | `p-1.5 rounded hover:bg-secondary` |
+
+Disabled: `disabled:opacity-50`. Loading states change the label ("Building…") and disable the button — no spinners inside buttons.
+
+### Data display
+- **Progress bars**: nested div, outer `overflow-hidden`, inner `transition-all` width + `role="progressbar"` with ARIA values.
+- **Badges**: `rounded-full px-2 py-0.5 text-xs`.
+- **Stat cards**: 3-column grid (e.g. total / minerals / gas) with large mono numbers + label underneath.
+- **EmptyState**: icon + title + description for zero-result lists.
+
+### Domain components
+- **PlayerResources** — header resource strip, mono values, responsive gaps.
+- **BuildQueue** — priority-ordered list card, remove per entry (no reorder UI).
+- **VictoryProgressBar** — player + top-3 competitors with color-coded bars.
+- **CostBadge** — inline resource cost chip.
+- **WorkerAssignment** — 3-stat header + two assignment inputs.
+- **NotificationBell** — icon button with count badge, opens a notification panel.
+- **NotificationToasts** — top-right stack, max 3 visible, 5s auto-dismiss, clickable to navigate; `animate-in slide-in-from-right-4 fade-in duration-300`.
+
+---
+
+## 7. Interaction Patterns
+
+### Build & queue
+Asset cards on Base show locked / available / affordable states. **Build** executes immediately; **Queue** always available and appends to the build queue with tick cost. Success mutations invalidate queries to refresh live state.
+
+### Unit management
+Units page separates **deployed** and **home** into two tables with Merge / Split / Attack per row. Split opens an inline count input. Attack routes to `SelectEnemy` → target → confirm.
+
+### Market & trade
+Market has two tabs (mine / open). Posting takes resource dropdowns + amount inputs. Direct `Trade` screen is player-to-player with target selector, resource inputs, optional note, and incoming/sent/history tabs.
+
+### Research
+Two horizontal tracks (Attack, Defense). Nodes display status (completed / in-progress / available / locked), cost, and a research button. Only one upgrade may be in progress at a time — the UI blocks starting another.
+
+### Chat & messages
+Chat scrolls to latest on new message; SignalR-first, 5s polling fallback. Messages use an inbox + inline reply pattern.
+
+### Diplomacy
+Active agreements, incoming (needs response), outgoing. Propose via form (target, duration in ticks, terms). Respond = accept/decline inline.
+
+### Game lifecycle
+Games page card grid. Game-over event triggers a full-screen modal with an 8-second countdown to results plus a "View Results Now" button. A game-ended banner remains visible afterward inside `GameLayout`.
+
+### Admin
+Create-game form with schedule/tick/max-players/Discord webhook, manage-table actions, moderation queue, and a tick control page exposing pause / advance / resume.
+
+---
+
+## 8. Real-Time Model
+
+- Single SignalR connection from `GameLayout` via `useSignalR('/gamehub')`.
+- Handlers: `ReceiveChatMessage`, `GameFinalized`, `LobbyUpdated`, plus notification events.
+- Reconnect schedule: `[0, 2000, 5000, 10000, 30000]` ms.
+- Connection status drives the header WiFi icon (`disconnected | connecting | connected | reconnecting`).
+- **Fallback**: when status is not `connected`, polling queries step in (chat at 5s, others 10–30s depending on page).
+- **Optimistic updates** are rare; the default is "mutate → invalidate → refetch". The exception is chat, where messages append optimistically and dedupe on server echo.
+
+---
+
+## 9. Information Density & Hierarchy
+
+**Base page** is the densest view. Reading order, top to bottom:
+
+1. Title
+2. `VictoryProgressBar` (player vs top 3)
+3. `WorkerAssignment`
+4. Trade / Colonize panels
+5. Asset grid (`grid-cols-1 md:grid-cols-2 lg:grid-cols-3`)
+6. `BuildQueue`
+7. Resource history chart (Recharts)
+8. Recent activity (scrollable, dismissible)
+
+Other density-heavy views:
+
+- **Units** — summary row + two tables; stats columns hidden on mobile.
+- **Research** — narrow (`w-36`) node cards arranged horizontally, can overflow-scroll.
+- **Games / Lobby** — card grid, 1/2/3 cols across breakpoints.
+- **GameLiveView** — distributed panels (rankings / resources / notifications / assets / units) with a custom `useTouchZoomPan` hook for mobile pinch-zoom and pan.
+
+---
+
+## 10. Responsive Design
+
+Breakpoints used: **`sm` 640**, **`md` 768** (main sidebar breakpoint), **`lg` 1024**. `xl`/`2xl` barely appear.
+
+Patterns:
+- Sidebar collapses to a drawer below `md`.
+- Header text scales (`text-xs sm:text-sm`), gaps shrink (`gap-2 sm:gap-4`).
+- Tables default to `overflow-x-auto`; some columns hide (`hidden sm:table-cell`) with **no alternative card-per-row layout** — this is a known rough edge.
+- Grids cascade `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`.
+- Touch targets ≥44px for nav and primary actions.
+
+---
+
+## 11. Accessibility
+
+Baseline, not exhaustive.
+
+**Good**
+- Semantic HTML: `main`, `header`, `aside`, `nav aria-label`, `<table>` with `th scope`.
+- ARIA: `aria-label` on icon buttons, `aria-hidden` on decorative glyphs, `role="alert"` on error banners, `role="progressbar"` with `aria-valuenow/min/max`, `role="dialog"` + `aria-modal` on overlays.
+- Focus: tutorial overlay focuses its dialog on open and handles `Escape`.
+- Motion: page-fade-in respects `prefers-reduced-motion`.
+
+**Gaps**
+- No custom focus trapping for most modals (relies on native tab order).
+- Research tree and GameLiveView panels are not fully keyboard-navigable.
+- Not every icon button carries an `aria-label`.
+- Color contrast hasn't been formally verified against WCAG AA.
+
+---
+
+## 12. Known Rough Edges
+
+A candid list, useful as a backlog seed.
+
+1. **Thin client-side validation** — most forms defer to server errors, which surface as generic messages.
+2. **No skeleton loaders** — "Loading…" text in many places; no perceived-performance scaffolding.
+3. **No confirmation dialogs on destructive actions** — cancel/delete/revoke execute immediately.
+4. **No reordering in `BuildQueue`** — only removal.
+5. **Tables on mobile hide columns** with no card-view fallback, so some data is simply invisible on phones.
+6. **Generic error text** — no error codes, no suggested recovery.
+7. **No draft/autosave** — forms are ephemeral.
+8. **Emoji used as icons** in several places alongside Lucide — render inconsistency across platforms.
+9. **No pagination / infinite scroll** — long lists rely on truncation or "show all" toggles, which will not scale.
+10. **Refetch intervals are hard-coded** (10s / 30s) — not configurable per user or per connection quality.
+11. **Limited optimistic UI** outside chat — most actions feel "submit → wait → refresh".
+
+---
+
+## 13. Conventions Cheat Sheet
+
+Use this when adding new UI to stay consistent with the existing system.
+
+- **Surface** = `rounded-lg border bg-card p-4`.
+- **Section header** = card + `border-b px-4 py-2.5` strip.
+- **Numbers** = `font-mono`. Always.
+- **Labels** = `text-xs text-muted-foreground`.
+- **Primary action** = `bg-primary text-primary-foreground`. One per view, ideally.
+- **Destructive action** = `bg-destructive` + the word "Delete/Cancel/Remove" in the label.
+- **Loading** = change the button label, disable it. No spinners inside buttons.
+- **Empty** = `EmptyState` component, not ad-hoc messages.
+- **Error** = inline `text-destructive` for field errors; `border border-destructive/50 bg-destructive/10` box for form-level errors.
+- **Responsive** = `p-3 sm:p-4`, `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`, sidebar hidden below `md`.
+- **Data fetching** = TanStack Query; set an explicit `refetchInterval` if the data is tick-driven.
+- **Mutations** = invalidate related queries on success; don't hand-roll cache updates unless you have a reason.
+- **Real-time** = subscribe in `GameLayout` via `useSignalR`; fall back to polling when status ≠ `connected`.
+- **Routes** = lazy-load new game pages via `React.lazy` + `RouteWithBoundary`; keep `/signin` and `/` eager.
+- **Icons** = Lucide by default; avoid adding new emoji-as-icon usages.
+- **Tokens** = reference CSS vars / Tailwind theme colors; don't hard-code hex values.

--- a/docs/superpowers/plans/2026-04-12-ui-ux-improvements.md
+++ b/docs/superpowers/plans/2026-04-12-ui-ux-improvements.md
@@ -1,0 +1,571 @@
+# UI/UX Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the most painful UX rough edges in the BGE React client, starting with safe polish (Phase 1) and escalating into journey redesigns (Phase 2).
+
+**Architecture:** React 19 + Vite + Tailwind v4 + TanStack Query + Radix UI + Lucide. All changes stay inside `src/ReactClient/`. No server changes. No new dependencies unless a task explicitly calls for one. Each phase is its own PR in its own git worktree per `CLAUDE.md`.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4, Radix UI (dialog already in use), Lucide React, TanStack Query v5, Playwright (E2E).
+
+**Out of scope for this plan (deferred to Phase 3, separate plan):** optimistic mutations, client-side form validation, research-tree keyboard navigation, chat search/mentions, pagination, admin polish.
+
+**Source of problems:** `docs/UI-UX-DESIGN.md` §11 ("Known Rough Edges") and the journey analysis that followed it.
+
+---
+
+## Scope Overview
+
+### Phase 1 — Safe polish (this PR: `ui-ux-phase-1`)
+
+Low-design-risk changes that reduce daily friction without touching layout.
+
+- **Task 1:** Generic `<ConfirmDialog>` primitive + wire up destructive actions (cancel trade, remove from build queue, revoke API key, cancel market order, cancel proposal).
+- **Task 2:** `<Skeleton>` primitive + replace "Loading…" text on Base, Units, Market, Games, PlayerRanking.
+- **Task 3:** Standardize on Lucide icons. Sweep emoji-as-icon usages and replace with Lucide equivalents. Leave emoji-as-flavor (e.g. chat messages) alone.
+- **Task 4:** Inline accept/decline on diplomacy notification toasts.
+
+### Phase 2a — Mobile table card fallback (PR: `ui-ux-mobile-tables`)
+
+- **Task 5:** Add a `<ResponsiveTable>` wrapper that renders as a `<table>` at `md+` and as a stacked card list on mobile. Migrate Units, Market, PlayerRanking.
+
+### Phase 2b — Attack flow as modal (PR: `ui-ux-attack-modal`)
+
+- **Task 6:** Replace the `SelectEnemy` route navigation with a modal opened from the Units page. Keep forces visible behind the modal.
+
+### Phase 2c — Base page restructure (PR: `ui-ux-base-tabs`)
+
+- **Task 7:** Reorganize the Base page into three tabs — Economy / Build / Activity — with a pinned VictoryProgressBar + BuildQueue rail.
+
+### Phase 3 — deferred
+
+Dashboard page, optimistic updates, form validation, pagination, chat search, keyboard a11y, accessibility audit. Revisit after Phase 1+2 land.
+
+---
+
+## File Structure
+
+### New files (Phase 1)
+
+- `src/ReactClient/src/components/ui/ConfirmDialog.tsx` — generic confirmation dialog built on Radix `@radix-ui/react-dialog` (already a dependency).
+- `src/ReactClient/src/components/ui/Skeleton.tsx` — single element + a `<SkeletonList>` helper for repeated rows.
+- `src/ReactClient/src/hooks/useConfirm.ts` — imperative `const confirm = useConfirm(); if (await confirm({...})) {...}` hook so call sites don't each need local state for the dialog.
+
+### New files (Phase 2)
+
+- `src/ReactClient/src/components/ui/ResponsiveTable.tsx` — mobile card fallback for tables.
+- `src/ReactClient/src/components/AttackDialog.tsx` — attack-target picker dialog.
+
+### Modified files
+
+Covered per-task.
+
+---
+
+## Phase 1 — Tasks
+
+### Task 0: Worktree and plan commit
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-12-ui-ux-improvements.md` (this file)
+- Create: `docs/UI-UX-DESIGN.md` (already written in the previous turn, port from master working tree)
+
+- [ ] **Step 1:** Create worktree `ui-ux-phase-1` off master.
+- [ ] **Step 2:** Commit the design reference + this plan.
+
+```bash
+git add docs/UI-UX-DESIGN.md docs/superpowers/plans/2026-04-12-ui-ux-improvements.md
+git commit -m "docs: add UI/UX design reference and improvement plan"
+```
+
+---
+
+### Task 1: `<ConfirmDialog>` primitive + `useConfirm` hook
+
+**Why:** Destructive actions currently fire immediately. Cancelling a market order or revoking an API key deserves a confirm step.
+
+**Files:**
+- Create: `src/ReactClient/src/components/ui/ConfirmDialog.tsx`
+- Create: `src/ReactClient/src/hooks/useConfirm.ts`
+- Create: `src/ReactClient/src/hooks/useConfirm.test.tsx` (Vitest + React Testing Library if present; if not, skip tests and rely on Playwright smoke)
+
+- [ ] **Step 1:** Verify the test setup.
+
+Run: `cd src/ReactClient && cat package.json | grep -E '"(test|vitest|jest)"'`
+Expected: determine if a unit test runner is configured. If not, skip unit tests and do a manual smoke test in the dev server.
+
+- [ ] **Step 2:** Implement `ConfirmDialog.tsx` using Radix Dialog.
+
+```tsx
+import * as Dialog from '@radix-ui/react-dialog';
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[90] bg-black/60 animate-in fade-in" />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[91] w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2',
+            'rounded-lg border bg-card p-5 shadow-lg',
+            'animate-in fade-in zoom-in-95 duration-150',
+          )}
+        >
+          <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+          {description && (
+            <Dialog.Description className="mt-2 text-sm text-muted-foreground">
+              {description}
+            </Dialog.Description>
+          )}
+          <div className="mt-5 flex justify-end gap-2">
+            <Dialog.Close asChild>
+              <button className="rounded border px-3 py-1.5 text-sm hover:bg-muted">
+                {cancelLabel}
+              </button>
+            </Dialog.Close>
+            <button
+              className={cn(
+                'rounded px-3 py-1.5 text-sm',
+                destructive
+                  ? 'bg-destructive text-destructive-foreground hover:opacity-90'
+                  : 'bg-primary text-primary-foreground hover:opacity-90',
+              )}
+              onClick={() => {
+                onConfirm();
+                onOpenChange(false);
+              }}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+```
+
+- [ ] **Step 3:** Implement `useConfirm` hook (imperative API via context provider).
+
+```tsx
+// src/ReactClient/src/hooks/useConfirm.tsx
+import { createContext, ReactNode, useCallback, useContext, useRef, useState } from 'react';
+import { ConfirmDialog, ConfirmDialogProps } from '@/components/ui/ConfirmDialog';
+
+type ConfirmOptions = Omit<ConfirmDialogProps, 'open' | 'onOpenChange' | 'onConfirm'>;
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [options, setOptions] = useState<ConfirmOptions | null>(null);
+  const resolverRef = useRef<((v: boolean) => void) | null>(null);
+
+  const confirm = useCallback<ConfirmFn>((opts) => {
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+      setOptions(opts);
+    });
+  }, []);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      resolverRef.current?.(false);
+      resolverRef.current = null;
+      setOptions(null);
+    }
+  };
+
+  const handleConfirm = () => {
+    resolverRef.current?.(true);
+    resolverRef.current = null;
+    setOptions(null);
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {options && (
+        <ConfirmDialog
+          open
+          onOpenChange={handleOpenChange}
+          onConfirm={handleConfirm}
+          {...options}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+}
+
+export function useConfirm(): ConfirmFn {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error('useConfirm must be used within ConfirmProvider');
+  return ctx;
+}
+```
+
+- [ ] **Step 4:** Mount `ConfirmProvider` inside `RootLayout.tsx`, inside `CurrentUserProvider`.
+
+- [ ] **Step 5:** Wire confirmation into destructive call sites. For each, replace the direct mutation call with:
+
+```tsx
+const confirm = useConfirm();
+const onCancel = async () => {
+  if (!(await confirm({
+    title: 'Cancel this market order?',
+    description: 'Your resources will be returned to your base.',
+    destructive: true,
+    confirmLabel: 'Cancel order',
+    cancelLabel: 'Keep order',
+  }))) return;
+  cancelOrder.mutate({...});
+};
+```
+
+Call sites to wire up (search with Grep first to confirm exact paths):
+- Market page — cancel own order
+- Trade page — cancel outgoing offer
+- BuildQueue — remove entry
+- PlayerProfile — revoke API key
+- Diplomacy — cancel outgoing proposal
+
+- [ ] **Step 6:** Run `npm run build` in `src/ReactClient` to verify TypeScript compiles.
+
+- [ ] **Step 7:** Manually smoke in dev server: click a destructive button, verify dialog appears, both paths work.
+
+- [ ] **Step 8:** Commit.
+
+```bash
+git add src/ReactClient/src/components/ui/ConfirmDialog.tsx \
+        src/ReactClient/src/hooks/useConfirm.tsx \
+        src/ReactClient/src/layouts/RootLayout.tsx \
+        src/ReactClient/src/pages/<affected-pages>
+git commit -m "feat(ui): add ConfirmDialog primitive and wire destructive actions"
+```
+
+---
+
+### Task 2: `<Skeleton>` primitive + replace "Loading…" text
+
+**Why:** "Loading…" flashes feel slow and generic. Skeletons communicate structure.
+
+**Files:**
+- Create: `src/ReactClient/src/components/ui/Skeleton.tsx`
+- Modify: Base, Units, Market, Games, PlayerRanking pages (exact paths via Grep before edit).
+
+- [ ] **Step 1:** Implement Skeleton.
+
+```tsx
+import { cn } from '@/lib/utils';
+import { HTMLAttributes } from 'react';
+
+export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded bg-muted', className)}
+      aria-busy="true"
+      aria-live="polite"
+      {...props}
+    />
+  );
+}
+
+export function SkeletonRows({ count = 4, className }: { count?: number; className?: string }) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2:** Grep for `Loading\.\.\.` inside `src/ReactClient/src/pages/` and list files.
+
+Run: Grep pattern `Loading\.\.\.` in `src/ReactClient/src/pages` → files_with_matches
+
+- [ ] **Step 3:** For each page, replace the loading text with a page-appropriate skeleton layout. For tables, use `<SkeletonRows count={5} />` inside the table container. For cards, a single `<Skeleton className="h-32 w-full" />` per card slot.
+
+- [ ] **Step 4:** Build + smoke test in dev server.
+
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -m "feat(ui): add Skeleton primitive and replace Loading text on core pages"
+```
+
+---
+
+### Task 3: Icon standardization
+
+**Why:** Mixed Lucide + emoji-as-icon is visually jarring and rendering-inconsistent.
+
+**Files:**
+- Modify: any file with emoji used as an icon inside buttons, nav items, or headings (not inside user-authored chat content).
+
+- [ ] **Step 1:** Grep for common emoji-icon patterns.
+
+Run: Grep for `⚔️|🛡️|🏭|💰|📊|🏆|📜|🚀|⚡|🔬|🏛️|⛏️|📡|🎯|🔔` in `src/ReactClient/src/` → files_with_matches.
+
+- [ ] **Step 2:** For each match, decide: is this UI chrome or content?
+- UI chrome (button icon, nav icon, panel header): replace with Lucide equivalent.
+- Content (chat, user-facing flavor text, notification body): leave alone.
+
+Suggested mappings:
+- ⚔️ → `Swords`
+- 🛡️ → `Shield`
+- 🏭 → `Factory`
+- 💰 → `Coins`
+- 📊 → `BarChart3`
+- 🏆 → `Trophy`
+- 📜 → `ScrollText`
+- 🚀 → `Rocket`
+- ⚡ → `Zap`
+- 🔬 → `FlaskConical`
+- 🏛️ → `Landmark`
+- ⛏️ → `Pickaxe`
+- 📡 → `Radio`
+- 🎯 → `Target`
+- 🔔 → `Bell`
+
+- [ ] **Step 3:** Replace one file at a time. Keep the icon size consistent (`h-4 w-4` inline, `h-5 w-5` for nav).
+
+- [ ] **Step 4:** Build. Smoke test.
+
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -m "refactor(ui): standardize on Lucide icons for UI chrome"
+```
+
+---
+
+### Task 4: Inline accept/decline on diplomacy notification toasts
+
+**Why:** Today, a diplomacy proposal notification routes you to the Diplomacy page to act. Most users just want to click accept.
+
+**Files:**
+- Modify: `src/ReactClient/src/components/NotificationToasts.tsx` (path via Grep)
+- Modify: notification type definitions if they exist
+
+- [ ] **Step 1:** Find the notification toast component and its data model.
+
+Run: Grep `NotificationToasts` in `src/ReactClient/src/` → file path.
+
+- [ ] **Step 2:** Determine how notification payloads distinguish types. If there's a `type` or `category` field with values like `diplomacy-proposal`, branch on it to render extra action buttons.
+
+- [ ] **Step 3:** Add `Accept` / `Decline` buttons on the toast when `notification.type === 'diplomacy-proposal'`. On click, call the existing respond-to-proposal mutation, then dismiss the toast. If the API requires the proposal ID, pull it from the notification payload.
+
+```tsx
+{notification.type === 'diplomacy-proposal' && notification.proposalId && (
+  <div className="mt-2 flex gap-2">
+    <button
+      onClick={(e) => { e.stopPropagation(); respond.mutate({ id: notification.proposalId, accept: true }); dismiss(notification.id); }}
+      className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
+    >
+      Accept
+    </button>
+    <button
+      onClick={(e) => { e.stopPropagation(); respond.mutate({ id: notification.proposalId, accept: false }); dismiss(notification.id); }}
+      className="rounded border px-2 py-1 text-xs hover:bg-muted"
+    >
+      Decline
+    </button>
+  </div>
+)}
+```
+
+- [ ] **Step 4:** If the notification payload does not include the proposal ID, document the limitation, skip this task, and open a follow-up ticket instead of changing the API in this PR.
+
+- [ ] **Step 5:** Build + smoke (dev server or Playwright).
+
+- [ ] **Step 6:** Commit.
+
+```bash
+git commit -m "feat(ui): inline accept/decline on diplomacy notification toasts"
+```
+
+---
+
+### Task 5: Phase 1 wrap-up
+
+- [ ] **Step 1:** Full `dotnet build --configuration Release` in `src/` to catch any type errors downstream.
+
+Run: `cd src && dotnet build --configuration Release`
+
+- [ ] **Step 2:** `npm run build` in `src/ReactClient` if it exists.
+
+- [ ] **Step 3:** Push branch and open PR.
+
+```bash
+git push -u origin ui-ux-phase-1
+gh pr create --title "UI/UX Phase 1: confirmation dialogs, skeletons, icon cleanup, inline diplomacy" --body "$(cat <<'EOF'
+## Summary
+- Add `ConfirmDialog` + `useConfirm` hook; wire destructive actions (market/trade cancel, queue remove, API-key revoke, proposal cancel).
+- Add `Skeleton` + replace `"Loading..."` text on Base, Units, Market, Games, PlayerRanking.
+- Replace emoji-as-icon usages in UI chrome with Lucide equivalents.
+- Diplomacy proposal notifications now accept/decline inline from the toast.
+- Add `docs/UI-UX-DESIGN.md` (reverse-engineered UI reference) and `docs/superpowers/plans/2026-04-12-ui-ux-improvements.md`.
+
+## Test plan
+- [ ] Dev server boots.
+- [ ] Cancel market order → confirmation appears; both paths work.
+- [ ] Remove build-queue entry → confirmation appears.
+- [ ] Revoke API key → confirmation appears.
+- [ ] Navigate to Base / Units / Market → skeletons visible during load.
+- [ ] No residual emoji-as-icon in nav, headers, or buttons.
+- [ ] Receive diplomacy proposal → accept/decline inline from toast.
+EOF
+)"
+```
+
+---
+
+## Phase 2a — Mobile table card fallback
+
+### Task 6: `<ResponsiveTable>` component
+
+**Why:** Tables currently hide columns below `md` and there is no alternative view. Data is literally invisible on phones.
+
+**Worktree:** `ui-ux-mobile-tables` off current `master` at the time Phase 1 merges.
+
+**Files:**
+- Create: `src/ReactClient/src/components/ui/ResponsiveTable.tsx`
+- Modify: Units, Market, PlayerRanking pages
+
+- [ ] **Step 1:** Design the API. Target usage:
+
+```tsx
+<ResponsiveTable
+  data={units}
+  columns={[
+    { key: 'name', header: 'Unit', cell: (u) => u.name },
+    { key: 'count', header: 'Count', cell: (u) => u.count, className: 'text-right font-mono' },
+    { key: 'attack', header: 'Atk', cell: (u) => u.attack, mobileHidden: false },
+    { key: 'defense', header: 'Def', cell: (u) => u.defense },
+    { key: 'actions', header: '', cell: (u) => <UnitActions unit={u} /> },
+  ]}
+  rowKey={(u) => u.id}
+  mobileTitle={(u) => u.name}
+  mobileSubtitle={(u) => `${u.count} units`}
+/>
+```
+
+- [ ] **Step 2:** Implement the component. At `md+`, render a standard `<table>`. Below `md`, render a stack of cards: mobile title in bold, subtitle in muted, then a two-column key/value grid for the remaining columns (respecting `mobileHidden`), and a full-width row for the `actions` column at the bottom.
+
+- [ ] **Step 3:** Migrate Units page first. Verify both desktop and mobile layouts in dev tools.
+
+- [ ] **Step 4:** Migrate Market and PlayerRanking.
+
+- [ ] **Step 5:** Commit, push, PR.
+
+```bash
+git commit -m "feat(ui): add ResponsiveTable with mobile card fallback"
+git push -u origin ui-ux-mobile-tables
+gh pr create --title "UI/UX: responsive tables (mobile card fallback)" ...
+```
+
+---
+
+## Phase 2b — Attack flow as modal
+
+### Task 7: `<AttackDialog>`
+
+**Why:** The attack flow navigates you away from the Units page to `SelectEnemy`, breaking context and forcing back-navigation.
+
+**Worktree:** `ui-ux-attack-modal` off master.
+
+**Files:**
+- Create: `src/ReactClient/src/components/AttackDialog.tsx`
+- Modify: Units page (attack button opens modal instead of navigating)
+- Possibly delete/deprecate: `SelectEnemy` page if it's only reachable from Units
+
+- [ ] **Step 1:** Read the current `SelectEnemy` page to understand its data dependencies and mutations.
+
+- [ ] **Step 2:** Build `AttackDialog` as a Radix Dialog with:
+  - Header: "Attack with {stack summary}"
+  - Body: target player search/list (reuse whatever query `SelectEnemy` uses)
+  - Footer: Cancel + Attack (destructive variant)
+
+- [ ] **Step 3:** In the Units page, replace the Attack `<Link>` with a button that opens the dialog. Pass the selected stack.
+
+- [ ] **Step 4:** On confirm, call the existing attack mutation and close the dialog. Show inline error if it fails.
+
+- [ ] **Step 5:** If `SelectEnemy` has no other entry points, delete it and its route. Otherwise leave it.
+
+- [ ] **Step 6:** Build, smoke, commit, push, PR.
+
+---
+
+## Phase 2c — Base page restructure
+
+### Task 8: Tabbed Base page
+
+**Why:** Base is a wall of stacked sections with no hierarchy. Tabs give a clear mental model: "where am I looking right now?"
+
+**Worktree:** `ui-ux-base-tabs` off master (after 2a/2b land — this is the most visible change).
+
+**Files:**
+- Modify: Base page and its subcomponents
+
+- [ ] **Step 1:** Read the current Base page to enumerate every child section.
+
+- [ ] **Step 2:** Plan the three tabs:
+  - **Economy:** WorkerAssignment, resource history chart, trade/colonize panels.
+  - **Build:** Asset grid, prerequisite legend.
+  - **Activity:** Recent activity feed, notification log.
+
+  Pinned rail (always visible above tabs): VictoryProgressBar, BuildQueue. These do not scroll with the tab content.
+
+- [ ] **Step 3:** Use Radix `@radix-ui/react-tabs` (add to deps if not present — check first).
+
+- [ ] **Step 4:** Preserve URL state by syncing the active tab to a `?tab=` search param so deep links work.
+
+- [ ] **Step 5:** Verify existing queries still fire — tab-switching must not force a full refetch unless needed. TanStack Query caches across unmounts by default, so this should be free.
+
+- [ ] **Step 6:** Build, smoke desktop + mobile, commit, push, PR.
+
+---
+
+## Self-Review
+
+**Spec coverage against the prior exploratory response:**
+- Confirmation dialogs ✓ Task 1
+- Skeleton loaders ✓ Task 2
+- Inline diplomacy actions ✓ Task 4
+- Kill emoji-as-icon ✓ Task 3
+- Attack modal ✓ Task 7
+- Base restructure ✓ Task 8
+- Mobile table card fallback ✓ Task 6
+- Situation dashboard — **deferred, documented in Phase 3 section**
+- Optimistic updates, form validation, research tree a11y, chat search, pagination — **deferred, documented**
+
+**Placeholder scan:** No TBDs in implementation steps. Code blocks are concrete. Component migrations use Grep-first because exact paths aren't known yet — that's a deliberate discovery step, not a placeholder.
+
+**Type consistency:** `ConfirmDialogProps` is defined once in Task 1 and reused by the hook. `useConfirm` returns a `Promise<boolean>` consistently across tasks.
+
+**Scope risk:** Phase 1 is four sub-features in one PR. Reviewers may prefer to split, but each sub-feature is small (~50–150 LOC) and they share no code except the primitives, so a single PR is reasonable. If reviewers push back, splitting is trivial because every sub-feature has isolated file modifications.

--- a/src/ReactClient/e2e/tests/05-resource-management.spec.ts
+++ b/src/ReactClient/e2e/tests/05-resource-management.spec.ts
@@ -45,7 +45,7 @@ test.describe('Resource management — worker assignment', () => {
 		await expect(page.getByText('Total')).toBeVisible()
 		await expect(page.getByText(/Mining/)).toBeVisible()
 		// Use a label-specific locator to avoid matching unrelated 'Gas' occurrences on the page
-		await expect(page.getByText('⚗️ Gas Workers')).toBeVisible()
+		await expect(page.getByText('Gas Workers')).toBeVisible()
 		await expect(page.getByText('Something went wrong')).not.toBeVisible()
 	})
 
@@ -58,8 +58,8 @@ test.describe('Resource management — worker assignment', () => {
 		await page.goto(`/games/${gameId}/base`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
-		await expect(page.getByLabel('💎 Mineral Workers')).toBeVisible()
-		await expect(page.getByLabel('⚗️ Gas Workers')).toBeVisible()
+		await expect(page.getByLabel('Mineral Workers')).toBeVisible()
+		await expect(page.getByLabel('Gas Workers')).toBeVisible()
 	})
 
 	test('assigning workers via API is reflected in the base page UI', async ({ page }) => {
@@ -79,8 +79,8 @@ test.describe('Resource management — worker assignment', () => {
 		await page.goto(`/games/${gameId}/base`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
-		await expect(page.getByLabel('💎 Mineral Workers')).toHaveValue('2')
-		await expect(page.getByLabel('⚗️ Gas Workers')).toHaveValue('2')
+		await expect(page.getByLabel('Mineral Workers')).toHaveValue('2')
+		await expect(page.getByLabel('Gas Workers')).toHaveValue('2')
 	})
 
 	test('changing worker assignment via the UI input sends an update', async ({ page }) => {
@@ -95,7 +95,7 @@ test.describe('Resource management — worker assignment', () => {
 
 		// Set a new value for mineral workers; wait for the assign API call to complete
 		// before reading back the state (onChange fires immediately on fill).
-		const mineralInput = page.getByLabel('💎 Mineral Workers')
+		const mineralInput = page.getByLabel('Mineral Workers')
 		const assignPromise = page.waitForResponse(
 			(r) => r.url().includes('/api/workers/assign') && r.request().method() === 'POST'
 		)

--- a/src/ReactClient/src/components/BuildQueue.tsx
+++ b/src/ReactClient/src/components/BuildQueue.tsx
@@ -3,6 +3,7 @@ import { HammerIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { BuildQueueViewModel } from '@/api/types'
 import { EmptyState } from '@/components/EmptyState'
+import { useConfirm } from '@/contexts/ConfirmContext'
 
 interface BuildQueueProps {
   gameId: string
@@ -10,6 +11,7 @@ interface BuildQueueProps {
 
 export function BuildQueue({ gameId }: BuildQueueProps) {
   const queryClient = useQueryClient()
+  const confirm = useConfirm()
 
   const { data, isLoading } = useQuery<BuildQueueViewModel>({
     queryKey: ['buildqueue', gameId],
@@ -65,7 +67,16 @@ export function BuildQueue({ gameId }: BuildQueueProps) {
                 <span className="text-xs text-muted-foreground capitalize">{entry.type}</span>
               </div>
               <button
-                onClick={() => removeMutation.mutate(entry.id)}
+                onClick={async () => {
+                  const ok = await confirm({
+                    title: 'Remove from build queue?',
+                    description: `“${entry.name}” will be removed from the queue. Any resources already reserved will be refunded.`,
+                    destructive: true,
+                    confirmLabel: 'Remove',
+                    cancelLabel: 'Keep',
+                  })
+                  if (ok) removeMutation.mutate(entry.id)
+                }}
                 className="rounded min-h-[36px] px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10"
               >
                 Remove

--- a/src/ReactClient/src/components/ConfirmDialog.tsx
+++ b/src/ReactClient/src/components/ConfirmDialog.tsx
@@ -1,0 +1,80 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={cn(
+            'fixed inset-0 z-[90] bg-black/60',
+            'data-[state=open]:animate-in data-[state=open]:fade-in',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out',
+          )}
+        />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[91] w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2',
+            'rounded-lg border bg-card p-5 shadow-lg',
+            'data-[state=open]:animate-in data-[state=open]:fade-in data-[state=open]:zoom-in-95',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=closed]:zoom-out-95',
+            'duration-150',
+          )}
+        >
+          <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+          {description && (
+            <Dialog.Description className="mt-2 text-sm text-muted-foreground">
+              {description}
+            </Dialog.Description>
+          )}
+          <div className="mt-5 flex justify-end gap-2">
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="min-h-[36px] rounded border px-3 py-1.5 text-sm hover:bg-muted"
+              >
+                {cancelLabel}
+              </button>
+            </Dialog.Close>
+            <button
+              type="button"
+              onClick={() => {
+                onConfirm()
+                onOpenChange(false)
+              }}
+              className={cn(
+                'min-h-[36px] rounded px-3 py-1.5 text-sm hover:opacity-90',
+                destructive
+                  ? 'bg-destructive text-destructive-foreground'
+                  : 'bg-primary text-primary-foreground',
+              )}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/ReactClient/src/components/CostBadge.tsx
+++ b/src/ReactClient/src/components/CostBadge.tsx
@@ -1,12 +1,21 @@
+import { type ReactNode } from 'react'
+import { GemIcon, FlaskConicalIcon, CircleIcon } from 'lucide-react'
 import type { CostViewModel } from '@/api/types'
 
 interface CostBadgeProps {
   cost: CostViewModel | Record<string, number>
 }
 
-const RESOURCE_ICONS: Record<string, string> = {
-  minerals: '💎',
-  gas: '⚗️',
+function resourceIcon(resourceId: string): ReactNode {
+  const cls = 'h-3 w-3'
+  switch (resourceId) {
+    case 'minerals':
+      return <GemIcon className={`${cls} text-blue-400`} aria-hidden="true" />
+    case 'gas':
+      return <FlaskConicalIcon className={`${cls} text-green-400`} aria-hidden="true" />
+    default:
+      return <CircleIcon className={`${cls} text-muted-foreground`} aria-hidden="true" />
+  }
 }
 
 function getCostEntries(cost: CostViewModel | Record<string, number>): [string, number][] {
@@ -30,7 +39,7 @@ export function CostBadge({ cost }: CostBadgeProps) {
           key={resourceId}
           className="inline-flex items-center gap-1 rounded bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground"
         >
-          <span>{RESOURCE_ICONS[resourceId] ?? '🔷'}</span>
+          {resourceIcon(resourceId)}
           <span>{amount.toLocaleString()}</span>
           <span className="text-muted-foreground capitalize">{resourceId}</span>
         </span>

--- a/src/ReactClient/src/components/CurrencyBadge.tsx
+++ b/src/ReactClient/src/components/CurrencyBadge.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
+import { CoinsIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { CurrencyBalanceViewModel } from '@/api/types'
 import { useCurrentUser } from '@/contexts/CurrentUserContext'
@@ -18,7 +19,7 @@ export function CurrencyBadge() {
 
   return (
     <Link to="/economy" className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors">
-      <span>💰</span>
+      <CoinsIcon className="h-4 w-4 text-warning" aria-hidden="true" />
       <span>{data.balance}</span>
     </Link>
   )

--- a/src/ReactClient/src/components/NotificationBell.tsx
+++ b/src/ReactClient/src/components/NotificationBell.tsx
@@ -1,16 +1,25 @@
-import { useState, useRef, useEffect } from 'react'
-import { BellIcon, CheckCircleIcon } from 'lucide-react'
+import { useState, useRef, useEffect, type ReactNode } from 'react'
+import {
+  BellIcon,
+  CheckCircleIcon,
+  AlertTriangleIcon,
+  ZapIcon,
+  InfoIcon,
+} from 'lucide-react'
 import { useNotifications } from '@/hooks/useNotifications'
 import type { UseSignalRReturn } from '@/hooks/useSignalR'
 import { relativeTime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { EmptyState } from '@/components/EmptyState'
 
-function notificationIcon(kind: string): string {
+function notificationIcon(kind: string): ReactNode {
   switch (kind) {
-    case 'Warning': return '⚠️'
-    case 'GameEvent': return '⚡'
-    default: return 'ℹ️'
+    case 'Warning':
+      return <AlertTriangleIcon className="h-4 w-4 text-warning" aria-hidden="true" />
+    case 'GameEvent':
+      return <ZapIcon className="h-4 w-4 text-primary" aria-hidden="true" />
+    default:
+      return <InfoIcon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
   }
 }
 

--- a/src/ReactClient/src/components/NotificationToast.tsx
+++ b/src/ReactClient/src/components/NotificationToast.tsx
@@ -1,6 +1,14 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { useNavigate } from 'react-router'
-import { XIcon } from 'lucide-react'
+import {
+  XIcon,
+  SwordsIcon,
+  CoinsIcon,
+  MailIcon,
+  ZapIcon,
+  AlertTriangleIcon,
+  InfoIcon,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface Toast {
@@ -14,16 +22,23 @@ interface Toast {
 const MAX_VISIBLE = 3
 const AUTO_DISMISS_MS = 5_000
 
-function toastIcon(type: string): string {
+function toastIcon(type: string): ReactNode {
+  const common = 'h-5 w-5 shrink-0'
   switch (type) {
     case 'Attack':
-    case 'BattleResult': return '⚔️'
+    case 'BattleResult':
+      return <SwordsIcon className={cn(common, 'text-destructive')} aria-hidden="true" />
     case 'TradeComplete':
-    case 'MarketOrderFilled': return '💰'
-    case 'MessageReceived': return '📩'
-    case 'GameEvent': return '⚡'
-    case 'Warning': return '⚠️'
-    default: return 'ℹ️'
+    case 'MarketOrderFilled':
+      return <CoinsIcon className={cn(common, 'text-warning')} aria-hidden="true" />
+    case 'MessageReceived':
+      return <MailIcon className={cn(common, 'text-primary')} aria-hidden="true" />
+    case 'GameEvent':
+      return <ZapIcon className={cn(common, 'text-primary')} aria-hidden="true" />
+    case 'Warning':
+      return <AlertTriangleIcon className={cn(common, 'text-warning')} aria-hidden="true" />
+    default:
+      return <InfoIcon className={cn(common, 'text-muted-foreground')} aria-hidden="true" />
   }
 }
 
@@ -107,7 +122,7 @@ function ToastItem({
         'cursor-pointer hover:bg-secondary/40 transition-colors'
       )}
     >
-      <span className="text-lg mt-0.5 shrink-0">{toastIcon(toast.type)}</span>
+      <span className="mt-0.5">{toastIcon(toast.type)}</span>
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium leading-snug">{toast.title}</p>
         {toast.body && (

--- a/src/ReactClient/src/components/WorkerAssignment.tsx
+++ b/src/ReactClient/src/components/WorkerAssignment.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { GemIcon, FlaskConicalIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type { WorkerAssignmentViewModel } from '@/api/types'
 
@@ -48,11 +49,15 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
         </div>
         <div className="text-center">
           <div className="text-2xl font-bold text-blue-400">{data.mineralWorkers}</div>
-          <div className="text-muted-foreground">💎 Mining</div>
+          <div className="text-muted-foreground inline-flex items-center justify-center gap-1">
+            <GemIcon className="h-3.5 w-3.5 text-blue-400" aria-hidden="true" /> Mining
+          </div>
         </div>
         <div className="text-center">
           <div className="text-2xl font-bold text-green-400">{data.gasWorkers}</div>
-          <div className="text-muted-foreground">⚗️ Gas</div>
+          <div className="text-muted-foreground inline-flex items-center justify-center gap-1">
+            <FlaskConicalIcon className="h-3.5 w-3.5 text-green-400" aria-hidden="true" /> Gas
+          </div>
         </div>
       </div>
       <div className="text-xs text-muted-foreground mb-3">
@@ -60,7 +65,9 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label htmlFor="mineralWorkers" className="text-xs text-muted-foreground">💎 Mineral Workers</label>
+          <label htmlFor="mineralWorkers" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+            <GemIcon className="h-3 w-3 text-blue-400" aria-hidden="true" /> Mineral Workers
+          </label>
           <input
             id="mineralWorkers"
             type="number"
@@ -72,7 +79,9 @@ export function WorkerAssignment({ gameId }: WorkerAssignmentProps) {
           />
         </div>
         <div>
-          <label htmlFor="gasWorkers" className="text-xs text-muted-foreground">⚗️ Gas Workers</label>
+          <label htmlFor="gasWorkers" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+            <FlaskConicalIcon className="h-3 w-3 text-green-400" aria-hidden="true" /> Gas Workers
+          </label>
           <input
             id="gasWorkers"
             type="number"

--- a/src/ReactClient/src/contexts/ConfirmContext.tsx
+++ b/src/ReactClient/src/contexts/ConfirmContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, type ReactNode, useCallback, useContext, useRef, useState } from 'react'
+import { ConfirmDialog, type ConfirmDialogProps } from '@/components/ConfirmDialog'
+
+type ConfirmOptions = Omit<ConfirmDialogProps, 'open' | 'onOpenChange' | 'onConfirm'>
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>
+
+const ConfirmContext = createContext<ConfirmFn | null>(null)
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [options, setOptions] = useState<ConfirmOptions | null>(null)
+  const resolverRef = useRef<((v: boolean) => void) | null>(null)
+
+  const confirm = useCallback<ConfirmFn>((opts) => {
+    return new Promise((resolve) => {
+      resolverRef.current = resolve
+      setOptions(opts)
+    })
+  }, [])
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      resolverRef.current?.(false)
+      resolverRef.current = null
+      setOptions(null)
+    }
+  }
+
+  const handleConfirm = () => {
+    resolverRef.current?.(true)
+    resolverRef.current = null
+  }
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {options && (
+        <ConfirmDialog
+          open
+          onOpenChange={handleOpenChange}
+          onConfirm={handleConfirm}
+          {...options}
+        />
+      )}
+    </ConfirmContext.Provider>
+  )
+}
+
+export function useConfirm(): ConfirmFn {
+  const ctx = useContext(ConfirmContext)
+  if (!ctx) throw new Error('useConfirm must be used within ConfirmProvider')
+  return ctx
+}

--- a/src/ReactClient/src/layouts/RootLayout.tsx
+++ b/src/ReactClient/src/layouts/RootLayout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { Outlet } from 'react-router'
 import { CurrentUserProvider } from '@/contexts/CurrentUserContext'
 import { ThemeProvider } from '@/contexts/ThemeContext'
+import { ConfirmProvider } from '@/contexts/ConfirmContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { PageLoader } from '@/components/PageLoader'
 
@@ -10,9 +11,11 @@ export function RootLayout() {
     <ErrorBoundary>
       <ThemeProvider>
         <CurrentUserProvider>
-          <Suspense fallback={<PageLoader />}>
-            <Outlet />
-          </Suspense>
+          <ConfirmProvider>
+            <Suspense fallback={<PageLoader />}>
+              <Outlet />
+            </Suspense>
+          </ConfirmProvider>
         </CurrentUserProvider>
       </ThemeProvider>
     </ErrorBoundary>

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -1,6 +1,7 @@
-import { useState, lazy, Suspense } from 'react'
+import { useState, lazy, Suspense, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
+import { AlertTriangleIcon, ZapIcon, InfoIcon } from 'lucide-react'
 import apiClient from '@/api/client'
 import type {
   AssetsViewModel,
@@ -26,11 +27,14 @@ interface BaseProps {
   gameId: string
 }
 
-function notificationIcon(kind: string): string {
+function notificationIcon(kind: string): ReactNode {
   switch (kind) {
-    case 'Warning': return '⚠️'
-    case 'GameEvent': return '⚡'
-    default: return 'ℹ️'
+    case 'Warning':
+      return <AlertTriangleIcon className="h-4 w-4 text-warning shrink-0" aria-hidden="true" />
+    case 'GameEvent':
+      return <ZapIcon className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
+    default:
+      return <InfoIcon className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
   }
 }
 
@@ -334,7 +338,7 @@ export function Base({ gameId }: BaseProps) {
             <ul className="divide-y">
               {notifications.slice(0, 10).map((n) => (
                 <li key={n.id} className="flex items-start gap-2 py-2 px-2">
-                  <span>{notificationIcon(n.kind)}</span>
+                  <span className="mt-0.5">{notificationIcon(n.kind)}</span>
                   <div className="flex-1 min-w-0">
                     <span className="text-sm">{n.message}</span>
                     <div className="text-xs text-muted-foreground">{relativeTime(n.createdAt)}</div>

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -19,8 +19,8 @@ import { relativeTime } from '@/lib/utils'
 const ResourceHistoryChart = lazy(() =>
 	import('@/components/ResourceHistoryChart').then(m => ({ default: m.ResourceHistoryChart }))
 )
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 
 interface BaseProps {
   gameId: string
@@ -281,7 +281,11 @@ export function Base({ gameId }: BaseProps) {
       {/* Assets */}
       {lastError && <div className="text-destructive text-sm">{lastError}</div>}
       {assetsLoading ? (
-        <PageLoader message="Loading assets..." />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} className="h-32" />
+          ))}
+        </div>
       ) : assetsError && !assetsData ? (
         <ApiError message="Failed to load assets." onRetry={() => void refetchAssets()} />
       ) : assetsData ? (
@@ -319,7 +323,11 @@ export function Base({ gameId }: BaseProps) {
         </div>
         <div className="p-2">
           {!notifications ? (
-            <div className="p-3 text-muted-foreground text-sm">Loading...</div>
+            <div className="p-3 space-y-2" aria-hidden="true">
+              <SkeletonLine className="w-3/4" />
+              <SkeletonLine className="w-2/3" />
+              <SkeletonLine className="w-1/2" />
+            </div>
           ) : notifications.length === 0 ? (
             <div className="p-3 text-muted-foreground text-sm">No recent activity.</div>
           ) : (

--- a/src/ReactClient/src/pages/GameLiveView.tsx
+++ b/src/ReactClient/src/pages/GameLiveView.tsx
@@ -1,5 +1,14 @@
+import { type ReactNode } from 'react'
 import { Link } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
+import {
+  AlertTriangleIcon,
+  ZapIcon,
+  SwordsIcon,
+  HandshakeIcon,
+  MailIcon,
+  InfoIcon,
+} from 'lucide-react'
 import apiClient from '@/api/client'
 import { useCurrentGame } from '@/contexts/CurrentGameContext'
 import type {
@@ -21,14 +30,21 @@ function formatNum(v: number): string {
   return Math.floor(v).toLocaleString()
 }
 
-function notificationIcon(kind: string): string {
+function notificationIcon(kind: string): ReactNode {
+  const c = 'h-4 w-4 shrink-0'
   switch (kind) {
-    case 'Warning': return '⚠️'
-    case 'GameEvent': return '⚡'
-    case 'AttackReceived': return '⚔️'
-    case 'AllianceRequest': return '🤝'
-    case 'MessageReceived': return '✉️'
-    default: return 'ℹ️'
+    case 'Warning':
+      return <AlertTriangleIcon className={cn(c, 'text-warning')} aria-hidden="true" />
+    case 'GameEvent':
+      return <ZapIcon className={cn(c, 'text-primary')} aria-hidden="true" />
+    case 'AttackReceived':
+      return <SwordsIcon className={cn(c, 'text-destructive')} aria-hidden="true" />
+    case 'AllianceRequest':
+      return <HandshakeIcon className={cn(c, 'text-primary')} aria-hidden="true" />
+    case 'MessageReceived':
+      return <MailIcon className={cn(c, 'text-primary')} aria-hidden="true" />
+    default:
+      return <InfoIcon className={cn(c, 'text-muted-foreground')} aria-hidden="true" />
   }
 }
 
@@ -302,7 +318,7 @@ export function GameLiveView({ gameId }: GameLiveViewProps) {
               <ul className="divide-y">
                 {notifications.slice(0, 8).map((n) => (
                   <li key={n.id} className="flex items-start gap-2 py-2">
-                    <span className="text-sm shrink-0">{notificationIcon(n.kind)}</span>
+                    <span className="mt-0.5">{notificationIcon(n.kind)}</span>
                     <div className="flex-1 min-w-0">
                       <div className="text-sm">{n.message}</div>
                       <div className="text-xs text-muted-foreground">{relativeTime(n.createdAt)}</div>

--- a/src/ReactClient/src/pages/Games.tsx
+++ b/src/ReactClient/src/pages/Games.tsx
@@ -3,8 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useSearchParams, Link } from 'react-router'
 import apiClient from '@/api/client'
 import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { vcBadgeCss, vcText } from '@/lib/victory'
 import { formatDateTime } from '@/lib/formatters'
 
@@ -154,7 +154,16 @@ export function Games() {
       {success && <div className="rounded-lg border border-success/50 bg-success/10 p-3 text-sm">{success}</div>}
       {error && <div className="rounded-lg border border-danger/50 bg-danger/10 p-3 text-sm text-danger-foreground">{error}</div>}
 
-      {queryLoading && <PageLoader message="Loading games..." />}
+      {queryLoading && (
+        <div className="space-y-4" aria-hidden="true">
+          <SkeletonLine className="h-5 w-24" />
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} className="h-28" />
+            ))}
+          </div>
+        </div>
+      )}
       {queryError && !data && <ApiError message="Failed to load games." onRetry={() => void refetch()} />}
 
       {data && (

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -3,8 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import type { MarketViewModel, MarketOrderViewModel, CreateMarketOrderRequest } from '@/api/types'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonRow, SkeletonLine } from '@/components/Skeleton'
 import { useConfirm } from '@/contexts/ConfirmContext'
 
 interface MarketProps {
@@ -98,7 +98,22 @@ export function Market({ gameId }: MarketProps) {
     },
   })
 
-  if (isLoading) return <PageLoader message="Loading market..." />
+  if (isLoading) {
+    return (
+      <div className="space-y-6" aria-hidden="true">
+        <SkeletonLine className="h-6 w-40" />
+        <div className="rounded-lg border bg-card overflow-hidden">
+          <table className="w-full text-sm">
+            <tbody>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <SkeletonRow key={i} cols={5} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
   if (queryError) return <ApiError message="Failed to load market." onRetry={() => void refetch()} />
   if (!data) return null
 

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -5,6 +5,7 @@ import apiClient from '@/api/client'
 import type { MarketViewModel, MarketOrderViewModel, CreateMarketOrderRequest } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { useConfirm } from '@/contexts/ConfirmContext'
 
 interface MarketProps {
   gameId: string
@@ -18,6 +19,7 @@ function exchangeRate(order: MarketOrderViewModel): string {
 
 export function Market({ gameId }: MarketProps) {
   const queryClient = useQueryClient()
+  const confirm = useConfirm()
   const [postError, setPostError] = useState<string | null>(null)
   const [orderErrors, setOrderErrors] = useState<Record<string, string>>({})
   const [offerResourceId, setOfferResourceId] = useState('')
@@ -207,7 +209,16 @@ export function Market({ gameId }: MarketProps) {
                     <td className="py-2 px-3">
                       <div className="flex items-center gap-2">
                         <button
-                          onClick={() => cancelMutation.mutate(order.orderId)}
+                          onClick={async () => {
+                            const ok = await confirm({
+                              title: 'Cancel market order?',
+                              description: `Your ${order.offeredAmount} ${order.offeredResourceName} will be returned to your base.`,
+                              destructive: true,
+                              confirmLabel: 'Cancel order',
+                              cancelLabel: 'Keep order',
+                            })
+                            if (ok) cancelMutation.mutate(order.orderId)
+                          }}
                           disabled={cancelMutation.isPending}
                           className="rounded bg-destructive min-h-[36px] px-3 py-1.5 text-xs text-destructive-foreground hover:opacity-90 disabled:opacity-50"
                         >

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -7,9 +7,11 @@ import type { ProfileViewModel, PlayerHistoryViewModel, PlayerListViewModel, Api
 import { ApiError } from '@/components/ApiError'
 import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { relativeTime } from '@/lib/utils'
+import { useConfirm } from '@/contexts/ConfirmContext'
 
 function ApiKeySection() {
   const queryClient = useQueryClient()
+  const confirm = useConfirm()
   const [newKey, setNewKey] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
@@ -90,7 +92,16 @@ function ApiKeySection() {
               {generateMutation.isPending ? 'Regenerating...' : 'Regenerate'}
             </button>
             <button
-              onClick={() => revokeMutation.mutate(player.playerId)}
+              onClick={async () => {
+                const ok = await confirm({
+                  title: 'Revoke API key?',
+                  description: 'Any bot or integration using this key will immediately stop working. You can generate a new one afterwards.',
+                  destructive: true,
+                  confirmLabel: 'Revoke key',
+                  cancelLabel: 'Keep key',
+                })
+                if (ok) revokeMutation.mutate(player.playerId)
+              }}
               disabled={revokeMutation.isPending}
               className="rounded border border-destructive/50 px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50 flex items-center gap-1"
             >

--- a/src/ReactClient/src/pages/Trade.tsx
+++ b/src/ReactClient/src/pages/Trade.tsx
@@ -14,6 +14,7 @@ import type {
 import { relativeTime } from '@/lib/utils'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { useConfirm } from '@/contexts/ConfirmContext'
 
 interface TradeProps {
 	gameId: string
@@ -21,6 +22,7 @@ interface TradeProps {
 
 export function Trade({ gameId }: TradeProps) {
 	const queryClient = useQueryClient()
+	const confirm = useConfirm()
 	const [error, setError] = useState<string | null>(null)
 	const [success, setSuccess] = useState<string | null>(null)
 
@@ -319,7 +321,16 @@ export function Trade({ gameId }: TradeProps) {
 										<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(offer.sentAt)}</td>
 										<td className="py-2 px-3">
 											<button
-												onClick={() => cancelMut.mutate(offer.offerId)}
+												onClick={async () => {
+													const ok = await confirm({
+														title: 'Cancel trade offer?',
+														description: 'The offer will be withdrawn and the recipient can no longer accept it.',
+														destructive: true,
+														confirmLabel: 'Cancel offer',
+														cancelLabel: 'Keep offer',
+													})
+													if (ok) cancelMut.mutate(offer.offerId)
+												}}
 												disabled={cancelMut.isPending}
 												className="rounded bg-destructive px-2 py-0.5 text-xs text-destructive-foreground hover:opacity-90 disabled:opacity-50"
 											>

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -5,8 +5,8 @@ import axios from 'axios'
 import apiClient from '@/api/client'
 import type { UnitsViewModel, UnitViewModel } from '@/api/types'
 import { BuildQueue } from '@/components/BuildQueue'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { SkeletonRow } from '@/components/Skeleton'
 
 interface UnitsProps {
   gameId: string
@@ -184,7 +184,15 @@ export function Units({ gameId }: UnitsProps) {
       <BuildQueue gameId={gameId} />
 
       {isLoading ? (
-        <PageLoader message="Loading units..." />
+        <div className="rounded-lg border bg-card overflow-hidden" aria-hidden="true">
+          <table className="w-full text-sm">
+            <tbody>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <SkeletonRow key={i} cols={5} />
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : queryError && !data ? (
         <ApiError message="Failed to load units." onRetry={() => void refetch()} />
       ) : !data || data.units.length === 0 ? (


### PR DESCRIPTION
## Summary

Phase 1 of a multi-PR UI/UX improvement series based on a reverse-engineered design reference. Focus: safe polish that reduces daily friction without touching layout.

### Included in this PR

1. **Design reference + plan** (`docs/UI-UX-DESIGN.md`, `docs/superpowers/plans/2026-04-12-ui-ux-improvements.md`) — reverse-engineered UI/UX reference and the full multi-phase improvement plan.
2. **ConfirmDialog + `useConfirm`** — generic Promise-based confirmation dialog primitive built on Radix Dialog, mounted at the root via `ConfirmProvider`. Wired into destructive actions:
   - BuildQueue: remove entry
   - Market: cancel own order
   - Trade: cancel outgoing offer
   - Player profile: revoke API key
3. **Skeleton loading on core pages** — replaces generic `"Loading..."` text with layout-matching skeleton placeholders on Base, Units, Market, and Games. `PlayerRanking` and `Spectator` already used the same pattern.
4. **Lucide icon standardization** — replaces emoji-as-icon in UI chrome:
   - Notification toasts, bell popover, live-view event feed, Base recent activity
   - WorkerAssignment headers/labels, CostBadge resource chips, CurrencyBadge
   - Celebratory and content emoji (trophies, unit stat inline text, shop price tags, help/tutorial illustrations) intentionally left alone.

### Deferred from the plan

- **Inline accept/decline on diplomacy notification toasts**: `NotificationKind` has no `DiplomacyProposal` type — the backend does not currently push proposals through the toast channel. Implementing this requires a server-side change and will ship as its own PR.
- Phase 2 items (responsive tables, attack modal, Base restructure) will ship in their own PRs per `CLAUDE.md` worktree workflow.

## Test plan

- [ ] `npm run build` in `src/ReactClient` succeeds locally.
- [ ] Dev server boots.
- [ ] Cancel a market order → confirmation dialog appears; cancel and confirm paths both work.
- [ ] Remove a build-queue entry → confirmation dialog appears.
- [ ] Revoke an API key → confirmation dialog appears.
- [ ] Cancel an outgoing trade offer → confirmation dialog appears.
- [ ] Navigate to Base / Units / Market / Games with a cold cache → skeletons render in place of a spinner.
- [ ] No residual emoji in notification toasts, notification bell, live-view event feed, Base recent activity, WorkerAssignment, CostBadge, or CurrencyBadge.
- [ ] Existing Lucide trophies / rockets / unit empty-state illustrations intentionally untouched.