### PR TITLE
feat(ui): color-code Land, Minerals, and Gas across the client

### DIFF
--- a/src/ReactClient/src/components/PlayerResources.tsx
+++ b/src/ReactClient/src/components/PlayerResources.tsx
@@ -2,6 +2,14 @@ import { useQuery } from '@tanstack/react-query'
 import apiClient from '@/api/client'
 import type { PlayerResourcesViewModel } from '@/api/types'
 import { formatNumber } from '@/lib/formatters'
+import { ResourceIcon } from '@/components/ui/resource-icon'
+import { resourceHex, resourceTextClass } from '@/lib/resource-colors'
+
+const GLOWS: Record<string, string> = {
+  minerals: '0 0 6px rgba(96,165,250,0.45)',
+  gas: '0 0 6px rgba(74,222,128,0.45)',
+  land: '0 0 6px rgba(184,128,74,0.45)',
+}
 
 export function PlayerResources({ gameId }: { gameId: string }) {
   const { data } = useQuery({
@@ -19,13 +27,14 @@ export function PlayerResources({ gameId }: { gameId: string }) {
   return (
     <div className="flex items-center gap-4 whitespace-nowrap">
       {all.map(([name, value]) => {
-        const isLand = name.toLowerCase() === 'land'
+        const key = name.toLowerCase()
         return (
           <div key={name} className="flex items-baseline gap-1.5">
-            <span className="label text-[9px]">{name}</span>
+            <ResourceIcon name={name} className="self-center" />
+            <span className={`label text-[9px] ${resourceTextClass(name)}`}>{name}</span>
             <span
-              className={`mono text-[13px] font-semibold ${isLand ? 'text-interactive' : 'text-resource'}`}
-              style={isLand ? undefined : { textShadow: '0 0 6px rgba(34,197,94,0.35)' }}
+              className={`mono text-[13px] font-semibold ${resourceTextClass(name)}`}
+              style={{ color: resourceHex(name), textShadow: GLOWS[key] }}
             >
               {formatNumber(value)}
             </span>

--- a/src/ReactClient/src/components/ResourceHistoryChart.tsx
+++ b/src/ReactClient/src/components/ResourceHistoryChart.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import apiClient from '@/api/client'
 import type { ResourceHistoryViewModel } from '@/api/types'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts'
+import { resourceHex } from '@/lib/resource-colors'
 
 interface ResourceHistoryChartProps {
   gameId: string
@@ -47,9 +48,9 @@ export function ResourceHistoryChart({ gameId }: ResourceHistoryChartProps) {
           <YAxis tick={{ fontSize: 12 }} />
           <Tooltip />
           <Legend />
-          <Line type="monotone" dataKey="minerals" stroke="#3b82f6" name="Minerals" dot={false} />
-          <Line type="monotone" dataKey="gas" stroke="#22c55e" name="Gas" dot={false} />
-          <Line type="monotone" dataKey="land" stroke="#f59e0b" name="Land" dot={false} />
+          <Line type="monotone" dataKey="minerals" stroke={resourceHex('minerals')} name="Minerals" dot={false} />
+          <Line type="monotone" dataKey="gas" stroke={resourceHex('gas')} name="Gas" dot={false} />
+          <Line type="monotone" dataKey="land" stroke={resourceHex('land')} name="Land" dot={false} />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/src/ReactClient/src/components/ui/resource-icon.tsx
+++ b/src/ReactClient/src/components/ui/resource-icon.tsx
@@ -1,5 +1,6 @@
 import { Gem, FlaskConical, Coins, Mountain, Circle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { resourceTextClass } from '@/lib/resource-colors'
 
 const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   minerals: Gem,
@@ -16,5 +17,10 @@ interface ResourceIconProps {
 
 export function ResourceIcon({ name, className }: ResourceIconProps) {
   const Icon = ICONS[name.toLowerCase()] ?? Circle
-  return <Icon className={cn('h-3.5 w-3.5 shrink-0', className)} aria-hidden />
+  return (
+    <Icon
+      className={cn('h-3.5 w-3.5 shrink-0', resourceTextClass(name), className)}
+      aria-hidden
+    />
+  )
 }

--- a/src/ReactClient/src/lib/resource-colors.ts
+++ b/src/ReactClient/src/lib/resource-colors.ts
@@ -1,0 +1,26 @@
+// Shared visual identity for the three primary resources.
+// Minerals = blue, Gas = green, Land = brown.
+
+export const RESOURCE_HEX: Record<string, string> = {
+  minerals: '#60a5fa', // blue-400
+  gas: '#4ade80',      // green-400
+  land: '#b8804a',     // warm brown
+  credits: '#facc15',  // yellow-400
+  gold: '#facc15',
+}
+
+export const RESOURCE_TEXT_CLASS: Record<string, string> = {
+  minerals: 'text-blue-400',
+  gas: 'text-green-400',
+  land: 'text-[#b8804a]',
+  credits: 'text-yellow-400',
+  gold: 'text-yellow-400',
+}
+
+export function resourceTextClass(name: string): string {
+  return RESOURCE_TEXT_CLASS[name.toLowerCase()] ?? ''
+}
+
+export function resourceHex(name: string): string {
+  return RESOURCE_HEX[name.toLowerCase()] ?? 'currentColor'
+}

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -199,22 +199,26 @@ function EconomyStat({
 	value,
 	detail,
 	action,
+	iconClassName,
+	valueClassName,
 }: {
 	icon: ReactNode
 	label: string
 	value: ReactNode
 	detail?: ReactNode
 	action?: { label: string; onClick: () => void; disabled?: boolean }
+	iconClassName?: string
+	valueClassName?: string
 }) {
 	return (
 		<Card className="py-3 gap-2">
 			<CardContent className="px-4 flex items-center gap-3">
-				<div className="shrink-0 rounded-md bg-primary/10 p-2 text-primary">
+				<div className={`shrink-0 rounded-md p-2 ${iconClassName ?? 'bg-primary/10 text-primary'}`}>
 					{icon}
 				</div>
 				<div className="min-w-0 flex-1">
 					<div className="label">{label}</div>
-					<div className="mono text-xl font-semibold leading-tight truncate">{value}</div>
+					<div className={`mono text-xl font-semibold leading-tight truncate ${valueClassName ?? ''}`}>{value}</div>
 					{detail && <div className="text-xs text-muted-foreground mt-0.5">{detail}</div>}
 				</div>
 				{action && (
@@ -398,7 +402,11 @@ export function Base({ gameId }: BaseProps) {
 					detail={
 						totalWorkers === 0
 							? 'Train WBFs / drones / probes to gather resources.'
-							: `Auto-assigned · ${100 - gasPercent}% minerals / ${gasPercent}% gas`
+							: (
+								<>
+									Auto-assigned · <span className="text-blue-400">{100 - gasPercent}% minerals</span> / <span className="text-green-400">{gasPercent}% gas</span>
+								</>
+							)
 					}
 					action={{ label: 'Adjust', onClick: () => setWorkersOpen(true), disabled: isFinished }}
 				/>
@@ -406,9 +414,15 @@ export function Base({ gameId }: BaseProps) {
 					icon={<MountainIcon className="h-5 w-5" />}
 					label="Land"
 					value={formatNumber(land)}
+					iconClassName="bg-[#b8804a]/15 text-[#b8804a]"
+					valueClassName="text-[#b8804a]"
 					detail={
 						resources
-							? `${formatNumber(resources.colonizationCostPerLand)} minerals per new tile`
+							? (
+								<>
+									<span className="text-blue-400">{formatNumber(resources.colonizationCostPerLand)} minerals</span> per new tile
+								</>
+							)
 							: undefined
 					}
 					action={{ label: 'Colonize', onClick: () => setColonizeOpen(true), disabled: isFinished }}

--- a/src/ReactClient/src/pages/GameBriefing.tsx
+++ b/src/ReactClient/src/pages/GameBriefing.tsx
@@ -186,8 +186,17 @@ export function GameBriefing() {
         <>
           <SectionHeader label="Rules" />
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-5">
-            <Stat label="Starting resources" value={`${lobby.settings.startingMinerals.toLocaleString()}m / ${lobby.settings.startingGas.toLocaleString()}g`} />
-            <Stat label="Starting land" value={lobby.settings.startingLand} />
+            <Stat
+              label="Starting resources"
+              value={
+                <>
+                  <span className="text-blue-400">{lobby.settings.startingMinerals.toLocaleString()}m</span>
+                  {' / '}
+                  <span className="text-green-400">{lobby.settings.startingGas.toLocaleString()}g</span>
+                </>
+              }
+            />
+            <Stat label="Starting land" value={<span className="text-[#b8804a]">{lobby.settings.startingLand}</span>} />
             <Stat label="End tick" value={lobby.settings.endTick.toLocaleString()} />
             <Stat label="Protection" value={`${lobby.settings.protectionTicks} ticks`} />
           </div>

--- a/src/ReactClient/src/pages/GameResults.tsx
+++ b/src/ReactClient/src/pages/GameResults.tsx
@@ -5,6 +5,7 @@ import type { GameResultsViewModel } from '@/api/types'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { formatDuration } from '@/lib/formatters'
+import { ResourceIcon } from '@/components/ui/resource-icon'
 
 export function GameResults() {
   const { gameId } = useParams<{ gameId: string }>()
@@ -57,14 +58,18 @@ export function GameResults() {
               <div className="rounded-lg border border-border text-center p-4 w-36">
                 <div className="text-2xl">🥈</div>
                 <div className="font-bold text-sm">{second.playerName}</div>
-                <div className="text-muted-foreground text-xs">{second.land.toLocaleString()}</div>
+                <div className="text-xs text-[#b8804a] inline-flex items-center justify-center gap-1">
+                  <ResourceIcon name="land" /> {second.land.toLocaleString()}
+                </div>
               </div>
             )}
             {first && (
               <div className="rounded-lg border border-warning/50 text-center p-4 w-40">
                 <div className="text-3xl">🏆</div>
                 <div className="font-bold">{first.playerName}</div>
-                <div className="text-muted-foreground text-sm">{first.land.toLocaleString()}</div>
+                <div className="text-sm text-[#b8804a] inline-flex items-center justify-center gap-1">
+                  <ResourceIcon name="land" /> {first.land.toLocaleString()}
+                </div>
                 <span className="text-xs px-2 py-0.5 rounded bg-warning text-warning-foreground mt-1 inline-block">Winner</span>
               </div>
             )}
@@ -72,7 +77,9 @@ export function GameResults() {
               <div className="rounded-lg border border-border text-center p-4 w-36">
                 <div className="text-2xl">🥉</div>
                 <div className="font-bold text-sm">{third.playerName}</div>
-                <div className="text-muted-foreground text-xs">{third.land.toLocaleString()}</div>
+                <div className="text-xs text-[#b8804a] inline-flex items-center justify-center gap-1">
+                  <ResourceIcon name="land" /> {third.land.toLocaleString()}
+                </div>
               </div>
             )}
           </div>
@@ -83,7 +90,11 @@ export function GameResults() {
               <tr className="border-b border-border text-left text-muted-foreground">
                 <th scope="col" className="py-2 pr-4">Rank</th>
                 <th scope="col" className="py-2 pr-4">Player</th>
-                <th scope="col" className="py-2">Land</th>
+                <th scope="col" className="py-2">
+                  <span className="inline-flex items-center gap-1 text-[#b8804a]">
+                    <ResourceIcon name="land" /> Land
+                  </span>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -108,7 +119,7 @@ export function GameResults() {
                         <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-warning text-warning-foreground">Winner</span>
                       )}
                     </td>
-                    <td className="py-2">{entry.land.toLocaleString()}</td>
+                    <td className="py-2 text-[#b8804a]">{entry.land.toLocaleString()}</td>
                   </tr>
                 )
               })}

--- a/src/ReactClient/src/pages/InGamePlayerProfile.tsx
+++ b/src/ReactClient/src/pages/InGamePlayerProfile.tsx
@@ -8,6 +8,7 @@ import type { InGamePlayerProfileViewModel } from '@/api/types'
 import { relativeTime } from '@/lib/utils'
 import { ApiError } from '@/components/ApiError'
 import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
+import { ResourceIcon } from '@/components/ui/resource-icon'
 
 interface InGamePlayerProfileProps {
   gameId: string
@@ -164,8 +165,10 @@ export function InGamePlayerProfile({ gameId }: InGamePlayerProfileProps) {
         {/* Stats grid */}
         <div className="grid grid-cols-2 gap-3">
           <div className="rounded border bg-secondary/20 p-3">
-            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Land</div>
-            <div className="text-2xl font-bold">{Math.floor(player.land).toLocaleString()}</div>
+            <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 inline-flex items-center gap-1">
+              <ResourceIcon name="land" /> Land
+            </div>
+            <div className="text-2xl font-bold text-[#b8804a]">{Math.floor(player.land).toLocaleString()}</div>
           </div>
           <div className="rounded border bg-secondary/20 p-3">
             <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Rank</div>

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -8,6 +8,7 @@ import { ApiError } from '@/components/ApiError'
 import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { relativeTime } from '@/lib/utils'
 import { useConfirm } from '@/contexts/ConfirmContext'
+import { ResourceIcon } from '@/components/ui/resource-icon'
 
 function ApiKeySection() {
   const queryClient = useQueryClient()
@@ -235,16 +236,22 @@ export function PlayerProfile() {
 
             <div className="grid grid-cols-3 gap-3">
               <div className="rounded border bg-secondary/20 p-3">
-                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Land</div>
-                <div className="text-lg font-semibold">{Math.floor(profile.land).toLocaleString()}</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 inline-flex items-center gap-1">
+                  <ResourceIcon name="land" /> Land
+                </div>
+                <div className="text-lg font-semibold text-[#b8804a]">{Math.floor(profile.land).toLocaleString()}</div>
               </div>
               <div className="rounded border bg-secondary/20 p-3">
-                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Minerals</div>
-                <div className="text-lg font-semibold">{Math.floor(profile.minerals).toLocaleString()}</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 inline-flex items-center gap-1">
+                  <ResourceIcon name="minerals" /> Minerals
+                </div>
+                <div className="text-lg font-semibold text-blue-400">{Math.floor(profile.minerals).toLocaleString()}</div>
               </div>
               <div className="rounded border bg-secondary/20 p-3">
-                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Gas</div>
-                <div className="text-lg font-semibold">{Math.floor(profile.gas).toLocaleString()}</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1 inline-flex items-center gap-1">
+                  <ResourceIcon name="gas" /> Gas
+                </div>
+                <div className="text-lg font-semibold text-green-400">{Math.floor(profile.gas).toLocaleString()}</div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Resource displays are now consistently color-coded across the app: **Minerals = blue**, **Gas = green**, **Land = brown**.
- Centralized the palette in `src/ReactClient/src/lib/resource-colors.ts` so every component pulls from the same source.
- `ResourceIcon` applies the resource-specific tint by default; callers can override via `className`.

## What changed
- **PlayerResources** header tints icon, label, and number per resource (with matching glow).
- **Base** economy strip: Land card gets a brown icon background and value; worker mineral/gas split detail is colored.
- **PlayerProfile** / **InGamePlayerProfile**: tinted values with resource icons.
- **GameResults**: Land header, podium entries, and standings rows tinted.
- **GameBriefing**: starting Minerals/Gas/Land stats tinted.
- **ResourceHistoryChart**: stroke colors now come from the shared palette so the chart matches the rest of the UI.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npm test -- --run` (29 tests passing)
- [ ] Visual check: PlayerResources, Base economy strip, profile pages, game results podium/table, briefing stats


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx3ntfeW2j2Ude6aiGL8FC)_