### PR TITLE
fix: route new GitHub users to create-player instead of 401 loop

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ProfileController.cs
@@ -51,18 +51,30 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(typeof(ProfileViewModel), StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		public ActionResult<ProfileViewModel> Get() {
-			if (!currentUserContext.IsValid) return Unauthorized();
-
-			var playerId = currentUserContext.PlayerId!;
-			var player = playerRepository.Get(playerId);
+			if (!currentUserContext.IsValid && currentUserContext.UserId == null) return Unauthorized();
 
 			var user = currentUserContext.UserId != null
 				? userRepository.GetByUserId(currentUserContext.UserId)
 				: null;
-
 			var avatarUrl = user?.GithubLogin != null
 				? $"https://github.com/{user.GithubLogin}.png"
 				: null;
+
+			// Authenticated but no player yet: return a minimal profile so the client
+			// can route to the create-player flow instead of treating it as 401.
+			if (!currentUserContext.IsValid) {
+				return new ProfileViewModel {
+					PlayerName = null,
+					DisplayName = user?.DisplayName,
+					AvatarUrl = avatarUrl,
+					JoinedAt = currentUserContext.UserId != null
+						? globalState.GetUserCreated(currentUserContext.UserId)
+						: null
+				};
+			}
+
+			var playerId = currentUserContext.PlayerId!;
+			var player = playerRepository.Get(playerId);
 
 			var land = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
 			var minerals = resourceRepository.GetAmount(playerId, Id.ResDef("minerals"));

--- a/src/ReactClient/src/pages/Index.tsx
+++ b/src/ReactClient/src/pages/Index.tsx
@@ -16,6 +16,10 @@ export function Index() {
 
   useEffect(() => {
     if (!profile) return
+    if (!profile.playerName) {
+      void navigate('/createplayer', { replace: true })
+      return
+    }
     if (profile.currentGameId) {
       void navigate(`/games/${profile.currentGameId}/base`, { replace: true })
     } else {


### PR DESCRIPTION
## Summary

After GitHub OAuth, authenticated users with no linked player hit 401 on `/api/profile` and were bounced back to `/signin` by the axios 401 interceptor, making login appear broken. The `/createplayer` route existed but was orphaned — nothing navigated there.

## Root cause

1. OAuth succeeds, `BGE.AuthCookie` is set.
2. React `Index` queries `GET /api/profile`.
3. `ProfileController.Get()` checks `currentUserContext.IsValid` and returns **401** when false.
4. `IsValid` is only set when `CurrentUserMiddleware` resolves a player for the user — new users have no player, so it stays false.
5. `apiClient` 401 interceptor redirects to `/signin?returnUrl=%2F` → user appears stuck.

## Changes

- `ProfileController.Get` returns a minimal profile (`PlayerName=null`) when authenticated but no player, instead of 401. Still returns 401 when neither cookie user nor bearer player is resolved.
- `Index` navigates to `/createplayer` when `profile.playerName` is empty.

## Test plan

- [x] `dotnet test` — 541 passed (including `GenerateApiKey_ThenUseAsBearer_Authenticates` which exercises the bearer path)
- [x] `npm run build` (ReactClient)
- [ ] Manual: log into prod with a fresh GitHub account → should land on `/createplayer`
- [ ] Manual: existing user with a player → should land on `/games/:id/base` as before
- [ ] Manual: unauthenticated `/api/profile` → still 401