### PR TITLE
fix(ui): keep header tick timer smooth at 0:00

### DIFF
--- a/src/ReactClient/src/layouts/GameLayout.tsx
+++ b/src/ReactClient/src/layouts/GameLayout.tsx
@@ -143,7 +143,13 @@ function GameLayoutInner() {
   const { data: tickInfo } = useQuery<TickInfoViewModel>({
     queryKey: ['tickinfo', gameId],
     queryFn: () => apiClient.get('/api/game/tick-info').then((r) => r.data),
-    refetchInterval: 30_000,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data) return 30_000
+      const remaining = new Date(data.nextTickAt).getTime() - Date.now()
+      if (remaining <= 0) return 1_000
+      return Math.min(30_000, remaining + 500)
+    },
     enabled: !!gameId && !isFinished,
   })
 


### PR DESCRIPTION
## Summary
- The header `TimerRing` polled `/api/game/tick-info` on a fixed 30s interval, so once the client-side countdown hit 0:00 it could sit there for up to half a minute before the next `NextTickAt` arrived.
- `src/ReactClient/src/layouts/GameLayout.tsx` now uses a dynamic `refetchInterval`: schedule the next poll just after the current tick is expected to expire (capped at 30s), and back off to 1s while remaining is non-positive so the new `NextTickAt` is picked up as soon as the server advances.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npx vitest run test/components/timer-ring.test.tsx` — 3/3 passing
- [ ] Manually verify in-game: countdown ring transitions smoothly through 0:00 to the next cycle

https://claude.ai/code/session_01XrcLo721B2gCJ6nUeg2vSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrcLo721B2gCJ6nUeg2vSi)_