### PR TITLE
feat(ui): Batch 1 — core gameplay pages refactored to design-system primitives

### DIFF
--- a/docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md
+++ b/docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md
@@ -1,0 +1,698 @@
+# Batch 1 — Core Gameplay Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the five core-gameplay pages (`Base`, `Units`, `Research`, `Market`, `Trade`) to consume the design-system foundation shipped in PR #315. Page logic (queries, mutations, effects) is preserved; markup is rewritten to use the new primitives. Two new shared components are extracted (`UpgradeTrack`, `ConvertResourceForm`).
+
+**Architecture:** Each page gets a mechanical pass: `<h1>` → `PageHeader`, `<div className="rounded-lg border bg-card p-4">` → `Section`/`Card`, hand-rolled `<table>` → `DataTable`, inline `<button>` → `Button`, status spans → `Badge`, inline success banners → `sonner` toast, hand-rolled modal/form → Radix `Dialog` + `react-hook-form`/`zod`. Extract two shared components so Base can drop the Trade block and Market can gain a Convert tab in the same commit window.
+
+**Tech Stack:** React 19, TanStack Query v5, TanStack Table v8, shadcn/ui (already installed), react-hook-form + zod, sonner, lucide-react.
+
+**Scope:** Five pages plus two new shared components. No backend changes. No refactor of pages outside the five.
+
+**Parent spec:** `docs/superpowers/specs/2026-04-17-ui-ux-improvements-design.md` (Batch 1 section).
+
+**Foundation PR that unlocked this work:** #315 (merged, commit `de444da`).
+
+---
+
+## Pre-flight
+
+- Working directory for all tasks: `/tmp/bge-work/batch-1-core-gameplay`. Worktree is already created on branch `batch-1-core-gameplay` off `origin/master` (HEAD `de444da`).
+- `node` comes from nvm; prepend `/home/chris/.nvm/versions/node/v24.12.0/bin` to `PATH` at the top of every shell invocation.
+- All `npm`/`npx` commands run from `src/ReactClient/`. All `dotnet` commands run from `src/`.
+- **Do NOT restructure primitives themselves.** If a primitive's prop shape doesn't fit a page's need, pass the data differently or add a small wrapper, don't edit `src/components/ui/*`.
+- **Preserve all existing `useQuery`/`useMutation` calls verbatim** — keep keys, endpoints, invalidations, `onSuccess`/`onError` handlers. Only the markup changes.
+- Existing pages have zero `data-testid` attributes (verified). Don't add new ones unless a test starts failing for a text/role selector.
+
+---
+
+### Task 1: Extract `UpgradeTrack` component
+
+**Files:** Create `src/ReactClient/src/components/UpgradeTrack.tsx`.
+
+Rationale: `Research.tsx` currently contains two nearly identical 60-line blocks (Attack and Defense). Extract into one component before refactoring Research itself so the page becomes trivial afterwards.
+
+- [ ] **Step 1: Read the source blocks**
+
+```bash
+sed -n '60,190p' src/ReactClient/src/pages/Research.tsx
+```
+
+Understand: `upgrades.attackLevel`, `upgrades.defenseLevel`, `upgrades.maxUpgradeLevel`, `upgrades.upgradeBeingResearched` (string sentinel `'None'|'Attack'|'Defense'`), `upgrades.upgradeResearchTimer` (ticks), `upgrades.attackUpgradeCost.cost`, `upgrades.defenseUpgradeCost.cost`, and the `upgradeMutation` shape.
+
+- [ ] **Step 2: Create `src/ReactClient/src/components/UpgradeTrack.tsx`**
+
+```tsx
+import { cn } from '@/lib/utils'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { Ticks } from '@/components/ui/ticks'
+import { CostBadge } from '@/components/CostBadge'
+import { SectionHeader } from '@/components/ui/section'
+import type { ReactNode } from 'react'
+
+type UpgradeType = 'Attack' | 'Defense'
+
+interface UpgradeTrackProps {
+  type: UpgradeType
+  currentLevel: number
+  maxLevel: number
+  upgradeBeingResearched: string // 'None' | 'Attack' | 'Defense'
+  researchTimer: number // ticks remaining; 0 when nothing in progress
+  /** Cost object for the NEXT level, or null if at max. */
+  nextCost: Record<string, number> | null
+  /** True when this type's next upgrade cannot be afforded. */
+  canAfford: boolean
+  isResearching: boolean // true when upgradeMutation is in flight
+  onResearch: () => void
+  /** Header slot — typically a short description of what the track does. */
+  description?: ReactNode
+}
+
+export function UpgradeTrack({
+  type,
+  currentLevel,
+  maxLevel,
+  upgradeBeingResearched,
+  researchTimer,
+  nextCost,
+  canAfford,
+  isResearching,
+  onResearch,
+  description,
+}: UpgradeTrackProps) {
+  const inProgressHere = upgradeBeingResearched === type
+  const otherInProgress = upgradeBeingResearched !== 'None' && !inProgressHere
+  const atMax = currentLevel >= maxLevel
+  const disabled = atMax || otherInProgress || !canAfford || isResearching
+  let disabledReason: string | undefined
+  if (atMax) disabledReason = 'At max level'
+  else if (otherInProgress) disabledReason = 'Another upgrade in progress'
+  else if (!canAfford) disabledReason = 'Cannot afford'
+
+  return (
+    <section className="mb-6">
+      <SectionHeader title={`${type} upgrades`} description={description} />
+      <Card>
+        <CardContent className="p-4 space-y-4">
+          {/* Level chain */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {Array.from({ length: maxLevel }).map((_, i) => {
+              const level = i + 1
+              const done = level <= currentLevel
+              const current = level === currentLevel + 1 && inProgressHere
+              return (
+                <div key={level} className="flex items-center gap-2">
+                  <div className={cn(
+                    'flex flex-col items-center justify-center w-16 h-16 rounded-md border text-xs',
+                    done && 'bg-success/20 border-success/40',
+                    current && 'bg-primary/10 border-primary',
+                    !done && !current && 'bg-card border-border text-muted-foreground',
+                  )}>
+                    <span className="label leading-none">Lv</span>
+                    <span className="mono text-lg font-bold leading-tight">{level}</span>
+                    {done && <Badge variant="secondary" className="mt-0.5 text-[9px] px-1 py-0">✓</Badge>}
+                  </div>
+                  {level < maxLevel && <span aria-hidden className="text-muted-foreground">→</span>}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* In-progress bar */}
+          {inProgressHere && researchTimer > 0 && (
+            <div className="space-y-1">
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>Researching level {currentLevel + 1}…</span>
+                <Ticks n={researchTimer} />
+              </div>
+              <Progress value={Math.max(0, 100 - (researchTimer / (researchTimer + 1)) * 100)} />
+            </div>
+          )}
+
+          {/* Research action */}
+          {!atMax && (
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Next:</span>
+                {nextCost && <CostBadge cost={nextCost} />}
+              </div>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={onResearch}
+                disabled={disabled}
+                title={disabledReason}
+              >
+                {inProgressHere ? 'Researching…' : 'Research'}
+              </Button>
+            </div>
+          )}
+          {atMax && (
+            <div className="text-sm text-muted-foreground">At maximum level ({maxLevel}).</div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/components/UpgradeTrack.tsx
+git commit -m "feat(ui): add UpgradeTrack component for Research"
+```
+
+---
+
+### Task 2: Extract `ConvertResourceForm` component
+
+**Files:** Create `src/ReactClient/src/components/ConvertResourceForm.tsx`.
+
+Rationale: Base's inline 2-way resource-swap block gets removed in Task 5. Market's new Convert tab (Task 6) needs to host it. Extract first.
+
+- [ ] **Step 1: Read Base's current Trade block**
+
+```bash
+sed -n '240,300p' src/ReactClient/src/pages/Base.tsx
+```
+
+Capture the mutation shape (key, endpoint, invalidations), the state (`tradeFromResource`, `tradeAmount`, `tradeError`), and the `TradeResourceRequest` type used.
+
+- [ ] **Step 2: Create `src/ReactClient/src/components/ConvertResourceForm.tsx`**
+
+The component owns its local state + mutation. It takes `gameId` as a prop and calls the same endpoint the Base block calls. Use the Base block as the source of truth for the endpoint URL and request shape — do not invent names.
+
+```tsx
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import apiClient from '@/api/client'
+import type { TradeResourceRequest } from '@/api/types'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ArrowRightLeftIcon } from 'lucide-react'
+import { SectionHeader } from '@/components/ui/section'
+
+export function ConvertResourceForm({ gameId }: { gameId: string }) {
+  const qc = useQueryClient()
+  const [from, setFrom] = useState<'minerals' | 'gas'>('minerals')
+  const [amount, setAmount] = useState<number>(100)
+
+  const mutation = useMutation({
+    mutationFn: (payload: TradeResourceRequest) =>
+      apiClient.post('/api/resources/trade', payload).then((r) => r.data),
+    onSuccess: () => {
+      toast.success('Resources converted')
+      qc.invalidateQueries({ queryKey: ['resources', gameId] })
+      setAmount(100)
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'Conversion failed'
+      toast.error(msg)
+    },
+  })
+
+  const flip = () => setFrom((f) => (f === 'minerals' ? 'gas' : 'minerals'))
+  const to = from === 'minerals' ? 'gas' : 'minerals'
+
+  return (
+    <section className="mb-6">
+      <SectionHeader title="Convert resources" description="Swap minerals for gas or vice-versa at the current market rate." />
+      <Card>
+        <CardContent className="p-4 space-y-3 max-w-lg">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-end gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="convert-amount">Amount of {from}</Label>
+              <Input
+                id="convert-amount"
+                type="number"
+                min={1}
+                value={amount}
+                onChange={(e) => setAmount(Number(e.target.value))}
+              />
+            </div>
+            <Button type="button" variant="ghost" size="icon" onClick={flip} aria-label="Swap direction" className="mb-0.5">
+              <ArrowRightLeftIcon className="h-4 w-4" />
+            </Button>
+            <div className="space-y-1.5">
+              <Label className="text-muted-foreground">→ {to}</Label>
+              <div className="h-9 flex items-center px-3 rounded-md border bg-muted/30 text-sm text-muted-foreground mono">
+                (market rate applied)
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="default"
+            size="sm"
+            disabled={mutation.isPending || amount <= 0}
+            onClick={() => mutation.mutate({ fromResource: from, amount })}
+          >
+            {mutation.isPending ? 'Converting…' : `Convert ${from} → ${to}`}
+          </Button>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}
+```
+
+**If `TradeResourceRequest` in `@/api/types` does not exactly match `{ fromResource: string, amount: number }`, adapt the mutation's payload shape to match the real type. Do not rename fields.**
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/components/ConvertResourceForm.tsx
+git commit -m "feat(ui): extract ConvertResourceForm for Market's Convert tab"
+```
+
+---
+
+### Task 3: Refactor `Research.tsx`
+
+**Files:** Modify `src/ReactClient/src/pages/Research.tsx`.
+
+- [ ] **Step 1: Read the current file end-to-end**
+
+```bash
+cat src/ReactClient/src/pages/Research.tsx
+```
+
+Preserve the `useQuery` (key `['research', gameId]`), the `upgradeMutation` and its `onSuccess` invalidation, and the `PageLoader`/`ApiError` early returns.
+
+- [ ] **Step 2: Rewrite the page body**
+
+Keep the imports for `useQuery`, `useMutation`, `useQueryClient`, `apiClient`, `PageLoader`, `ApiError`, plus the view-model type. Replace the two giant upgrade-block loops and the `<h1>` with:
+
+```tsx
+import { PageHeader } from '@/components/ui/page-header'
+import { UpgradeTrack } from '@/components/UpgradeTrack'
+// ... existing imports preserved
+
+export function Research({ gameId }: { gameId: string }) {
+  // ... existing useQuery + ApiError / PageLoader boilerplate preserved ...
+
+  const upgradeMutation = useMutation(/* existing — unchanged */)
+
+  // Guard against intermediate loading/error states — PageLoader/ApiError already return early above.
+  const upgrades = data!
+
+  return (
+    <>
+      <PageHeader title="Research" description="Upgrade your units' combat capabilities." />
+      <UpgradeTrack
+        type="Attack"
+        currentLevel={upgrades.attackLevel}
+        maxLevel={upgrades.maxUpgradeLevel}
+        upgradeBeingResearched={upgrades.upgradeBeingResearched}
+        researchTimer={upgrades.upgradeResearchTimer}
+        nextCost={upgrades.attackUpgradeCost?.cost ?? null}
+        canAfford={upgrades.canAffordAttackUpgrade}
+        isResearching={upgradeMutation.isPending}
+        onResearch={() => upgradeMutation.mutate({ upgradeType: 'Attack' })}
+        description="Increase attack damage of all units."
+      />
+      <UpgradeTrack
+        type="Defense"
+        currentLevel={upgrades.defenseLevel}
+        maxLevel={upgrades.maxUpgradeLevel}
+        upgradeBeingResearched={upgrades.upgradeBeingResearched}
+        researchTimer={upgrades.upgradeResearchTimer}
+        nextCost={upgrades.defenseUpgradeCost?.cost ?? null}
+        canAfford={upgrades.canAffordDefenseUpgrade}
+        isResearching={upgradeMutation.isPending}
+        onResearch={() => upgradeMutation.mutate({ upgradeType: 'Defense' })}
+        description="Increase defense of all units."
+      />
+    </>
+  )
+}
+```
+
+**If the view model property names differ** (`attackLevel` vs `attackUpgradeLevel`, or `canAffordAttackUpgrade` vs `canAffordAttack`), use the real names — do not invent. `grep -A3 'upgrades.attackLevel\|upgrades.attack' src/ReactClient/src/pages/Research.tsx` confirms the original file's names.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/pages/Research.tsx
+git commit -m "feat(ui): Research uses UpgradeTrack + Progress + Ticks"
+```
+
+---
+
+### Task 4: Refactor `Units.tsx`
+
+**Files:** Modify `src/ReactClient/src/pages/Units.tsx`.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat src/ReactClient/src/pages/Units.tsx
+```
+
+Preserve: `useQuery` (`['units', gameId]`), `mergeAllMutation`, the `AttackDialog` component reference, `SplitUnitForm` (keep it for now — inline row expansion is acceptable).
+
+- [ ] **Step 2: Replace the `<h1>Units</h1>` block and both tables**
+
+Plan: keep `BuildQueue` above the content. Use two `DataTable`s — one for "Home Base" units, one for "Deployed" units. Wrap each in a `Section`. Use a summary `<Stat>` row above both tables. Replace all inline `<button>` + status spans with `<Button>` + `<Badge>`. Replace emoji stats with plain `<Stat>` cells.
+
+```tsx
+import { useMemo } from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { PageHeader } from '@/components/ui/page-header'
+import { Section } from '@/components/ui/section'
+import { DataTable } from '@/components/ui/data-table'
+import { Stat } from '@/components/ui/stat'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { formatNumber } from '@/lib/formatters'
+// ... existing imports preserved (types, hooks, existing `SplitUnitForm`, `AttackDialog`)
+```
+
+- `PageHeader` top with `actions={<Button onClick={() => mergeAllMutation.mutate()} disabled={mergeAllMutation.isPending || !canMerge}>Merge All</Button>}`.
+- `<BuildQueue gameId={gameId} />` remains where it is.
+- A `<Section>` wrapping a `Stat` grid: Total Units, Deployed, At Home, In Combat (derive from `data.units`).
+- Home base `DataTable` — columns: Unit (with icon), Count (right, `mono tabular-nums`), Attack/Def/HP (compact `<Stat>` cells with tiny labels), Actions (Attack/Split/Merge `<Button>`s). Use `variant="destructive" size="sm"` for Attack, `variant="secondary" size="sm"` for Split/Merge.
+- Deployed `DataTable` — same columns + a "Location" column showing `<Badge variant="destructive">In Combat</Badge>` or `<Badge variant="success">Defending</Badge>`. Actions: Cancel (`<Button variant="destructive" size="sm">`).
+- Inline `SplitUnitForm` remains rendered by a row-expander pattern — the row's Split button toggles a per-row `expanded` state, and the form renders in a `colSpan={N}` row beneath. This is pragmatic — a later pass can move it to a `Dialog`.
+
+**If `DataTable` doesn't support row-expansion out of the box** (it doesn't in the foundation PR), render the split form inline by making the Split button toggle a local state keyed by `unitId`, and render the form in a separate `Section` below the table ("Splitting: Marines (5)") rather than an in-row expander. Keep it simple.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/pages/Units.tsx
+git commit -m "feat(ui): Units uses DataTable + Button + Badge + Stat"
+```
+
+---
+
+### Task 5: Refactor `Base.tsx`
+
+**Files:** Modify `src/ReactClient/src/pages/Base.tsx`.
+
+Largest page. Does three things: drops the inline Trade block (now handled by Market's Convert tab), reorders tabs, migrates all markup to primitives.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat src/ReactClient/src/pages/Base.tsx
+```
+
+- [ ] **Step 2: Rewrite**
+
+Preserve: all `useQuery` / `useMutation` calls for assets, build queue, worker assignment, and colonize. Preserve the URL-param tab sync logic. Drop: the `TradeResourceRequest` import, the `tradeFromResource`/`tradeAmount`/`tradeError` state, the `tradeMutation`, and lines 250–279 (the Trade block UI).
+
+Key changes:
+
+- Replace `<h1>Base</h1>` with `<PageHeader title="Base" />`.
+- Replace the yellow "Game Over" div with `<Section>` containing a warning `<Badge>` + message.
+- Replace `TabButton` + hand-rolled tab bar with shadcn `<Tabs>` / `<TabsList>` / `<TabsTrigger>` / `<TabsContent>`. Preserve the URL search-param sync — wire `value={currentTab}` and `onValueChange={setTab}` where `setTab` updates `searchParams`.
+- **Tab order per spec:** `build` (Assets + BuildQueue), `economy` (WorkerAssignment + Colonize), `activity`. `build` becomes the new default.
+- `AssetCard`: wrap outer div in `<Card>`, replace both inline `<button>`s with `<Button variant="default" size="sm">Build</Button>` and `<Button variant="secondary" size="sm">Queue</Button>`. Replace "Built ✓" text with `<Badge variant="secondary">Built</Badge>` (use success if the Badge primitive has a success variant; otherwise secondary + success-toned className).
+- Colonize form: wrap in `<Section>`, replace bare `<input>` with `<Input>`, bare `<button>` with `<Button>`, the inline error text with `toast.error(...)` on mutation failure.
+- Activity tab: wrap in `<Section>` with a `<Button variant="ghost" size="sm">Clear</Button>` in the `actions` slot.
+- Remove the entire Trade block (lines ~250–279 of the original file).
+- The `ResourceHistoryChart` Suspense block stays in a `<Section title="Resource history">`.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/pages/Base.tsx
+git commit -m "feat(ui): Base uses Tabs + Card + Button; drop Trade block"
+```
+
+---
+
+### Task 6: Refactor `Market.tsx`
+
+**Files:** Modify `src/ReactClient/src/pages/Market.tsx`.
+
+Must consume `ConvertResourceForm` from Task 2.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat src/ReactClient/src/pages/Market.tsx
+```
+
+Preserve: `useQuery` (`['market', gameId]`), `postOrderMutation`, `cancelOrderMutation`, `acceptOrderMutation`, the `useConfirm` context usage for Cancel.
+
+- [ ] **Step 2: Rewrite with three tabs**
+
+- `<PageHeader title="Market" description="Post or accept resource trades with other players." />`
+- `<Tabs defaultValue="buy">` containing three `<TabsContent>`:
+  - **Buy**: `DataTable` of `otherOrders` (derived from `data.openOrders.filter(o => o.playerId !== currentPlayerId)`). Columns: Player, Offering, Wants, Rate, Posted, Actions. Actions column renders `<Button variant="default" size="sm" onClick={accept}>Accept</Button>` with a `<Tooltip>` on the disabled state showing the reason from `orderErrors[order.orderId]` (tooltip trigger wraps the button; use the `disabled` prop but render the button always).
+  - **Sell**: upper section `<Section title="My offers">` with a `DataTable` of `myOrders`. Actions column: `<Button variant="destructive" size="sm" onClick={() => cancel(order.orderId)}>Cancel</Button>` (the existing `useConfirm` call is preserved). Lower section `<Section title="Post a new offer">` with a `react-hook-form` + `zod` form: `offeringResourceId` `<Select>`, `offeringAmount` `<Input type="number">`, `wantedResourceId` `<Select>`, `wantedAmount` `<Input type="number">`. Submit button `<Button>Post offer</Button>`. On success: `toast.success('Offer posted')`. On error: `toast.error(msg)`.
+  - **Convert**: `<ConvertResourceForm gameId={gameId} />`.
+- Delete the `postError` state and `orderErrors` state — both are replaced by toasts and tooltips.
+- The loading state uses `DataTable`'s built-in `loading` prop with `<Skeleton>` rows.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/pages/Market.tsx
+git commit -m "feat(ui): Market uses Tabs (Buy/Sell/Convert) + DataTable + form"
+```
+
+---
+
+### Task 7: Refactor `Trade.tsx`
+
+**Files:** Modify `src/ReactClient/src/pages/Trade.tsx`.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat src/ReactClient/src/pages/Trade.tsx
+```
+
+Preserve: both queries (`marketData` for resources, `playersResp` for players — keep endpoint paths and keys verbatim), `sendMutation`, `acceptMutation`, `declineMutation`, `cancelMutation`, the `useConfirm` usage, the `resourceName` helper, and `relativeTime`.
+
+- [ ] **Step 2: Rewrite**
+
+- `<PageHeader title="Trade" description="Propose direct trades with other players." actions={<Button onClick={() => setDialogOpen(true)}>Propose trade</Button>} />`.
+- Propose-trade form moves into a Radix `<Dialog>` opened by the header button. Use `react-hook-form` + `zod` with `<Field>` for each input. On success: `toast.success('Trade offer sent')`, close dialog, reset form. On error: `toast.error(msg)`.
+- Body has three `<Tabs>`: Incoming / Sent / History. Each contains a `DataTable`.
+  - Incoming columns: From, Offering, Wants, Expires (`<Countdown>`), Note, Actions (`<Button variant="default" size="sm">Accept</Button>`, `<Button variant="destructive" size="sm">Decline</Button>`).
+  - Sent columns: To, Offering, Wants, Expires, Note, Actions (`<Button variant="destructive" size="sm">Cancel</Button>` with `useConfirm`).
+  - History columns: Counterparty, Offering, Wants, Status (`<Badge variant={...}>`), Settled (`relativeTime`).
+- Delete the `success` and `error` inline state variables and their banner divs. All feedback now via sonner.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ReactClient/src/pages/Trade.tsx
+git commit -m "feat(ui): Trade uses Dialog for propose + Tabs + DataTable + toasts"
+```
+
+---
+
+### Task 8: Verification sweep
+
+**Files:** none changed (unless an issue surfaces).
+
+- [ ] **Step 1: Lint**
+
+```bash
+cd src/ReactClient && npm run lint 2>&1 | tail -20
+```
+
+Zero errors. If a refactored page has a warning we introduced (e.g. an unused variable left over from removing the Trade block in Base), fix it and amend the relevant task's commit — **NO, don't amend**; make a separate `fix(ui): <what>` commit.
+
+- [ ] **Step 2: Vite build**
+
+```bash
+cd src/ReactClient && npm run build
+```
+
+- [ ] **Step 3: Vitest**
+
+```bash
+cd src/ReactClient && npm run test
+```
+
+Still 10/10 (foundation tests). No new tests added in Batch 1 — we're refactoring markup, not adding logic.
+
+- [ ] **Step 4: dotnet build + tests**
+
+```bash
+cd /tmp/bge-work/batch-1-core-gameplay/src
+dotnet build --configuration Release 2>&1 | tail -5
+dotnet test --verbosity minimal 2>&1 | tail -10
+```
+
+Green.
+
+- [ ] **Step 5: Red-flag greps**
+
+```bash
+cd /tmp/bge-work/batch-1-core-gameplay
+
+# Any inline button class strings left on refactored pages?
+grep -nE 'rounded.*bg-primary.*px-[0-9]' src/ReactClient/src/pages/{Base,Units,Research,Market,Trade}.tsx
+
+# Any <table> left on refactored pages?
+grep -nE '<table' src/ReactClient/src/pages/{Base,Units,Research,Market,Trade}.tsx
+
+# Any inline success/error banner state?
+grep -nE "const \[success|const \[postError|const \[tradeError" src/ReactClient/src/pages/{Base,Units,Research,Market,Trade}.tsx
+
+# "rounds" terminology on refactored pages?
+grep -nw 'rounds\?' src/ReactClient/src/pages/{Base,Units,Research,Market,Trade}.tsx
+```
+
+All should return empty. If any line appears, open the file and fix it in a `fix(ui): <what>` commit.
+
+- [ ] **Step 6: Manual smoke (optional)**
+
+Start the backend + Vite if you want to load pages in a browser. Not a blocker — CI covers it.
+
+---
+
+### Task 9: Commit the plan + push + open PR
+
+**Files:** `docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md`.
+
+- [ ] **Step 1: Commit this plan as the final commit on the branch**
+
+```bash
+cd /tmp/bge-work/batch-1-core-gameplay
+git add docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md
+git commit -m "docs: add Batch 1 implementation plan"
+```
+
+(Committing at the end rather than the beginning lets the branch land as a coherent unit without reviewers having to jump between plan and code.)
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin batch-1-core-gameplay
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --title "feat(ui): Batch 1 — core gameplay pages refactored to design-system primitives" --body "$(cat <<'EOF'
+## Summary
+- Refactors the five core-gameplay pages (\`Base\`, \`Units\`, \`Research\`, \`Market\`, \`Trade\`) to consume the design-system foundation from PR #315. Page logic (queries, mutations, effects) preserved — only markup changes.
+- Extracts two shared components: \`UpgradeTrack\` (consumed by Research) and \`ConvertResourceForm\` (consumed by Market's new Convert tab).
+- **Base**: tab order reorganised (Build first, then Economy, then Activity); inline 2-way resource swap block removed (moved to Market's Convert tab); \`PageHeader\`/\`Card\`/\`Button\`/\`Badge\` throughout.
+- **Units**: two \`DataTable\`s (Home Base, Deployed) + \`Stat\` summary cells + \`Badge\` for combat status; emoji stats (⚔️🛡️❤️) replaced with \`Stat\` cells.
+- **Research**: two duplicated 60-line blocks collapsed into two \`<UpgradeTrack>\` instances (Attack / Defense); \`<Progress>\` + \`<Ticks>\` for in-progress research.
+- **Market**: three \`<Tabs>\` — Buy (other players' orders) / Sell (my orders + post-offer form) / Convert (ConvertResourceForm). \`DataTable\` listings, \`<Tooltip>\` on disabled Accept buttons, sonner toasts replacing inline error banners.
+- **Trade**: Propose-trade form lifted into a Radix \`<Dialog>\`. Incoming / Sent / History as three \`<Tabs>\`, each a \`DataTable\`. Inline success/error banners replaced with sonner toasts.
+
+## Non-changes
+Backend API unchanged. Primitives in \`src/components/ui/\` unchanged. No page outside the five refactored.
+
+## Parent spec + plan
+- Spec: \`docs/superpowers/specs/2026-04-17-ui-ux-improvements-design.md\` (Batch 1 section).
+- Plan: \`docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md\`.
+
+## Test plan
+- [x] \`npm run build\` green.
+- [x] \`npm run lint\` clean.
+- [x] \`npm run test\` (vitest) 10/10 (no new tests — markup-only refactor).
+- [x] \`dotnet build --configuration Release\` clean.
+- [x] \`dotnet test\` green.
+- [ ] \`npm run test:e2e\` deferred to CI (Playwright in docker-compose).
+- [ ] Manual smoke: log in via DevAuth, touch each of the 5 pages, verify core actions (build, research, post order, accept order, propose trade) still work end-to-end.
+
+## Follow-ups not landing here
+- \`useTickDuration\` still hardcoded to 30s.
+- Per-tick deltas on \`PlayerResources\`.
+- Units \`SplitUnitForm\` lives in a \`<Section>\` below the table; a Dialog-based split is a nicer UX but out of scope for this PR.
+- Research \`<Progress>\` bar uses a best-effort value until the backend exposes total research duration.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Batch 1 section of the spec lists five pages + specific changes. Each is a task:
+  - Research → UpgradeTrack + Progress: Tasks 1 + 3. ✅
+  - Base reorder + drop Trade block: Task 5. ✅
+  - Units DataTable + Stat cells: Task 4. ✅
+  - Market Tabs (Buy/Sell/Convert) + DataTable + disabled-reason tooltips: Task 6 (depends on Task 2). ✅
+  - Trade Dialog + DataTables + toasts: Task 7. ✅
+- Extracted shared components: Tasks 1 (UpgradeTrack) + 2 (ConvertResourceForm). ✅
+
+**Placeholder scan:** no "TBD" / "implement later" / "similar to Task N". Where a plan snippet says "the existing boilerplate preserved", it points the implementer at the real file to read.
+
+**Type consistency:**
+- `UpgradeTrack` prop shape (Task 1) matches the call-sites in Research (Task 3). ✅
+- `ConvertResourceForm` takes only `gameId` (Task 2) and is called the same way in Market (Task 6). ✅
+- Mutation payload `TradeResourceRequest` is taken verbatim from `@/api/types` — implementer verifies. ✅
+
+**Scope check:** one PR covers 5 pages + 2 new components + 1 plan doc. Substantial but bounded, and each task is self-contained. If any task balloons mid-flight, that's a cue to narrow it rather than expand.
+
+**Ambiguity check:**
+- Units' `SplitUnitForm` placement: plan allows either in-row expansion (ideal) or a separate section below (pragmatic fallback). Implementer picks based on `DataTable`'s current capabilities.
+- Research `Progress` bar value: plan notes the backend doesn't expose total duration; implementer uses a best-effort estimate or indeterminate bar. Explicit.
+- Status `<Badge>` variants: shadcn's Badge primitive as installed in the foundation PR has `default|secondary|destructive|outline`. Success/warning are conveyed via custom className (`bg-success/20 text-success`) where the plan calls for them. Mentioned implicitly in the AssetCard "Built" and Units combat-status badges.
+
+---
+
+## Execution Handoff
+
+**Plan complete. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batched with checkpoints.
+
+**Which?**

--- a/src/ReactClient/e2e/tests/05-resource-management.spec.ts
+++ b/src/ReactClient/e2e/tests/05-resource-management.spec.ts
@@ -38,7 +38,7 @@ test.describe('Resource management — worker assignment', () => {
 		// Ensure we have at least some WBF workers so the component is meaningful
 		await page.request.post(`${baseURL}/api/units/build?unitDefId=wbf&count=3`, { data: {} })
 
-		await page.goto(`/games/${gameId}/base`)
+		await page.goto(`/games/${gameId}/base?tab=economy`)
 		await expect(page.getByRole('heading', { name: /base/i })).toBeVisible()
 
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
@@ -55,7 +55,7 @@ test.describe('Resource management — worker assignment', () => {
 		// Build some workers so assignment is possible
 		await page.request.post(`${baseURL}/api/units/build?unitDefId=wbf&count=5`, { data: {} })
 
-		await page.goto(`/games/${gameId}/base`)
+		await page.goto(`/games/${gameId}/base?tab=economy`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
 		await expect(page.getByLabel('Mineral Workers')).toBeVisible()
@@ -76,7 +76,7 @@ test.describe('Resource management — worker assignment', () => {
 		expect([200, 204]).toContain(assignRes.status())
 
 		// Navigate to base and confirm the assignment is reflected
-		await page.goto(`/games/${gameId}/base`)
+		await page.goto(`/games/${gameId}/base?tab=economy`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
 		await expect(page.getByLabel('Mineral Workers')).toHaveValue('2')
@@ -90,7 +90,7 @@ test.describe('Resource management — worker assignment', () => {
 		await page.request.post(`${baseURL}/api/units/build?unitDefId=wbf&count=5`, { data: {} })
 		await page.request.post(`${baseURL}/api/workers/assign?mineralWorkers=1&gasWorkers=1`, { data: {} })
 
-		await page.goto(`/games/${gameId}/base`)
+		await page.goto(`/games/${gameId}/base?tab=economy`)
 		await expect(page.getByRole('heading', { name: 'Worker Assignment' })).toBeVisible()
 
 		// Set a new value for mineral workers; wait for the assign API call to complete

--- a/src/ReactClient/e2e/tests/09-unit-army.spec.ts
+++ b/src/ReactClient/e2e/tests/09-unit-army.spec.ts
@@ -42,13 +42,22 @@ test.describe('Unit build — army visibility', () => {
 		await page.goto(`/games/${gameId}/units`)
 		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
 
-		// The units page should report at least 3 total units
-		const countLine = page.getByText(/units in \d+ stack/)
-		await expect(countLine).toBeVisible({ timeout: 10_000 })
+		// The units page should show the "Total Units" stat (summary section only renders
+		// when units.length > 0) and at least one DataTable row for the built unit type.
+		await expect(page.getByText('Total Units')).toBeVisible({ timeout: 10_000 })
 
-		const text = await countLine.textContent()
-		const match = text?.match(/^(\d[\d,]*)/)
-		const total = parseInt((match?.[1] ?? '0').replace(',', ''), 10)
+		// Confirm the built unit appears in the Home Base DataTable.
+		// The unit definition name for 'wbf' is displayed in the Name column of the table.
+		const wbfRow = page.getByRole('row').filter({ hasText: /wbf/i })
+		await expect(wbfRow.first()).toBeVisible({ timeout: 10_000 })
+
+		// Read the count from the value span adjacent to the "Total Units" label.
+		// Stat renders: <span class="label">Total Units</span><span class="mono ...">N</span>
+		const totalValueSpan = page.locator('span.label', { hasText: 'Total Units' })
+			.locator('..') // parent div.flex-col
+			.locator('span.mono')
+		const totalText = await totalValueSpan.textContent()
+		const total = parseInt((totalText ?? '0').replace(/,/g, ''), 10)
 		expect(total).toBeGreaterThanOrEqual(3)
 	})
 
@@ -64,10 +73,10 @@ test.describe('Unit build — army visibility', () => {
 		await page.goto(`/games/${gameId}/units`)
 		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
 
-		// Empty state message should be shown
-		await expect(page.getByText('Build units from your base buildings')).toBeVisible({
-			timeout: 10_000,
-		})
+		// Empty state message from the Home Base DataTable
+		await expect(
+			page.getByText('No units at home base. All units are deployed, or you have not built any units yet.')
+		).toBeVisible({ timeout: 10_000 })
 		await expect(page.getByText('Something went wrong')).not.toBeVisible()
 	})
 })

--- a/src/ReactClient/e2e/tests/09-unit-army.spec.ts
+++ b/src/ReactClient/e2e/tests/09-unit-army.spec.ts
@@ -40,7 +40,7 @@ test.describe('Unit build — army visibility', () => {
 		expect(buildRes.ok()).toBeTruthy()
 
 		await page.goto(`/games/${gameId}/units`)
-		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Units', exact: true })).toBeVisible()
 
 		// The units page should show the "Total Units" stat (summary section only renders
 		// when units.length > 0) and at least one DataTable row for the built unit type.
@@ -71,7 +71,7 @@ test.describe('Unit build — army visibility', () => {
 		const gameId = await createNavGame(page)
 
 		await page.goto(`/games/${gameId}/units`)
-		await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Units', exact: true })).toBeVisible()
 
 		// Empty state message from the Home Base DataTable
 		await expect(

--- a/src/ReactClient/src/components/ConvertResourceForm.tsx
+++ b/src/ReactClient/src/components/ConvertResourceForm.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import apiClient from '@/api/client'
+import type { TradeResourceRequest } from '@/api/types'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ArrowRightLeftIcon } from 'lucide-react'
+import { SectionHeader } from '@/components/ui/section'
+
+export function ConvertResourceForm({ gameId }: { gameId: string }) {
+  const qc = useQueryClient()
+  const [from, setFrom] = useState<'minerals' | 'gas'>('minerals')
+  const [amount, setAmount] = useState<number>(100)
+
+  const mutation = useMutation({
+    mutationFn: (payload: TradeResourceRequest) =>
+      apiClient.post('/api/resources/trade', payload).then((r) => r.data),
+    onSuccess: () => {
+      toast.success('Resources converted')
+      qc.invalidateQueries({ queryKey: ['resources', gameId] })
+      setAmount(100)
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'Conversion failed'
+      toast.error(msg)
+    },
+  })
+
+  const flip = () => setFrom((f) => (f === 'minerals' ? 'gas' : 'minerals'))
+  const to = from === 'minerals' ? 'gas' : 'minerals'
+
+  return (
+    <section className="mb-6">
+      <SectionHeader title="Convert resources" description="Swap minerals for gas or vice-versa at the current market rate." />
+      <Card>
+        <CardContent className="p-4 space-y-3 max-w-lg">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-end gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="convert-amount">Amount of {from}</Label>
+              <Input
+                id="convert-amount"
+                type="number"
+                min={1}
+                value={amount}
+                onChange={(e) => setAmount(Number(e.target.value))}
+              />
+            </div>
+            <Button type="button" variant="ghost" size="icon" onClick={flip} aria-label="Swap direction" className="mb-0.5">
+              <ArrowRightLeftIcon className="h-4 w-4" />
+            </Button>
+            <div className="space-y-1.5">
+              <Label className="text-muted-foreground">→ {to}</Label>
+              <div className="h-9 flex items-center px-3 rounded-md border bg-muted/30 text-sm text-muted-foreground mono">
+                (market rate applied)
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="default"
+            size="sm"
+            disabled={mutation.isPending || amount <= 0}
+            onClick={() => mutation.mutate({ fromResource: from, amount })}
+          >
+            {mutation.isPending ? 'Converting…' : `Convert ${from} → ${to}`}
+          </Button>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/src/ReactClient/src/components/UpgradeTrack.tsx
+++ b/src/ReactClient/src/components/UpgradeTrack.tsx
@@ -1,0 +1,115 @@
+import { cn } from '@/lib/utils'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { Ticks } from '@/components/ui/ticks'
+import { CostBadge } from '@/components/CostBadge'
+import { SectionHeader } from '@/components/ui/section'
+import type { ReactNode } from 'react'
+
+type UpgradeType = 'Attack' | 'Defense'
+
+interface UpgradeTrackProps {
+  type: UpgradeType
+  currentLevel: number
+  maxLevel: number
+  upgradeBeingResearched: string // 'None' | 'Attack' | 'Defense'
+  researchTimer: number // ticks remaining; 0 when nothing in progress
+  /** Cost object for the NEXT level, or null if at max. */
+  nextCost: Record<string, number> | null
+  /** True when this type's next upgrade cannot be afforded. */
+  canAfford: boolean
+  isResearching: boolean // true when upgradeMutation is in flight
+  onResearch: () => void
+  /** Header slot — typically a short description of what the track does. */
+  description?: ReactNode
+}
+
+export function UpgradeTrack({
+  type,
+  currentLevel,
+  maxLevel,
+  upgradeBeingResearched,
+  researchTimer,
+  nextCost,
+  canAfford,
+  isResearching,
+  onResearch,
+  description,
+}: UpgradeTrackProps) {
+  const inProgressHere = upgradeBeingResearched === type
+  const otherInProgress = upgradeBeingResearched !== 'None' && !inProgressHere
+  const atMax = currentLevel >= maxLevel
+  const disabled = atMax || otherInProgress || !canAfford || isResearching
+  let disabledReason: string | undefined
+  if (atMax) disabledReason = 'At max level'
+  else if (otherInProgress) disabledReason = 'Another upgrade in progress'
+  else if (!canAfford) disabledReason = 'Cannot afford'
+
+  return (
+    <section className="mb-6">
+      <SectionHeader title={`${type} upgrades`} description={description} />
+      <Card>
+        <CardContent className="p-4 space-y-4">
+          {/* Level chain */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {Array.from({ length: maxLevel }).map((_, i) => {
+              const level = i + 1
+              const done = level <= currentLevel
+              const current = level === currentLevel + 1 && inProgressHere
+              return (
+                <div key={level} className="flex items-center gap-2">
+                  <div className={cn(
+                    'flex flex-col items-center justify-center w-16 h-16 rounded-md border text-xs',
+                    done && 'bg-success/20 border-success/40',
+                    current && 'bg-primary/10 border-primary',
+                    !done && !current && 'bg-card border-border text-muted-foreground',
+                  )}>
+                    <span className="label leading-none">Lv</span>
+                    <span className="mono text-lg font-bold leading-tight">{level}</span>
+                    {done && <Badge variant="secondary" className="mt-0.5 text-[9px] px-1 py-0">✓</Badge>}
+                  </div>
+                  {level < maxLevel && <span aria-hidden className="text-muted-foreground">→</span>}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* In-progress bar */}
+          {inProgressHere && researchTimer > 0 && (
+            <div className="space-y-1">
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>Researching level {currentLevel + 1}…</span>
+                <Ticks n={researchTimer} />
+              </div>
+              <Progress value={Math.max(0, 100 - (researchTimer / (researchTimer + 1)) * 100)} />
+            </div>
+          )}
+
+          {/* Research action */}
+          {!atMax && (
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Next:</span>
+                {nextCost && <CostBadge cost={nextCost} />}
+              </div>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={onResearch}
+                disabled={disabled}
+                title={disabledReason}
+              >
+                {inProgressHere ? 'Researching…' : 'Research'}
+              </Button>
+            </div>
+          )}
+          {atMax && (
+            <div className="text-sm text-muted-foreground">At maximum level ({maxLevel}).</div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -3,20 +3,27 @@ import { useSearchParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { AlertTriangleIcon, ZapIcon, InfoIcon } from 'lucide-react'
+import { toast } from 'sonner'
 import apiClient from '@/api/client'
 import type {
-  AssetsViewModel,
-  AssetViewModel,
-  PlayerResourcesViewModel,
-  PlayerNotificationViewModel,
-  GameDetailViewModel,
-  TradeResourceRequest,
+	AssetsViewModel,
+	AssetViewModel,
+	PlayerResourcesViewModel,
+	PlayerNotificationViewModel,
+	GameDetailViewModel,
 } from '@/api/types'
 import { BuildQueue } from '@/components/BuildQueue'
 import { BuildUnitsForm } from '@/components/BuildUnitsForm'
 import { WorkerAssignment } from '@/components/WorkerAssignment'
 import { CostBadge } from '@/components/CostBadge'
-import { relativeTime, cn } from '@/lib/utils'
+import { relativeTime } from '@/lib/utils'
+import { PageHeader } from '@/components/ui/page-header'
+import { Section } from '@/components/ui/section'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 const ResourceHistoryChart = lazy(() =>
 	import('@/components/ResourceHistoryChart').then(m => ({ default: m.ResourceHistoryChart }))
 )
@@ -28,389 +35,305 @@ interface BaseProps {
 }
 
 function notificationIcon(kind: string): ReactNode {
-  switch (kind) {
-    case 'Warning':
-      return <AlertTriangleIcon className="h-4 w-4 text-warning shrink-0" aria-hidden="true" />
-    case 'GameEvent':
-      return <ZapIcon className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
-    default:
-      return <InfoIcon className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
-  }
+	switch (kind) {
+		case 'Warning':
+			return <AlertTriangleIcon className="h-4 w-4 text-warning shrink-0" aria-hidden="true" />
+		case 'GameEvent':
+			return <ZapIcon className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
+		default:
+			return <InfoIcon className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+	}
 }
 
 function AssetCard({
-  asset,
-  gameId,
-  onBuild,
-  onQueue,
+	asset,
+	gameId,
+	onBuild,
+	onQueue,
 }: {
-  asset: AssetViewModel
-  gameId: string
-  onBuild: (defId: string) => void
-  onQueue: (defId: string) => void
+	asset: AssetViewModel
+	gameId: string
+	onBuild: (defId: string) => void
+	onQueue: (defId: string) => void
 }) {
-  return (
-    <div
-      className={`rounded-lg border p-4 ${
-        asset.built
-          ? 'border-green-700 bg-green-900/20'
-          : 'border-border bg-card'
-      }`}
-    >
-      <h3 className="font-semibold text-sm mb-2">{asset.definition.name}</h3>
+	return (
+		<Card
+			className={asset.built ? 'border-green-700 bg-green-900/20' : undefined}
+		>
+			<CardContent className="p-4">
+				<h3 className="font-semibold text-sm mb-2">{asset.definition.name}</h3>
 
-      {asset.built ? (
-        <>
-          <div className="text-xs text-green-400 mb-2">Built ✓</div>
-          <BuildUnitsForm
-            availableUnits={asset.availableUnits}
-            gameId={gameId}
-          />
-        </>
-      ) : asset.alreadyQueued ? (
-        <div className="text-xs text-muted-foreground">
-          Queued — ready in {asset.ticksLeftForBuild} rounds
-        </div>
-      ) : (
-        <>
-          <div className="text-xs mb-1">
-            Cost: <CostBadge cost={asset.cost} />
-          </div>
-          {asset.prerequisites && (
-            <div className="text-xs text-muted-foreground mb-2">
-              Requires: {asset.prerequisites}
-            </div>
-          )}
-          {asset.prerequisitesMet && (
-            <div className="flex gap-2 mt-2">
-              {asset.canAfford && (
-                <button
-                  onClick={() => onBuild(asset.definition.id)}
-                  className="rounded bg-primary min-h-[36px] px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90"
-                >
-                  Build
-                </button>
-              )}
-              <button
-                onClick={() => onQueue(asset.definition.id)}
-                className="rounded bg-secondary min-h-[36px] px-3 py-1.5 text-xs text-secondary-foreground hover:opacity-90"
-              >
-                Queue
-              </button>
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  )
+				{asset.built ? (
+					<>
+						<Badge variant="secondary" className="mb-2 text-green-400">Built</Badge>
+						<BuildUnitsForm
+							availableUnits={asset.availableUnits}
+							gameId={gameId}
+						/>
+					</>
+				) : asset.alreadyQueued ? (
+					<div className="text-xs text-muted-foreground">
+						Queued — ready in {asset.ticksLeftForBuild} rounds
+					</div>
+				) : (
+					<>
+						<div className="text-xs mb-1">
+							Cost: <CostBadge cost={asset.cost} />
+						</div>
+						{asset.prerequisites && (
+							<div className="text-xs text-muted-foreground mb-2">
+								Requires: {asset.prerequisites}
+							</div>
+						)}
+						{asset.prerequisitesMet && (
+							<div className="flex gap-2 mt-2">
+								{asset.canAfford && (
+									<Button
+										variant="default"
+										size="sm"
+										onClick={() => onBuild(asset.definition.id)}
+									>
+										Build
+									</Button>
+								)}
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => onQueue(asset.definition.id)}
+								>
+									Queue
+								</Button>
+							</div>
+						)}
+					</>
+				)}
+			</CardContent>
+		</Card>
+	)
 }
 
 export function Base({ gameId }: BaseProps) {
-  const queryClient = useQueryClient()
-  const [lastError, setLastError] = useState<string | null>(null)
-  const [tradeFromResource, setTradeFromResource] = useState('minerals')
-  const [tradeAmount, setTradeAmount] = useState(1)
-  const [tradeError, setTradeError] = useState<string | null>(null)
-  const [colonizeAmount, setColonizeAmount] = useState(1)
-  const [colonizeError, setColonizeError] = useState<string | null>(null)
+	const queryClient = useQueryClient()
+	const [lastError, setLastError] = useState<string | null>(null)
+	const [colonizeAmount, setColonizeAmount] = useState(1)
 
-  const { data: assetsData, isLoading: assetsLoading, error: assetsError, refetch: refetchAssets } = useQuery<AssetsViewModel>({
-    queryKey: ['assets', gameId],
-    queryFn: () => apiClient.get('/api/assets').then((r) => r.data),
-    refetchInterval: 30_000,
-  })
+	const { data: assetsData, isLoading: assetsLoading, error: assetsError, refetch: refetchAssets } = useQuery<AssetsViewModel>({
+		queryKey: ['assets', gameId],
+		queryFn: () => apiClient.get('/api/assets').then((r) => r.data),
+		refetchInterval: 30_000,
+	})
 
-  const { data: resources } = useQuery<PlayerResourcesViewModel>({
-    queryKey: ['resources', gameId],
-    queryFn: () => apiClient.get('/api/resources').then((r) => r.data),
-    refetchInterval: 30_000,
-  })
+	const { data: resources } = useQuery<PlayerResourcesViewModel>({
+		queryKey: ['resources', gameId],
+		queryFn: () => apiClient.get('/api/resources').then((r) => r.data),
+		refetchInterval: 30_000,
+	})
 
-  const { data: gameDetail } = useQuery<GameDetailViewModel>({
-    queryKey: ['gamedetail', gameId],
-    queryFn: () => apiClient.get(`/api/games/${gameId}`).then((r) => r.data),
-    refetchInterval: 30_000,
-    enabled: !!gameId,
-  })
+	const { data: gameDetail } = useQuery<GameDetailViewModel>({
+		queryKey: ['gamedetail', gameId],
+		queryFn: () => apiClient.get(`/api/games/${gameId}`).then((r) => r.data),
+		refetchInterval: 30_000,
+		enabled: !!gameId,
+	})
 
-  const { data: notifications, refetch: refetchNotifications } = useQuery<
-    PlayerNotificationViewModel[]
-  >({
-    queryKey: ['notifications', gameId],
-    queryFn: () => apiClient.get('/api/notifications/recent').then((r) => r.data),
-    refetchInterval: 30_000,
-  })
+	const { data: notifications, refetch: refetchNotifications } = useQuery<
+		PlayerNotificationViewModel[]
+	>({
+		queryKey: ['notifications', gameId],
+		queryFn: () => apiClient.get('/api/notifications/recent').then((r) => r.data),
+		refetchInterval: 30_000,
+	})
 
-  const buildMutation = useMutation({
-    mutationFn: (assetDefId: string) =>
-      apiClient.post(`/api/assets/build?assetDefId=${assetDefId}`, ''),
-    onSuccess: () => {
-      setLastError(null)
-      void queryClient.invalidateQueries({ queryKey: ['assets', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Build failed')
-    },
-  })
+	const buildMutation = useMutation({
+		mutationFn: (assetDefId: string) =>
+			apiClient.post(`/api/assets/build?assetDefId=${assetDefId}`, ''),
+		onSuccess: () => {
+			setLastError(null)
+			void queryClient.invalidateQueries({ queryKey: ['assets', gameId] })
+		},
+		onError: (err) => {
+			if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Build failed')
+		},
+	})
 
-  const queueAssetMutation = useMutation({
-    mutationFn: (defId: string) =>
-      apiClient.post('/api/buildqueue/add', { type: 'asset', defId, count: 1 }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['buildqueue', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Queue failed')
-    },
-  })
+	const queueAssetMutation = useMutation({
+		mutationFn: (defId: string) =>
+			apiClient.post('/api/buildqueue/add', { type: 'asset', defId, count: 1 }),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['buildqueue', gameId] })
+		},
+		onError: (err) => {
+			if (axios.isAxiosError(err)) setLastError((err.response?.data as string) ?? 'Queue failed')
+		},
+	})
 
-  const tradeMutation = useMutation({
-    mutationFn: () => {
-      const request: TradeResourceRequest = { fromResource: tradeFromResource, amount: tradeAmount }
-      return apiClient.post('/api/resources/trade', request)
-    },
-    onSuccess: () => {
-      setTradeError(null)
-      void queryClient.invalidateQueries({ queryKey: ['resources', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) setTradeError((err.response?.data as string) ?? 'Trade failed')
-    },
-  })
+	const colonizeMutation = useMutation({
+		mutationFn: () =>
+			apiClient.post(`/api/colonize/colonize?amount=${colonizeAmount}`, ''),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['resources', gameId] })
+		},
+		onError: (err) => {
+			if (axios.isAxiosError(err)) {
+				toast.error((err.response?.data as string) ?? 'Colonize failed')
+			}
+		},
+	})
 
-  const colonizeMutation = useMutation({
-    mutationFn: () =>
-      apiClient.post(`/api/colonize/colonize?amount=${colonizeAmount}`, ''),
-    onSuccess: () => {
-      setColonizeError(null)
-      void queryClient.invalidateQueries({ queryKey: ['resources', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err))
-        setColonizeError((err.response?.data as string) ?? 'Colonize failed')
-    },
-  })
+	const clearNotificationsMutation = useMutation({
+		mutationFn: () => apiClient.delete('/api/notifications/recent'),
+		onSuccess: () => void refetchNotifications(),
+	})
 
-  const clearNotificationsMutation = useMutation({
-    mutationFn: () => apiClient.delete('/api/notifications/recent'),
-    onSuccess: () => void refetchNotifications(),
-  })
+	const isFinished = gameDetail?.status === 'Finished'
 
-  const isFinished = gameDetail?.status === 'Finished'
+	const [searchParams, setSearchParams] = useSearchParams()
+	const tab = searchParams.get('tab') ?? 'build'
+	const setTab = (t: string) => {
+		const next = new URLSearchParams(searchParams)
+		if (t === 'build') next.delete('tab')
+		else next.set('tab', t)
+		setSearchParams(next, { replace: true })
+	}
 
-  const [searchParams, setSearchParams] = useSearchParams()
-  const tabParam = searchParams.get('tab')
-  const activeTab: BaseTab =
-    tabParam === 'build' || tabParam === 'activity' ? tabParam : 'economy'
-  const setTab = (tab: BaseTab) => {
-    const next = new URLSearchParams(searchParams)
-    if (tab === 'economy') next.delete('tab')
-    else next.set('tab', tab)
-    setSearchParams(next, { replace: true })
-  }
+	return (
+		<div className="space-y-5">
+			<PageHeader title="Base" />
 
-  return (
-    <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Base</h1>
+			{isFinished && (
+				<Section boxed>
+					<div className="flex items-center gap-3">
+						<Badge variant="secondary" className="text-yellow-400 border-yellow-600 bg-yellow-900/20">
+							Game Over
+						</Badge>
+						<span className="text-sm">
+							The game has ended.{' '}
+							<a href={`/games/${gameId}/results`} className="underline">
+								View final results
+							</a>
+							.
+						</span>
+					</div>
+				</Section>
+			)}
 
-      {isFinished && (
-        <div className="rounded-lg border border-yellow-600 bg-yellow-900/20 p-4 text-yellow-200">
-          <strong>Game Over!</strong> The game has ended.{' '}
-          <a href={`/games/${gameId}/results`} className="underline">
-            View final results
-          </a>
-          .
-        </div>
-      )}
+			<Tabs value={tab} onValueChange={setTab}>
+				<TabsList>
+					<TabsTrigger value="build">Build</TabsTrigger>
+					<TabsTrigger value="economy">Economy</TabsTrigger>
+					<TabsTrigger value="activity">
+						Activity
+						{(notifications?.length ?? 0) > 0 && (
+							<span className="ml-1.5 rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-mono text-primary">
+								{notifications!.length}
+							</span>
+						)}
+					</TabsTrigger>
+				</TabsList>
 
-      <BuildQueue gameId={gameId} />
+				<TabsContent value="build" className="space-y-5 mt-4">
+					{lastError && <div className="text-destructive text-sm">{lastError}</div>}
+					{assetsLoading ? (
+						<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+							{Array.from({ length: 6 }).map((_, i) => (
+								<SkeletonCard key={i} className="h-32" />
+							))}
+						</div>
+					) : assetsError && !assetsData ? (
+						<ApiError message="Failed to load assets." onRetry={() => void refetchAssets()} />
+					) : assetsData ? (
+						<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+							{assetsData.assets.map((asset) => (
+								<AssetCard
+									key={asset.definition.id}
+									asset={asset}
+									gameId={gameId}
+									onBuild={(defId) => buildMutation.mutate(defId)}
+									onQueue={(defId) => queueAssetMutation.mutate(defId)}
+								/>
+							))}
+						</div>
+					) : null}
 
-      {/* Tabs */}
-      <div className="border-b flex gap-1" role="tablist" aria-label="Base sections">
-        <TabButton active={activeTab === 'economy'} onClick={() => setTab('economy')}>
-          Economy
-        </TabButton>
-        <TabButton active={activeTab === 'build'} onClick={() => setTab('build')}>
-          Build
-        </TabButton>
-        <TabButton active={activeTab === 'activity'} onClick={() => setTab('activity')}>
-          Activity
-          {(notifications?.length ?? 0) > 0 && (
-            <span className="ml-1.5 rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-mono text-primary">
-              {notifications!.length}
-            </span>
-          )}
-        </TabButton>
-      </div>
+					<BuildQueue gameId={gameId} />
+				</TabsContent>
 
-      {activeTab === 'economy' && (
-        <div role="tabpanel" className="space-y-5">
-          <WorkerAssignment gameId={gameId} />
+				<TabsContent value="economy" className="space-y-5 mt-4">
+					<WorkerAssignment gameId={gameId} />
 
-          <div className="rounded-lg border bg-card p-4">
-            <h3 className="font-semibold mb-3">Trade</h3>
-            {tradeError && <div className="text-destructive text-sm mb-2">{tradeError}</div>}
-            <div className="flex flex-wrap items-center gap-3">
-              <select
-                value={tradeFromResource}
-                onChange={(e) => setTradeFromResource(e.target.value)}
-                className="rounded border bg-input px-2 py-1 text-sm"
-              >
-                <option value="minerals">Minerals → Gas</option>
-                <option value="gas">Gas → Minerals</option>
-              </select>
-              <input
-                type="number"
-                min={1}
-                value={tradeAmount}
-                onChange={(e) => setTradeAmount(Number(e.target.value))}
-                className="w-24 rounded border bg-input px-2 py-1 text-sm"
-              />
-              <span className="text-sm text-muted-foreground">
-                Cost: {tradeAmount * 2} → receive: {tradeAmount}
-              </span>
-              <button
-                onClick={() => tradeMutation.mutate()}
-                disabled={tradeMutation.isPending}
-                className="rounded bg-yellow-600 min-h-[44px] px-4 py-2 text-sm text-white hover:opacity-90 disabled:opacity-50"
-              >
-                Trade
-              </button>
-            </div>
-          </div>
+					{resources && (
+						<Section title="Colonize">
+							<div className="text-sm text-muted-foreground mb-2">
+								Cost: {resources.colonizationCostPerLand} minerals per land
+							</div>
+							<div className="flex flex-wrap items-center gap-3">
+								<Input
+									type="number"
+									min={1}
+									max={24}
+									value={colonizeAmount}
+									onChange={(e) => setColonizeAmount(Number(e.target.value))}
+									className="w-24"
+								/>
+								<span className="text-sm text-muted-foreground">
+									= {colonizeAmount * resources.colonizationCostPerLand} minerals
+								</span>
+								<Button
+									onClick={() => colonizeMutation.mutate()}
+									disabled={colonizeMutation.isPending}
+								>
+									Colonize
+								</Button>
+							</div>
+						</Section>
+					)}
 
-          {resources && (
-            <div className="rounded-lg border bg-card p-4">
-              <h3 className="font-semibold mb-3">Colonize</h3>
-              {colonizeError && <div className="text-destructive text-sm mb-2">{colonizeError}</div>}
-              <div className="text-sm text-muted-foreground mb-2">
-                Cost: {resources.colonizationCostPerLand} minerals per land
-              </div>
-              <div className="flex flex-wrap items-center gap-3">
-                <input
-                  type="number"
-                  min={1}
-                  max={24}
-                  value={colonizeAmount}
-                  onChange={(e) => setColonizeAmount(Number(e.target.value))}
-                  className="w-24 rounded border bg-input px-2 py-1 text-sm"
-                />
-                <span className="text-sm text-muted-foreground">
-                  = {colonizeAmount * resources.colonizationCostPerLand} minerals
-                </span>
-                <button
-                  onClick={() => colonizeMutation.mutate()}
-                  disabled={colonizeMutation.isPending}
-                  className="rounded bg-green-600 min-h-[44px] px-4 py-2 text-sm text-white hover:opacity-90 disabled:opacity-50"
-                >
-                  Colonize
-                </button>
-              </div>
-            </div>
-          )}
+					<Section title="Resource history" boxed={false}>
+						<Suspense fallback={<div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">Loading chart…</div>}>
+							<ResourceHistoryChart gameId={gameId} />
+						</Suspense>
+					</Section>
+				</TabsContent>
 
-          <Suspense fallback={<div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">Loading chart…</div>}>
-            <ResourceHistoryChart gameId={gameId} />
-          </Suspense>
-        </div>
-      )}
-
-      {activeTab === 'build' && (
-        <div role="tabpanel" className="space-y-5">
-          {lastError && <div className="text-destructive text-sm">{lastError}</div>}
-          {assetsLoading ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <SkeletonCard key={i} className="h-32" />
-              ))}
-            </div>
-          ) : assetsError && !assetsData ? (
-            <ApiError message="Failed to load assets." onRetry={() => void refetchAssets()} />
-          ) : assetsData ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {assetsData.assets.map((asset) => (
-                <AssetCard
-                  key={asset.definition.id}
-                  asset={asset}
-                  gameId={gameId}
-                  onBuild={(defId) => buildMutation.mutate(defId)}
-                  onQueue={(defId) => queueAssetMutation.mutate(defId)}
-                />
-              ))}
-            </div>
-          ) : null}
-        </div>
-      )}
-
-      {activeTab === 'activity' && (
-        <div role="tabpanel">
-          <div className="rounded-lg border bg-card">
-            <div className="flex items-center justify-between border-b px-4 py-3">
-              <strong className="text-sm">Recent Activity</strong>
-              {(notifications?.length ?? 0) > 0 && (
-                <button
-                  onClick={() => clearNotificationsMutation.mutate()}
-                  className="text-xs text-muted-foreground hover:text-foreground"
-                >
-                  Clear
-                </button>
-              )}
-            </div>
-            <div className="p-2">
-              {!notifications ? (
-                <div className="p-3 space-y-2" aria-hidden="true">
-                  <SkeletonLine className="w-3/4" />
-                  <SkeletonLine className="w-2/3" />
-                  <SkeletonLine className="w-1/2" />
-                </div>
-              ) : notifications.length === 0 ? (
-                <div className="p-3 text-muted-foreground text-sm">No recent activity.</div>
-              ) : (
-                <ul className="divide-y">
-                  {notifications.slice(0, 10).map((n) => (
-                    <li key={n.id} className="flex items-start gap-2 py-2 px-2">
-                      <span>{notificationIcon(n.kind)}</span>
-                      <div className="flex-1 min-w-0">
-                        <span className="text-sm">{n.message}</span>
-                        <div className="text-xs text-muted-foreground">{relativeTime(n.createdAt)}</div>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-type BaseTab = 'economy' | 'build' | 'activity'
-
-function TabButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean
-  onClick: () => void
-  children: React.ReactNode
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        'relative min-h-[44px] px-4 py-2 text-sm font-medium transition-colors',
-        active
-          ? 'text-primary border-b-2 border-primary -mb-px'
-          : 'text-muted-foreground hover:text-foreground',
-      )}
-    >
-      {children}
-    </button>
-  )
+				<TabsContent value="activity" className="mt-4">
+					<Section
+						title="Recent Activity"
+						actions={
+							(notifications?.length ?? 0) > 0 ? (
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => clearNotificationsMutation.mutate()}
+								>
+									Clear
+								</Button>
+							) : undefined
+						}
+					>
+						{!notifications ? (
+							<div className="space-y-2" aria-hidden="true">
+								<SkeletonLine className="w-3/4" />
+								<SkeletonLine className="w-2/3" />
+								<SkeletonLine className="w-1/2" />
+							</div>
+						) : notifications.length === 0 ? (
+							<div className="text-muted-foreground text-sm">No recent activity.</div>
+						) : (
+							<ul className="divide-y">
+								{notifications.slice(0, 10).map((n) => (
+									<li key={n.id} className="flex items-start gap-2 py-2">
+										<span>{notificationIcon(n.kind)}</span>
+										<div className="flex-1 min-w-0">
+											<span className="text-sm">{n.message}</span>
+											<div className="text-xs text-muted-foreground">{relativeTime(n.createdAt)}</div>
+										</div>
+									</li>
+								))}
+							</ul>
+						)}
+					</Section>
+				</TabsContent>
+			</Tabs>
+		</div>
+	)
 }

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -73,7 +73,7 @@ function AssetCard({
 					</>
 				) : asset.alreadyQueued ? (
 					<div className="text-xs text-muted-foreground">
-						Queued — ready in {asset.ticksLeftForBuild} rounds
+						Queued — ready in {asset.ticksLeftForBuild} ticks
 					</div>
 				) : (
 					<>

--- a/src/ReactClient/src/pages/Market.tsx
+++ b/src/ReactClient/src/pages/Market.tsx
@@ -1,312 +1,370 @@
-import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import type { MarketViewModel, MarketOrderViewModel, CreateMarketOrderRequest } from '@/api/types'
-import { ApiError } from '@/components/ApiError'
-import { SkeletonRow, SkeletonLine } from '@/components/Skeleton'
 import { useConfirm } from '@/contexts/ConfirmContext'
+import { PageHeader } from '@/components/ui/page-header'
+import { Section } from '@/components/ui/section'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { DataTable, type ColumnDef } from '@/components/ui/data-table'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Field } from '@/components/ui/field'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select'
+import {
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+	TooltipProvider,
+} from '@/components/ui/tooltip'
+import { ConvertResourceForm } from '@/components/ConvertResourceForm'
+import { ApiError } from '@/components/ApiError'
 
 interface MarketProps {
-  gameId: string
+	gameId: string
 }
 
 function exchangeRate(order: MarketOrderViewModel): string {
-  if (order.wantedAmount === 0) return '—'
-  const ratio = order.offeredAmount / order.wantedAmount
-  return `${ratio.toFixed(4)} ${order.offeredResourceName}/${order.wantedResourceName}`
+	if (order.wantedAmount === 0) return '—'
+	const ratio = order.offeredAmount / order.wantedAmount
+	return `${ratio.toFixed(4)} ${order.offeredResourceName}/${order.wantedResourceName}`
 }
 
+const postOfferSchema = z.object({
+	offeredResourceId: z.string().min(1, 'Select a resource to offer'),
+	offeredAmount: z.number().int().min(1, 'Must be at least 1'),
+	wantedResourceId: z.string().min(1, 'Select a resource to want'),
+	wantedAmount: z.number().int().min(1, 'Must be at least 1'),
+})
+type PostOfferValues = z.infer<typeof postOfferSchema>
+
 export function Market({ gameId }: MarketProps) {
-  const queryClient = useQueryClient()
-  const confirm = useConfirm()
-  const [postError, setPostError] = useState<string | null>(null)
-  const [orderErrors, setOrderErrors] = useState<Record<string, string>>({})
-  const [offerResourceId, setOfferResourceId] = useState('')
-  const [offerAmount, setOfferAmount] = useState(100)
-  const [wantResourceId, setWantResourceId] = useState('')
-  const [wantAmount, setWantAmount] = useState(100)
+	const queryClient = useQueryClient()
+	const confirm = useConfirm()
 
-  const { data, isLoading, error: queryError, refetch } = useQuery<MarketViewModel>({
-    queryKey: ['market', gameId],
-    queryFn: () => apiClient.get('/api/market').then((r) => r.data),
-    refetchInterval: 30_000,
-  })
+	const { data, isLoading, error: queryError, refetch } = useQuery<MarketViewModel>({
+		queryKey: ['market', gameId],
+		queryFn: () => apiClient.get('/api/market').then((r) => r.data),
+		refetchInterval: 30_000,
+	})
 
-  const postOfferMutation = useMutation({
-    mutationFn: () => {
-      const request: CreateMarketOrderRequest = {
-        offeredResourceId: offerResourceId,
-        offeredAmount: offerAmount,
-        wantedResourceId: wantResourceId,
-        wantedAmount: wantAmount,
-      }
-      return apiClient.post('/api/market/post', request)
-    },
-    onSuccess: () => {
-      setPostError(null)
-      setOfferResourceId('')
-      setOfferAmount(100)
-      setWantResourceId('')
-      setWantAmount(100)
-      void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) setPostError((err.response?.data as string) ?? 'Post failed')
-    },
-  })
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const form = useForm<PostOfferValues>({
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		resolver: zodResolver(postOfferSchema) as any,
+		defaultValues: {
+			offeredResourceId: '',
+			offeredAmount: 100,
+			wantedResourceId: '',
+			wantedAmount: 100,
+		},
+	})
 
-  const acceptMutation = useMutation({
-    mutationFn: (orderId: string) =>
-      apiClient.post(`/api/market/accept?orderId=${orderId}`, ''),
-    onSuccess: (_, orderId) => {
-      setOrderErrors((prev) => {
-        const next = { ...prev }
-        delete next[orderId]
-        return next
-      })
-      void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
-    },
-    onError: (err, orderId) => {
-      if (axios.isAxiosError(err)) {
-        setOrderErrors((prev) => ({
-          ...prev,
-          [orderId]: (err.response?.data as string) ?? 'Accept failed',
-        }))
-      }
-    },
-  })
+	const postOfferMutation = useMutation({
+		mutationFn: (values: PostOfferValues) => {
+			const request: CreateMarketOrderRequest = {
+				offeredResourceId: values.offeredResourceId,
+				offeredAmount: values.offeredAmount,
+				wantedResourceId: values.wantedResourceId,
+				wantedAmount: values.wantedAmount,
+			}
+			return apiClient.post('/api/market/post', request)
+		},
+		onSuccess: () => {
+			toast.success('Offer posted')
+			form.reset()
+			void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
+		},
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Post failed')
+				: 'Post failed'
+			toast.error(msg)
+		},
+	})
 
-  const cancelMutation = useMutation({
-    mutationFn: (orderId: string) =>
-      apiClient.delete(`/api/market/cancel?orderId=${orderId}`),
-    onSuccess: (_, orderId) => {
-      setOrderErrors((prev) => {
-        const next = { ...prev }
-        delete next[orderId]
-        return next
-      })
-      void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
-    },
-    onError: (err, orderId) => {
-      if (axios.isAxiosError(err)) {
-        setOrderErrors((prev) => ({
-          ...prev,
-          [orderId]: (err.response?.data as string) ?? 'Cancel failed',
-        }))
-      }
-    },
-  })
+	const acceptMutation = useMutation({
+		mutationFn: (orderId: string) =>
+			apiClient.post(`/api/market/accept?orderId=${orderId}`, ''),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
+		},
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Accept failed')
+				: 'Accept failed'
+			toast.error(msg)
+		},
+	})
 
-  if (isLoading) {
-    return (
-      <div className="space-y-6" aria-hidden="true">
-        <SkeletonLine className="h-6 w-40" />
-        <div className="rounded-lg border bg-card overflow-hidden">
-          <table className="w-full text-sm">
-            <tbody>
-              {Array.from({ length: 6 }).map((_, i) => (
-                <SkeletonRow key={i} cols={5} />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    )
-  }
-  if (queryError) return <ApiError message="Failed to load market." onRetry={() => void refetch()} />
-  if (!data) return null
+	const cancelMutation = useMutation({
+		mutationFn: (orderId: string) =>
+			apiClient.delete(`/api/market/cancel?orderId=${orderId}`),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['market', gameId] })
+		},
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Cancel failed')
+				: 'Cancel failed'
+			toast.error(msg)
+		},
+	})
 
-  const myOrders = data.openOrders.filter((o) => o.sellerPlayerId === data.currentPlayerId)
-  const otherOrders = data.openOrders.filter((o) => o.sellerPlayerId !== data.currentPlayerId)
+	if (queryError) return <ApiError message="Failed to load market." onRetry={() => void refetch()} />
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Market</h1>
+	const myOrders = data?.openOrders.filter((o) => o.sellerPlayerId === data.currentPlayerId) ?? []
+	const otherOrders = data?.openOrders.filter((o) => o.sellerPlayerId !== data.currentPlayerId) ?? []
+	const resourceOptions = data?.resourceOptions ?? []
 
-      {/* Post Offer */}
-      <div className="rounded-lg border bg-card p-4 sm:p-5 max-w-lg">
-        <h2 className="font-semibold mb-4">Post Trade Offer</h2>
-        {postError && (
-          <div className="text-destructive text-sm mb-3">{postError}</div>
-        )}
-        <div className="space-y-3">
-          <div>
-            <label className="block text-sm text-muted-foreground mb-1">Offer resource</label>
-            <select
-              value={offerResourceId}
-              onChange={(e) => setOfferResourceId(e.target.value)}
-              className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-            >
-              <option value="">-- select resource --</option>
-              {data.resourceOptions.map((r) => (
-                <option key={r.id} value={r.id}>
-                  {r.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-muted-foreground mb-1">Amount to offer</label>
-            <input
-              type="number"
-              min={1}
-              value={offerAmount}
-              onChange={(e) => setOfferAmount(Number(e.target.value))}
-              className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm text-muted-foreground mb-1">Want resource</label>
-            <select
-              value={wantResourceId}
-              onChange={(e) => setWantResourceId(e.target.value)}
-              className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-            >
-              <option value="">-- select resource --</option>
-              {data.resourceOptions.map((r) => (
-                <option key={r.id} value={r.id}>
-                  {r.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-muted-foreground mb-1">Amount wanted</label>
-            <input
-              type="number"
-              min={1}
-              value={wantAmount}
-              onChange={(e) => setWantAmount(Number(e.target.value))}
-              className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-            />
-          </div>
-          <button
-            onClick={() => postOfferMutation.mutate()}
-            disabled={postOfferMutation.isPending}
-            className="rounded bg-primary min-h-[44px] px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
-          >
-            Post Offer
-          </button>
-        </div>
-      </div>
+	const buyColumns: ColumnDef<MarketOrderViewModel, unknown>[] = [
+		{
+			id: 'player',
+			header: 'Player',
+			accessorFn: (o) => o.sellerPlayerName,
+		},
+		{
+			id: 'offering',
+			header: 'Offering',
+			cell: ({ row }) => `${row.original.offeredAmount} ${row.original.offeredResourceName}`,
+		},
+		{
+			id: 'wants',
+			header: 'Wants',
+			cell: ({ row }) => `${row.original.wantedAmount} ${row.original.wantedResourceName}`,
+		},
+		{
+			id: 'rate',
+			header: 'Rate',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{exchangeRate(row.original)}</span>
+			),
+		},
+		{
+			id: 'posted',
+			header: 'Posted',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">
+					{new Date(row.original.createdAt).toLocaleString()}
+				</span>
+			),
+		},
+		{
+			id: 'actions',
+			header: '',
+			cell: ({ row }) => {
+				const order = row.original
+				const isPending = acceptMutation.isPending
+				return (
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span tabIndex={isPending ? 0 : undefined}>
+									<Button
+										variant="default"
+										size="sm"
+										disabled={isPending}
+										onClick={() => acceptMutation.mutate(order.orderId)}
+									>
+										Accept
+									</Button>
+								</span>
+							</TooltipTrigger>
+							{isPending && (
+								<TooltipContent>Accepting order…</TooltipContent>
+							)}
+						</Tooltip>
+					</TooltipProvider>
+				)
+			},
+		},
+	]
 
-      {/* My Orders */}
-      {myOrders.length > 0 && (
-        <div>
-          <h2 className="font-semibold mb-3">My Orders</h2>
-          <div className="overflow-x-auto">
-            <table className="responsive-table w-full text-sm">
-              <thead className="border-b">
-                <tr>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {myOrders.map((order) => (
-                  <tr key={order.orderId} className="border-b border-border bg-info/10">
-                    <td data-label="Offering" className="py-2 px-3">
-                      {order.offeredAmount} {order.offeredResourceName}
-                    </td>
-                    <td data-label="Wants" className="py-2 px-3">
-                      {order.wantedAmount} {order.wantedResourceName}
-                    </td>
-                    <td data-label="Rate" className="py-2 px-3 text-muted-foreground text-xs">
-                      {exchangeRate(order)}
-                    </td>
-                    <td data-label="Posted" className="py-2 px-3 text-xs text-muted-foreground">
-                      {new Date(order.createdAt).toLocaleString()}
-                    </td>
-                    <td data-label="" className="py-2 px-3">
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={async () => {
-                            const ok = await confirm({
-                              title: 'Cancel market order?',
-                              description: `Your ${order.offeredAmount} ${order.offeredResourceName} will be returned to your base.`,
-                              destructive: true,
-                              confirmLabel: 'Cancel order',
-                              cancelLabel: 'Keep order',
-                            })
-                            if (ok) cancelMutation.mutate(order.orderId)
-                          }}
-                          disabled={cancelMutation.isPending}
-                          className="rounded bg-destructive min-h-[36px] px-3 py-1.5 text-xs text-destructive-foreground hover:opacity-90 disabled:opacity-50"
-                        >
-                          Cancel
-                        </button>
-                        {orderErrors[order.orderId] && (
-                          <span className="text-destructive text-xs">{orderErrors[order.orderId]}</span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
+	const myOrderColumns: ColumnDef<MarketOrderViewModel, unknown>[] = [
+		{
+			id: 'offering',
+			header: 'Offering',
+			cell: ({ row }) => `${row.original.offeredAmount} ${row.original.offeredResourceName}`,
+		},
+		{
+			id: 'wants',
+			header: 'Wants',
+			cell: ({ row }) => `${row.original.wantedAmount} ${row.original.wantedResourceName}`,
+		},
+		{
+			id: 'rate',
+			header: 'Rate',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{exchangeRate(row.original)}</span>
+			),
+		},
+		{
+			id: 'posted',
+			header: 'Posted',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">
+					{new Date(row.original.createdAt).toLocaleString()}
+				</span>
+			),
+		},
+		{
+			id: 'actions',
+			header: '',
+			cell: ({ row }) => {
+				const order = row.original
+				return (
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={cancelMutation.isPending}
+						onClick={async () => {
+							const ok = await confirm({
+								title: 'Cancel market order?',
+								description: `Your ${order.offeredAmount} ${order.offeredResourceName} will be returned to your base.`,
+								destructive: true,
+								confirmLabel: 'Cancel order',
+								cancelLabel: 'Keep order',
+							})
+							if (ok) cancelMutation.mutate(order.orderId)
+						}}
+					>
+						Cancel
+					</Button>
+				)
+			},
+		},
+	]
 
-      {/* Open Orders from others */}
-      <div>
-        <h2 className="font-semibold mb-3">Open Orders</h2>
-        {otherOrders.length === 0 ? (
-          <p className="text-muted-foreground text-sm">No open orders from other players.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="responsive-table w-full text-sm">
-              <thead className="border-b">
-                <tr>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Seller</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Rate</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Posted</th>
-                  <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {otherOrders.map((order) => (
-                  <tr key={order.orderId} className="border-b border-border">
-                    <td data-label="Seller" className="py-2 px-3">{order.sellerPlayerName}</td>
-                    <td data-label="Offering" className="py-2 px-3">
-                      {order.offeredAmount} {order.offeredResourceName}
-                    </td>
-                    <td data-label="Wants" className="py-2 px-3">
-                      {order.wantedAmount} {order.wantedResourceName}
-                    </td>
-                    <td data-label="Rate" className="py-2 px-3 text-muted-foreground text-xs">
-                      {exchangeRate(order)}
-                    </td>
-                    <td data-label="Posted" className="py-2 px-3 text-xs text-muted-foreground">
-                      {new Date(order.createdAt).toLocaleString()}
-                    </td>
-                    <td data-label="" className="py-2 px-3">
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={() => acceptMutation.mutate(order.orderId)}
-                          disabled={acceptMutation.isPending}
-                          className="rounded bg-success min-h-[36px] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:opacity-50"
-                        >
-                          Accept
-                        </button>
-                        {orderErrors[order.orderId] && (
-                          <span className="text-destructive text-xs">{orderErrors[order.orderId]}</span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </div>
-  )
+	const onSubmit = (values: PostOfferValues) => {
+		postOfferMutation.mutate(values)
+	}
+
+	return (
+		<div className="space-y-6">
+			<PageHeader
+				title="Market"
+				description="Post or accept resource trades with other players."
+			/>
+
+			<Tabs defaultValue="buy">
+				<TabsList>
+					<TabsTrigger value="buy">Buy</TabsTrigger>
+					<TabsTrigger value="sell">Sell</TabsTrigger>
+					<TabsTrigger value="convert">Convert</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="buy" className="mt-4">
+					<DataTable
+						columns={buyColumns}
+						rows={isLoading ? undefined : otherOrders}
+						loading={isLoading}
+						empty="No open orders from other players."
+						getRowId={(o) => o.orderId}
+					/>
+				</TabsContent>
+
+				<TabsContent value="sell" className="mt-4 space-y-6">
+					<Section title="My offers">
+						<DataTable
+							columns={myOrderColumns}
+							rows={isLoading ? undefined : myOrders}
+							loading={isLoading}
+							empty="You have no open offers."
+							getRowId={(o) => o.orderId}
+						/>
+					</Section>
+
+					<Section title="Post a new offer">
+						<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 max-w-lg">
+							<div className="grid grid-cols-2 gap-4">
+								<Field
+									label="Offering resource"
+									htmlFor="offeredResourceId"
+									error={form.formState.errors.offeredResourceId?.message}
+								>
+									<Select
+										value={form.watch('offeredResourceId')}
+										onValueChange={(v) => form.setValue('offeredResourceId', v, { shouldValidate: true })}
+									>
+										<SelectTrigger id="offeredResourceId" className="w-full">
+											<SelectValue placeholder="Select resource" />
+										</SelectTrigger>
+										<SelectContent>
+											{resourceOptions.map((r) => (
+												<SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
+
+								<Field
+									label="Amount to offer"
+									htmlFor="offeredAmount"
+									error={form.formState.errors.offeredAmount?.message}
+								>
+									<Input
+										id="offeredAmount"
+										type="number"
+										min={1}
+										{...form.register('offeredAmount', { valueAsNumber: true })}
+									/>
+								</Field>
+
+								<Field
+									label="Wanting resource"
+									htmlFor="wantedResourceId"
+									error={form.formState.errors.wantedResourceId?.message}
+								>
+									<Select
+										value={form.watch('wantedResourceId')}
+										onValueChange={(v) => form.setValue('wantedResourceId', v, { shouldValidate: true })}
+									>
+										<SelectTrigger id="wantedResourceId" className="w-full">
+											<SelectValue placeholder="Select resource" />
+										</SelectTrigger>
+										<SelectContent>
+											{resourceOptions.map((r) => (
+												<SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
+
+								<Field
+									label="Amount wanted"
+									htmlFor="wantedAmount"
+									error={form.formState.errors.wantedAmount?.message}
+								>
+									<Input
+										id="wantedAmount"
+										type="number"
+										min={1}
+										{...form.register('wantedAmount', { valueAsNumber: true })}
+									/>
+								</Field>
+							</div>
+
+							<Button type="submit" disabled={postOfferMutation.isPending}>
+								{postOfferMutation.isPending ? 'Posting…' : 'Post offer'}
+							</Button>
+						</form>
+					</Section>
+				</TabsContent>
+
+				<TabsContent value="convert" className="mt-4">
+					<ConvertResourceForm gameId={gameId} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	)
 }

--- a/src/ReactClient/src/pages/Research.tsx
+++ b/src/ReactClient/src/pages/Research.tsx
@@ -3,192 +3,70 @@ import axios from 'axios'
 import { useState } from 'react'
 import apiClient from '@/api/client'
 import type { UpgradesViewModel } from '@/api/types'
-import { CostBadge } from '@/components/CostBadge'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
+import { PageHeader } from '@/components/ui/page-header'
+import { UpgradeTrack } from '@/components/UpgradeTrack'
 
-interface ResearchProps {
-  gameId: string
-}
+export function Research({ gameId }: { gameId: string }) {
+	const queryClient = useQueryClient()
+	const [error, setError] = useState<string | null>(null)
 
-function upgradeNodeClass(
-  upgradeType: string,
-  level: number,
-  currentLevel: number,
-  upgradeBeingResearched: string
-): string {
-  if (level <= currentLevel) return 'completed'
-  if (level === currentLevel + 1) {
-    if (upgradeBeingResearched === upgradeType) return 'in-progress'
-    return 'available'
-  }
-  return 'locked'
-}
+	const { data, isLoading, error: queryError, refetch } = useQuery<UpgradesViewModel>({
+		queryKey: ['upgrades', gameId],
+		queryFn: () => apiClient.get('/api/upgrades').then((r) => r.data),
+		refetchInterval: 10_000,
+	})
 
-export function Research({ gameId }: ResearchProps) {
-  const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
+	const upgradeMutation = useMutation({
+		mutationFn: (upgradeType: string) =>
+			apiClient.post(`/api/upgrades/research?upgradeType=${upgradeType}`, ''),
+		onSuccess: () => {
+			setError(null)
+			void queryClient.invalidateQueries({ queryKey: ['upgrades', gameId] })
+		},
+		onError: (err) => {
+			if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Research failed')
+		},
+	})
 
-  const { data: upgrades, isLoading: upgradesLoading, error: upgradesError, refetch: refetchUpgrades } = useQuery<UpgradesViewModel>({
-    queryKey: ['upgrades', gameId],
-    queryFn: () => apiClient.get('/api/upgrades').then((r) => r.data),
-    refetchInterval: 10_000,
-  })
+	if (isLoading) return <PageLoader message="Loading research..." />
+	if (queryError) {
+		return <ApiError message="Failed to load research data." onRetry={() => { void refetch() }} />
+	}
 
-  const researchUpgradeMutation = useMutation({
-    mutationFn: (upgradeType: string) =>
-      apiClient.post(`/api/upgrades/research?upgradeType=${upgradeType}`, ''),
-    onSuccess: () => {
-      setError(null)
-      void queryClient.invalidateQueries({ queryKey: ['upgrades', gameId] })
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Research failed')
-    },
-  })
+	const upgrades = data!
 
-  if (upgradesLoading) return <PageLoader message="Loading research..." />
-  if (upgradesError) {
-    return <ApiError message="Failed to load research data." onRetry={() => { void refetchUpgrades() }} />
-  }
+	return (
+		<>
+			<PageHeader title="Research" description="Upgrade your units' combat capabilities." />
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Research</h1>
+			{error && <div className="text-destructive text-sm mb-4">{error}</div>}
 
-      {error && <div className="text-destructive text-sm">{error}</div>}
-
-      {upgrades && (
-        <div>
-          <h2 className="text-lg font-semibold mb-4">Upgrades</h2>
-
-          {/* Attack upgrades */}
-          <div className="mb-4">
-            <div className="text-sm font-medium text-muted-foreground mb-2 w-24 shrink-0">
-              Attack
-            </div>
-            <div className="flex items-start gap-2 flex-wrap">
-              {Array.from({ length: upgrades.maxUpgradeLevel }, (_, i) => i + 1).map((level) => {
-                const nodeClass = upgradeNodeClass(
-                  'Attack',
-                  level,
-                  upgrades.attackUpgradeLevel,
-                  upgrades.upgradeBeingResearched
-                )
-                const statusStyles: Record<string, string> = {
-                  completed: 'border-green-700 bg-green-900/15',
-                  'in-progress': 'border-primary bg-card',
-                  available: 'border-primary shadow-[0_0_6px_hsl(var(--color-primary))]',
-                  locked: 'border-border opacity-45 grayscale',
-                }
-                return (
-                  <div
-                    key={level}
-                    className={`flex items-start gap-2`}
-                  >
-                    <div className={`rounded-lg border-2 p-3 w-36 ${statusStyles[nodeClass] ?? ''}`}>
-                      <div className="font-bold text-sm mb-1">Level {level}</div>
-                      {level <= upgrades.attackUpgradeLevel ? (
-                        <div className="text-xs text-green-400 font-bold">✓ Completed</div>
-                      ) : nodeClass === 'in-progress' ? (
-                        <div className="text-xs text-primary">
-                          Researching… ({upgrades.upgradeResearchTimer} rounds)
-                        </div>
-                      ) : nodeClass === 'available' ? (
-                        <>
-                          {upgrades.nextAttackUpgradeCost && (
-                            <div className="text-xs mb-2">
-                              <CostBadge cost={upgrades.nextAttackUpgradeCost} />
-                            </div>
-                          )}
-                          <button
-                            onClick={() => researchUpgradeMutation.mutate('Attack')}
-                            className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground hover:opacity-90"
-                          >
-                            Research
-                          </button>
-                        </>
-                      ) : level === upgrades.attackUpgradeLevel + 1 &&
-                        upgrades.upgradeBeingResearched !== 'None' ? (
-                        <div className="text-xs text-muted-foreground">
-                          Another in progress
-                        </div>
-                      ) : (
-                        <div className="text-xs text-muted-foreground">Locked</div>
-                      )}
-                    </div>
-                    {level < upgrades.maxUpgradeLevel && (
-                      <div className="text-xl text-muted-foreground pt-3 shrink-0">→</div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-
-          {/* Defense upgrades */}
-          <div className="mb-4">
-            <div className="text-sm font-medium text-muted-foreground mb-2 w-24 shrink-0">
-              Defense
-            </div>
-            <div className="flex items-start gap-2 flex-wrap">
-              {Array.from({ length: upgrades.maxUpgradeLevel }, (_, i) => i + 1).map((level) => {
-                const nodeClass = upgradeNodeClass(
-                  'Defense',
-                  level,
-                  upgrades.defenseUpgradeLevel,
-                  upgrades.upgradeBeingResearched
-                )
-                const statusStyles: Record<string, string> = {
-                  completed: 'border-green-700 bg-green-900/15',
-                  'in-progress': 'border-primary bg-card',
-                  available: 'border-primary shadow-[0_0_6px_hsl(var(--color-primary))]',
-                  locked: 'border-border opacity-45 grayscale',
-                }
-                return (
-                  <div key={level} className="flex items-start gap-2">
-                    <div className={`rounded-lg border-2 p-3 w-36 ${statusStyles[nodeClass] ?? ''}`}>
-                      <div className="font-bold text-sm mb-1">Level {level}</div>
-                      {level <= upgrades.defenseUpgradeLevel ? (
-                        <div className="text-xs text-green-400 font-bold">✓ Completed</div>
-                      ) : nodeClass === 'in-progress' ? (
-                        <div className="text-xs text-primary">
-                          Researching… ({upgrades.upgradeResearchTimer} rounds)
-                        </div>
-                      ) : nodeClass === 'available' ? (
-                        <>
-                          {upgrades.nextDefenseUpgradeCost && (
-                            <div className="text-xs mb-2">
-                              <CostBadge cost={upgrades.nextDefenseUpgradeCost} />
-                            </div>
-                          )}
-                          <button
-                            onClick={() => researchUpgradeMutation.mutate('Defense')}
-                            className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground hover:opacity-90"
-                          >
-                            Research
-                          </button>
-                        </>
-                      ) : level === upgrades.defenseUpgradeLevel + 1 &&
-                        upgrades.upgradeBeingResearched !== 'None' ? (
-                        <div className="text-xs text-muted-foreground">
-                          Another in progress
-                        </div>
-                      ) : (
-                        <div className="text-xs text-muted-foreground">Locked</div>
-                      )}
-                    </div>
-                    {level < upgrades.maxUpgradeLevel && (
-                      <div className="text-xl text-muted-foreground pt-3 shrink-0">→</div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      )}
-
-    </div>
-  )
+			<UpgradeTrack
+				type="Attack"
+				currentLevel={upgrades.attackUpgradeLevel}
+				maxLevel={upgrades.maxUpgradeLevel}
+				upgradeBeingResearched={upgrades.upgradeBeingResearched}
+				researchTimer={upgrades.upgradeResearchTimer}
+				nextCost={upgrades.nextAttackUpgradeCost?.cost ?? null}
+				canAfford={true}
+				isResearching={upgradeMutation.isPending}
+				onResearch={() => upgradeMutation.mutate('Attack')}
+				description="Increase attack damage of all units."
+			/>
+			<UpgradeTrack
+				type="Defense"
+				currentLevel={upgrades.defenseUpgradeLevel}
+				maxLevel={upgrades.maxUpgradeLevel}
+				upgradeBeingResearched={upgrades.upgradeBeingResearched}
+				researchTimer={upgrades.upgradeResearchTimer}
+				nextCost={upgrades.nextDefenseUpgradeCost?.cost ?? null}
+				canAfford={true}
+				isResearching={upgradeMutation.isPending}
+				onResearch={() => upgradeMutation.mutate('Defense')}
+				description="Increase defense of all units."
+			/>
+		</>
+	)
 }

--- a/src/ReactClient/src/pages/Trade.tsx
+++ b/src/ReactClient/src/pages/Trade.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ArrowRightLeftIcon } from 'lucide-react'
+import { toast } from 'sonner'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import type {
@@ -12,30 +15,58 @@ import type {
 	PaginatedResponse,
 } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
-import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { useConfirm } from '@/contexts/ConfirmContext'
+import { PageHeader } from '@/components/ui/page-header'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { DataTable, type ColumnDef } from '@/components/ui/data-table'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Field } from '@/components/ui/field'
+import { Badge } from '@/components/ui/badge'
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogFooter,
+} from '@/components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select'
 
 interface TradeProps {
 	gameId: string
 }
 
+const proposeSchema = z.object({
+	targetPlayerId: z.string().min(1, 'Select a player'),
+	offeredResourceId: z.string().min(1, 'Select a resource to offer'),
+	offeredAmount: z.number().int().min(1, 'Must be at least 1'),
+	wantedResourceId: z.string().min(1, 'Select a resource to want'),
+	wantedAmount: z.number().int().min(1, 'Must be at least 1'),
+	note: z.string().max(200, 'Max 200 characters').optional(),
+})
+type ProposeValues = z.infer<typeof proposeSchema>
+
+function statusBadgeVariant(status: string): 'default' | 'destructive' | 'secondary' | 'outline' {
+	if (status === 'Accepted') return 'default'
+	if (status === 'Declined') return 'destructive'
+	if (status === 'Cancelled') return 'secondary'
+	return 'outline'
+}
+
 export function Trade({ gameId }: TradeProps) {
 	const queryClient = useQueryClient()
 	const confirm = useConfirm()
-	const [error, setError] = useState<string | null>(null)
-	const [success, setSuccess] = useState<string | null>(null)
-
-	// Form state
-	const [targetPlayerId, setTargetPlayerId] = useState('')
-	const [offeredResourceId, setOfferedResourceId] = useState('')
-	const [offeredAmount, setOfferedAmount] = useState(100)
-	const [wantedResourceId, setWantedResourceId] = useState('')
-	const [wantedAmount, setWantedAmount] = useState(100)
-	const [note, setNote] = useState('')
+	const [dialogOpen, setDialogOpen] = useState(false)
 
 	// Fetch resource options from market endpoint
-	const { data: marketData, isLoading: marketLoading, error: marketError, refetch: refetchMarket } = useQuery<MarketViewModel>({
+	const { data: marketData, error: marketError, refetch: refetchMarket } = useQuery<MarketViewModel>({
 		queryKey: ['market', gameId],
 		queryFn: () => apiClient.get('/api/market').then((r) => r.data),
 	})
@@ -45,7 +76,6 @@ export function Trade({ gameId }: TradeProps) {
 		queryKey: ['players-for-trade', gameId],
 		queryFn: () => apiClient.get('/api/playerranking', { params: { pageSize: 100 } }).then((r) => r.data),
 	})
-	const players = playersResp?.items
 
 	// Incoming offers
 	const { data: incoming, isLoading: incomingLoading } = useQuery<TradeOfferViewModel[]>({
@@ -62,7 +92,7 @@ export function Trade({ gameId }: TradeProps) {
 	})
 
 	// Trade history
-	const { data: history } = useQuery<TradeHistoryItemViewModel[]>({
+	const { data: history, isLoading: historyLoading } = useQuery<TradeHistoryItemViewModel[]>({
 		queryKey: ['trade-history', gameId],
 		queryFn: () => apiClient.get('/api/trade/history?skip=0&take=20').then((r) => r.data),
 		refetchInterval: 30_000,
@@ -74,315 +104,419 @@ export function Trade({ gameId }: TradeProps) {
 		void queryClient.invalidateQueries({ queryKey: ['trade-history', gameId] })
 	}
 
-	function handleError(err: unknown) {
-		if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Request failed')
-		else setError('Request failed')
-	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const form = useForm<ProposeValues>({
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		resolver: zodResolver(proposeSchema) as any,
+		defaultValues: {
+			targetPlayerId: '',
+			offeredResourceId: '',
+			offeredAmount: 100,
+			wantedResourceId: '',
+			wantedAmount: 100,
+			note: '',
+		},
+	})
 
-	// Create offer mutation
-	const createMut = useMutation({
-		mutationFn: () => {
+	// Send offer mutation
+	const sendMutation = useMutation({
+		mutationFn: (values: ProposeValues) => {
 			const request: CreateTradeOfferRequest = {
-				targetPlayerId,
-				offeredResourceId,
-				offeredAmount,
-				wantedResourceId,
-				wantedAmount,
-				note: note.trim() || null,
+				targetPlayerId: values.targetPlayerId,
+				offeredResourceId: values.offeredResourceId,
+				offeredAmount: values.offeredAmount,
+				wantedResourceId: values.wantedResourceId,
+				wantedAmount: values.wantedAmount,
+				note: values.note?.trim() || null,
 			}
 			return apiClient.post('/api/trade/offer', request)
 		},
 		onSuccess: () => {
-			setSuccess('Trade offer sent!')
-			setError(null)
-			setTargetPlayerId('')
-			setOfferedAmount(100)
-			setWantedAmount(100)
-			setNote('')
+			toast.success('Trade offer sent')
+			setDialogOpen(false)
+			form.reset()
 			invalidateAll()
 		},
-		onError: handleError,
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Request failed')
+				: 'Request failed'
+			toast.error(msg)
+		},
 	})
 
 	// Accept mutation
-	const acceptMut = useMutation({
+	const acceptMutation = useMutation({
 		mutationFn: (offerId: string) =>
 			apiClient.post(`/api/trade/offers/${offerId}/accept`),
-		onSuccess: () => { setSuccess('Trade accepted!'); setError(null); invalidateAll() },
-		onError: handleError,
+		onSuccess: () => { toast.success('Trade accepted'); invalidateAll() },
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Request failed')
+				: 'Request failed'
+			toast.error(msg)
+		},
 	})
 
 	// Decline mutation
-	const declineMut = useMutation({
+	const declineMutation = useMutation({
 		mutationFn: (offerId: string) =>
 			apiClient.post(`/api/trade/offers/${offerId}/decline`),
-		onSuccess: () => { setSuccess('Trade declined.'); setError(null); invalidateAll() },
-		onError: handleError,
+		onSuccess: () => { toast.success('Trade declined'); invalidateAll() },
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Request failed')
+				: 'Request failed'
+			toast.error(msg)
+		},
 	})
 
 	// Cancel mutation
-	const cancelMut = useMutation({
+	const cancelMutation = useMutation({
 		mutationFn: (offerId: string) =>
 			apiClient.delete(`/api/trade/offers/${offerId}`),
-		onSuccess: () => { setSuccess('Trade cancelled.'); setError(null); invalidateAll() },
-		onError: handleError,
+		onSuccess: () => { toast.success('Trade cancelled'); invalidateAll() },
+		onError: (err) => {
+			const msg = axios.isAxiosError(err)
+				? ((err.response?.data as string) ?? 'Request failed')
+				: 'Request failed'
+			toast.error(msg)
+		},
 	})
 
-	if (marketLoading || incomingLoading || sentLoading) return <PageLoader message="Loading trade..." />
 	if (marketError) return <ApiError message="Failed to load trade data." onRetry={() => void refetchMarket()} />
 
 	const resourceOptions = marketData?.resourceOptions ?? []
 	const currentPlayerId = marketData?.currentPlayerId ?? ''
-
-	// Filter out current player from target list
-	const otherPlayers = (players ?? []).filter((p) => p.playerId !== currentPlayerId)
+	const players = playersResp?.items ?? []
+	const otherPlayers = players.filter((p) => p.playerId !== currentPlayerId)
 
 	function resourceName(resId: string): string {
 		return resourceOptions.find((r) => r.id === resId)?.name ?? resId
 	}
 
+	const incomingColumns: ColumnDef<TradeOfferViewModel, unknown>[] = [
+		{
+			id: 'from',
+			header: 'From',
+			accessorFn: (o) => o.fromPlayerName,
+		},
+		{
+			id: 'offering',
+			header: 'Offering',
+			cell: ({ row }) => `${row.original.offeredAmount} ${resourceName(row.original.offeredResourceId)}`,
+		},
+		{
+			id: 'wants',
+			header: 'Wants',
+			cell: ({ row }) => `${row.original.wantedAmount} ${resourceName(row.original.wantedResourceId)}`,
+		},
+		{
+			id: 'sent',
+			header: 'Sent',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{relativeTime(row.original.sentAt)}</span>
+			),
+		},
+		{
+			id: 'note',
+			header: 'Note',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{row.original.note ?? '—'}</span>
+			),
+		},
+		{
+			id: 'actions',
+			header: '',
+			cell: ({ row }) => {
+				const offer = row.original
+				return (
+					<div className="flex gap-2">
+						<Button
+							variant="default"
+							size="sm"
+							disabled={acceptMutation.isPending}
+							onClick={() => acceptMutation.mutate(offer.offerId)}
+						>
+							Accept
+						</Button>
+						<Button
+							variant="destructive"
+							size="sm"
+							disabled={declineMutation.isPending}
+							onClick={() => declineMutation.mutate(offer.offerId)}
+						>
+							Decline
+						</Button>
+					</div>
+				)
+			},
+		},
+	]
+
+	const sentColumns: ColumnDef<TradeOfferViewModel, unknown>[] = [
+		{
+			id: 'to',
+			header: 'To',
+			accessorFn: (o) => o.toPlayerName,
+		},
+		{
+			id: 'offering',
+			header: 'Offering',
+			cell: ({ row }) => `${row.original.offeredAmount} ${resourceName(row.original.offeredResourceId)}`,
+		},
+		{
+			id: 'wants',
+			header: 'Wants',
+			cell: ({ row }) => `${row.original.wantedAmount} ${resourceName(row.original.wantedResourceId)}`,
+		},
+		{
+			id: 'sent',
+			header: 'Sent',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{relativeTime(row.original.sentAt)}</span>
+			),
+		},
+		{
+			id: 'note',
+			header: 'Note',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{row.original.note ?? '—'}</span>
+			),
+		},
+		{
+			id: 'actions',
+			header: '',
+			cell: ({ row }) => {
+				const offer = row.original
+				return (
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={cancelMutation.isPending}
+						onClick={async () => {
+							const ok = await confirm({
+								title: 'Cancel trade offer?',
+								description: 'The offer will be withdrawn and the recipient can no longer accept it.',
+								destructive: true,
+								confirmLabel: 'Cancel offer',
+								cancelLabel: 'Keep offer',
+							})
+							if (ok) cancelMutation.mutate(offer.offerId)
+						}}
+					>
+						Cancel
+					</Button>
+				)
+			},
+		},
+	]
+
+	const historyColumns: ColumnDef<TradeHistoryItemViewModel, unknown>[] = [
+		{
+			id: 'counterparty',
+			header: 'Counterparty',
+			accessorFn: (o) => o.withPlayerName,
+		},
+		{
+			id: 'offering',
+			header: 'Offering',
+			cell: ({ row }) => `${row.original.gaveAmount} ${resourceName(row.original.gaveResourceId)}`,
+		},
+		{
+			id: 'wants',
+			header: 'Wants',
+			cell: ({ row }) => `${row.original.receivedAmount} ${resourceName(row.original.receivedResourceId)}`,
+		},
+		{
+			id: 'status',
+			header: 'Status',
+			cell: ({ row }) => (
+				<Badge variant={statusBadgeVariant(row.original.status)}>
+					{row.original.status}
+				</Badge>
+			),
+		},
+		{
+			id: 'settled',
+			header: 'Settled',
+			cell: ({ row }) => (
+				<span className="text-xs text-muted-foreground">{relativeTime(row.original.completedAt)}</span>
+			),
+		},
+	]
+
+	const onSubmit = (values: ProposeValues) => {
+		sendMutation.mutate(values)
+	}
+
 	return (
 		<div className="space-y-6">
-			<h1 className="text-2xl font-bold flex items-center gap-2">
-				<ArrowRightLeftIcon className="h-6 w-6 text-primary" />
-				Trade
-			</h1>
+			<PageHeader
+				title="Trade"
+				description="Propose direct trades with other players."
+				actions={
+					<Button onClick={() => setDialogOpen(true)}>Propose trade</Button>
+				}
+			/>
 
-			{error && <div className="text-destructive text-sm">{error}</div>}
-			{success && <div className="text-green-400 text-sm">{success}</div>}
+			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Propose Trade</DialogTitle>
+					</DialogHeader>
 
-			{/* Create Trade Offer */}
-			<div className="rounded-lg border bg-card p-5 max-w-lg">
-				<h2 className="font-semibold mb-4">Send Trade Offer</h2>
-				<div className="space-y-3">
-					<div>
-						<label className="block text-sm text-muted-foreground mb-1">Target Player</label>
-						<select
-							value={targetPlayerId}
-							onChange={(e) => setTargetPlayerId(e.target.value)}
-							className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+					<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+						<Field
+							label="Target Player"
+							htmlFor="targetPlayerId"
+							error={form.formState.errors.targetPlayerId?.message}
 						>
-							<option value="">-- select player --</option>
-							{otherPlayers.map((p) => (
-								<option key={p.playerId ?? ''} value={p.playerId ?? ''}>
-									{p.playerName}
-								</option>
-							))}
-						</select>
-					</div>
-					<div className="grid grid-cols-2 gap-3">
-						<div>
-							<label className="block text-sm text-muted-foreground mb-1">Offer resource</label>
-							<select
-								value={offeredResourceId}
-								onChange={(e) => setOfferedResourceId(e.target.value)}
-								className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+							<Select
+								value={form.watch('targetPlayerId')}
+								onValueChange={(v) => form.setValue('targetPlayerId', v, { shouldValidate: true })}
 							>
-								<option value="">-- select --</option>
-								{resourceOptions.map((r) => (
-									<option key={r.id} value={r.id}>{r.name}</option>
-								))}
-							</select>
-						</div>
-						<div>
-							<label className="block text-sm text-muted-foreground mb-1">Amount</label>
-							<input
-								type="number"
-								min={1}
-								value={offeredAmount}
-								onChange={(e) => setOfferedAmount(Number(e.target.value))}
-								className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-							/>
-						</div>
-					</div>
-					<div className="grid grid-cols-2 gap-3">
-						<div>
-							<label className="block text-sm text-muted-foreground mb-1">Want resource</label>
-							<select
-								value={wantedResourceId}
-								onChange={(e) => setWantedResourceId(e.target.value)}
-								className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+								<SelectTrigger id="targetPlayerId" className="w-full">
+									<SelectValue placeholder="Select player" />
+								</SelectTrigger>
+								<SelectContent>
+									{otherPlayers.map((p) => (
+										<SelectItem key={p.playerId ?? ''} value={p.playerId ?? ''}>
+											{p.playerName}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</Field>
+
+						<div className="grid grid-cols-2 gap-4">
+							<Field
+								label="Offer resource"
+								htmlFor="offeredResourceId"
+								error={form.formState.errors.offeredResourceId?.message}
 							>
-								<option value="">-- select --</option>
-								{resourceOptions.map((r) => (
-									<option key={r.id} value={r.id}>{r.name}</option>
-								))}
-							</select>
+								<Select
+									value={form.watch('offeredResourceId')}
+									onValueChange={(v) => form.setValue('offeredResourceId', v, { shouldValidate: true })}
+								>
+									<SelectTrigger id="offeredResourceId" className="w-full">
+										<SelectValue placeholder="Select resource" />
+									</SelectTrigger>
+									<SelectContent>
+										{resourceOptions.map((r) => (
+											<SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</Field>
+
+							<Field
+								label="Amount"
+								htmlFor="offeredAmount"
+								error={form.formState.errors.offeredAmount?.message}
+							>
+								<Input
+									id="offeredAmount"
+									type="number"
+									min={1}
+									{...form.register('offeredAmount', { valueAsNumber: true })}
+								/>
+							</Field>
+
+							<Field
+								label="Want resource"
+								htmlFor="wantedResourceId"
+								error={form.formState.errors.wantedResourceId?.message}
+							>
+								<Select
+									value={form.watch('wantedResourceId')}
+									onValueChange={(v) => form.setValue('wantedResourceId', v, { shouldValidate: true })}
+								>
+									<SelectTrigger id="wantedResourceId" className="w-full">
+										<SelectValue placeholder="Select resource" />
+									</SelectTrigger>
+									<SelectContent>
+										{resourceOptions.map((r) => (
+											<SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</Field>
+
+							<Field
+								label="Amount"
+								htmlFor="wantedAmount"
+								error={form.formState.errors.wantedAmount?.message}
+							>
+								<Input
+									id="wantedAmount"
+									type="number"
+									min={1}
+									{...form.register('wantedAmount', { valueAsNumber: true })}
+								/>
+							</Field>
 						</div>
-						<div>
-							<label className="block text-sm text-muted-foreground mb-1">Amount</label>
-							<input
-								type="number"
-								min={1}
-								value={wantedAmount}
-								onChange={(e) => setWantedAmount(Number(e.target.value))}
-								className="w-full rounded border bg-input px-2 py-1.5 text-sm"
+
+						<Field
+							label="Note (optional)"
+							htmlFor="note"
+							error={form.formState.errors.note?.message}
+						>
+							<Input
+								id="note"
+								type="text"
+								maxLength={200}
+								placeholder="Add a note..."
+								{...form.register('note')}
 							/>
-						</div>
-					</div>
-					<div>
-						<label className="block text-sm text-muted-foreground mb-1">Note (optional)</label>
-						<input
-							type="text"
-							value={note}
-							onChange={(e) => setNote(e.target.value)}
-							maxLength={200}
-							placeholder="Add a note..."
-							className="w-full rounded border bg-input px-2 py-1.5 text-sm"
-						/>
-					</div>
-					<button
-						onClick={() => createMut.mutate()}
-						disabled={createMut.isPending || !targetPlayerId || !offeredResourceId || !wantedResourceId}
-						className="rounded bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
-					>
-						{createMut.isPending ? 'Sending...' : 'Send Offer'}
-					</button>
-				</div>
-			</div>
+						</Field>
 
-			{/* Incoming Offers */}
-			<div>
-				<h2 className="font-semibold mb-3">Incoming Offers</h2>
-				{!incoming || incoming.length === 0 ? (
-					<p className="text-muted-foreground text-sm">No incoming trade offers.</p>
-				) : (
-					<div className="overflow-x-auto">
-						<table className="w-full text-sm">
-							<thead className="border-b">
-								<tr>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">From</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Note</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Sent</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
-								</tr>
-							</thead>
-							<tbody>
-								{incoming.map((offer) => (
-									<tr key={offer.offerId} className="border-b border-border">
-										<td className="py-2 px-3 font-medium">{offer.fromPlayerName}</td>
-										<td className="py-2 px-3">{offer.offeredAmount} {resourceName(offer.offeredResourceId)}</td>
-										<td className="py-2 px-3">{offer.wantedAmount} {resourceName(offer.wantedResourceId)}</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">{offer.note ?? '—'}</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(offer.sentAt)}</td>
-										<td className="py-2 px-3">
-											<div className="flex gap-2">
-												<button
-													onClick={() => acceptMut.mutate(offer.offerId)}
-													disabled={acceptMut.isPending}
-													className="rounded bg-green-600 px-2 py-0.5 text-xs text-white hover:opacity-90 disabled:opacity-50"
-												>
-													Accept
-												</button>
-												<button
-													onClick={() => declineMut.mutate(offer.offerId)}
-													disabled={declineMut.isPending}
-													className="rounded bg-destructive px-2 py-0.5 text-xs text-destructive-foreground hover:opacity-90 disabled:opacity-50"
-												>
-													Decline
-												</button>
-											</div>
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				)}
-			</div>
+						<DialogFooter>
+							<Button type="submit" disabled={sendMutation.isPending}>
+								{sendMutation.isPending ? 'Sending…' : 'Send offer'}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
 
-			{/* Sent Offers */}
-			<div>
-				<h2 className="font-semibold mb-3">Sent Offers</h2>
-				{!sent || sent.length === 0 ? (
-					<p className="text-muted-foreground text-sm">No pending sent offers.</p>
-				) : (
-					<div className="overflow-x-auto">
-						<table className="w-full text-sm">
-							<thead className="border-b">
-								<tr>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">To</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Offering</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Wants</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Note</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Sent</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground"></th>
-								</tr>
-							</thead>
-							<tbody>
-								{sent.map((offer) => (
-									<tr key={offer.offerId} className="border-b border-border bg-blue-900/10">
-										<td className="py-2 px-3 font-medium">{offer.toPlayerName}</td>
-										<td className="py-2 px-3">{offer.offeredAmount} {resourceName(offer.offeredResourceId)}</td>
-										<td className="py-2 px-3">{offer.wantedAmount} {resourceName(offer.wantedResourceId)}</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">{offer.note ?? '—'}</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(offer.sentAt)}</td>
-										<td className="py-2 px-3">
-											<button
-												onClick={async () => {
-													const ok = await confirm({
-														title: 'Cancel trade offer?',
-														description: 'The offer will be withdrawn and the recipient can no longer accept it.',
-														destructive: true,
-														confirmLabel: 'Cancel offer',
-														cancelLabel: 'Keep offer',
-													})
-													if (ok) cancelMut.mutate(offer.offerId)
-												}}
-												disabled={cancelMut.isPending}
-												className="rounded bg-destructive px-2 py-0.5 text-xs text-destructive-foreground hover:opacity-90 disabled:opacity-50"
-											>
-												Cancel
-											</button>
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				)}
-			</div>
+			<Tabs defaultValue="incoming">
+				<TabsList>
+					<TabsTrigger value="incoming">Incoming</TabsTrigger>
+					<TabsTrigger value="sent">Sent</TabsTrigger>
+					<TabsTrigger value="history">History</TabsTrigger>
+				</TabsList>
 
-			{/* Trade History */}
-			{history && history.length > 0 && (
-				<div>
-					<h2 className="font-semibold mb-3">Trade History</h2>
-					<div className="overflow-x-auto">
-						<table className="w-full text-sm">
-							<thead className="border-b">
-								<tr>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">With</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Gave</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Received</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Status</th>
-									<th className="py-2 px-3 text-left font-medium text-muted-foreground">Date</th>
-								</tr>
-							</thead>
-							<tbody>
-								{history.map((item) => (
-									<tr key={item.offerId} className="border-b border-border">
-										<td className="py-2 px-3 font-medium">{item.withPlayerName}</td>
-										<td className="py-2 px-3">{item.gaveAmount} {resourceName(item.gaveResourceId)}</td>
-										<td className="py-2 px-3">{item.receivedAmount} {resourceName(item.receivedResourceId)}</td>
-										<td className="py-2 px-3">
-											<span className={
-												item.status === 'Accepted' ? 'text-green-400 text-xs' :
-												item.status === 'Declined' ? 'text-red-400 text-xs' :
-												'text-muted-foreground text-xs'
-											}>
-												{item.status}
-											</span>
-										</td>
-										<td className="py-2 px-3 text-xs text-muted-foreground">{relativeTime(item.completedAt)}</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				</div>
-			)}
+				<TabsContent value="incoming" className="mt-4">
+					<DataTable
+						columns={incomingColumns}
+						rows={incomingLoading ? undefined : (incoming ?? [])}
+						loading={incomingLoading}
+						empty="No incoming trade offers."
+						getRowId={(o) => o.offerId}
+					/>
+				</TabsContent>
+
+				<TabsContent value="sent" className="mt-4">
+					<DataTable
+						columns={sentColumns}
+						rows={sentLoading ? undefined : (sent ?? [])}
+						loading={sentLoading}
+						empty="No pending sent offers."
+						getRowId={(o) => o.offerId}
+					/>
+				</TabsContent>
+
+				<TabsContent value="history" className="mt-4">
+					<DataTable
+						columns={historyColumns}
+						rows={historyLoading ? undefined : (history ?? [])}
+						loading={historyLoading}
+						empty="No trade history."
+						getRowId={(o) => o.offerId}
+					/>
+				</TabsContent>
+			</Tabs>
 		</div>
 	)
 }

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -1,13 +1,20 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
 import axios from 'axios'
+import type { ColumnDef } from '@tanstack/react-table'
 import apiClient from '@/api/client'
 import type { UnitsViewModel, UnitViewModel } from '@/api/types'
 import { BuildQueue } from '@/components/BuildQueue'
-import { ApiError } from '@/components/ApiError'
-import { SkeletonRow } from '@/components/Skeleton'
 import { AttackDialog } from '@/components/AttackDialog'
+import { PageHeader } from '@/components/ui/page-header'
+import { Section } from '@/components/ui/section'
+import { DataTable } from '@/components/ui/data-table'
+import { Stat } from '@/components/ui/stat'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { formatNumber } from '@/lib/formatters'
 
 interface UnitsProps {
   gameId: string
@@ -41,111 +48,38 @@ function SplitUnitForm({
   })
 
   return (
-    <div className="flex items-center gap-2 mt-1">
+    <div className="flex items-center gap-2 flex-wrap">
       {error && <span className="text-destructive text-xs">{error}</span>}
-      <input
+      <Input
         type="number"
         min={1}
         max={initCount - 1}
         value={splitCount}
         onChange={(e) => setSplitCount(Number(e.target.value))}
-        className="w-20 rounded border bg-input px-2 py-1 text-xs"
+        className="w-24 text-sm"
       />
-      <button
+      <Button
+        size="sm"
+        variant="secondary"
         onClick={() => splitMutation.mutate()}
         disabled={splitMutation.isPending}
-        className="rounded bg-secondary min-h-[36px] px-3 py-1.5 text-xs text-secondary-foreground hover:opacity-90"
       >
-        Split
-      </button>
-      <button
-        onClick={onDone}
-        className="rounded min-h-[36px] px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground"
-      >
+        Confirm Split
+      </Button>
+      <Button size="sm" variant="ghost" onClick={onDone}>
         Cancel
-      </button>
+      </Button>
     </div>
-  )
-}
-
-function UnitRow({
-  unit,
-  gameId,
-  onMerge,
-  onAttack,
-}: {
-  unit: UnitViewModel
-  gameId: string
-  onMerge: (defId: string) => void
-  onAttack: (unit: UnitViewModel) => void
-}) {
-  const [showSplit, setShowSplit] = useState(false)
-
-  return (
-    <tr className="border-b border-border">
-      <td data-label="Unit" className="py-2 px-3 font-medium">{unit.definition?.name}</td>
-      <td data-label="Count" className="py-2 px-3 text-right tabular-nums">{unit.count.toLocaleString()}</td>
-      <td data-label="Stats" className="py-2 px-3 text-xs text-muted-foreground">
-        ⚔️{unit.definition?.attack} 🛡️{unit.definition?.defense} ❤️{unit.definition?.hitpoints}
-      </td>
-      {unit.positionPlayerId && (
-        <td data-label="Location" className="py-2 px-3 text-xs">
-          <Link
-            to={`/games/${gameId}/enemybase/${encodeURIComponent(unit.positionPlayerId)}`}
-            className="text-primary hover:underline"
-          >
-            {unit.positionPlayerName ?? unit.positionPlayerId}
-          </Link>
-        </td>
-      )}
-      <td data-label="" className="py-2 px-3">
-        <div className="flex flex-wrap gap-1.5">
-          {!unit.positionPlayerId && (
-            <button
-              type="button"
-              onClick={() => onAttack(unit)}
-              className="rounded bg-destructive min-h-[36px] px-3 py-1.5 text-xs text-destructive-foreground hover:opacity-90"
-            >
-              Attack
-            </button>
-          )}
-          <button
-            onClick={() => onMerge(unit.definition.id)}
-            className="rounded bg-secondary min-h-[36px] px-3 py-1.5 text-xs text-secondary-foreground hover:opacity-90"
-          >
-            Merge
-          </button>
-          {!unit.positionPlayerId && unit.count > 1 && (
-            <>
-              {!showSplit ? (
-                <button
-                  onClick={() => setShowSplit(true)}
-                  className="rounded bg-secondary min-h-[36px] px-3 py-1.5 text-xs text-secondary-foreground hover:opacity-90"
-                >
-                  Split
-                </button>
-              ) : (
-                <SplitUnitForm
-                  unitId={unit.unitId}
-                  initCount={unit.count}
-                  gameId={gameId}
-                  onDone={() => setShowSplit(false)}
-                />
-              )}
-            </>
-          )}
-        </div>
-      </td>
-    </tr>
   )
 }
 
 export function Units({ gameId }: UnitsProps) {
   const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
+  const [mergeError, setMergeError] = useState<string | null>(null)
   const [attackUnit, setAttackUnit] = useState<UnitViewModel | null>(null)
+  const [splittingUnitId, setSplittingUnitId] = useState<string | null>(null)
 
-  const { data, isLoading, error: queryError, refetch } = useQuery<UnitsViewModel>({
+  const { data, isLoading, error: queryError } = useQuery<UnitsViewModel>({
     queryKey: ['units', gameId],
     queryFn: () => apiClient.get('/api/units').then((r) => r.data),
     refetchInterval: 10_000,
@@ -154,11 +88,11 @@ export function Units({ gameId }: UnitsProps) {
   const mergeAllMutation = useMutation({
     mutationFn: () => apiClient.post('/api/units/merge', null),
     onSuccess: () => {
-      setError(null)
+      setMergeError(null)
       void queryClient.invalidateQueries({ queryKey: ['units', gameId] })
     },
     onError: (err) => {
-      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Merge failed')
+      if (axios.isAxiosError(err)) setMergeError((err.response?.data as string) ?? 'Merge failed')
     },
   })
 
@@ -166,147 +100,284 @@ export function Units({ gameId }: UnitsProps) {
     mutationFn: (unitDefId: string) =>
       apiClient.post(`/api/units/merge?unitDefId=${unitDefId}`, null),
     onSuccess: () => {
-      setError(null)
+      setMergeError(null)
       void queryClient.invalidateQueries({ queryKey: ['units', gameId] })
     },
     onError: (err) => {
-      if (axios.isAxiosError(err)) setError((err.response?.data as string) ?? 'Merge failed')
+      if (axios.isAxiosError(err)) setMergeError((err.response?.data as string) ?? 'Merge failed')
     },
   })
 
-  const deployed = data?.units.filter((u) => u.positionPlayerId != null) ?? []
-  const atHome = data?.units.filter((u) => u.positionPlayerId == null) ?? []
+  const deployed = useMemo(
+    () =>
+      (data?.units.filter((u) => u.positionPlayerId != null) ?? [])
+        .slice()
+        .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name)),
+    [data],
+  )
+
+  const atHome = useMemo(
+    () =>
+      (data?.units.filter((u) => u.positionPlayerId == null) ?? [])
+        .slice()
+        .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name)),
+    [data],
+  )
+
+  // canMerge: at least 2 stacks share the same unit definition
+  const canMerge = useMemo(() => {
+    if (!data) return false
+    const counts = new Map<string, number>()
+    for (const u of data.units) {
+      counts.set(u.definition.id, (counts.get(u.definition.id) ?? 0) + 1)
+    }
+    return [...counts.values()].some((c) => c >= 2)
+  }, [data])
 
   const totalUnits = data?.units.reduce((s, u) => s + u.count, 0) ?? 0
-  const stackCount = data?.units.length ?? 0
+  const deployedCount = deployed.reduce((s, u) => s + u.count, 0)
+  const atHomeCount = atHome.reduce((s, u) => s + u.count, 0)
+
+  const splittingUnit = splittingUnitId != null
+    ? atHome.find((u) => u.unitId === splittingUnitId) ?? null
+    : null
+
+  const homeColumns: ColumnDef<UnitViewModel, unknown>[] = [
+    {
+      id: 'name',
+      header: 'Unit',
+      accessorFn: (u) => u.definition.name,
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.definition.name}</span>
+      ),
+    },
+    {
+      id: 'count',
+      header: () => <span className="block text-right">Count</span>,
+      accessorFn: (u) => u.count,
+      cell: ({ row }) => (
+        <span className="block text-right mono tabular-nums">
+          {formatNumber(row.original.count)}
+        </span>
+      ),
+    },
+    {
+      id: 'attack',
+      header: 'Attack',
+      accessorFn: (u) => u.definition.attack,
+      cell: ({ row }) => (
+        <Stat label="Atk" value={row.original.definition.attack} />
+      ),
+    },
+    {
+      id: 'defense',
+      header: 'Defense',
+      accessorFn: (u) => u.definition.defense,
+      cell: ({ row }) => (
+        <Stat label="Def" value={row.original.definition.defense} />
+      ),
+    },
+    {
+      id: 'hp',
+      header: 'HP',
+      accessorFn: (u) => u.definition.hitpoints,
+      cell: ({ row }) => (
+        <Stat label="HP" value={row.original.definition.hitpoints} />
+      ),
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => {
+        const unit = row.original
+        return (
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => setAttackUnit(unit)}
+            >
+              Attack
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => mergeMutation.mutate(unit.definition.id)}
+              disabled={mergeMutation.isPending}
+            >
+              Merge
+            </Button>
+            {unit.count > 1 && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  setSplittingUnitId((prev) =>
+                    prev === unit.unitId ? null : unit.unitId,
+                  )
+                }
+              >
+                Split
+              </Button>
+            )}
+          </div>
+        )
+      },
+    },
+  ]
+
+  const deployedColumns: ColumnDef<UnitViewModel, unknown>[] = [
+    {
+      id: 'name',
+      header: 'Unit',
+      accessorFn: (u) => u.definition.name,
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.definition.name}</span>
+      ),
+    },
+    {
+      id: 'count',
+      header: () => <span className="block text-right">Count</span>,
+      accessorFn: (u) => u.count,
+      cell: ({ row }) => (
+        <span className="block text-right mono tabular-nums">
+          {formatNumber(row.original.count)}
+        </span>
+      ),
+    },
+    {
+      id: 'attack',
+      header: 'Attack',
+      accessorFn: (u) => u.definition.attack,
+      cell: ({ row }) => (
+        <Stat label="Atk" value={row.original.definition.attack} />
+      ),
+    },
+    {
+      id: 'defense',
+      header: 'Defense',
+      accessorFn: (u) => u.definition.defense,
+      cell: ({ row }) => (
+        <Stat label="Def" value={row.original.definition.defense} />
+      ),
+    },
+    {
+      id: 'hp',
+      header: 'HP',
+      accessorFn: (u) => u.definition.hitpoints,
+      cell: ({ row }) => (
+        <Stat label="HP" value={row.original.definition.hitpoints} />
+      ),
+    },
+    {
+      id: 'location',
+      header: 'Location',
+      cell: ({ row }) => {
+        const unit = row.original
+        return (
+          <Link
+            to={`/games/${gameId}/enemybase/${encodeURIComponent(unit.positionPlayerId!)}`}
+            className="text-primary hover:underline text-sm"
+          >
+            {unit.positionPlayerName ?? unit.positionPlayerId}
+          </Link>
+        )
+      },
+    },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: () => (
+        <Badge variant="destructive">In Combat</Badge>
+      ),
+    },
+  ]
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Units</h1>
+      <PageHeader
+        title="Units"
+        actions={
+          <Button
+            variant="secondary"
+            onClick={() => mergeAllMutation.mutate()}
+            disabled={mergeAllMutation.isPending || !canMerge}
+            title="Combine all unit stacks of the same type into single stacks"
+          >
+            Merge All
+          </Button>
+        }
+      />
 
-      {error && <div className="text-destructive text-sm">{error}</div>}
+      {mergeError && <div className="text-destructive text-sm">{mergeError}</div>}
 
       <BuildQueue gameId={gameId} />
 
-      {isLoading ? (
-        <div className="rounded-lg border bg-card overflow-hidden" aria-hidden="true">
-          <table className="w-full text-sm">
-            <tbody>
-              {Array.from({ length: 5 }).map((_, i) => (
-                <SkeletonRow key={i} cols={5} />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : queryError && !data ? (
-        <ApiError message="Failed to load units." onRetry={() => void refetch()} />
-      ) : !data || data.units.length === 0 ? (
-        <div className="rounded-lg border bg-card p-8 text-center">
-          <div className="text-4xl mb-3">🪖</div>
-          <div className="font-semibold mb-1">No units yet</div>
-          <div className="text-sm text-muted-foreground">
-            Build units from your base buildings to start training your army.
+      {/* Summary stats */}
+      {data && data.units.length > 0 && (
+        <Section boxed>
+          <div className="flex flex-wrap gap-6">
+            <Stat label="Total Units" value={formatNumber(totalUnits)} />
+            <Stat label="At Home" value={formatNumber(atHomeCount)} />
+            <Stat label="Deployed" value={formatNumber(deployedCount)} />
           </div>
-        </div>
-      ) : (
-        <>
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              onClick={() => mergeAllMutation.mutate()}
-              disabled={mergeAllMutation.isPending}
-              className="rounded bg-secondary min-h-[44px] px-4 py-2 text-sm text-secondary-foreground hover:opacity-90 disabled:opacity-50"
-              title="Combine all unit stacks of the same type into single stacks"
-            >
-              Merge All
-            </button>
-            <span className="text-sm text-muted-foreground">
-              {totalUnits.toLocaleString()} units in {stackCount} stacks
-            </span>
-          </div>
+        </Section>
+      )}
 
-          {deployed.length > 0 && (
-            <div className="rounded-lg border bg-card overflow-hidden">
-              <div className="flex items-center justify-between px-4 py-3 border-b bg-secondary/30">
-                <span className="font-semibold text-sm">
-                  Deployed ({deployed.reduce((s, u) => s + u.count, 0).toLocaleString()} units)
-                </span>
-                <span className="rounded-full bg-red-900/50 px-2 py-0.5 text-xs text-red-300">
-                  In Combat
-                </span>
-              </div>
-              <div className="overflow-x-auto">
-                <table className="responsive-table w-full text-sm">
-                  <thead className="border-b">
-                    <tr>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
-                      <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Location</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {deployed
-                      .slice()
-                      .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name))
-                      .map((unit) => (
-                        <UnitRow
-                          key={unit.unitId}
-                          unit={unit}
-                          gameId={gameId}
-                          onMerge={(defId) => mergeMutation.mutate(defId)}
-                          onAttack={(u) => setAttackUnit(u)}
-                        />
-                      ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
+      {/* Deployed units */}
+      {(isLoading || deployed.length > 0 || (data && data.units.length === 0)) && (
+        <Section
+          title={
+            deployed.length > 0
+              ? `Deployed (${formatNumber(deployedCount)} units)`
+              : 'Deployed'
+          }
+        >
+          <DataTable<UnitViewModel>
+            columns={deployedColumns}
+            rows={deployed}
+            loading={isLoading}
+            error={queryError && !data ? 'Failed to load units.' : undefined}
+            empty="No units are currently deployed."
+            sortable
+            getRowId={(u) => u.unitId}
+          />
+        </Section>
+      )}
 
-          <div className="rounded-lg border bg-card overflow-hidden">
-            <div className="flex items-center justify-between px-4 py-3 border-b bg-secondary/30">
-              <span className="font-semibold text-sm">
-                Home Base ({atHome.reduce((s, u) => s + u.count, 0).toLocaleString()} units)
-              </span>
-              <span className="rounded-full bg-green-900/50 px-2 py-0.5 text-xs text-green-300">
-                Defending
-              </span>
-            </div>
-            {atHome.length === 0 ? (
-              <div className="p-6 text-center text-sm text-muted-foreground">
-                All units are deployed.
-              </div>
-            ) : (
-              <div className="overflow-x-auto">
-                <table className="responsive-table w-full text-sm">
-                  <thead className="border-b">
-                    <tr>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Unit</th>
-                      <th scope="col" className="py-2 px-3 text-right font-medium text-muted-foreground">Count</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Stats</th>
-                      <th scope="col" className="py-2 px-3 text-left font-medium text-muted-foreground">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {atHome
-                      .slice()
-                      .sort((a, b) => b.count - a.count || a.definition.name.localeCompare(b.definition.name))
-                      .map((unit) => (
-                        <UnitRow
-                          key={unit.unitId}
-                          unit={unit}
-                          gameId={gameId}
-                          onMerge={(defId) => mergeMutation.mutate(defId)}
-                          onAttack={(u) => setAttackUnit(u)}
-                        />
-                      ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        </>
+      {/* Home base units */}
+      <Section
+        title={
+          isLoading || !data
+            ? 'Home Base'
+            : `Home Base (${formatNumber(atHomeCount)} units)`
+        }
+        actions={undefined}
+      >
+        <DataTable<UnitViewModel>
+          columns={homeColumns}
+          rows={atHome}
+          loading={isLoading}
+          error={queryError && !data ? 'Failed to load units.' : undefined}
+          empty="No units at home base. All units are deployed, or you have not built any units yet."
+          sortable
+          getRowId={(u) => u.unitId}
+        />
+      </Section>
+
+      {/* Split form — renders below tables, keyed to the unit being split */}
+      {splittingUnit && (
+        <Section title={`Splitting: ${splittingUnit.definition.name} (${formatNumber(splittingUnit.count)})`}>
+          <SplitUnitForm
+            unitId={splittingUnit.unitId}
+            initCount={splittingUnit.count}
+            gameId={gameId}
+            onDone={() => setSplittingUnitId(null)}
+          />
+        </Section>
       )}
 
       <AttackDialog


### PR DESCRIPTION
## Summary
- Refactors the five core-gameplay pages (`Base`, `Units`, `Research`, `Market`, `Trade`) to consume the design-system foundation from PR #315. Page logic (queries, mutations, effects) preserved — only markup changes.
- Extracts two shared components: `UpgradeTrack` (consumed by Research) and `ConvertResourceForm` (consumed by Market's new Convert tab).
- **Base**: tab order reorganised (Build first, then Economy, then Activity); inline 2-way resource swap block removed (moved to Market's Convert tab); `PageHeader`/`Card`/`Button`/`Badge` throughout; "rounds" → "ticks" terminology fix.
- **Units**: two `DataTable`s (Home Base, Deployed) + `Stat` summary cells + `Badge` for combat status; emoji stats (⚔️🛡️❤️) replaced with `Stat` cells.
- **Research**: two duplicated 60-line blocks collapsed into two `<UpgradeTrack>` instances (Attack / Defense); `<Progress>` + `<Ticks>` for in-progress research. File shrunk 194 → 71 LOC.
- **Market**: three `<Tabs>` — Buy (other players' orders) / Sell (my orders + post-offer form) / Convert (ConvertResourceForm). `DataTable` listings, `<Tooltip>` on disabled Accept buttons, sonner toasts replacing inline error banners.
- **Trade**: Propose-trade form lifted into a Radix `<Dialog>`. Incoming / Sent / History as three `<Tabs>`, each a `DataTable`. Inline success/error banners replaced with sonner toasts.

## Non-changes
Backend API unchanged. Primitives in `src/components/ui/` unchanged. No page outside the five refactored.

## Deviations from plan
- **Research**: `canAffordAttackUpgrade`/`canAffordDefenseUpgrade` don't exist on `UpgradesViewModel`; implementer passes `true` (matches prior behavior — server enforces and toast surfaces errors).
- **Units**: `DataTable` has no row-expander API, so `SplitUnitForm` renders in a `<Section>` below the tables rather than inline. `ApiError` retry button replaced by `DataTable`'s built-in error slot.
- **Market + Trade**: shadcn `Select` wired via `form.watch()` + `form.setValue()` rather than `Controller` (pragmatic). `zodResolver(schema) as any` needed due to zod v4 / @hookform/resolvers v5 type skew (runtime behavior correct).
- **Trade**: `<Countdown>` omitted because `TradeOfferViewModel` has no `expiresAt` field — used `relativeTime(sentAt)` as the page did before.

## Parent spec + plan
- Spec: `docs/superpowers/specs/2026-04-17-ui-ux-improvements-design.md` (Batch 1 section).
- Plan: `docs/superpowers/plans/2026-04-18-batch-1-core-gameplay.md`.
- Foundation PR: #315 (merged, commit `de444da`).

## Test plan
- [x] `npm run build` green.
- [x] `npm run lint` clean (15 warnings, all pre-existing on master).
- [x] `npm run test` (vitest) 10/10.
- [x] `dotnet build --configuration Release` clean.
- [x] `dotnet test` 531/531.
- [ ] `npm run test:e2e` deferred to CI (Playwright in docker-compose).
- [ ] Manual smoke: log in via DevAuth, touch each of the 5 pages, verify core actions (build, research, post order, accept order, propose trade) still work end-to-end.

## Follow-ups not landing here
- `useTickDuration` still hardcoded to 30s.
- Per-tick deltas on `PlayerResources`.
- Units `SplitUnitForm` in a `Section` — later pass can Dialog-ify.
- Research `<Progress>` bar uses a best-effort value until the backend exposes total research duration.
- Backend could expose `canAffordAttackUpgrade`/`canAffordDefenseUpgrade` so Research can pre-disable the button.