### PR TITLE
fix(ui): add page padding and mobile overflow to Games page

### DIFF
--- a/src/ReactClient/src/components/games/GamesTable.tsx
+++ b/src/ReactClient/src/components/games/GamesTable.tsx
@@ -86,10 +86,11 @@ function fmtDate(iso: string | null): string {
 export function GamesTable({ section, games }: GamesTableProps) {
   if (games.length === 0) return null
   return (
-    <table className="w-full text-[12.5px] border-collapse">
+    <div className="overflow-x-auto -mx-3 sm:mx-0">
+    <table className="w-full text-[12.5px] border-collapse min-w-[640px]">
       <thead>
         <tr className="text-left [&>th]:border-b [&>th]:border-border">
-          <th className="label py-1.5 pr-3 w-[88px]">Status</th>
+          <th className="label py-1.5 pr-3 w-[88px] pl-3 sm:pl-0">Status</th>
           <th className="label py-1.5 pr-3">Game</th>
           {section === 'active' && (
             <>
@@ -129,7 +130,7 @@ export function GamesTable({ section, games }: GamesTableProps) {
           )
           return (
             <tr key={g.gameId} className={rowClass}>
-              <td className="py-2 pr-3"><StatusBadge section={section} /></td>
+              <td className="py-2 pr-3 pl-3 sm:pl-0"><StatusBadge section={section} /></td>
               <td className="py-2 pr-3"><NameCell game={g} section={section} /></td>
 
               {section === 'active' && (
@@ -163,11 +164,12 @@ export function GamesTable({ section, games }: GamesTableProps) {
                 </>
               )}
 
-              <td className="py-2 text-right whitespace-nowrap"><Actions game={g} section={section} /></td>
+              <td className="py-2 pr-3 sm:pr-0 text-right whitespace-nowrap"><Actions game={g} section={section} /></td>
             </tr>
           )
         })}
       </tbody>
     </table>
+    </div>
   )
 }

--- a/src/ReactClient/src/pages/Games.tsx
+++ b/src/ReactClient/src/pages/Games.tsx
@@ -47,7 +47,7 @@ export function Games() {
   const visibleFinished = showAllFinished || finished.length <= 5 ? finished : finished.slice(0, 5)
 
   return (
-    <div className="max-w-5xl">
+    <div className="max-w-5xl mx-auto p-3 sm:p-4">
       <h1 className="text-[22px] font-bold tracking-tight">Games</h1>
       <p className="text-[11.5px] text-muted-foreground mt-1 mb-4">
         Season schedule · live, upcoming, and finished seasons · {games.length} total


### PR DESCRIPTION
## Summary

The `/games` page has no horizontal spacing — the page header, status badges, and table cells sit flush against the viewport edges on both desktop and mobile. On mobile, fixed-width table columns also cause severe text wrapping inside cells.

Two root causes:

1. **No page padding / no centering.** `/games` renders directly inside `RootLayout`'s bare `<Outlet />`, unlike pages under `GameLayout` which get `p-3 sm:p-4` on `<main>`. The wrapper was `<div className="max-w-5xl">` with no `mx-auto`, so on wide desktop screens the content stayed pinned to the left edge instead of centering. Added `mx-auto p-3 sm:p-4`.
2. **Table squished on mobile.** Fixed-width columns (~640px total) wrapped text aggressively in narrow viewports. Wrapped `GamesTable` in `overflow-x-auto -mx-3 sm:mx-0` and gave the table `min-w-[640px]` so it scrolls horizontally on phones; first/last cells get `pl-3`/`pr-3` to preserve visual edge spacing.

## Note

This re-lands the change from #332. That PR was merged into the `claude/fix-e2e-tests-qPH8w` branch, but PR #330 had already squash-merged to master ~19s earlier from an older SHA, so my commit ended up on a dead branch and never reached master. This PR targets master directly.

## Test plan

- [x] `npm run build` passes locally
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK6TQQvYrKJrTCxvjGprXX)_