### PR TITLE
fix(dev): unbreak dev.sh — OpenTelemetry audit + AllianceWarId dict key

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
+++ b/src/BrowserGameEngine.FrontendServer/BrowserGameEngine.FrontendServer.csproj
@@ -27,8 +27,8 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
 		<PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.4" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />


### PR DESCRIPTION
## Summary
- Bump OpenTelemetry packages 1.15.0 → 1.15.2/1.15.3 so `dotnet restore` stops failing on NU1902 audit advisories (GHSA-g94r-2vxg-569j, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933) under `TreatWarningsAsErrors=true`.
- Register `AllianceWarId` parser in `GameStateJsonSerializer` so the `Wars` dictionary in existing `state.json` blobs can be deserialized at startup (was throwing `NotSupportedException` and crashing the container).

## Test plan
- [x] `./dev.sh --dev-auth` now builds the image and the container boots, runs game ticks, and persists state without errors.