### PR TITLE
feat(api-keys): multiple bot API keys per player with individual revocation

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerManagementController.cs
@@ -16,6 +16,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 	[Authorize]
 	[Route("api/player-management")]
 	public class PlayerManagementController : ControllerBase {
+		private const string ApiKeyPrefix = "bge_k_";
+		// Number of characters of the raw key (excluding prefix) to retain for display/identification.
+		private const int KeyPrefixDisplayChars = 8;
+
 		private readonly ILogger<PlayerManagementController> logger;
 		private readonly CurrentUserContext currentUserContext;
 		private readonly UserRepository userRepository;
@@ -52,7 +56,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				Players = players.Select(p => new PlayerSummaryViewModel {
 					PlayerId = p.PlayerId.Id,
 					PlayerName = p.Name,
-					HasApiKey = p.ApiKeyHash != null
+					ApiKeyCount = p.ApiKeys?.Count ?? 0
 				}).ToList()
 			};
 		}
@@ -76,7 +80,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new PlayerSummaryViewModel {
 				PlayerId = playerId.Id,
 				PlayerName = model.PlayerName,
-				HasApiKey = false
+				ApiKeyCount = 0
 			};
 		}
 
@@ -97,42 +101,81 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return NoContent();
 		}
 
-		/// <summary>Generates a new bot API key for a player. Replaces any existing key.</summary>
+		/// <summary>Lists all bot API keys for a player. Hashes are never returned.</summary>
 		/// <param name="playerId">The player identifier.</param>
-		/// <returns>The raw API key (shown once — store it securely).</returns>
-		[HttpPost("{playerId}/apikey")]
-		[ProducesResponseType(typeof(ApiKeyViewModel), StatusCodes.Status200OK)]
+		[HttpGet("{playerId}/apikeys")]
+		[ProducesResponseType(typeof(ApiKeyListViewModel), StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status403Forbidden)]
-		public ActionResult<ApiKeyViewModel> GenerateApiKey(string playerId) {
+		public ActionResult<ApiKeyListViewModel> ListApiKeys(string playerId) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var pid = PlayerIdFactory.Create(playerId);
 			var player = playerRepository.Get(pid);
 			if (player.UserId != currentUserContext.UserId) return Forbid();
 
-			var rawKey = "bge_k_" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
-				.Replace("+", "-").Replace("/", "_").TrimEnd('=');
-			var hash = BearerTokenMiddleware.HashApiKey(rawKey);
-			userRepositoryWrite.SetApiKeyHash(pid, hash);
+			var keys = userRepository.GetApiKeys(pid)
+				.OrderByDescending(k => k.CreatedAt)
+				.Select(k => new ApiKeyInfoViewModel {
+					KeyId = k.KeyId,
+					Name = k.Name,
+					KeyPrefix = k.KeyPrefix,
+					CreatedAt = k.CreatedAt,
+					LastAccessedAt = k.LastAccessedAt
+				}).ToList();
 
-			return new ApiKeyViewModel { ApiKey = rawKey };
+			return new ApiKeyListViewModel { Keys = keys };
 		}
 
-		/// <summary>Revokes the bot API key for a player.</summary>
+		/// <summary>Creates a new bot API key for a player. The raw key is returned once and never shown again.</summary>
 		/// <param name="playerId">The player identifier.</param>
-		[HttpDelete("{playerId}/apikey")]
+		/// <param name="request">Optional metadata (e.g. a friendly name).</param>
+		[HttpPost("{playerId}/apikeys")]
+		[ProducesResponseType(typeof(CreateApiKeyResponse), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		public ActionResult<CreateApiKeyResponse> CreateApiKey(string playerId, [FromBody] CreateApiKeyRequest? request) {
+			if (currentUserContext.UserId == null) return Unauthorized();
+			var pid = PlayerIdFactory.Create(playerId);
+			var player = playerRepository.Get(pid);
+			if (player.UserId != currentUserContext.UserId) return Forbid();
+
+			var name = request?.Name;
+			if (name != null && name.Length > 50) return BadRequest("Name must be 50 characters or fewer.");
+
+			var randomPart = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+				.Replace("+", "-").Replace("/", "_").TrimEnd('=');
+			var rawKey = ApiKeyPrefix + randomPart;
+			var hash = BearerTokenMiddleware.HashApiKey(rawKey);
+			var displayPrefix = ApiKeyPrefix + randomPart.Substring(0, Math.Min(KeyPrefixDisplayChars, randomPart.Length));
+
+			var record = userRepositoryWrite.AddApiKey(pid, hash, displayPrefix, name);
+
+			return new CreateApiKeyResponse {
+				KeyId = record.KeyId,
+				ApiKey = rawKey,
+				Name = record.Name,
+				KeyPrefix = record.KeyPrefix,
+				CreatedAt = record.CreatedAt
+			};
+		}
+
+		/// <summary>Revokes a single bot API key for a player.</summary>
+		/// <param name="playerId">The player identifier.</param>
+		/// <param name="keyId">The key identifier.</param>
+		[HttpDelete("{playerId}/apikeys/{keyId}")]
 		[ProducesResponseType(StatusCodes.Status204NoContent)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status403Forbidden)]
-		public ActionResult RevokeApiKey(string playerId) {
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public ActionResult RevokeApiKey(string playerId, string keyId) {
 			if (currentUserContext.UserId == null) return Unauthorized();
 			var pid = PlayerIdFactory.Create(playerId);
 			var player = playerRepository.Get(pid);
 			if (player.UserId != currentUserContext.UserId) return Forbid();
 
-			userRepositoryWrite.SetApiKeyHash(pid, null);
+			var removed = userRepositoryWrite.RemoveApiKey(pid, keyId);
+			if (!removed) return NotFound();
 			return NoContent();
 		}
-
 	}
 }

--- a/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/PlayerRankingController.cs
@@ -87,7 +87,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				AllianceRole = allianceRole,
 				IsOnline = onlineStatusRepository.IsOnline(pid),
 				LastOnline = player.LastOnline,
-				IsAgent = player.ApiKeyHash != null,
+				IsAgent = player.ApiKeys != null && player.ApiKeys.Count > 0,
 				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining,
 				UserId = player.UserId,
 			};

--- a/src/BrowserGameEngine.FrontendServer/Controllers/SpectatorController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/SpectatorController.cs
@@ -70,7 +70,7 @@ public class SpectatorController : ControllerBase
 				PlayerName: x.Player.Name,
 				Land: x.Land,
 				IsOnline: _onlineStatusRepository.IsOnline(x.Player.PlayerId),
-				IsAgent: x.Player.ApiKeyHash != null
+				IsAgent: x.Player.ApiKeys.Count > 0
 			))
 			.ToList();
 

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ViewModelExtensions.cs
@@ -19,7 +19,7 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 				Land = resourceRepository.GetLand(player.PlayerId),
 				ProtectionTicksRemaining = player.State.ProtectionTicksRemaining,
 				UserDisplayName = player.UserId != null ? userRepository.GetDisplayNameByUserId(player.UserId) : null,
-				IsAgent = player.ApiKeyHash != null,
+				IsAgent = player.ApiKeys != null && player.ApiKeys.Count > 0,
 				LastOnline = player.LastOnline,
 				IsOnline = onlineStatusRepository.IsOnline(player.PlayerId)
 			};

--- a/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/BearerTokenMiddleware.cs
@@ -20,7 +20,7 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 			_next = next;
 		}
 
-		public async Task InvokeAsync(HttpContext context, UserRepository userRepository) {
+		public async Task InvokeAsync(HttpContext context, UserRepository userRepository, UserRepositoryWrite userRepositoryWrite) {
 			var authHeader = context.Request.Headers[HeaderNames.Authorization].FirstOrDefault();
 			if (authHeader != null && authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) {
 				var token = authHeader["Bearer ".Length..].Trim();
@@ -29,6 +29,7 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 					context.Items["ApiKeyHash"] = hash;
 					var player = userRepository.GetPlayerByApiKeyHash(hash);
 					if (player != null) {
+						userRepositoryWrite.TouchApiKey(hash);
 						context.Items["BearerPlayerId"] = player.PlayerId.Id;
 						var claims = new[] {
 							new Claim(ClaimTypes.NameIdentifier, player.PlayerId.Id),

--- a/src/BrowserGameEngine.GameModel/ApiKeyRecordImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/ApiKeyRecordImmutable.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BrowserGameEngine.GameModel {
+	public record ApiKeyRecordImmutable(
+		string KeyId,
+		string KeyHash,
+		string KeyPrefix,
+		DateTime CreatedAt,
+		string? Name = null,
+		DateTime? LastAccessedAt = null
+	);
+}

--- a/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
+++ b/src/BrowserGameEngine.GameModel/PlayerImmutable.cs
@@ -1,4 +1,4 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -11,7 +11,7 @@ namespace BrowserGameEngine.GameModel {
 		DateTime Created,
 		PlayerStateImmutable State,
 		string? UserId = null,
-		string? ApiKeyHash = null,
+		IReadOnlyList<ApiKeyRecordImmutable>? ApiKeys = null,
 		DateTime? LastOnline = null,
 		AllianceId? AllianceId = null,
 		bool IsBanned = false

--- a/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
+++ b/src/BrowserGameEngine.Shared/PlayerManagementViewModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace BrowserGameEngine.Shared {
@@ -8,14 +9,35 @@ namespace BrowserGameEngine.Shared {
 	public class PlayerSummaryViewModel {
 		public string PlayerId { get; set; } = "";
 		public string PlayerName { get; set; } = "";
-		public bool HasApiKey { get; set; }
+		public int ApiKeyCount { get; set; }
 	}
 
 	public class CreatePlayerForUserViewModel {
 		public string PlayerName { get; set; } = "";
 	}
 
-	public class ApiKeyViewModel {
+	public class ApiKeyInfoViewModel {
+		public string KeyId { get; set; } = "";
+		public string? Name { get; set; }
+		public string KeyPrefix { get; set; } = "";
+		public DateTime CreatedAt { get; set; }
+		public DateTime? LastAccessedAt { get; set; }
+	}
+
+	public class ApiKeyListViewModel {
+		public List<ApiKeyInfoViewModel> Keys { get; set; } = new();
+	}
+
+	public class CreateApiKeyRequest {
+		public string? Name { get; set; }
+	}
+
+	public class CreateApiKeyResponse {
+		public string KeyId { get; set; } = "";
+		/// <summary>The raw API key. Only returned on creation; never shown again.</summary>
 		public string ApiKey { get; set; } = "";
+		public string? Name { get; set; }
+		public string KeyPrefix { get; set; } = "";
+		public DateTime CreatedAt { get; set; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/Integration/PlayerManagementControllerIntegrationTest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using BrowserGameEngine.Shared;
 using Xunit;
@@ -36,49 +37,107 @@ namespace BrowserGameEngine.StatefulGameServer.Test.Integration {
 			Assert.NotNull(vm);
 			Assert.Single(vm!.Players);
 			Assert.Equal("PMTestPlayer1", vm.Players[0].PlayerName);
+			Assert.Equal(0, vm.Players[0].ApiKeyCount);
 		}
 
 		[Fact]
-		public async Task GenerateApiKey_Unauthenticated_Returns401() {
+		public async Task CreateApiKey_Unauthenticated_Returns401() {
 			var client = CreateClient();
-			var response = await client.PostAsync("/api/player-management/some-player-id/apikey", null);
+			var response = await client.PostAsync("/api/player-management/some-player-id/apikeys", null);
 			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 		}
 
 		[Fact]
-		public async Task GenerateApiKey_ForOwnPlayer_ReturnsToken() {
+		public async Task CreateApiKey_ForOwnPlayer_ReturnsTokenAndMetadata() {
 			var userId = "user-pm-apikey-1";
 			var playerId = await CreatePlayerAsync(userId, "APIKeyPlayer1");
 
 			var client = CreateClient(userId);
-			var response = await client.PostAsync($"/api/player-management/{playerId}/apikey", null);
+			var response = await client.PostAsJsonAsync(
+				$"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "my-bot" });
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-			var vm = await DeserializeAsync<ApiKeyViewModel>(response);
+			var vm = await DeserializeAsync<CreateApiKeyResponse>(response);
 			Assert.NotNull(vm);
 			Assert.False(string.IsNullOrEmpty(vm!.ApiKey));
+			Assert.False(string.IsNullOrEmpty(vm.KeyId));
+			Assert.Equal("my-bot", vm.Name);
+			Assert.StartsWith("bge_k_", vm.KeyPrefix);
 		}
 
 		[Fact]
-		public async Task GenerateApiKey_ThenUseAsBearer_Authenticates() {
+		public async Task ListApiKeys_AfterCreate_IncludesKey() {
+			var userId = "user-pm-apikey-list-1";
+			var playerId = await CreatePlayerAsync(userId, "ListKeyPlayer1");
+
+			var client = CreateClient(userId);
+			await client.PostAsJsonAsync($"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "first" });
+			await client.PostAsJsonAsync($"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "second" });
+
+			var listResp = await client.GetAsync($"/api/player-management/{playerId}/apikeys");
+			Assert.Equal(HttpStatusCode.OK, listResp.StatusCode);
+			var list = await DeserializeAsync<ApiKeyListViewModel>(listResp);
+			Assert.NotNull(list);
+			Assert.Equal(2, list!.Keys.Count);
+			Assert.Contains(list.Keys, k => k.Name == "first");
+			Assert.Contains(list.Keys, k => k.Name == "second");
+		}
+
+		[Fact]
+		public async Task RevokeApiKey_RemovesOnlyTargetedKey() {
+			var userId = "user-pm-revoke-1";
+			var playerId = await CreatePlayerAsync(userId, "RevokeKeyPlayer1");
+
+			var client = CreateClient(userId);
+			var first = await (await client.PostAsJsonAsync($"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "keep" })).Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+			var second = await (await client.PostAsJsonAsync($"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "revoke-me" })).Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+
+			var revokeResp = await client.DeleteAsync($"/api/player-management/{playerId}/apikeys/{second!.KeyId}");
+			Assert.Equal(HttpStatusCode.NoContent, revokeResp.StatusCode);
+
+			var list = await DeserializeAsync<ApiKeyListViewModel>(
+				await client.GetAsync($"/api/player-management/{playerId}/apikeys"));
+			Assert.Single(list!.Keys);
+			Assert.Equal(first!.KeyId, list.Keys[0].KeyId);
+		}
+
+		[Fact]
+		public async Task RevokeApiKey_UnknownKey_Returns404() {
+			var userId = "user-pm-revoke-404";
+			var playerId = await CreatePlayerAsync(userId, "Revoke404");
+
+			var client = CreateClient(userId);
+			var response = await client.DeleteAsync($"/api/player-management/{playerId}/apikeys/nonexistent-key-id");
+			Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		}
+
+		[Fact]
+		public async Task CreateApiKey_ThenUseAsBearer_AuthenticatesAndUpdatesLastAccessed() {
 			var userId = "user-pm-apikey-bearer-1";
 			var playerId = await CreatePlayerAsync(userId, "BearerPlayer1");
 
-			// Generate the API key via cookie-authenticated client
 			var authClient = CreateClient(userId);
-			var genResponse = await authClient.PostAsync($"/api/player-management/{playerId}/apikey", null);
+			var genResponse = await authClient.PostAsJsonAsync(
+				$"/api/player-management/{playerId}/apikeys",
+				new CreateApiKeyRequest { Name = "bot" });
 			Assert.Equal(HttpStatusCode.OK, genResponse.StatusCode);
-			var vm = await DeserializeAsync<ApiKeyViewModel>(genResponse);
+			var vm = await DeserializeAsync<CreateApiKeyResponse>(genResponse);
 			Assert.NotNull(vm);
-			Assert.False(string.IsNullOrEmpty(vm!.ApiKey));
 
-			// Use the API key as a Bearer token on an unauthenticated client
-			var bearerClient = CreateClient(); // no cookie auth
+			var bearerClient = CreateClient();
 			bearerClient.DefaultRequestHeaders.Authorization =
-				new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", vm.ApiKey);
+				new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", vm!.ApiKey);
 
-			// Hit a protected endpoint — should succeed, not 401
 			var response = await bearerClient.GetAsync("/api/profile");
 			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+			var listAfter = await DeserializeAsync<ApiKeyListViewModel>(
+				await authClient.GetAsync($"/api/player-management/{playerId}/apikeys"));
+			Assert.NotNull(listAfter!.Keys[0].LastAccessedAt);
 		}
 
 		[Fact]

--- a/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/UserRepositoryTest.cs
@@ -70,7 +70,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
-		public void SetApiKeyHash_AndLookup_FindsPlayer() {
+		public void AddApiKey_AndLookup_FindsPlayer() {
 			var game = new TestGame();
 			var userRepo = new UserRepository(game.GlobalState, game.World);
 			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
@@ -80,11 +80,51 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
 
 			const string testHash = "abc123hash";
-			userRepoWrite.SetApiKeyHash(playerId, testHash);
+			var added = userRepoWrite.AddApiKey(playerId, testHash, "bge_k_abc12345", "primary");
+
+			Assert.NotNull(added);
+			Assert.Equal("primary", added.Name);
+			Assert.Equal("bge_k_abc12345", added.KeyPrefix);
 
 			var found = userRepo.GetPlayerByApiKeyHash(testHash);
 			Assert.NotNull(found);
 			Assert.Equal(playerId, found!.PlayerId);
+			Assert.Single(found.ApiKeys!);
+		}
+
+		[Fact]
+		public void AddApiKey_MultipleKeys_AllResolveToSamePlayer() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("ghmultikey", "multi", "Multi");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			userRepoWrite.AddApiKey(playerId, "hash-a", "bge_k_aaaa", "key-a");
+			userRepoWrite.AddApiKey(playerId, "hash-b", "bge_k_bbbb", "key-b");
+
+			Assert.Equal(playerId, userRepo.GetPlayerByApiKeyHash("hash-a")!.PlayerId);
+			Assert.Equal(playerId, userRepo.GetPlayerByApiKeyHash("hash-b")!.PlayerId);
+			Assert.Equal(2, userRepo.GetApiKeys(playerId).Count());
+		}
+
+		[Fact]
+		public void TouchApiKey_UpdatesLastAccessedAt() {
+			var game = new TestGame();
+			var userRepo = new UserRepository(game.GlobalState, game.World);
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("ghtouch", "touchuser", "Touch User");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			userRepoWrite.AddApiKey(playerId, "touch-hash", "bge_k_touch123", null);
+			Assert.Null(userRepo.GetApiKeys(playerId).Single().LastAccessedAt);
+
+			userRepoWrite.TouchApiKey("touch-hash");
+			Assert.NotNull(userRepo.GetApiKeys(playerId).Single().LastAccessedAt);
 		}
 
 		[Fact]
@@ -132,7 +172,7 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 		}
 
 		[Fact]
-		public void RevokeApiKey_ClearsHash() {
+		public void RemoveApiKey_RemovesOnlyTheTargetedKey() {
 			var game = new TestGame();
 			var userRepo = new UserRepository(game.GlobalState, game.World);
 			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
@@ -141,11 +181,28 @@ namespace BrowserGameEngine.StatefulGameServer.Test {
 			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
 			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
 
-			userRepoWrite.SetApiKeyHash(playerId, "somehash");
-			userRepoWrite.SetApiKeyHash(playerId, null);
+			var key1 = userRepoWrite.AddApiKey(playerId, "hash-1", "bge_k_1111", "k1");
+			var key2 = userRepoWrite.AddApiKey(playerId, "hash-2", "bge_k_2222", "k2");
 
-			var found = userRepo.GetPlayerByApiKeyHash("somehash");
-			Assert.Null(found);
+			var removed = userRepoWrite.RemoveApiKey(playerId, key1.KeyId);
+
+			Assert.True(removed);
+			Assert.Null(userRepo.GetPlayerByApiKeyHash("hash-1"));
+			Assert.NotNull(userRepo.GetPlayerByApiKeyHash("hash-2"));
+			Assert.Single(userRepo.GetApiKeys(playerId));
+		}
+
+		[Fact]
+		public void RemoveApiKey_UnknownKey_ReturnsFalse() {
+			var game = new TestGame();
+			var userRepoWrite = new UserRepositoryWrite(game.GlobalState, game.World, TimeProvider.System);
+
+			var user = userRepoWrite.CreateUser("ghrevoke2", "revokeuser2", "Revoke2");
+			var playerId = PlayerIdFactory.Create(Guid.NewGuid().ToString());
+			game.PlayerRepositoryWrite.CreatePlayer(playerId, user.UserId);
+
+			var removed = userRepoWrite.RemoveApiKey(playerId, "nonexistent");
+			Assert.False(removed);
 		}
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/ApiKeyRecord.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/ApiKeyRecord.cs
@@ -1,0 +1,37 @@
+using BrowserGameEngine.GameModel;
+using System;
+
+namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
+	internal class ApiKeyRecord {
+		public required string KeyId { get; init; }
+		public required string KeyHash { get; init; }
+		public required string KeyPrefix { get; init; }
+		public required DateTime CreatedAt { get; init; }
+		public string? Name { get; set; }
+		public DateTime? LastAccessedAt { get; set; }
+	}
+
+	internal static class ApiKeyRecordExtensions {
+		internal static ApiKeyRecordImmutable ToImmutable(this ApiKeyRecord r) {
+			return new ApiKeyRecordImmutable(
+				KeyId: r.KeyId,
+				KeyHash: r.KeyHash,
+				KeyPrefix: r.KeyPrefix,
+				CreatedAt: r.CreatedAt,
+				Name: r.Name,
+				LastAccessedAt: r.LastAccessedAt
+			);
+		}
+
+		internal static ApiKeyRecord ToMutable(this ApiKeyRecordImmutable r) {
+			return new ApiKeyRecord {
+				KeyId = r.KeyId,
+				KeyHash = r.KeyHash,
+				KeyPrefix = r.KeyPrefix,
+				CreatedAt = r.CreatedAt,
+				Name = r.Name,
+				LastAccessedAt = r.LastAccessedAt
+			};
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/Player.cs
@@ -1,7 +1,8 @@
-﻿using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
@@ -12,7 +13,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 		public DateTime Created { get; init; }
 		public required PlayerState State { get; init; }
 		public string? UserId { get; set; }
-		public string? ApiKeyHash { get; set; }
+		public List<ApiKeyRecord> ApiKeys { get; set; } = new();
 		public DateTime? LastOnline { get; set; }
 		public AllianceId? AllianceId { get; set; }
 		public bool IsBanned { get; set; }
@@ -27,7 +28,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created: player.Created,
 				State: player.State.ToImmutable(),
 				UserId: player.UserId,
-				ApiKeyHash: player.ApiKeyHash,
+				ApiKeys: player.ApiKeys.Select(k => k.ToImmutable()).ToList(),
 				LastOnline: player.LastOnline,
 				AllianceId: player.AllianceId,
 				IsBanned: player.IsBanned
@@ -42,7 +43,7 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 				Created = playerImmutable.Created,
 				State = playerImmutable.State.ToMutable(),
 				UserId = playerImmutable.UserId,
-				ApiKeyHash = playerImmutable.ApiKeyHash,
+				ApiKeys = playerImmutable.ApiKeys?.Select(k => k.ToMutable()).ToList() ?? new(),
 				LastOnline = playerImmutable.LastOnline,
 				AllianceId = playerImmutable.AllianceId,
 				IsBanned = playerImmutable.IsBanned

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpectatorTickModule.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/SpectatorTickModule.cs
@@ -57,7 +57,7 @@ public class SpectatorTickModule : IGameTickModule
 				playerName = p.Name,
 				land = p.State.Resources.TryGetValue(landResource, out var s) ? s : 0m,
 				isOnline = p.LastOnline.HasValue && DateTime.UtcNow - p.LastOnline.Value < TimeSpan.FromMinutes(8),
-				isAgent = p.ApiKeyHash != null,
+				isAgent = p.ApiKeys.Count > 0,
 			})
 			.OrderByDescending(p => p.land)
 			.Take(20)

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/Player/PlayerRepositoryWrite.cs
@@ -143,7 +143,7 @@ namespace BrowserGameEngine.StatefulGameServer {
 			lock (_lock) {
 				if (!world.PlayerExists(playerId)) return;
 				var player = world.Players[playerId];
-				player.ApiKeyHash = null;
+				player.ApiKeys.Clear();
 				world.Players.Remove(playerId);
 			}
 		}

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepository.cs
@@ -32,8 +32,13 @@ namespace BrowserGameEngine.StatefulGameServer {
 		}
 
 		public PlayerImmutable? GetPlayerByApiKeyHash(string apiKeyHash) {
-			var player = world.Players.Values.FirstOrDefault(p => p.ApiKeyHash == apiKeyHash);
+			var player = world.Players.Values.FirstOrDefault(p => p.ApiKeys.Any(k => k.KeyHash == apiKeyHash));
 			return player?.ToImmutable();
+		}
+
+		public IEnumerable<ApiKeyRecordImmutable> GetApiKeys(PlayerId playerId) {
+			if (!world.Players.TryGetValue(playerId, out var player)) return Enumerable.Empty<ApiKeyRecordImmutable>();
+			return player.ApiKeys.Select(k => k.ToImmutable()).ToList();
 		}
 
 		public UserImmutable? GetByUserId(string userId) {

--- a/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/Repositories/User/UserRepositoryWrite.cs
@@ -2,6 +2,7 @@ using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace BrowserGameEngine.StatefulGameServer {
@@ -62,9 +63,49 @@ namespace BrowserGameEngine.StatefulGameServer {
 			}
 		}
 
-		public void SetApiKeyHash(PlayerId playerId, string? apiKeyHash) {
+		public ApiKeyRecordImmutable AddApiKey(PlayerId playerId, string keyHash, string keyPrefix, string? name) {
 			lock (_lock) {
-				world.Players[playerId].ApiKeyHash = apiKeyHash;
+				var record = new ApiKeyRecord {
+					KeyId = Guid.NewGuid().ToString(),
+					KeyHash = keyHash,
+					KeyPrefix = keyPrefix,
+					CreatedAt = timeProvider.GetLocalNow().DateTime,
+					Name = string.IsNullOrWhiteSpace(name) ? null : name.Trim()
+				};
+				world.Players[playerId].ApiKeys.Add(record);
+				return record.ToImmutable();
+			}
+		}
+
+		/// <summary>Returns true if a key was found and removed.</summary>
+		public bool RemoveApiKey(PlayerId playerId, string keyId) {
+			lock (_lock) {
+				if (!world.Players.TryGetValue(playerId, out var player)) return false;
+				var idx = player.ApiKeys.FindIndex(k => k.KeyId == keyId);
+				if (idx < 0) return false;
+				player.ApiKeys.RemoveAt(idx);
+				return true;
+			}
+		}
+
+		public void RemoveAllApiKeys(PlayerId playerId) {
+			lock (_lock) {
+				if (world.Players.TryGetValue(playerId, out var player)) {
+					player.ApiKeys.Clear();
+				}
+			}
+		}
+
+		/// <summary>Updates the LastAccessedAt timestamp for the key matching the given hash. Best-effort, no-op if not found.</summary>
+		public void TouchApiKey(string keyHash) {
+			lock (_lock) {
+				foreach (var player in world.Players.Values) {
+					var key = player.ApiKeys.FirstOrDefault(k => k.KeyHash == keyHash);
+					if (key != null) {
+						key.LastAccessedAt = timeProvider.GetLocalNow().DateTime;
+						return;
+					}
+				}
 			}
 		}
 	}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -782,15 +782,35 @@ export interface AllTimePlayerListViewModel {
 export interface PlayerSummaryViewModel {
   playerId: string
   playerName: string
-  hasApiKey: boolean
+  apiKeyCount: number
 }
 
 export interface PlayerListViewModel {
   players: PlayerSummaryViewModel[]
 }
 
-export interface ApiKeyViewModel {
+export interface ApiKeyInfoViewModel {
+  keyId: string
+  name: string | null
+  keyPrefix: string
+  createdAt: string
+  lastAccessedAt: string | null
+}
+
+export interface ApiKeyListViewModel {
+  keys: ApiKeyInfoViewModel[]
+}
+
+export interface CreateApiKeyRequest {
+  name?: string | null
+}
+
+export interface CreateApiKeyResponse {
+  keyId: string
   apiKey: string
+  name: string | null
+  keyPrefix: string
+  createdAt: string
 }
 
 // Create Player

--- a/src/ReactClient/src/pages/PlayerProfile.tsx
+++ b/src/ReactClient/src/pages/PlayerProfile.tsx
@@ -1,9 +1,15 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router'
-import { TrophyIcon, SwordsIcon, StarIcon, KeyIcon, CopyIcon, CheckIcon, Trash2Icon } from 'lucide-react'
+import { TrophyIcon, SwordsIcon, StarIcon, KeyIcon, CopyIcon, CheckIcon, Trash2Icon, PlusIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { ProfileViewModel, PlayerHistoryViewModel, PlayerListViewModel, ApiKeyViewModel } from '@/api/types'
+import type {
+  ProfileViewModel,
+  PlayerHistoryViewModel,
+  PlayerListViewModel,
+  ApiKeyListViewModel,
+  CreateApiKeyResponse,
+} from '@/api/types'
 import { ApiError } from '@/components/ApiError'
 import { SkeletonCard, SkeletonLine } from '@/components/Skeleton'
 import { relativeTime } from '@/lib/utils'
@@ -15,27 +21,44 @@ function ApiKeySection() {
   const confirm = useConfirm()
   const [newKey, setNewKey] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [newKeyName, setNewKeyName] = useState('')
 
-  const { data: playerList, isLoading } = useQuery({
+  const { data: playerList, isLoading: isPlayersLoading } = useQuery({
     queryKey: ['my-players'],
     queryFn: () => apiClient.get<PlayerListViewModel>('/api/player-management').then(r => r.data),
   })
 
-  const generateMutation = useMutation({
-    mutationFn: (playerId: string) =>
-      apiClient.post<ApiKeyViewModel>(`/api/player-management/${playerId}/apikey`).then(r => r.data),
+  const player = playerList?.players?.[0]
+  const playerId = player?.playerId
+
+  const { data: keysData, isLoading: isKeysLoading } = useQuery({
+    queryKey: ['api-keys', playerId],
+    queryFn: () =>
+      apiClient.get<ApiKeyListViewModel>(`/api/player-management/${playerId}/apikeys`).then(r => r.data),
+    enabled: !!playerId,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: ({ playerId, name }: { playerId: string; name: string }) =>
+      apiClient
+        .post<CreateApiKeyResponse>(`/api/player-management/${playerId}/apikeys`, {
+          name: name.trim() || null,
+        })
+        .then(r => r.data),
     onSuccess: (data) => {
       setNewKey(data.apiKey)
+      setNewKeyName('')
       void queryClient.invalidateQueries({ queryKey: ['my-players'] })
+      void queryClient.invalidateQueries({ queryKey: ['api-keys', playerId] })
     },
   })
 
   const revokeMutation = useMutation({
-    mutationFn: (playerId: string) =>
-      apiClient.delete(`/api/player-management/${playerId}/apikey`),
+    mutationFn: ({ playerId, keyId }: { playerId: string; keyId: string }) =>
+      apiClient.delete(`/api/player-management/${playerId}/apikeys/${keyId}`),
     onSuccess: () => {
-      setNewKey(null)
       void queryClient.invalidateQueries({ queryKey: ['my-players'] })
+      void queryClient.invalidateQueries({ queryKey: ['api-keys', playerId] })
     },
   })
 
@@ -46,19 +69,20 @@ function ApiKeySection() {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  if (isLoading) return null
+  if (isPlayersLoading) return null
+  if (!player || !playerId) return null
 
-  const player = playerList?.players?.[0]
-  if (!player) return null
+  const keys = keysData?.keys ?? []
 
   return (
     <div className="rounded-lg border bg-card p-5 space-y-3">
       <strong className="text-sm flex items-center gap-1.5">
         <KeyIcon className="h-4 w-4 text-primary" />
-        Bot API Key
+        Bot API Keys
       </strong>
       <p className="text-xs text-muted-foreground">
-        Use an API key to control your player programmatically via the REST API.
+        Use an API key to control your player programmatically via the REST API. You can have
+        multiple keys; revoke any one individually without affecting the others.
       </p>
 
       {newKey && (
@@ -82,46 +106,82 @@ function ApiKeySection() {
       )}
 
       <div className="flex items-center gap-2">
-        {player.hasApiKey ? (
-          <>
-            <span className="text-xs text-muted-foreground">Active key configured</span>
-            <button
-              onClick={() => generateMutation.mutate(player.playerId)}
-              disabled={generateMutation.isPending}
-              className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
-            >
-              {generateMutation.isPending ? 'Regenerating...' : 'Regenerate'}
-            </button>
-            <button
-              onClick={async () => {
-                const ok = await confirm({
-                  title: 'Revoke API key?',
-                  description: 'Any bot or integration using this key will immediately stop working. You can generate a new one afterwards.',
-                  destructive: true,
-                  confirmLabel: 'Revoke key',
-                  cancelLabel: 'Keep key',
-                })
-                if (ok) revokeMutation.mutate(player.playerId)
-              }}
-              disabled={revokeMutation.isPending}
-              className="rounded border border-destructive/50 px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50 flex items-center gap-1"
-            >
-              <Trash2Icon className="h-3 w-3" />
-              {revokeMutation.isPending ? 'Revoking...' : 'Revoke'}
-            </button>
-          </>
-        ) : (
-          <button
-            onClick={() => generateMutation.mutate(player.playerId)}
-            disabled={generateMutation.isPending}
-            className="rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50"
-          >
-            {generateMutation.isPending ? 'Generating...' : 'Generate API Key'}
-          </button>
-        )}
+        <input
+          type="text"
+          value={newKeyName}
+          onChange={(e) => setNewKeyName(e.target.value)}
+          placeholder="Key name (optional)"
+          maxLength={50}
+          className="flex-1 min-w-0 rounded border bg-background px-2 py-1.5 text-xs"
+          disabled={createMutation.isPending}
+        />
+        <button
+          onClick={() => createMutation.mutate({ playerId, name: newKeyName })}
+          disabled={createMutation.isPending}
+          className="shrink-0 rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:opacity-90 disabled:opacity-50 flex items-center gap-1"
+        >
+          <PlusIcon className="h-3 w-3" />
+          {createMutation.isPending ? 'Creating...' : 'Create key'}
+        </button>
       </div>
 
-      {(generateMutation.isError || revokeMutation.isError) && (
+      {isKeysLoading ? (
+        <div className="text-xs text-muted-foreground">Loading keys...</div>
+      ) : keys.length === 0 ? (
+        <div className="text-xs text-muted-foreground italic">No API keys yet.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs" aria-label="API keys">
+            <thead className="border-b">
+              <tr className="text-left text-muted-foreground">
+                <th scope="col" className="py-1.5 pr-2 font-medium">Name</th>
+                <th scope="col" className="py-1.5 px-2 font-medium">Identifier</th>
+                <th scope="col" className="py-1.5 px-2 font-medium">Created</th>
+                <th scope="col" className="py-1.5 px-2 font-medium">Last used</th>
+                <th scope="col" className="py-1.5 pl-2"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.keyId} className="border-b border-border last:border-0">
+                  <td className="py-2 pr-2">
+                    {k.name ?? <span className="text-muted-foreground italic">unnamed</span>}
+                  </td>
+                  <td className="py-2 px-2 font-mono text-muted-foreground">{k.keyPrefix}…</td>
+                  <td className="py-2 px-2 text-muted-foreground whitespace-nowrap">
+                    {relativeTime(k.createdAt)}
+                  </td>
+                  <td className="py-2 px-2 text-muted-foreground whitespace-nowrap">
+                    {k.lastAccessedAt ? relativeTime(k.lastAccessedAt) : <span className="italic">never</span>}
+                  </td>
+                  <td className="py-2 pl-2 text-right">
+                    <button
+                      onClick={async () => {
+                        const ok = await confirm({
+                          title: 'Revoke API key?',
+                          description: `Any bot or integration using "${k.name ?? k.keyPrefix}" will immediately stop working. Other keys remain active.`,
+                          destructive: true,
+                          confirmLabel: 'Revoke key',
+                          cancelLabel: 'Keep key',
+                        })
+                        if (ok) revokeMutation.mutate({ playerId, keyId: k.keyId })
+                      }}
+                      disabled={revokeMutation.isPending}
+                      className="rounded border border-destructive/50 px-2 py-1 text-destructive hover:bg-destructive/10 disabled:opacity-50 inline-flex items-center gap-1"
+                      aria-label={`Revoke key ${k.name ?? k.keyPrefix}`}
+                    >
+                      <Trash2Icon className="h-3 w-3" />
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {(createMutation.isError || revokeMutation.isError) && (
         <p className="text-xs text-destructive">Something went wrong. Please try again.</p>
       )}
     </div>


### PR DESCRIPTION
## Summary

Replaces the single per-player `ApiKeyHash` field with a list of named API keys. Previously, "Regenerate" silently overwrote the existing key, instantly invalidating any bot using it. Players can now manage multiple keys independently and see when each was last used.

- **Data model**: `Player.ApiKeyHash` (single string) → `Player.ApiKeys` (list of `ApiKeyRecord` with KeyId, KeyHash, KeyPrefix, Name, CreatedAt, LastAccessedAt)
- **API**:
  - `GET /api/player-management/{playerId}/apikeys` — list keys (no hashes returned)
  - `POST /api/player-management/{playerId}/apikeys` — create a new key with optional name
  - `DELETE /api/player-management/{playerId}/apikeys/{keyId}` — revoke a single key
- **Auth**: `BearerTokenMiddleware` now scans across all keys and updates `LastAccessedAt` on each successful authentication
- **UI**: `ApiKeySection` rewritten as a table (Name / Identifier / Created / Last used / Revoke) plus an inline name input and "Create key" button. Each revoke prompts to confirm and only affects that key.
- `PlayerSummaryViewModel.HasApiKey` replaced with `ApiKeyCount`.

## Test plan

- [ ] CI build & test pass (couldn't run `dotnet` locally — .NET 10 SDK unavailable in the sandbox)
- [ ] Profile page shows the new table; create a key, copy it, and verify the prefix matches
- [ ] Create a second key with a different name; both appear in the table
- [ ] Hit a protected endpoint with each key as `Authorization: Bearer …` and confirm `Last used` updates
- [ ] Revoke one key — only that key disappears, the other still authenticates
- [ ] Old persisted state with legacy `ApiKeyHash` still loads (existing keys won't migrate; users must recreate)

https://claude.ai/code/session_01Y2coeXqLMXEewDYLbRsuBY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2coeXqLMXEewDYLbRsuBY)_