### PR TITLE
fix(buildqueue): prevent duplicate buildings in queue and clarify UI

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/BuildQueueController.cs
@@ -57,13 +57,19 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			}
 			if (request.Count <= 0) return BadRequest("Count must be greater than 0.");
 			if (request.Count > 10000) return BadRequest("Count must be 10,000 or less.");
-			buildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(
-				currentUserContext.PlayerId!,
-				request.Type,
-				request.DefId,
-				request.Count
-			));
-			return Ok();
+			try {
+				buildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(
+					currentUserContext.PlayerId!,
+					request.Type,
+					request.DefId,
+					request.Count
+				));
+				return Ok();
+			} catch (AssetAlreadyBuiltException e) {
+				return BadRequest(e.Message);
+			} catch (AssetAlreadyQueuedException e) {
+				return BadRequest(e.Message);
+			}
 		}
 
 		/// <summary>Removes an entry from the build queue by its ID.</summary>

--- a/src/BrowserGameEngine.StatefulGameServer.Test/BuildQueueTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/BuildQueueTest.cs
@@ -165,6 +165,50 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
+		public void AddToQueue_Asset_AlreadyInQueue_Throws() {
+			var g = new TestGame();
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+
+			Assert.Throws<AssetAlreadyQueuedException>(() =>
+				g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1)));
+
+			Assert.Single(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void AddToQueue_Asset_AlreadyBuilt_Throws() {
+			var g = new TestGame();
+			Assert.True(g.AssetRepository.HasAsset(g.Player1, Id.AssetDef("asset1")));
+
+			Assert.Throws<AssetAlreadyBuiltException>(() =>
+				g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset1", 1)));
+
+			Assert.Empty(g.BuildQueueRepository.GetQueue(g.Player1));
+		}
+
+		[Fact]
+		public void AddToQueue_Asset_AlreadyBuilding_Throws() {
+			var g = new TestGame();
+			// Move the entry from BuildQueue into the ActionQueue (currently building)
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1));
+			g.BuildQueueRepositoryWrite.TryExecuteAndDequeueFirst(g.Player1);
+			Assert.True(g.AssetRepository.IsBuildQueued(g.Player1, Id.AssetDef("asset2")));
+
+			Assert.Throws<AssetAlreadyQueuedException>(() =>
+				g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "asset", "asset2", 1)));
+		}
+
+		[Fact]
+		public void AddToQueue_Unit_DuplicatesAllowed() {
+			var g = new TestGame();
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 5));
+			g.BuildQueueRepositoryWrite.AddToQueue(new AddToQueueCommand(g.Player1, "unit", "unit1", 3));
+
+			var queue = g.BuildQueueRepository.GetQueue(g.Player1);
+			Assert.Equal(2, queue.Count);
+		}
+
+		[Fact]
 		public void TryExecuteAndDequeueFirst_ExecutesFrontEntry_LeavesRestInQueue() {
 			var g = new TestGame();
 			// Queue two units; player can afford both but TryExecuteAndDequeueFirst only processes the front

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/BuildQueue/BuildQueueRepositoryWrite.cs
@@ -45,6 +45,12 @@ namespace BrowserGameEngine.StatefulGameServer {
 		public void AddToQueue(AddToQueueCommand command) {
 			var state = world.GetPlayer(command.PlayerId).State;
 			lock (state.StateLock) {
+				if (command.Type == BuildQueueEntryConstants.TypeAsset) {
+					var assetDefId = Id.AssetDef(command.DefId);
+					if (assetRepository.HasAsset(command.PlayerId, assetDefId)) throw new AssetAlreadyBuiltException(assetDefId);
+					if (assetRepository.IsBuildQueued(command.PlayerId, assetDefId)) throw new AssetAlreadyQueuedException(assetDefId);
+					if (state.BuildQueue.Any(x => x.Type == BuildQueueEntryConstants.TypeAsset && x.DefId == command.DefId)) throw new AssetAlreadyQueuedException(assetDefId);
+				}
 				var priority = buildQueueRepository.GetNextPriority(command.PlayerId);
 				state.BuildQueue.Add(new BuildQueueEntry {
 					Id = Guid.NewGuid(),

--- a/src/ReactClient/src/components/BuildQueue.tsx
+++ b/src/ReactClient/src/components/BuildQueue.tsx
@@ -32,8 +32,13 @@ export function BuildQueue({ gameId }: BuildQueueProps) {
 
   return (
     <div>
-      <div className="label mb-1.5">
-        Build Queue <span className="text-muted-foreground">({data.entries.length})</span>
+      <div className="mb-1.5">
+        <div className="label">
+          Build Queue <span className="text-muted-foreground">({data.entries.length})</span>
+        </div>
+        <div className="text-xs text-muted-foreground mt-0.5">
+          Items start one after another in this order. Resources are deducted when each build begins.
+        </div>
       </div>
       <div className="flex flex-wrap gap-1.5">
         {data.entries

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -137,32 +137,50 @@ function AssetCard({
 				)}
 
 				{state === 'ready' && (
-					<div className="space-y-2">
-						<AffordabilityChip cost={asset.cost} affordable={asset.canAfford} block />
-						<div className="flex gap-1.5">
-							<Button
-								size="sm"
-								onClick={() => onBuild(asset.definition.id)}
-								disabled={disabled || !asset.canAfford}
-								className="flex-1"
-								title={asset.canAfford ? 'Build now' : 'Not enough resources — try Queue instead'}
-							>
-								<HammerIcon className="h-3.5 w-3.5" />
-								Build
-							</Button>
+					queueEntryId ? (
+						<div className="space-y-2">
+							<div className="text-xs text-muted-foreground">
+								Waiting in build queue · resources will be deducted when the build starts.
+							</div>
 							<Button
 								size="sm"
 								variant="outline"
-								onClick={() => onQueue(asset.definition.id)}
+								className="w-full"
+								onClick={() => onCancelQueue(queueEntryId)}
 								disabled={disabled}
-								className="flex-1"
-								title="Add to build queue; resources are reserved when the build starts"
 							>
-								<PlusCircleIcon className="h-3.5 w-3.5" />
-								Queue
+								<XIcon className="h-3.5 w-3.5" />
+								Remove from queue
 							</Button>
 						</div>
-					</div>
+					) : (
+						<div className="space-y-2">
+							<AffordabilityChip cost={asset.cost} affordable={asset.canAfford} block />
+							<div className="flex gap-1.5">
+								<Button
+									size="sm"
+									onClick={() => onBuild(asset.definition.id)}
+									disabled={disabled || !asset.canAfford}
+									className="flex-1"
+									title={asset.canAfford ? 'Build now' : 'Not enough resources — add to queue and it will start when you can afford it'}
+								>
+									<HammerIcon className="h-3.5 w-3.5" />
+									Build now
+								</Button>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => onQueue(asset.definition.id)}
+									disabled={disabled}
+									className="flex-1"
+									title="Add to build queue — starts after the items above it; resources are deducted when the build begins"
+								>
+									<PlusCircleIcon className="h-3.5 w-3.5" />
+									Add to queue
+								</Button>
+							</div>
+						</div>
+					)
 				)}
 
 				{state === 'locked' && asset.prerequisites && (


### PR DESCRIPTION
## Summary

- Reject `AddToQueue` for an asset that is already built, currently being built, or already waiting in the build queue. Units can still be queued multiple times.
- `BuildQueueController.Add` surfaces the validation as a 400 with the exception message.
- When an asset has a pending build-queue entry, the asset card on the Base page shows "Waiting in build queue · resources will be deducted when the build starts" with a **Remove from queue** button instead of Build/Queue — duplicates are physically impossible to enqueue.
- Clarified what "Queue" means: secondary button renamed **Queue → Add to queue**, and the Build Queue header now has a subtitle: *"Items start one after another in this order. Resources are deducted when each build begins."*

## Test plan

- [x] Added 4 unit tests in `BuildQueueTest.cs`:
  - duplicate asset in queue throws `AssetAlreadyQueuedException`
  - already-built asset throws `AssetAlreadyBuiltException`
  - asset currently being built throws `AssetAlreadyQueuedException`
  - units can still be added multiple times (regression)
- [ ] CI: `dotnet build --configuration Release` and `dotnet test` (couldn't run locally — no `dotnet` on PATH)
- [ ] Manual: queue Barracks, confirm card flips to "Waiting in build queue" and second click is impossible
- [ ] Manual: queue same unit twice — still allowed

https://claude.ai/code/session_018FRQFdDRTdDMSjH7KYKcDv

---
_Generated by [Claude Code](https://claude.ai/code/session_018FRQFdDRTdDMSjH7KYKcDv)_