### PR TITLE
feat(colonization): per-tile cumulative cost, no batch cap

### DIFF
--- a/docs/superpowers/specs/2026-04-26-colonization-ux-design.md
+++ b/docs/superpowers/specs/2026-04-26-colonization-ux-design.md
@@ -1,0 +1,124 @@
+# Colonization UX redesign — per-tile cost, no batch cap
+
+**Date:** 2026-04-26
+**Status:** Draft, pending implementation plan
+
+## Problem
+
+Today's colonization is capped at 24 tiles per call (`ColonizeDialog.tsx:22`, `ColonizeRepositoryWrite.cs:24`). The cap was the mechanism that made colonization progressively expensive: cost per tile is `max(1, currentLand / 4)` and is **flat within a batch**, so larger goals (e.g. 240 land) require repeating the dialog 10 times — each repeat priced higher than the last.
+
+The cap delivers progressive cost but at heavy UX expense. The goal of this redesign is to keep — and smooth — the progressive-cost mechanic while reducing it to a single user action.
+
+## Goal
+
+A player who wants to colonize N tiles does it in **one** dialog interaction, sees the cumulative cost up front, and pays a price that grows continuously with land owned (no within-batch flat-rate discount).
+
+## Non-goals
+
+- Changing the underlying cost coefficient (`/4`) or any other game balance constant.
+- Adding cooldowns, queues, or any time-based pacing of colonization.
+- Reworking the Base page's "X minerals per new tile" hint.
+
+## Design
+
+### Cost mechanic (server)
+
+Replace flat-batch pricing with per-tile integral pricing. Colonizing N tiles starting at L land costs:
+
+```
+totalCost = Σ_{k=0..N−1} max(1, (L + k) / 4)
+```
+
+Computed exactly in `decimal`. Closed-form for the common case `L ≥ 4`:
+
+```
+totalCost = N · (2L + N − 1) / 8
+```
+
+For `L < 4` (early game, where the floor `max(1, …)` matters), iterate the first `4 − L` terms at cost 1 each, then closed-form the remainder.
+
+**Code locations:**
+
+- `BrowserGameEngine.StatefulGameServer/Repositories/Resources/ColonizeRepositoryWrite.cs`
+  - Drop the `1..24` argument check; require `Amount ≥ 1`.
+  - Add `public static decimal GetCostForTiles(decimal currentLand, int amount)` implementing the formula above.
+  - `Colonize(ColonizeCommand)`:
+    1. Compute `totalCost = GetCostForTiles(currentLand, command.Amount)`.
+    2. Call `resourceRepositoryWrite.DeductCost(playerId, mineralsId, totalCost)` — throws `CannotAffordException` if insufficient (existing behaviour).
+    3. Add `command.Amount` land.
+  - `GetCostPerLand(currentLand)` stays — used by `/api/resources` for the Base page hint.
+
+### Server API
+
+`POST /api/colonize/colonize?amount=N` — unchanged signature; server-side range check loosened to `N ≥ 1`.
+
+**New:** `GET /api/colonize/preview?amount=N` returning:
+
+```json
+{
+  "amount": N,
+  "totalCost": <decimal>,
+  "firstTileCost": <decimal>,
+  "lastTileCost": <decimal>,
+  "maxAffordable": <int>
+}
+```
+
+- `firstTileCost = max(1, L/4)`, `lastTileCost = max(1, (L + N − 1)/4)`.
+- `maxAffordable` = largest M such that `GetCostForTiles(L, M) ≤ minerals`. Solved via the quadratic inverse plus a one-step floor adjustment for the floor case.
+- Endpoint is read-only and cheap; no rate limiting required beyond standard auth.
+
+The endpoint keeps the cost formula authoritative on the server. The client never re-implements it.
+
+`PlayerResourcesViewModel.ColonizationCostPerLand` is **unchanged** and still reflects "next single tile" cost (`GetCostPerLand(currentLand)`), keeping the Base-page hint and the polled `/api/resources` payload lean.
+
+### UI — `ColonizeDialog.tsx`
+
+Replace the current stepper-only control with a slider + stepper combo:
+
+1. **Title + description** — unchanged.
+2. **Slider** with range `[1, maxAffordable]`. Logarithmic scale when `maxAffordable > 100`, linear otherwise.
+3. **`NumberStepper`** — same component, `max={maxAffordable}`, no presets array. Slider and stepper share the `amount` state; either control updates the other.
+4. **"Max affordable (N)"** ghost button (kept) — sets `amount = maxAffordable`.
+5. **Cost panel** (replaces the flat "Total" row):
+   ```
+   Total                    <minerals icon> 4,200
+   Per tile        25 → 47  (avg 35)
+   ```
+   Border tint stays green (affordable) / red (not affordable).
+6. **Cancel / Colonize +N** buttons — unchanged.
+
+Data flow:
+- On dialog open and on every `amount` change (debounced ~150 ms), the dialog calls `/api/colonize/preview?amount=<amount>`. The response drives Total, per-tile range, affordability, and `maxAffordable`.
+- While debouncing, the panel shows the previous response's numbers (no flicker to zero).
+- Drop the `PRESETS` array and `MAX_PER_CALL` constant.
+
+### Bot
+
+`BrowserGameEngine.BalanceSim/GameSim/Bots/ConfigurableBot.cs:93` — the bot currently clamps `amount` to 24 and uses flat-batch math. Update to:
+
+1. Compute `maxAffordableUnderReserve = largest M such that GetCostForTiles(L, M) ≤ (minerals − MineralReserve)`.
+2. Cap by `LandTarget − currentLand`.
+3. If `M ≥ 1`, call `Colonize(new ColonizeCommand(playerId, M))`; else skip.
+
+This removes the bot's per-tick 24-tile cap. The bot still converges to `LandTarget`; the path differs slightly because each colonize call now pays the smooth integral instead of the discrete-batch flat rate.
+
+## Trade-offs and alternatives considered
+
+- **Inline the formula in TypeScript** instead of adding a `/preview` endpoint — rejected. The formula is something we expect to tune; duplicating it across server and client invites drift. Single round-trip per slider drag is cheap.
+- **Soft cap (e.g. max +50% of current land per call)** — rejected. The quadratic cost is already sharply self-regulating; a soft cap adds mechanic complexity without solving a real problem.
+- **Time/rate cooldown between calls** — rejected. Different mechanic, more invasive, not motivated by the user's stated goal.
+
+## Tests
+
+Add unit tests in `BrowserGameEngine.StatefulGameServer.Test`:
+
+- `GetCostForTiles`: closed-form correctness for `L ≥ 4`; floor handling for `L = 0..3`; `N = 1` matches `GetCostPerLand`; large-N stays positive and monotonic.
+- `Colonize`: succeeds for `N` well above 24; throws on insufficient minerals without mutating state; deducts the cumulative cost (not `N · GetCostPerLand(L)`).
+- Preview endpoint: `maxAffordable` round-trips — `GetCostForTiles(L, maxAffordable) ≤ minerals < GetCostForTiles(L, maxAffordable + 1)`.
+
+## Migration / compatibility
+
+- No persisted state changes. `WorldState` and `GlobalState` schemas unaffected.
+- API: `POST /api/colonize/colonize?amount=N` widens the accepted range; existing clients that only send `1..24` keep working. The new `GET /api/colonize/preview` is additive.
+- The `colonizationCostPerLand` field on `PlayerResourcesViewModel` is unchanged and still consumed by the Base-page hint at `Base.tsx:390`.

--- a/src/BrowserGameEngine.BalanceSim/GameSim/Bots/ConfigurableBot.cs
+++ b/src/BrowserGameEngine.BalanceSim/GameSim/Bots/ConfigurableBot.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
 
 namespace BrowserGameEngine.BalanceSim.GameSim.Bots;
@@ -94,11 +95,14 @@ public class ConfigurableBot : IBot {
 		var me = ctx.Me;
 		if (me.Land >= Config.LandTarget) return;
 		decimal currentLand = me.Land;
-		decimal costPerLand = Math.Max(1m, currentLand / 4m);
-		int amount = Math.Max(1, me.Minerals / Math.Max(1, (int)costPerLand) / 4);
-		amount = Math.Clamp(amount, 1, 24);
-		decimal totalCost = amount * costPerLand;
-		if (me.Minerals < totalCost + Config.MineralReserve) return;
+		decimal mineralsAvailable = me.Minerals - Config.MineralReserve;
+		if (mineralsAvailable <= 0) return;
+
+		int affordable = ColonizeRepositoryWrite.GetMaxAffordable(currentLand, mineralsAvailable);
+		int needed = Config.LandTarget - me.Land;
+		int amount = Math.Min(affordable, needed);
+		if (amount < 1) return;
+
 		try {
 			ctx.Game.ColonizeRepositoryWrite.Colonize(new ColonizeCommand(ctx.PlayerId, amount));
 		} catch (Exception) { /* retry next tick */ }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ColonizeController.cs
@@ -17,14 +17,17 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		private readonly ILogger<ColonizeController> logger;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly ColonizeRepositoryWrite colonizeRepositoryWrite;
+		private readonly ResourceRepository resourceRepository;
 
 		public ColonizeController(ILogger<ColonizeController> logger
 				, CurrentUserContext currentUserContext
 				, ColonizeRepositoryWrite colonizeRepositoryWrite
+				, ResourceRepository resourceRepository
 			) {
 			this.logger = logger;
 			this.currentUserContext = currentUserContext;
 			this.colonizeRepositoryWrite = colonizeRepositoryWrite;
+			this.resourceRepository = resourceRepository;
 		}
 
 		/// <summary>Colonizes additional land by spending the required resources.</summary>
@@ -45,6 +48,35 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			} catch (CannotAffordException e) {
 				return BadRequest(e.Message);
 			}
+		}
+
+		/// <summary>Previews the cost of colonizing a given amount of land tiles.</summary>
+		/// <param name="amount">Number of land tiles to preview.</param>
+		[HttpGet]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		public ActionResult<ColonizePreviewViewModel> Preview([FromQuery] int amount) {
+			if (!currentUserContext.IsValid) return Unauthorized();
+			if (amount < 1) return BadRequest("Amount must be at least 1.");
+			if (amount > 100000) return BadRequest("Amount must be 100,000 or less.");
+
+			var playerId = currentUserContext.PlayerId!;
+			var currentLand = resourceRepository.GetAmount(playerId, Id.ResDef("land"));
+			var minerals = resourceRepository.GetAmount(playerId, Id.ResDef("minerals"));
+
+			var totalCost = ColonizeRepositoryWrite.GetCostForTiles(currentLand, amount);
+			var firstTileCost = ColonizeRepositoryWrite.GetCostPerLand(currentLand);
+			var lastTileCost = ColonizeRepositoryWrite.GetCostPerLand(currentLand + amount - 1);
+			var maxAffordable = ColonizeRepositoryWrite.GetMaxAffordable(currentLand, minerals);
+
+			return Ok(new ColonizePreviewViewModel {
+				Amount = amount,
+				TotalCost = totalCost,
+				FirstTileCost = firstTileCost,
+				LastTileCost = lastTileCost,
+				MaxAffordable = maxAffordable,
+			});
 		}
 	}
 }

--- a/src/BrowserGameEngine.Shared/ColonizePreviewViewModel.cs
+++ b/src/BrowserGameEngine.Shared/ColonizePreviewViewModel.cs
@@ -1,0 +1,9 @@
+namespace BrowserGameEngine.Shared {
+	public record ColonizePreviewViewModel {
+		public required int Amount { get; init; }
+		public required decimal TotalCost { get; init; }
+		public required decimal FirstTileCost { get; init; }
+		public required decimal LastTileCost { get; init; }
+		public required int MaxAffordable { get; init; }
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/ColonizeTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/ColonizeTest.cs
@@ -1,0 +1,93 @@
+using System;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class ColonizeTest {
+		[Fact]
+		public void GetCostForTiles_SingleTile_MatchesGetCostPerLand() {
+			for (decimal land = 0; land <= 1000; land += 17) {
+				var single = ColonizeRepositoryWrite.GetCostForTiles(land, 1);
+				var perLand = ColonizeRepositoryWrite.GetCostPerLand(land);
+				Assert.Equal(perLand, single);
+			}
+		}
+
+		[Fact]
+		public void GetCostForTiles_LargeLand_MatchesClosedForm() {
+			// L=100, N=10: tiles cost 100/4..109/4 = 25, 25.25, ..., 27.25
+			// Sum = 10*(2*100 + 9)/8 = 10*209/8 = 261.25
+			Assert.Equal(261.25m, ColonizeRepositoryWrite.GetCostForTiles(100m, 10));
+			// L=1000, N=100: 100*(2*1000 + 99)/8 = 100*2099/8 = 26237.5
+			Assert.Equal(26237.5m, ColonizeRepositoryWrite.GetCostForTiles(1000m, 100));
+		}
+
+		[Fact]
+		public void GetCostForTiles_BoundaryAtFour_NoFloorEffect() {
+			// L=4, N=1: cost = 4/4 = 1
+			Assert.Equal(1m, ColonizeRepositoryWrite.GetCostForTiles(4m, 1));
+			// L=4, N=4: tiles 4,5,6,7 → 4/4 + 5/4 + 6/4 + 7/4 = 22/4 = 5.5
+			Assert.Equal(5.5m, ColonizeRepositoryWrite.GetCostForTiles(4m, 4));
+		}
+
+		[Fact]
+		public void GetCostForTiles_SmallLand_FloorApplied() {
+			// L=0, N=4: all four tiles floored to 1 (since (0+k)/4 < 1 for k<4)
+			Assert.Equal(4m, ColonizeRepositoryWrite.GetCostForTiles(0m, 4));
+			// L=0, N=8: first four floored to 1 each, then 4/4 + 5/4 + 6/4 + 7/4 = 22/4 = 5.5 → total 9.5
+			Assert.Equal(9.5m, ColonizeRepositoryWrite.GetCostForTiles(0m, 8));
+			// L=2, N=5: tiles k=0..4 → max(1, 2/4)=1, max(1,3/4)=1, max(1,4/4)=1, max(1,5/4)=1.25, max(1,6/4)=1.5
+			// Sum = 1 + 1 + 1 + 1.25 + 1.5 = 5.75
+			Assert.Equal(5.75m, ColonizeRepositoryWrite.GetCostForTiles(2m, 5));
+		}
+
+		[Fact]
+		public void GetCostForTiles_ZeroAmount_ReturnsZero() {
+			Assert.Equal(0m, ColonizeRepositoryWrite.GetCostForTiles(0m, 0));
+			Assert.Equal(0m, ColonizeRepositoryWrite.GetCostForTiles(1000m, 0));
+		}
+
+		[Fact]
+		public void GetCostForTiles_NegativeAmount_Throws() {
+			Assert.Throws<ArgumentOutOfRangeException>(() => ColonizeRepositoryWrite.GetCostForTiles(100m, -1));
+		}
+
+		[Fact]
+		public void GetCostForTiles_Monotonic() {
+			// Cost should strictly increase with N (each new tile costs at least 1)
+			for (decimal land = 0; land <= 500; land += 50) {
+				decimal previous = -1;
+				for (int n = 0; n <= 50; n++) {
+					var current = ColonizeRepositoryWrite.GetCostForTiles(land, n);
+					Assert.True(current > previous || n == 0, $"Cost not monotonic at L={land}, N={n}: prev={previous}, cur={current}");
+					previous = current;
+				}
+			}
+		}
+
+		[Fact]
+		public void GetMaxAffordable_RoundTripsWithGetCostForTiles() {
+			// For any (L, minerals), GetMaxAffordable must satisfy:
+			//   GetCostForTiles(L, M) <= minerals < GetCostForTiles(L, M+1)
+			(decimal land, decimal minerals)[] cases = {
+				(0m, 0m),
+				(0m, 3m),     // affords 3 tiles at floor cost
+				(0m, 4m),     // affords 4 tiles
+				(100m, 0m),
+				(100m, 25m),  // affords 1 tile at L=100 (cost=25)
+				(100m, 26m),
+				(100m, 261.25m),  // exactly 10 tiles
+				(100m, 261.26m),
+				(1000m, 1_000_000m),
+				(50m, 10_000m),
+			};
+			foreach (var (land, minerals) in cases) {
+				var max = ColonizeRepositoryWrite.GetMaxAffordable(land, minerals);
+				Assert.True(max >= 0, $"max negative at L={land}, minerals={minerals}");
+				var costAtMax = ColonizeRepositoryWrite.GetCostForTiles(land, max);
+				var costAtNext = ColonizeRepositoryWrite.GetCostForTiles(land, max + 1);
+				Assert.True(costAtMax <= minerals, $"cost({max})={costAtMax} > minerals={minerals} at L={land}");
+				Assert.True(costAtNext > minerals, $"cost({max + 1})={costAtNext} <= minerals={minerals} at L={land} (max={max})");
+			}
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ColonizeRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Resources/ColonizeRepositoryWrite.cs
@@ -20,16 +20,52 @@ namespace BrowserGameEngine.StatefulGameServer {
 			return Math.Max(1, currentLand / 4);
 		}
 
+		// Cumulative cost of colonizing `amount` tiles starting at `currentLand`.
+		// Per tile k (0-indexed): max(1, (currentLand + k) / 4). Floor applies to the
+		// k < 4 - currentLand prefix; the rest uses a closed-form arithmetic-series sum.
+		public static decimal GetCostForTiles(decimal currentLand, int amount) {
+			if (amount < 0) throw new ArgumentOutOfRangeException(nameof(amount), "Amount cannot be negative.");
+			if (amount == 0) return 0m;
+
+			int floored = 0;
+			if (currentLand < 4m) {
+				var threshold = Math.Ceiling(4m - currentLand);
+				floored = (int)Math.Min(threshold, amount);
+			}
+
+			int remaining = amount - floored;
+			if (remaining == 0) return floored;
+
+			// Σ_{k=floored..amount-1} (currentLand + k) / 4
+			//   = remaining * (2L + floored + amount - 1) / 8
+			var closedForm = remaining * (2m * currentLand + floored + amount - 1) / 8m;
+			return floored + closedForm;
+		}
+
+		// Largest N such that GetCostForTiles(currentLand, N) <= availableMinerals.
+		public static int GetMaxAffordable(decimal currentLand, decimal availableMinerals) {
+			if (availableMinerals <= 0) return 0;
+			// Each tile costs at least 1, so N <= availableMinerals is a safe upper bound.
+			long lo = 0;
+			long hi = (long)Math.Min(Math.Floor(availableMinerals) + 1m, int.MaxValue);
+			while (lo < hi) {
+				long mid = lo + (hi - lo + 1) / 2;
+				var cost = GetCostForTiles(currentLand, (int)mid);
+				if (cost <= availableMinerals) lo = mid;
+				else hi = mid - 1;
+			}
+			return (int)lo;
+		}
+
 		public void Colonize(ColonizeCommand command) {
-			if (command.Amount < 1 || command.Amount > 24) {
-				throw new ArgumentOutOfRangeException(nameof(command.Amount), "Colonization amount must be between 1 and 24.");
+			if (command.Amount < 1) {
+				throw new ArgumentOutOfRangeException(nameof(command.Amount), "Colonization amount must be at least 1.");
 			}
 
 			var landId = Id.ResDef("land");
 			var mineralsId = Id.ResDef("minerals");
 			var currentLand = resourceRepository.GetAmount(command.PlayerId, landId);
-			var costPerLand = GetCostPerLand(currentLand);
-			var totalCost = command.Amount * costPerLand;
+			var totalCost = GetCostForTiles(currentLand, command.Amount);
 
 			resourceRepositoryWrite.DeductCost(command.PlayerId, mineralsId, totalCost);
 			resourceRepositoryWrite.AddResources(command.PlayerId, landId, command.Amount);

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -94,6 +94,14 @@ export interface PlayerResourcesViewModel {
   colonizationCostPerLand: number
 }
 
+export interface ColonizePreviewViewModel {
+  amount: number
+  totalCost: number
+  firstTileCost: number
+  lastTileCost: number
+  maxAffordable: number
+}
+
 // Resource History
 
 export interface ResourceSnapshotViewModel {

--- a/src/ReactClient/src/components/ColonizeDialog.tsx
+++ b/src/ReactClient/src/components/ColonizeDialog.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { MountainIcon } from 'lucide-react'
 import axios from 'axios'
 import { toast } from 'sonner'
 import apiClient from '@/api/client'
-import type { PlayerResourcesViewModel } from '@/api/types'
+import type { ColonizePreviewViewModel } from '@/api/types'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { NumberStepper } from '@/components/ui/number-stepper'
@@ -18,37 +18,64 @@ interface ColonizeDialogProps {
   gameId: string
 }
 
-const PRESETS = [1, 5, 10, 20]
-const MAX_PER_CALL = 24
+const SLIDER_TICKS = 1000
+const LOG_THRESHOLD = 100
+
+function sliderToAmount(s: number, max: number): number {
+  if (max <= 1) return 1
+  const t = s / SLIDER_TICKS
+  if (max > LOG_THRESHOLD) {
+    return Math.max(1, Math.min(max, Math.round(Math.exp(t * Math.log(max)))))
+  }
+  return Math.max(1, Math.min(max, Math.round(1 + t * (max - 1))))
+}
+
+function amountToSlider(a: number, max: number): number {
+  if (max <= 1) return 0
+  const clamped = Math.max(1, Math.min(max, a))
+  if (max > LOG_THRESHOLD) {
+    return Math.round((Math.log(clamped) / Math.log(max)) * SLIDER_TICKS)
+  }
+  return Math.round(((clamped - 1) / (max - 1)) * SLIDER_TICKS)
+}
 
 export function ColonizeDialog({ open, onOpenChange, gameId }: ColonizeDialogProps) {
   const queryClient = useQueryClient()
   const [amount, setAmount] = useState(1)
-
-  const { data: resources } = useQuery<PlayerResourcesViewModel>({
-    queryKey: ['resources', gameId],
-    queryFn: () => apiClient.get('/api/resources').then((r) => r.data),
-    enabled: open,
-    refetchInterval: open ? 10_000 : false,
-  })
+  const [debouncedAmount, setDebouncedAmount] = useState(1)
 
   useEffect(() => {
     if (open) setAmount(1)
   }, [open])
 
-  const costPerLand = resources?.colonizationCostPerLand ?? 0
-  const minerals =
-    (resources?.primaryResource.cost.minerals ?? 0) +
-    (resources?.secondaryResources.cost.minerals ?? 0)
-  const maxByResources = costPerLand > 0 ? Math.floor(minerals / costPerLand) : MAX_PER_CALL
-  const maxAllowed = Math.min(MAX_PER_CALL, Math.max(1, maxByResources || 1))
-  const total = amount * costPerLand
-  const affordable = total <= minerals
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebouncedAmount(amount), 150)
+    return () => window.clearTimeout(t)
+  }, [amount])
+
+  const { data: preview } = useQuery<ColonizePreviewViewModel>({
+    queryKey: ['colonize-preview', gameId, debouncedAmount],
+    queryFn: () =>
+      apiClient.get(`/api/colonize/preview?amount=${debouncedAmount}`).then((r) => r.data),
+    enabled: open && debouncedAmount >= 1,
+    refetchInterval: open ? 10_000 : false,
+    placeholderData: (prev) => prev,
+  })
+
+  const maxAffordable = preview?.maxAffordable ?? 1
+  const sliderMax = Math.max(1, maxAffordable)
+  const total = preview?.totalCost ?? 0
+  const firstTileCost = preview?.firstTileCost ?? 0
+  const lastTileCost = preview?.lastTileCost ?? 0
+  const affordable = preview ? amount <= maxAffordable : false
+
+  const sliderValue = useMemo(() => amountToSlider(amount, sliderMax), [amount, sliderMax])
 
   const colonizeMutation = useMutation({
     mutationFn: () => apiClient.post(`/api/colonize/colonize?amount=${amount}`, ''),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['resources', gameId] })
+      void queryClient.invalidateQueries({ queryKey: ['colonize-preview', gameId] })
       toast.success(`Colonized +${formatNumber(amount)} land`)
       onOpenChange(false)
     },
@@ -65,40 +92,60 @@ export function ColonizeDialog({ open, onOpenChange, gameId }: ColonizeDialogPro
             <MountainIcon className="h-5 w-5 text-primary" aria-hidden /> Colonize land
           </DialogTitle>
           <DialogDescription>
-            Claim new land at <span className="mono">{formatNumber(costPerLand)}</span> <ResourceIcon name="minerals" className="inline" /> per tile. More land means more workers over time.
+            Each new tile costs more than the last. More land means more workers over time.
           </DialogDescription>
         </DialogHeader>
 
-        <div>
-          <div className="label mb-1.5">Tiles</div>
-          <NumberStepper
-            value={amount}
-            onChange={setAmount}
-            min={1}
-            max={MAX_PER_CALL}
-            presets={PRESETS.filter((p) => p <= MAX_PER_CALL)}
-          />
-          <div className="mt-2">
+        <div className="flex flex-col gap-3">
+          <div>
+            <div className="label mb-1.5">Tiles</div>
+            <input
+              type="range"
+              min={0}
+              max={SLIDER_TICKS}
+              step={1}
+              value={sliderValue}
+              onChange={(e) => setAmount(sliderToAmount(Number(e.target.value), sliderMax))}
+              disabled={maxAffordable < 1}
+              className="w-full accent-primary"
+              aria-label="Tiles to colonize"
+            />
+          </div>
+
+          <NumberStepper value={amount} onChange={setAmount} min={1} max={Math.max(1, maxAffordable)} />
+
+          <div>
             <Button
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() => setAmount(maxAllowed)}
-              title="Colonize as much as your minerals allow (capped at 24)"
+              onClick={() => setAmount(Math.max(1, maxAffordable))}
+              disabled={maxAffordable < 1}
+              title="Set to the largest amount your minerals can afford"
             >
-              Max affordable ({formatNumber(maxAllowed)})
+              Max affordable ({formatNumber(maxAffordable)})
             </Button>
           </div>
         </div>
 
         <div className={cn(
-          'rounded-md border px-3 py-2 flex items-center justify-between gap-3 text-sm',
+          'rounded-md border px-3 py-2 flex flex-col gap-1 text-sm',
           affordable ? 'border-success/40 bg-success/5' : 'border-destructive/40 bg-destructive/5',
         )}>
-          <span className="text-muted-foreground">Total</span>
-          <span className="inline-flex items-center gap-1 mono">
-            <ResourceIcon name="minerals" /> {formatNumber(total)}
-          </span>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Total</span>
+            <span className="inline-flex items-center gap-1 mono">
+              <ResourceIcon name="minerals" /> {formatNumber(total)}
+            </span>
+          </div>
+          {amount > 1 && (
+            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>Per tile</span>
+              <span className="mono">
+                {formatNumber(firstTileCost)} → {formatNumber(lastTileCost)}
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">


### PR DESCRIPTION
## Summary

- Replace the 24-tile per-call cap (which existed to make colonization progressively expensive) with per-tile integral pricing. A single dialog action now colonizes any amount the player can afford, no more 10× clicking to colonize 240 land.
- New `GET /api/colonize/preview?amount=N` returns `totalCost`, `firstTileCost`, `lastTileCost`, `maxAffordable` so the UI stays in sync with the authoritative server formula.
- ColonizeDialog gets a slider + stepper combo, live preview, and a per-tile cost range display (`25 → 47`).
- Bot updated to use `GetMaxAffordable` instead of the hardcoded 24-cap.

Spec: `docs/superpowers/specs/2026-04-26-colonization-ux-design.md` (committed in 1dafdd1)

## Cost formula

Cost of N tiles starting at L land:

```
totalCost = Σ_{k=0..N−1} max(1, (L + k) / 4)
```

Closed-form for `L ≥ 4`: `N · (2L + N − 1) / 8`. Floor handling for early-game `L < 4`.

## Test plan

- [x] `dotnet test` — 560 passed (8 new in `ColonizeTest`)
- [x] `npm run build` — succeeds
- [x] `npm test` — 29 passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [ ] Manual smoke test: open Colonize dialog, drag slider, verify preview updates and per-tile range matches expectations
- [ ] Manual smoke test: colonize a large amount in one click, verify minerals deducted correctly and land added

## Behaviour change vs. today

Old (flat-batch within ≤24): 10 batches of 24 each priced at the *batch-start* per-tile rate.
New (per-tile integral): single call, each tile priced at its own rate as land grows.

Total cost for the same end-state is slightly higher under the new mechanic (no within-batch flat-rate discount), in exchange for a smooth, honest curve and one-click UX. The bot's path to `LandTarget` shifts accordingly — it converges to the same value, just in different-sized increments.