### PR TITLE
UI/UX: responsive tables (mobile card fallback)

### DIFF
--- a/src/ReactClient/src/index.css
+++ b/src/ReactClient/src/index.css
@@ -91,3 +91,76 @@ body {
     animation: none;
   }
 }
+
+/*
+ * Responsive table — at md+ renders as a normal table, below md
+ * collapses into a stacked card-per-row layout with each cell
+ * prefixed by its column label (via the data-label attribute).
+ *
+ * Usage:
+ *   <table className="responsive-table">
+ *     <thead> ... </thead>
+ *     <tbody>
+ *       <tr>
+ *         <td data-label="Unit">Marine</td>
+ *         <td data-label="Count">42</td>
+ *       </tr>
+ *     </tbody>
+ *   </table>
+ *
+ * Cells may opt out of the label prefix with `data-label-hide` or by
+ * omitting `data-label` (the ::before will be empty).
+ */
+@media (max-width: 767px) {
+  .responsive-table {
+    display: block;
+  }
+  .responsive-table thead {
+    display: none;
+  }
+  .responsive-table tbody,
+  .responsive-table tr {
+    display: block;
+    width: 100%;
+  }
+  .responsive-table tr {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.5rem;
+    background-color: var(--color-card);
+  }
+  .responsive-table td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.25rem 0 !important;
+    border: none !important;
+    text-align: right;
+  }
+  .responsive-table td[data-label]::before {
+    content: attr(data-label);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-muted-foreground);
+    text-align: left;
+    flex-shrink: 0;
+  }
+  /* A cell with data-label="" (or no data-label) takes the full row —
+     useful for action rows or primary titles. */
+  .responsive-table td[data-label=""],
+  .responsive-table td:not([data-label]) {
+    display: block;
+    text-align: left;
+    padding-top: 0.5rem !important;
+  }
+  .responsive-table td[data-label=""]::before,
+  .responsive-table td:not([data-label])::before {
+    content: none;
+  }
+  /* Opt out: hide this cell entirely on mobile. */
+  .responsive-table td[data-label-hide] {
+    display: none;
+  }
+}

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -196,7 +196,7 @@ export function Market({ gameId }: MarketProps) {
         <div>
           <h2 className="font-semibold mb-3">My Orders</h2>
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="responsive-table w-full text-sm">
               <thead className="border-b">
                 <tr>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
@@ -209,19 +209,19 @@ export function Market({ gameId }: MarketProps) {
               <tbody>
                 {myOrders.map((order) => (
                   <tr key={order.orderId} className="border-b border-border bg-info/10">
-                    <td className="py-2 px-3">
+                    <td data-label="Offering" className="py-2 px-3">
                       {order.offeredAmount} {order.offeredResourceName}
                     </td>
-                    <td className="py-2 px-3">
+                    <td data-label="Wants" className="py-2 px-3">
                       {order.wantedAmount} {order.wantedResourceName}
                     </td>
-                    <td className="py-2 px-3 text-muted-foreground text-xs">
+                    <td data-label="Rate" className="py-2 px-3 text-muted-foreground text-xs">
                       {exchangeRate(order)}
                     </td>
-                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                    <td data-label="Posted" className="py-2 px-3 text-xs text-muted-foreground">
                       {new Date(order.createdAt).toLocaleString()}
                     </td>
-                    <td className="py-2 px-3">
+                    <td data-label="" className="py-2 px-3">
                       <div className="flex items-center gap-2">
                         <button
                           onClick={async () => {
@@ -259,7 +259,7 @@ export function Market({ gameId }: MarketProps) {
           <p className="text-muted-foreground text-sm">No open orders from other players.</p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="responsive-table w-full text-sm">
               <thead className="border-b">
                 <tr>
                   <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Seller</th>
@@ -273,20 +273,20 @@ export function Market({ gameId }: MarketProps) {
               <tbody>
                 {otherOrders.map((order) => (
                   <tr key={order.orderId} className="border-b border-border">
-                    <td className="py-2 px-3">{order.sellerPlayerName}</td>
-                    <td className="py-2 px-3">
+                    <td data-label="Seller" className="py-2 px-3">{order.sellerPlayerName}</td>
+                    <td data-label="Offering" className="py-2 px-3">
                       {order.offeredAmount} {order.offeredResourceName}
                     </td>
-                    <td className="py-2 px-3">
+                    <td data-label="Wants" className="py-2 px-3">
                       {order.wantedAmount} {order.wantedResourceName}
                     </td>
-                    <td className="py-2 px-3 text-muted-foreground text-xs">
+                    <td data-label="Rate" className="py-2 px-3 text-muted-foreground text-xs">
                       {exchangeRate(order)}
                     </td>
-                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                    <td data-label="Posted" className="py-2 px-3 text-xs text-muted-foreground">
                       {new Date(order.createdAt).toLocaleString()}
                     </td>
-                    <td className="py-2 px-3">
+                    <td data-label="" className="py-2 px-3">
                       <div className="flex items-center gap-2">
                         <button
                           onClick={() => acceptMutation.mutate(order.orderId)}

--- a/src/ReactClient/src/pages/PlayerRanking.tsx
+++ b/src/ReactClient/src/pages/PlayerRanking.tsx
@@ -71,17 +71,17 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
         <ApiError message="Failed to load ranking." onRetry={() => void refetch()} />
       ) : (
         <div className="rounded-lg border overflow-x-auto max-w-full">
-          <table className="w-full text-sm">
+          <table className="responsive-table w-full text-sm">
             <thead>
               <tr className="border-b bg-secondary/30 text-xs text-muted-foreground uppercase tracking-wide">
                 <th scope="col" className="px-4 py-2 text-left w-10">#</th>
                 <th scope="col" className="px-4 py-2 text-left">Player</th>
                 <th scope="col" className="px-4 py-2 text-right">Score</th>
-                <th scope="col" className="px-4 py-2 text-left hidden sm:table-cell w-32">Victory</th>
-                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Minerals</th>
-                <th scope="col" className="px-4 py-2 text-right hidden sm:table-cell">Gas</th>
-                <th scope="col" className="px-4 py-2 text-right hidden md:table-cell">Units</th>
-                <th scope="col" className="px-4 py-2 text-center hidden md:table-cell">Type</th>
+                <th scope="col" className="px-4 py-2 text-left w-32">Victory</th>
+                <th scope="col" className="px-4 py-2 text-right">Minerals</th>
+                <th scope="col" className="px-4 py-2 text-right">Gas</th>
+                <th scope="col" className="px-4 py-2 text-right">Units</th>
+                <th scope="col" className="px-4 py-2 text-center">Type</th>
                 <th scope="col" className="px-4 py-2 text-center">Status</th>
               </tr>
             </thead>
@@ -106,8 +106,8 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                     ? 'bg-primary/10 border-l-2 border-l-primary font-semibold'
                     : 'hover:bg-secondary/20'
                 )}>
-                  <td className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
-                  <td className="px-4 py-2">
+                  <td data-label="Rank" className="px-4 py-2 font-mono text-muted-foreground">#{i + 1}</td>
+                  <td data-label="Player" className="px-4 py-2">
                     <Link
                       to={`/games/${gameId}/player/${p.playerId}`}
                       className={cn(
@@ -122,8 +122,8 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                       <span className="ml-1.5 text-[10px] text-warning-foreground" title="Under protection">🛡</span>
                     )}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono">{Math.floor(p.score).toLocaleString()}</td>
-                  <td className="px-4 py-2 hidden sm:table-cell">
+                  <td data-label="Score" className="px-4 py-2 text-right font-mono">{Math.floor(p.score).toLocaleString()}</td>
+                  <td data-label="Victory" className="px-4 py-2">
                     {(() => {
                       const pct = Math.min(100, Math.round((p.score / VICTORY_THRESHOLD) * 100))
                       return (
@@ -139,16 +139,16 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                       )
                     })()}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                  <td data-label="Minerals" className="px-4 py-2 text-right font-mono">
                     {p.approxMinerals != null ? Math.floor(p.approxMinerals).toLocaleString() : <span className="text-muted-foreground italic">?</span>}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono hidden sm:table-cell">
+                  <td data-label="Gas" className="px-4 py-2 text-right font-mono">
                     {p.approxGas != null ? Math.floor(p.approxGas).toLocaleString() : <span className="text-muted-foreground italic">?</span>}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono hidden md:table-cell">
+                  <td data-label="Units" className="px-4 py-2 text-right font-mono">
                     {p.approxHomeUnitCount ?? <span className="text-muted-foreground italic">?</span>}
                   </td>
-                  <td className="px-4 py-2 text-center hidden md:table-cell">
+                  <td data-label="Type" className="px-4 py-2 text-center">
                     <span className={cn(
                       'rounded px-1.5 py-0.5 text-[10px] font-medium',
                       p.isAgent ? 'bg-accent text-accent-foreground' : 'bg-info/50 text-info-foreground'
@@ -156,7 +156,7 @@ export function PlayerRanking({ gameId }: PlayerRankingProps) {
                       {p.isAgent ? 'AI' : 'Human'}
                     </span>
                   </td>
-                  <td className="px-4 py-2 text-center">
+                  <td data-label="Status" className="px-4 py-2 text-center">
                     <span className={cn(
                       'inline-block h-2 w-2 rounded-full',
                       p.isOnline ? 'bg-success' : 'bg-muted-foreground'

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -80,13 +80,13 @@ function UnitRow({
 
   return (
     <tr className="border-b border-border">
-      <td className="py-2 px-3 font-medium">{unit.definition?.name}</td>
-      <td className="py-2 px-3 text-right tabular-nums">{unit.count.toLocaleString()}</td>
-      <td className="py-2 px-3 text-xs text-muted-foreground hidden sm:table-cell">
+      <td data-label="Unit" className="py-2 px-3 font-medium">{unit.definition?.name}</td>
+      <td data-label="Count" className="py-2 px-3 text-right tabular-nums">{unit.count.toLocaleString()}</td>
+      <td data-label="Stats" className="py-2 px-3 text-xs text-muted-foreground">
         ⚔️{unit.definition?.attack} 🛡️{unit.definition?.defense} ❤️{unit.definition?.hitpoints}
       </td>
       {unit.positionPlayerId && (
-        <td className="py-2 px-3 text-xs">
+        <td data-label="Location" className="py-2 px-3 text-xs">
           <Link
             to={`/games/${gameId}/enemybase/${encodeURIComponent(unit.positionPlayerId)}`}
             className="text-primary hover:underline"
@@ -95,7 +95,7 @@ function UnitRow({
           </Link>
         </td>
       )}
-      <td className="py-2 px-3">
+      <td data-label="" className="py-2 px-3">
         <div className="flex flex-wrap gap-1.5">
           {!unit.positionPlayerId && (
             <Link
@@ -230,12 +230,12 @@ export function Units({ gameId }: UnitsProps) {
                 </span>
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-sm">
+                <table className="responsive-table w-full text-sm">
                   <thead className="border-b">
                     <tr>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
                       <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Location</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
@@ -273,12 +273,12 @@ export function Units({ gameId }: UnitsProps) {
               </div>
             ) : (
               <div className="overflow-x-auto">
-                <table className="w-full text-sm">
+                <table className="responsive-table w-full text-sm">
                   <thead className="border-b">
                     <tr>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
                       <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Stats</th>
+                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
                       <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
                     </tr>
                   </thead>


### PR DESCRIPTION
## Summary

Tables on Units, Market, and PlayerRanking previously hid columns below `md` with `hidden sm:table-cell` / `hidden md:table-cell`, meaning data was literally invisible on phones.

This PR adds a **CSS-only** `.responsive-table` class to `index.css` that, below 767px, flips a standard `<table>` into a stacked card-per-row layout. Each cell uses its `data-label` attribute as a mobile prefix via a `::before`. No columns are hidden — everything is visible.

### Cell conventions

| Attribute | Behavior |
|---|---|
| `data-label=\"Score\"` | Mobile renders `Score: 123` as a row inside the card |
| `data-label=\"\"` | Cell becomes a full-width block (use for action rows) |
| `data-label-hide=\"\"` | Cell is hidden on mobile entirely |

### Migrated tables

- **Units** — deployed + home base (both tables)
- **Market** — my orders + open orders
- **PlayerRanking** — 9-column ranking table (rank, player, score, victory, minerals, gas, units, type, status)

## Tradeoffs

- **CSS-only, no new component.** Minimally invasive and leaves the existing table structure intact. The alternative (a config-driven `<ResponsiveTable>` wrapper) would have required every table to adopt a new API and rewrite per-row state handlers.
- **Not every table is migrated yet.** Diplomacy, Trade, Messages, admin tables still use plain tables. Can be migrated incrementally using the same one-line `className=\"responsive-table\"` + `data-label` additions.

## Test plan

- [ ] `npm run build` in `src/ReactClient` succeeds.
- [ ] At desktop width, Units / Market / PlayerRanking render as normal tables (no visual regression).
- [ ] Below 768px, each row renders as a card with labeled rows; no data is hidden.
- [ ] Per-row action buttons still work (cancel market order, merge/split/attack units).
- [ ] Player ranking status dot, victory progress bar, and numeric columns all display.