### PR TITLE
fix(dev): always rebuild image in dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -69,7 +69,7 @@ if [ "$MODE" = "devauth" ]; then
     # DevAuth requires placeholder GitHub creds to pass startup validation
     export GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-dev-placeholder}"
     export GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-dev-placeholder}"
-    $DOCKER_COMPOSE_CMD up
+    $DOCKER_COMPOSE_CMD up --build
 else
     # GitHub OAuth mode
     if [ -z "$GITHUB_CLIENT_ID" ]; then
@@ -81,5 +81,5 @@ else
         exit 1
     fi
     echo "🚀 Starting BGE dev server with GitHub OAuth..."
-    $DOCKER_COMPOSE_CMD up
+    $DOCKER_COMPOSE_CMD up --build
 fi


### PR DESCRIPTION
## Summary

- Plain \`docker compose up\` reuses the existing image. After a \`git pull\` or code edit, the first run silently starts the **stale** container, which is confusing during local dev.
- Add \`--build\` to both \`docker compose up\` invocations in \`dev.sh\`. Docker's layer cache makes the rebuild a no-op when nothing changed, so there's no speed cost on unchanged runs.

## Test plan

- [x] \`bash -n dev.sh\` — syntax OK
- [ ] Run \`./dev.sh --dev-auth\` twice with no changes → second run is cache-hit only, starts immediately.
- [ ] Edit a C# file, run \`./dev.sh --dev-auth\` → rebuild happens, new code is live.