### PR TITLE
fix(ui): gate tick timer and player actions on Finished game status

### DIFF
--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -138,11 +138,13 @@ function GameLayoutInner() {
   const gameFinalizedHandlerRef = useRef<((...args: unknown[]) => void) | null>(null)
   const race = usePlayerRace()
 
+  const isFinished = currentGame?.status === 'Finished'
+
   const { data: tickInfo } = useQuery<TickInfoViewModel>({
     queryKey: ['tickinfo', gameId],
     queryFn: () => apiClient.get('/api/game/tick-info').then((r) => r.data),
     refetchInterval: 30_000,
-    enabled: !!gameId,
+    enabled: !!gameId && !isFinished,
   })
 
   const onRealTimeNotification = useCallback(
@@ -196,7 +198,7 @@ function GameLayoutInner() {
                 <MenuIcon className="h-5 w-5" />
               </Button>
               <UserMenu race={race} />
-              {tickInfo && <TimerRing to={tickInfo.nextTickAt} />}
+              {tickInfo && !isFinished && <TimerRing to={tickInfo.nextTickAt} />}
             </div>
             <div className="flex items-center gap-3 sm:gap-4 min-w-0">
               <div className="hidden md:block"><PlayerResources gameId={gameId} /></div>

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -63,6 +63,7 @@ function AssetCard({
 	asset,
 	state,
 	queueEntryId,
+	disabled = false,
 	onBuild,
 	onQueue,
 	onTrainUnits,
@@ -71,6 +72,7 @@ function AssetCard({
 	asset: AssetViewModel
 	state: AssetState
 	queueEntryId?: string
+	disabled?: boolean
 	onBuild: (defId: string) => void
 	onQueue: (defId: string) => void
 	onTrainUnits: (asset: AssetViewModel) => void
@@ -104,6 +106,7 @@ function AssetCard({
 							size="sm"
 							className="w-full"
 							onClick={() => onTrainUnits(asset)}
+							disabled={disabled}
 						>
 							<SwordsIcon className="h-3.5 w-3.5" />
 							Train units
@@ -124,6 +127,7 @@ function AssetCard({
 								variant="outline"
 								className="w-full"
 								onClick={() => onCancelQueue(queueEntryId)}
+								disabled={disabled}
 							>
 								<XIcon className="h-3.5 w-3.5" />
 								Cancel
@@ -139,7 +143,7 @@ function AssetCard({
 							<Button
 								size="sm"
 								onClick={() => onBuild(asset.definition.id)}
-								disabled={!asset.canAfford}
+								disabled={disabled || !asset.canAfford}
 								className="flex-1"
 								title={asset.canAfford ? 'Build now' : 'Not enough resources — try Queue instead'}
 							>
@@ -150,6 +154,7 @@ function AssetCard({
 								size="sm"
 								variant="outline"
 								onClick={() => onQueue(asset.definition.id)}
+								disabled={disabled}
 								className="flex-1"
 								title="Add to build queue; resources are reserved when the build starts"
 							>
@@ -181,7 +186,7 @@ function EconomyStat({
 	label: string
 	value: ReactNode
 	detail?: ReactNode
-	action?: { label: string; onClick: () => void }
+	action?: { label: string; onClick: () => void; disabled?: boolean }
 }) {
 	return (
 		<Card className="py-3 gap-2">
@@ -195,7 +200,7 @@ function EconomyStat({
 					{detail && <div className="text-xs text-muted-foreground mt-0.5">{detail}</div>}
 				</div>
 				{action && (
-					<Button size="sm" variant="outline" onClick={action.onClick} className="shrink-0">
+					<Button size="sm" variant="outline" onClick={action.onClick} disabled={action.disabled} className="shrink-0">
 						{action.label}
 					</Button>
 				)}
@@ -379,7 +384,7 @@ export function Base({ gameId }: BaseProps) {
 								? `${formatNumber(idleWorkers)} idle — click Assign`
 								: 'All workers assigned'
 					}
-					action={{ label: 'Assign', onClick: () => setWorkersOpen(true) }}
+					action={{ label: 'Assign', onClick: () => setWorkersOpen(true), disabled: isFinished }}
 				/>
 				<EconomyStat
 					icon={<MountainIcon className="h-5 w-5" />}
@@ -390,7 +395,7 @@ export function Base({ gameId }: BaseProps) {
 							? `${formatNumber(resources.colonizationCostPerLand)} minerals per new tile`
 							: undefined
 					}
-					action={{ label: 'Colonize', onClick: () => setColonizeOpen(true) }}
+					action={{ label: 'Colonize', onClick: () => setColonizeOpen(true), disabled: isFinished }}
 				/>
 				<EconomyStat
 					icon={<HammerIcon className="h-5 w-5" />}
@@ -431,6 +436,7 @@ export function Base({ gameId }: BaseProps) {
 						<AssetGroup
 							title="Built"
 							assets={grouped.built}
+							disabled={isFinished}
 							onBuild={buildMutation.mutate}
 							onQueue={queueAssetMutation.mutate}
 							onTrainUnits={openTrain}
@@ -441,6 +447,7 @@ export function Base({ gameId }: BaseProps) {
 						<AssetGroup
 							title="Building"
 							assets={grouped.queued}
+							disabled={isFinished}
 							onBuild={buildMutation.mutate}
 							onQueue={queueAssetMutation.mutate}
 							onTrainUnits={openTrain}
@@ -451,6 +458,7 @@ export function Base({ gameId }: BaseProps) {
 						<AssetGroup
 							title="Ready to build"
 							assets={grouped.ready}
+							disabled={isFinished}
 							onBuild={buildMutation.mutate}
 							onQueue={queueAssetMutation.mutate}
 							onTrainUnits={openTrain}
@@ -461,6 +469,7 @@ export function Base({ gameId }: BaseProps) {
 						<AssetGroup
 							title="Locked"
 							assets={grouped.locked}
+							disabled={isFinished}
 							onBuild={buildMutation.mutate}
 							onQueue={queueAssetMutation.mutate}
 							onTrainUnits={openTrain}
@@ -557,6 +566,7 @@ export function Base({ gameId }: BaseProps) {
 function AssetGroup({
 	title,
 	assets,
+	disabled = false,
 	onBuild,
 	onQueue,
 	onTrainUnits,
@@ -567,6 +577,7 @@ function AssetGroup({
 }: {
 	title: string
 	assets: AssetViewModel[]
+	disabled?: boolean
 	onBuild: (defId: string) => void
 	onQueue: (defId: string) => void
 	onTrainUnits: (asset: AssetViewModel) => void
@@ -594,6 +605,7 @@ function AssetGroup({
 						asset={a}
 						state={assetState(a)}
 						queueEntryId={queueEntriesByDefId.get(a.definition.id)}
+						disabled={disabled}
 						onBuild={onBuild}
 						onQueue={onQueue}
 						onTrainUnits={onTrainUnits}

--- a/src/ReactClient/src/pages/Units.tsx
+++ b/src/ReactClient/src/pages/Units.tsx
@@ -6,6 +6,7 @@ import { SwordsIcon, MergeIcon, SplitIcon, HammerIcon } from 'lucide-react'
 import type { ColumnDef } from '@tanstack/react-table'
 import apiClient from '@/api/client'
 import type { UnitsViewModel, UnitViewModel } from '@/api/types'
+import { useCurrentGame } from '@/contexts/CurrentGameContext'
 import { BuildQueue } from '@/components/BuildQueue'
 import { AttackDialog } from '@/components/AttackDialog'
 import { TrainUnitsDialog } from '@/components/TrainUnitsDialog'
@@ -25,6 +26,8 @@ interface UnitsProps {
 
 export function Units({ gameId }: UnitsProps) {
   const queryClient = useQueryClient()
+  const { currentGame } = useCurrentGame()
+  const isFinished = currentGame?.status === 'Finished'
   const [mergeError, setMergeError] = useState<string | null>(null)
   const [attackUnit, setAttackUnit] = useState<UnitViewModel | null>(null)
   const [splitUnit, setSplitUnit] = useState<UnitViewModel | null>(null)
@@ -146,6 +149,7 @@ export function Units({ gameId }: UnitsProps) {
               variant="destructive"
               size="sm"
               onClick={() => setAttackUnit(unit)}
+              disabled={isFinished}
               title="Attack an enemy with this stack"
             >
               <SwordsIcon className="h-3.5 w-3.5" />
@@ -157,6 +161,7 @@ export function Units({ gameId }: UnitsProps) {
                 variant="outline"
                 size="sm"
                 onClick={() => setSplitUnit(unit)}
+                disabled={isFinished}
                 title="Split this stack"
               >
                 <SplitIcon className="h-3.5 w-3.5" />
@@ -169,7 +174,7 @@ export function Units({ gameId }: UnitsProps) {
                 variant="outline"
                 size="sm"
                 onClick={() => mergeTypeMutation.mutate(unit.definition.id)}
-                disabled={mergeTypeMutation.isPending}
+                disabled={isFinished || mergeTypeMutation.isPending}
                 title={`Merge all ${unit.definition.name} stacks into one`}
               >
                 <MergeIcon className="h-3.5 w-3.5" />
@@ -260,7 +265,7 @@ export function Units({ gameId }: UnitsProps) {
             <Button
               variant="outline"
               onClick={() => mergeAllMutation.mutate()}
-              disabled={mergeAllMutation.isPending || !canMergeAny}
+              disabled={isFinished || mergeAllMutation.isPending || !canMergeAny}
               title={canMergeAny
                 ? 'Combine all stacks of the same type into single stacks'
                 : 'Nothing to merge — each unit type only has one stack'}
@@ -270,6 +275,7 @@ export function Units({ gameId }: UnitsProps) {
             </Button>
             <Button
               onClick={() => setTrainOpen(true)}
+              disabled={isFinished}
               title="Open the training panel"
             >
               <HammerIcon className="h-4 w-4" />


### PR DESCRIPTION
## Summary

When a game finished, the `GameStatusBanner` correctly showed *"Commander X wins! — View final results"*, but the rest of the UI didn't reflect the end state:

- The tick countdown ring kept counting down in the header
- Build / Queue / Train units / Cancel-build buttons stayed enabled on the Base page
- Attack / Split / Merge / Merge-all / Train-units buttons stayed enabled on the Units page
- Assign-workers and Colonize chips stayed enabled
- The client kept polling `/api/game/tick-info` every 30s even though the server-side tick engine was already paused

Server-side state is already correct (`TickEngine.PauseTicks()` runs during finalization and `Status` flips to `Finished`); this PR just makes the client honour it.

## Changes

- `GameLayout.tsx` — derive `isFinished` from `currentGame.status`, disable the tick-info query and hide `<TimerRing />` when finished
- `Base.tsx` — thread `isFinished` through `AssetGroup` → `AssetCard` to disable Build / Queue / Cancel / Train-units; pass `disabled` to the Assign and Colonize action chips in the economy strip
- `Units.tsx` — read `currentGame.status` from `CurrentGameContext` and disable Attack / Split / Merge (per-row) plus Merge-all and Train-units in the page header

No server-side changes — the existing `Status === Finished` already comes back from `GET /api/games/{gameId}` via `GameDetailViewModel`.

## Test plan

- [ ] Finish a game (or wait for one to be finalized)
- [ ] Banner shows "X wins! — View final results"
- [ ] Tick timer disappears from the header
- [ ] On `/base`: Build, Queue, Train units, Cancel, Assign, Colonize are all disabled
- [ ] On `/units`: Attack, Split, Merge, Merge all, Train units are all disabled
- [ ] Active games still behave normally — timer ticks, all actions enabled

https://claude.ai/code/session_01TXmfdF84s5Kgc8ukLPfPMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXmfdF84s5Kgc8ukLPfPMY)_