### PR TITLE
Add Railway config for PR preview deployments

### DIFF
--- a/src/railway.toml
+++ b/src/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "BrowserGameEngine.FrontendServer/Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- Adds `src/railway.toml` so Railway can build the existing FrontendServer Dockerfile
- Enables Railway-based PR preview environments as an alternative to per-PR ECS plumbing

## Why
We wanted a low-effort way to get staging/preview deployments on every PR. Railway's PR environments spin up an ephemeral copy of the app per PR and tear it down on close/merge, so this is the test of that setup.

## Test plan
- [ ] Railway's GitHub integration auto-creates a PR environment for this PR
- [ ] That environment builds successfully and serves `/health` → 200
- [ ] Closing the PR tears the environment down