### PR TITLE
Grant admin console access to discostu105

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/appsettings.json
+++ b/src/BrowserGameEngine.FrontendServer/appsettings.json
@@ -2,6 +2,6 @@
   "AllowedHosts": "*",
   "Bge": {
     "DevAuth": false,
-    "AdminUserIds": []
+    "AdminUserIds": [ "10918780" ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds GitHub numeric user ID `10918780` (discostu105) to `Bge:AdminUserIds` in `appsettings.json`.
- This grants access to `/admin/*` routes and the `[Authorize(Policy = "Admin")]` API endpoints (game management, player admin, tick control, audit, etc.).

## How it works
The `Admin` policy in `FrontendServer/Program.cs:98-105` checks the `NameIdentifier` claim from GitHub OAuth (which is the numeric user ID) against `Bge:AdminUserIds`. Looked up via GitHub API: `discostu105` → id `10918780`.

## Test plan
- [ ] Deploy to ageofagents.net
- [ ] Sign in as `discostu105` via GitHub
- [ ] Navigate to `/admin/games` and confirm the page loads
- [ ] Create a test game to verify admin API access


---
_Generated by [Claude Code](https://claude.ai/code/session_015k2y4u4q7J8w4vYi1uYxZ8)_