### PR TITLE
fix(sco): all races generate worker income, not just Terran

### DIFF
--- a/src/BrowserGameEngine.BalanceSim/GameSim/Bots/ConfigurableBot.cs
+++ b/src/BrowserGameEngine.BalanceSim/GameSim/Bots/ConfigurableBot.cs
@@ -29,6 +29,11 @@ public class ConfigurableBot : IBot {
 	/// hoard hundreds of pending units behind it.</summary>
 	public int MaxQueueLength { get; init; } = 4;
 
+	/// <summary>Max units per queue entry (engine BuildUnit accepts Count). Larger batches
+	/// match how real players queue (a stack of 10 at a time) and avoid a 1-unit-per-tick
+	/// throughput cap from the build-queue tick module.</summary>
+	public int BatchSize { get; init; } = 10;
+
 	private readonly Dictionary<string, int> lastAttackTickByOpponent = new();
 	private int unitMixCursor;
 
@@ -74,9 +79,13 @@ public class ConfigurableBot : IBot {
 		var worker = WorkerUnit();
 		int have = ctx.Game.UnitRepository.CountByUnitDefId(ctx.PlayerId, Id.UnitDef(worker));
 		int queued = CountQueued(ctx, worker);
-		if (have + queued >= Config.WorkerTarget) return;
+		int needed = Config.WorkerTarget - have - queued;
+		if (needed <= 0) return;
 		if (QueueLength(ctx) >= MaxQueueLength) return;
-		Enqueue(ctx, SimGame.BuildQueueTypeUnit, worker, count: 1);
+		// Batch up to BatchSize, capped by what we can afford and what's still needed.
+		int batch = Math.Min(needed, AffordableUnitCount(ctx, worker, BatchSize));
+		if (batch <= 0) return;
+		Enqueue(ctx, SimGame.BuildQueueTypeUnit, worker, count: batch);
 	}
 
 	private void QueueNextBuilding(BotContext ctx) {
@@ -85,9 +94,16 @@ public class ConfigurableBot : IBot {
 			if (ctx.Game.AssetRepository.HasAsset(ctx.PlayerId, assetDefId)) continue;
 			if (ctx.Game.AssetRepository.IsBuildQueued(ctx.PlayerId, assetDefId)) return;
 			if (IsAssetQueuedInBuildQueue(ctx, assetId)) return;
+			if (!CanAffordAsset(ctx, assetId)) return; // avoid head-blocking the queue
 			Enqueue(ctx, SimGame.BuildQueueTypeAsset, assetId, count: 1);
 			return;
 		}
+	}
+
+	private static bool CanAffordAsset(BotContext ctx, string assetDefId) {
+		var def = ctx.Game.GameDef.GetAssetDef(Id.AssetDef(assetDefId));
+		if (def == null) return false;
+		return ctx.Game.ResourceRepository.CanAfford(ctx.PlayerId, def.Cost);
 	}
 
 	private void Colonize(BotContext ctx) {
@@ -124,12 +140,40 @@ public class ConfigurableBot : IBot {
 		if (QueueLength(ctx) >= MaxQueueLength) return;
 		var mix = Config.UnitMix ?? BotConfig.DefaultUnitMixFor(Race);
 		if (mix.Count == 0) return;
-		var available = mix.Where(kv => CanBuildUnit(ctx, kv.Key)).ToList();
+		// Filter to units we can both build (prerequisites met) AND afford at least one of
+		// right now. Head-of-queue blocking means a queued unit we can't afford stalls the
+		// whole queue.
+		var available = mix.Where(kv => CanBuildUnit(ctx, kv.Key) && CanAffordUnit(ctx, kv.Key)).ToList();
 		if (available.Count == 0) return;
 		var flat = available.SelectMany(kv => Enumerable.Repeat(kv.Key, kv.Value)).ToList();
 		if (flat.Count == 0) return;
 		var unit = flat[unitMixCursor++ % flat.Count];
-		Enqueue(ctx, SimGame.BuildQueueTypeUnit, unit, count: 1);
+		// Batch by how many we can afford up to BatchSize. The engine's BuildUnit handles
+		// Count > 1 atomically, so this matches what a real player would do (queue a stack
+		// of 10 marines instead of 1).
+		int batch = AffordableUnitCount(ctx, unit, BatchSize);
+		if (batch <= 0) return;
+		Enqueue(ctx, SimGame.BuildQueueTypeUnit, unit, count: batch);
+	}
+
+	private static bool CanAffordUnit(BotContext ctx, string unitDefId) {
+		var def = ctx.Game.GameDef.GetUnitDef(Id.UnitDef(unitDefId));
+		if (def == null) return false;
+		return ctx.Game.ResourceRepository.CanAfford(ctx.PlayerId, def.Cost);
+	}
+
+	/// <summary>How many of a unit can we afford right now, capped at <paramref name="cap"/>?</summary>
+	private static int AffordableUnitCount(BotContext ctx, string unitDefId, int cap) {
+		var def = ctx.Game.GameDef.GetUnitDef(Id.UnitDef(unitDefId));
+		if (def == null) return 0;
+		int max = cap;
+		foreach (var (resId, perUnit) in def.Cost.Resources) {
+			if (perUnit <= 0) continue;
+			var have = ctx.Game.ResourceRepository.GetAmount(ctx.PlayerId, resId);
+			int affordable = (int)(have / perUnit);
+			if (affordable < max) max = affordable;
+		}
+		return Math.Max(0, max);
 	}
 
 	private void MaybeAttack(BotContext ctx) {

--- a/src/BrowserGameEngine.BalanceSim/Program.cs
+++ b/src/BrowserGameEngine.BalanceSim/Program.cs
@@ -116,7 +116,7 @@ static void PrintUsage() {
 static Dictionary<string, string> ParseOptions(string[] args) {
 	var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 	// Flags don't take a value — they're set to "true" if present.
-	var flagKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "csv", "quiet" };
+	var flagKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "csv", "quiet", "breakdown" };
 	for (int i = 0; i < args.Length; i++) {
 		if (args[i].StartsWith("--")) {
 			var key = args[i][2..];

--- a/src/BrowserGameEngine.BalanceSim/Simulations/PlaythroughSimulation.cs
+++ b/src/BrowserGameEngine.BalanceSim/Simulations/PlaythroughSimulation.cs
@@ -29,6 +29,9 @@ public static class PlaythroughSimulation {
 		);
 
 		var snapshots = new List<(int Tick, IReadOnlyList<PlayerSnapshot> Ranking)>();
+		bool breakdown = options.GetBool("breakdown");
+		var unitBreakdowns = new List<(int Tick, PlayerId Player, IReadOnlyDictionary<string, int> UnitCounts)>();
+
 		var runner = new PlaythroughRunner {
 			GameDefOverride = gameDef,
 			Settings = settings,
@@ -36,6 +39,15 @@ public static class PlaythroughSimulation {
 			OnTick = (tick, game) => {
 				if (snapshotEvery > 0 && tick % snapshotEvery == 0) {
 					snapshots.Add((tick, game.Ranking()));
+					if (breakdown) {
+						foreach (var pid in game.Players) {
+							var p = game.PlayerRepository.Get(pid);
+							var counts = p.State.Units
+								.GroupBy(u => u.UnitDefId.Id)
+								.ToDictionary(g => g.Key, g => g.Sum(u => u.Count));
+							unitBreakdowns.Add((tick, pid, counts));
+						}
+					}
 				}
 			}
 		};
@@ -44,6 +56,10 @@ public static class PlaythroughSimulation {
 
 		Console.WriteLine();
 		PrintTimeline(result, snapshots, csv);
+		if (breakdown) {
+			Console.WriteLine();
+			PrintBreakdown(result, unitBreakdowns);
+		}
 		Console.WriteLine();
 		PrintFinalRanking(result, csv);
 		Console.WriteLine();
@@ -89,6 +105,18 @@ public static class PlaythroughSimulation {
 			foreach (var snap in ranking) {
 				var name = result.BotNamesByPlayer[snap.PlayerId];
 				Console.WriteLine($"| {tick,4} | {name,-21} | {snap.Land,4} | {snap.Minerals + snap.Gas,6} | {snap.UnitCount,5} | {snap.ArmyStrength,8} |");
+			}
+		}
+	}
+
+	private static void PrintBreakdown(PlaythroughResult result, List<(int Tick, PlayerId Player, IReadOnlyDictionary<string, int> UnitCounts)> rows) {
+		Console.WriteLine("Unit composition:");
+		foreach (var grouping in rows.GroupBy(r => r.Tick).OrderBy(g => g.Key)) {
+			Console.WriteLine($"  tick {grouping.Key}:");
+			foreach (var (_, player, counts) in grouping) {
+				var name = result.BotNamesByPlayer[player];
+				var listing = string.Join(", ", counts.OrderByDescending(kv => kv.Value).Select(kv => $"{kv.Key}={kv.Value}"));
+				Console.WriteLine($"    {name,-20} {listing}");
 			}
 		}
 	}

--- a/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
+++ b/src/BrowserGameEngine.GameDefinition.SCO/StarcraftOnlineGameDefFactory.cs
@@ -28,7 +28,10 @@ namespace BrowserGameEngine.GameDefinition.SCO {
 				GameTickModules = new List<GameTickModuleDef> {
 					new GameTickModuleDef("actionqueue:1", new Dictionary<string, string> { }.ToFrozenDictionary()),
 					new GameTickModuleDef("resource-growth-sco:1", new Dictionary<string, string> {
-						{ "worker-units", "wbf" },
+						// Comma-separated: one worker unit per playable race. Without this,
+						// only Terran (wbf) generates income — Zerg (drone) and Protoss (probe)
+						// are stuck on the 10 m / 10 g base income and can't compete economically.
+						{ "worker-units", "wbf,drone,probe" },
 						{ "growth-resource", "minerals" },
 						{ "gas-resource", "gas" },
 						{ "constraint-resource", "land" },

--- a/src/BrowserGameEngine.StatefulGameServer.Test/SimGameTests.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/SimGameTests.cs
@@ -143,4 +143,35 @@ public class SimGameTests {
 	public void ParseStrategy_throws_on_unknown_name() {
 		Assert.Throws<System.ArgumentException>(() => BotPresets.ParseStrategy("nonexistent"));
 	}
+
+	// Regression test for the SCO race-balance bug: the resource-growth-sco tick module used
+	// to recognize only one worker unit (wbf), so Zerg drones and Protoss probes generated no
+	// income — both races were stuck on the 10 m / 10 g/tick base income. Now that worker-units
+	// is comma-separated, every race's worker should grow income proportionally.
+	[Theory]
+	[InlineData("terran", "wbf")]
+	[InlineData("zerg", "drone")]
+	[InlineData("protoss", "probe")]
+	public void Worker_income_is_generated_for_every_race(string race, string workerUnitId) {
+		var sim = new SimGame(settings: new GameSettings(EndTick: 100, ProtectionTicks: 0));
+		var pid = sim.AddPlayer("p", race);
+		// Grant 10 workers and assign 5 mineral / 5 gas so income should be well above base.
+		sim.UnitRepositoryWrite.GrantUnits(pid, Id.UnitDef(workerUnitId), 10);
+		sim.PlayerRepositoryWrite.AssignWorkers(
+			new BrowserGameEngine.StatefulGameServer.Commands.AssignWorkersCommand(pid, MineralWorkers: 5, GasWorkers: 5),
+			totalWorkers: 10);
+
+		var startMin = sim.ResourceRepository.GetAmount(pid, Id.ResDef("minerals"));
+		var startGas = sim.ResourceRepository.GetAmount(pid, Id.ResDef("gas"));
+		sim.AdvanceTicks(10);
+		var endMin = sim.ResourceRepository.GetAmount(pid, Id.ResDef("minerals"));
+		var endGas = sim.ResourceRepository.GetAmount(pid, Id.ResDef("gas"));
+
+		// Base income alone over 10 ticks = 100 m + 100 g. Worker income on top should push
+		// well past that. Assert at least 50% above base to leave room for efficiency clamping.
+		Assert.True(endMin - startMin > 150,
+			$"{race}: expected mineral income > 150 over 10 ticks (got {endMin - startMin}); workers not counted?");
+		Assert.True(endGas - startGas > 150,
+			$"{race}: expected gas income > 150 over 10 ticks (got {endGas - startGas}); workers not counted?");
+	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
@@ -22,10 +22,16 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		private readonly UnitRepositoryWrite unitRepositoryWrite;
 		private readonly IActionLogger actionLogger;
 
-		private UnitDefId workerUnit = null!;
+		// Multiple worker unit ids supported via comma-separated property — one per playable
+		// race. The module sums counts across all listed worker units when computing income.
+		private System.Collections.Generic.List<UnitDefId> workerUnits = new();
 		private ResourceDefId mineralResource = null!;
 		private ResourceDefId? gasResource; // null = gas income disabled
 		private ResourceDefId constraintResource = null!;
+		// First entry is used as the "canonical" worker for emergency respawns. Per the spec
+		// this only matters when a player has zero workers AND zero income — emergency respawn
+		// grants workers of this type. (Older single-worker config paths still work.)
+		private UnitDefId PrimaryWorkerUnit => workerUnits[0];
 
 		// Base income added every tick regardless of workers (spec 2.3)
 		private const decimal BaseIncomeMinerals = 10m;
@@ -70,8 +76,16 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		public void SetProperty(string name, string value) {
 			switch(name) {
 				case "worker-units":
-					workerUnit = new UnitDefId(value);
-					gameDef.ValidateUnitDefId(workerUnit, $"{Name}.{name}");
+					// Comma-separated list — one worker unit id per playable race (e.g.
+					// "wbf,drone,probe"). Single-value strings still work for back-compat.
+					workerUnits.Clear();
+					foreach (var raw in value.Split(',', StringSplitOptions.RemoveEmptyEntries)) {
+						var id = new UnitDefId(raw.Trim());
+						gameDef.ValidateUnitDefId(id, $"{Name}.{name}");
+						workerUnits.Add(id);
+					}
+					if (workerUnits.Count == 0)
+						throw new InvalidGameDefException($"{Name}.{name} must list at least one worker unit id.");
 					break;
 				case "growth-resource":
 					mineralResource = new ResourceDefId(value);
@@ -91,7 +105,11 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		}
 
 		public void CalculateTick(PlayerId playerId) {
-			int totalWorkers = unitRepository.CountByUnitDefId(playerId, workerUnit);
+			// Sum worker counts across all configured worker unit types. This lets a single SCO
+			// game definition describe race-specific workers (wbf/drone/probe) and have a Zerg
+			// or Protoss player's workers actually count toward income.
+			int totalWorkers = 0;
+			foreach (var w in workerUnits) totalWorkers += unitRepository.CountByUnitDefId(playerId, w);
 			int mineralWorkers = playerRepository.GetMineralWorkers(playerId);
 			int gasWorkers = playerRepository.GetGasWorkers(playerId);
 
@@ -111,7 +129,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 					lowResources = lowResources && gas < EmergencyResourceThreshold;
 				}
 				if (lowResources) {
-					unitRepositoryWrite.GrantUnits(playerId, workerUnit, 2);
+					unitRepositoryWrite.GrantUnits(playerId, PrimaryWorkerUnit, 2);
 					playerRepositoryWrite.GrantEmergencyWorkers(playerId);
 					mineralWorkers = 1;
 					gasWorkers = 1;


### PR DESCRIPTION
## Summary

The SCO race balance was Terran-100%-wins because of a structural bug, not stat asymmetry: `ResourceGrowthSco` only counted **one** worker unit type (`wbf`), so Zerg drones and Protoss probes silently produced **zero income**. Both non-Terran races were stuck on the 10 m / 10 g / tick base income while Terran scaled normally with workers — every other strategy/stat tweak was downstream of this.

## Root-cause investigation

Hypothesis after merging the simulation harness: Terran's Spacemarine is just over-statted. **Wrong.** I tried:
- `Spacemarine 45m/2/4/60` → `55m/2/3/45` → `60m/2/2/35` → `60m/2/2/30`. **Zero matrix movement.** Terran still 100%.
- Combined nerf: `firebat 50m+25g/9/6` → `75m+50g/7/5` and `siegetank 125m+100g/40-def` → `175m+150g/25-def`. **Still 100%.**
- Buffed worker HP (drone 40→60, probe 20+20→30+30). **Still 100%.**

Adding a `--breakdown` flag to `playthrough` showed the actual cause: at tick 60 of a TvZ, Terran had 22 wbf + 25 marines + 13 firebats while Zerg had 22 drones + 11 zerglings. Same starting resources, same workers configured by the bot — but Terran's gas pile reached 11k while Zerg's barely moved. Trace: `unitRepository.CountByUnitDefId(zerg, "wbf") == 0`, so `ResourceGrowthSco.CalculateTick` saw 0 workers and granted only base income.

This is also a production bug: real Zerg/Protoss players in the live game are stuck on base income too.

## Fix

- `ResourceGrowthSco` now parses comma-separated `worker-units` and sums counts across all listed types.
- SCO game def passes `"wbf,drone,probe"`.
- Single-value form still parses (back-compat).
- Regression test `Worker_income_is_generated_for_every_race` covers all three races.

## Bot improvements (in this PR because they were needed to surface the bug)

- `ConfigurableBot` filters its queue choices by current affordability, not just prerequisites. The engine's build queue is head-blocking — an unaffordable entry stalls everything behind it.
- Batches up to 10 units per queue entry instead of 1 (matching how real players queue stacks).
- New `--breakdown` flag on `playthrough` shows unit-type composition at each snapshot.

## Balance impact

```
before this PR:    Terran 100%  / Zerg   0%  / Protoss   0%
after this PR:     Terran  60%  / Zerg  58%  / Protoss  32%

per-strategy (terran / zerg / protoss):
  rush     75 /   0 /  75
  balanced 37 /  97 /  17
  economy 100 /  50 /   0
  turtle    0 / 100 /  50
  air     100 /  50 /   0
  mass     50 /  50 /  50  ← perfectly balanced
```

Protoss is still the weakest race overall (32%) but no race is broken. The strategy × race interactions now look like real rock-paper-scissors. Further tuning (e.g. Zealot cost, Dragoon shields) can refine from here.

## Test plan

- [x] All 555 unit tests pass locally (Release)
- [x] New `Worker_income_is_generated_for_every_race` test covers terran/zerg/protoss
- [x] `Every_preset_unitmix_is_buildable_by_buildorder` still passes (no preset broke)
- [x] `dotnet run --project BrowserGameEngine.BalanceSim -- balance --strategy mass` confirms 50/50/50
- [ ] CI green
- [ ] Production smoke test with a Zerg or Protoss player to confirm income now flows

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gds6ruCp4bGudnqTAojCh4)_