### PR TITLE
feat(ui): surface Land → income relationship

### DIFF
--- a/docs/superpowers/specs/2026-04-26-land-income-visualization-design.md
+++ b/docs/superpowers/specs/2026-04-26-land-income-visualization-design.md
@@ -1,0 +1,117 @@
+# Land → Income Visualization
+
+**Date:** 2026-04-26
+**Status:** Approved
+
+## Problem
+
+Players see Land as just a number on the resource bar. Nothing in the UI explains
+that Land scales worker efficiency — so they undervalue colonization and don't
+know whether their worker assignment is well-matched to their territory.
+
+## Goals
+
+Surface the Land → income relationship in two places:
+
+1. **Always visible** — passive nudge on the Base page Land card.
+2. **Decision-time** — live income preview in the Worker Assignment dialog.
+
+Keep it simple: no formulas, no percentages on the Land card; ratios and
+sweet-spot targets only.
+
+Out of scope: changing balance, new tutorials, dedicated economy page.
+
+## Design
+
+### Backend (single source of truth)
+
+Constants currently live as private fields in
+`StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs`. Extract them into a
+public type so the API layer can read them without re-declaring values.
+
+**New type** — `BrowserGameEngine.Shared.EconomyFormulaViewModel`:
+
+```csharp
+public record EconomyFormulaViewModel {
+    public required decimal BaseIncomePerTick { get; init; }              // 10
+    public required decimal MaxIncomePerWorker { get; init; }             // 4
+    public required decimal MineralSweetSpotLandPerWorker { get; init; }  // 3
+    public required decimal GasSweetSpotLandPerWorker { get; init; }      // 6
+    public required decimal MinEfficiency { get; init; }                  // 0.002
+}
+```
+
+Sweet-spot values are derived from the existing efficiency factors:
+`sweetSpot = factor × efficiencyMax = factor × 100`.
+
+**Wiring** — extend `PlayerResourcesViewModel` with a `Formula` property and
+populate it in `ResourcesController.Get`. No new endpoint; the React client
+already polls `/api/resources` from both surfaces.
+
+### Frontend
+
+**Shared helper** — `src/ReactClient/src/lib/economy.ts`:
+
+```ts
+export interface EconomyFormula {
+  baseIncomePerTick: number
+  maxIncomePerWorker: number
+  mineralSweetSpotLandPerWorker: number
+  gasSweetSpotLandPerWorker: number
+  minEfficiency: number
+}
+
+export function workerIncome(workers: number, land: number,
+                             sweetSpot: number, formula: EconomyFormula): number
+export function landPerWorker(workers: number, land: number): number
+```
+
+The income formula mirrors `ResourceGrowthSco.CalculateWorkerIncome`:
+
+```
+if (workers === 0) return baseIncomePerTick
+ratio = land / (workers × sweetSpot)
+eff   = clamp(ratio, minEfficiency, 1)
+return baseIncomePerTick + workers × maxIncomePerWorker × eff
+```
+
+**Land card** (`Base.tsx`, `EconomyStat` for Land):
+- `detail` line: `1.5 / mineral worker · 3.0 / gas worker  ·  sweet 3 / 6`
+- Existing `colonizationCostPerLand` line moves to the Colonize button tooltip.
+
+**Worker Assignment dialog** (`WorkerAssignmentDialog.tsx`):
+- Add a preview block below the sliders:
+  ```
+  Income next tick · Land 30
+    Minerals   +50
+    Gas        +30
+  ```
+- Tip line appears only when **any pool with workers** has
+  `land / workers < sweetSpot / 2`. Muted color, not warning.
+- Special case: a pool with 0 workers shows just `+10` (the base) and never
+  triggers the tip.
+
+## Testing
+
+- **C#** — regression test in `StatefulGameServer.Test` that the
+  `EconomyFormulaViewModel` values surfaced via `/api/resources` match the
+  constants used by `ResourceGrowthSco`. Guards against drift if someone edits
+  one but not the other.
+- **TypeScript** — Vitest unit test for `workerIncome` and `landPerWorker`
+  against a small truth table matching the C# reference behavior (zero workers,
+  below sweet spot, at sweet spot, above sweet spot, floor case).
+- No Playwright changes; the additions are purely informational.
+
+## Files Touched
+
+- `src/BrowserGameEngine.Shared/EconomyFormulaViewModel.cs` (new)
+- `src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs` (add `Formula`)
+- `src/BrowserGameEngine.GameDefinition.SCO/EconomyFormulaConstants.cs` (new)
+- `src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs` (use the constants)
+- `src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs` (populate)
+- `src/BrowserGameEngine.StatefulGameServer.Test/EconomyFormulaTest.cs` (new)
+- `src/ReactClient/src/api/types.ts` (add types)
+- `src/ReactClient/src/lib/economy.ts` (new)
+- `src/ReactClient/src/lib/economy.test.ts` (new)
+- `src/ReactClient/src/pages/Base.tsx` (Land card detail)
+- `src/ReactClient/src/components/WorkerAssignmentDialog.tsx` (preview)

--- a/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/ResourceController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
 using BrowserGameEngine.FrontendServer;
 using BrowserGameEngine.StatefulGameServer.Commands;
 using BrowserGameEngine.GameModel;
@@ -45,7 +46,14 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 			return new PlayerResourcesViewModel {
 				PrimaryResource = CostViewModel.Create(resourceRepository.GetLandResource(playerId)),
 				SecondaryResources = CostViewModel.Create(resourceRepository.GetNonLandResources(playerId)),
-				ColonizationCostPerLand = ColonizeRepositoryWrite.GetCostPerLand(currentLand)
+				ColonizationCostPerLand = ColonizeRepositoryWrite.GetCostPerLand(currentLand),
+				Formula = new EconomyFormulaViewModel {
+					BaseIncomePerTick = ResourceGrowthScoFormula.BaseIncomePerTick,
+					MaxIncomePerWorker = ResourceGrowthScoFormula.MaxIncomePerWorker,
+					MineralSweetSpotLandPerWorker = ResourceGrowthScoFormula.MineralSweetSpotLandPerWorker,
+					GasSweetSpotLandPerWorker = ResourceGrowthScoFormula.GasSweetSpotLandPerWorker,
+					MinEfficiency = ResourceGrowthScoFormula.MinEfficiencyNormalized,
+				},
 			};
 		}
 

--- a/src/BrowserGameEngine.Shared/EconomyFormulaViewModel.cs
+++ b/src/BrowserGameEngine.Shared/EconomyFormulaViewModel.cs
@@ -1,0 +1,15 @@
+namespace BrowserGameEngine.Shared {
+	/// <summary>
+	/// Income formula parameters surfaced to the client so the worker assignment
+	/// dialog can render live previews and the Land card can show land/worker
+	/// ratios against the sweet-spot targets, without re-declaring the
+	/// server-side constants.
+	/// </summary>
+	public record EconomyFormulaViewModel {
+		public required decimal BaseIncomePerTick { get; init; }
+		public required decimal MaxIncomePerWorker { get; init; }
+		public required decimal MineralSweetSpotLandPerWorker { get; init; }
+		public required decimal GasSweetSpotLandPerWorker { get; init; }
+		public required decimal MinEfficiency { get; init; }
+	}
+}

--- a/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
+++ b/src/BrowserGameEngine.Shared/PlayerResourcesViewModel.cs
@@ -9,5 +9,6 @@ namespace BrowserGameEngine.Shared {
 		public required CostViewModel PrimaryResource { get; init; }
 		public required CostViewModel SecondaryResources { get; init; }
 		public decimal ColonizationCostPerLand { get; init; }
+		public required EconomyFormulaViewModel Formula { get; init; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer.Test/EconomyFormulaTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/EconomyFormulaTest.cs
@@ -1,0 +1,41 @@
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	/// <summary>
+	/// Guards against drift between the SCO income formula constants and the
+	/// values surfaced to the client via /api/resources. If anyone retunes the
+	/// formula they should update both the tick module and these expectations.
+	/// </summary>
+	public class EconomyFormulaTest {
+		[Fact]
+		public void SweetSpots_AreDerivedFromEfficiencyFactorTimesMaxEfficiency() {
+			Assert.Equal(
+				ResourceGrowthScoFormula.MineralEfficiencyFactor * ResourceGrowthScoFormula.EfficiencyMax,
+				ResourceGrowthScoFormula.MineralSweetSpotLandPerWorker);
+			Assert.Equal(
+				ResourceGrowthScoFormula.GasEfficiencyFactor * ResourceGrowthScoFormula.EfficiencyMax,
+				ResourceGrowthScoFormula.GasSweetSpotLandPerWorker);
+		}
+
+		[Fact]
+		public void MinEfficiencyNormalized_IsFloorOverMax() {
+			Assert.Equal(
+				ResourceGrowthScoFormula.EfficiencyMin / ResourceGrowthScoFormula.EfficiencyMax,
+				ResourceGrowthScoFormula.MinEfficiencyNormalized);
+		}
+
+		[Fact]
+		public void Constants_MatchExpectedSCOValues() {
+			Assert.Equal(10m, ResourceGrowthScoFormula.BaseIncomePerTick);
+			Assert.Equal(4m, ResourceGrowthScoFormula.MaxIncomePerWorker);
+			Assert.Equal(0.03m, ResourceGrowthScoFormula.MineralEfficiencyFactor);
+			Assert.Equal(0.06m, ResourceGrowthScoFormula.GasEfficiencyFactor);
+			Assert.Equal(0.2m, ResourceGrowthScoFormula.EfficiencyMin);
+			Assert.Equal(100m, ResourceGrowthScoFormula.EfficiencyMax);
+			Assert.Equal(3m, ResourceGrowthScoFormula.MineralSweetSpotLandPerWorker);
+			Assert.Equal(6m, ResourceGrowthScoFormula.GasSweetSpotLandPerWorker);
+			Assert.Equal(0.002m, ResourceGrowthScoFormula.MinEfficiencyNormalized);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthSco.cs
@@ -32,21 +32,16 @@ namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
 		// grants workers of this type. (Older single-worker config paths still work.)
 		private UnitDefId PrimaryWorkerUnit => workerUnits[0];
 
-		// Base income added every tick regardless of workers (spec 2.3)
-		private const decimal BaseIncomeMinerals = 10m;
-		private const decimal BaseIncomeGas = 10m;
-
-		// Per-worker base income before efficiency (spec 2.3)
-		private const decimal MineralsPerWorker = 4m;
-		private const decimal GasPerWorker = 4m;
-
-		// Efficiency factors (spec 2.3)
-		private const decimal MineralEfficiencyFactor = 0.03m;
-		private const decimal GasEfficiencyFactor = 0.06m;
-
-		// Efficiency clamp bounds (spec 2.3)
-		private const decimal EfficiencyMin = 0.2m;
-		private const decimal EfficiencyMax = 100m;
+		// Income formula constants live in ResourceGrowthScoFormula so the API layer
+		// can surface them to the client without duplicating values.
+		private const decimal BaseIncomeMinerals = ResourceGrowthScoFormula.BaseIncomePerTick;
+		private const decimal BaseIncomeGas = ResourceGrowthScoFormula.BaseIncomePerTick;
+		private const decimal MineralsPerWorker = ResourceGrowthScoFormula.MaxIncomePerWorker;
+		private const decimal GasPerWorker = ResourceGrowthScoFormula.MaxIncomePerWorker;
+		private const decimal MineralEfficiencyFactor = ResourceGrowthScoFormula.MineralEfficiencyFactor;
+		private const decimal GasEfficiencyFactor = ResourceGrowthScoFormula.GasEfficiencyFactor;
+		private const decimal EfficiencyMin = ResourceGrowthScoFormula.EfficiencyMin;
+		private const decimal EfficiencyMax = ResourceGrowthScoFormula.EfficiencyMax;
 
 		// Emergency respawn threshold (spec 2.5): auto-grant workers if resources below this
 		private const decimal EmergencyResourceThreshold = 50m;

--- a/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthScoFormula.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameTicks/Modules/ResourceGrowthScoFormula.cs
@@ -1,0 +1,22 @@
+namespace BrowserGameEngine.StatefulGameServer.GameTicks.Modules {
+	/// <summary>
+	/// Public constants for the SCO income formula. Exposed so the API layer can
+	/// surface them to the client (worker dialog preview, Land card ratio hint)
+	/// without re-declaring values that would drift from the tick module.
+	/// </summary>
+	public static class ResourceGrowthScoFormula {
+		public const decimal BaseIncomePerTick = 10m;
+		public const decimal MaxIncomePerWorker = 4m;
+
+		public const decimal MineralEfficiencyFactor = 0.03m;
+		public const decimal GasEfficiencyFactor = 0.06m;
+
+		public const decimal EfficiencyMin = 0.2m;
+		public const decimal EfficiencyMax = 100m;
+
+		public const decimal MineralSweetSpotLandPerWorker = MineralEfficiencyFactor * EfficiencyMax;
+		public const decimal GasSweetSpotLandPerWorker = GasEfficiencyFactor * EfficiencyMax;
+
+		public const decimal MinEfficiencyNormalized = EfficiencyMin / EfficiencyMax;
+	}
+}

--- a/src/ReactClient/src/api/types.ts
+++ b/src/ReactClient/src/api/types.ts
@@ -88,10 +88,19 @@ export interface AddToQueueRequest {
 
 // Resources
 
+export interface EconomyFormulaViewModel {
+  baseIncomePerTick: number
+  maxIncomePerWorker: number
+  mineralSweetSpotLandPerWorker: number
+  gasSweetSpotLandPerWorker: number
+  minEfficiency: number
+}
+
 export interface PlayerResourcesViewModel {
   primaryResource: CostViewModel
   secondaryResources: CostViewModel
   colonizationCostPerLand: number
+  formula: EconomyFormulaViewModel
 }
 
 export interface ColonizePreviewViewModel {

--- a/src/ReactClient/src/components/WorkerAssignmentDialog.tsx
+++ b/src/ReactClient/src/components/WorkerAssignmentDialog.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { FlaskConicalIcon, GemIcon, UsersIcon } from 'lucide-react'
+import { FlaskConicalIcon, GemIcon, MountainIcon, UsersIcon } from 'lucide-react'
 import apiClient from '@/api/client'
-import type { WorkerAssignmentViewModel } from '@/api/types'
+import type { PlayerResourcesViewModel, WorkerAssignmentViewModel } from '@/api/types'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { formatNumber } from '@/lib/formatters'
+import { workerIncome } from '@/lib/economy'
 
 interface WorkerAssignmentDialogProps {
   open: boolean
@@ -21,6 +22,12 @@ export function WorkerAssignmentDialog({ open, onOpenChange, gameId }: WorkerAss
     enabled: open,
   })
 
+  const { data: resources } = useQuery<PlayerResourcesViewModel>({
+    queryKey: ['resources', gameId],
+    queryFn: () => apiClient.get('/api/resources').then((r) => r.data),
+    enabled: open,
+  })
+
   const [gasPercent, setGasPercent] = useState(30)
 
   useEffect(() => {
@@ -32,6 +39,28 @@ export function WorkerAssignmentDialog({ open, onOpenChange, gameId }: WorkerAss
   const total = data?.totalWorkers ?? 0
   const previewGas = Math.round((total * gasPercent) / 100)
   const previewMinerals = total - previewGas
+
+  const land =
+    (resources?.primaryResource.cost.land ?? 0) +
+    (resources?.secondaryResources.cost.land ?? 0)
+  const formula = resources?.formula
+  const mineralsIncome = formula
+    ? workerIncome(previewMinerals, land, formula.mineralSweetSpotLandPerWorker, formula)
+    : null
+  const gasIncome = formula
+    ? workerIncome(previewGas, land, formula.gasSweetSpotLandPerWorker, formula)
+    : null
+
+  // Tip: warn when a pool with workers is below half its sweet spot. Pools
+  // with zero workers don't trigger the tip — they're only producing the flat
+  // base income, which is intentional.
+  const mineralsBelowHalf =
+    formula != null && previewMinerals > 0 &&
+    land / previewMinerals < formula.mineralSweetSpotLandPerWorker / 2
+  const gasBelowHalf =
+    formula != null && previewGas > 0 &&
+    land / previewGas < formula.gasSweetSpotLandPerWorker / 2
+  const showLowLandTip = mineralsBelowHalf || gasBelowHalf
 
   const assignMutation = useMutation({
     mutationFn: () =>
@@ -91,6 +120,34 @@ export function WorkerAssignmentDialog({ open, onOpenChange, gameId }: WorkerAss
             className="w-full"
           />
         </div>
+
+        {formula && (
+          <div className="rounded-md border border-success/20 bg-success/5 px-3 py-2 text-xs space-y-1">
+            <div className="label flex items-center justify-between">
+              <span>Income next tick</span>
+              <span className="text-muted-foreground inline-flex items-center gap-1">
+                <MountainIcon className="h-3 w-3 text-[#b8804a]" aria-hidden /> Land {formatNumber(land)}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="inline-flex items-center gap-1">
+                <GemIcon className="h-3 w-3 text-blue-400" aria-hidden /> Minerals
+              </span>
+              <span className="mono font-semibold text-success">+{formatNumber(mineralsIncome ?? 0)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="inline-flex items-center gap-1">
+                <FlaskConicalIcon className="h-3 w-3 text-green-400" aria-hidden /> Gas
+              </span>
+              <span className="mono font-semibold text-success">+{formatNumber(gasIncome ?? 0)}</span>
+            </div>
+            {showLowLandTip && (
+              <div className="text-muted-foreground pt-1">
+                Workers are choking on too little land — colonize more to boost income.
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="flex flex-wrap gap-1.5">
           <Button variant="ghost" size="xs" onClick={() => setGasPercent(50)}>

--- a/src/ReactClient/src/lib/economy.test.ts
+++ b/src/ReactClient/src/lib/economy.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { workerIncome, landPerWorker, type EconomyFormula } from './economy'
+
+const sco: EconomyFormula = {
+  baseIncomePerTick: 10,
+  maxIncomePerWorker: 4,
+  mineralSweetSpotLandPerWorker: 3,
+  gasSweetSpotLandPerWorker: 6,
+  minEfficiency: 0.002,
+}
+
+describe('workerIncome (mineral pool)', () => {
+  const sweet = sco.mineralSweetSpotLandPerWorker
+
+  it('returns just the base income when there are no workers', () => {
+    expect(workerIncome(0, 100, sweet, sco)).toBe(10)
+  })
+
+  it('caps at full efficiency at the sweet spot', () => {
+    // 20 workers × 3 land/worker = 60 land → eff 1.0
+    // 10 + 20 × 4 × 1.0 = 90
+    expect(workerIncome(20, 60, sweet, sco)).toBe(90)
+  })
+
+  it('does not exceed full efficiency past the sweet spot', () => {
+    expect(workerIncome(20, 600, sweet, sco)).toBe(90)
+  })
+
+  it('scales linearly below the sweet spot', () => {
+    // 20 workers, 30 land → ratio 0.5 → 10 + 20 × 4 × 0.5 = 50
+    expect(workerIncome(20, 30, sweet, sco)).toBe(50)
+  })
+
+  it('floors at minEfficiency for tiny land', () => {
+    // 100 workers, 0 land → eff floored at 0.002
+    // 10 + 100 × 4 × 0.002 = 10.8
+    expect(workerIncome(100, 0, sweet, sco)).toBeCloseTo(10.8, 5)
+  })
+})
+
+describe('workerIncome (gas pool — bigger sweet spot)', () => {
+  const sweet = sco.gasSweetSpotLandPerWorker
+
+  it('reaches full efficiency only with twice the land per worker', () => {
+    // 10 workers, 60 land, sweet 6 → ratio 1.0 → eff 1.0
+    expect(workerIncome(10, 60, sweet, sco)).toBe(50)
+  })
+
+  it('lags minerals at the same land/worker ratio', () => {
+    // 10 workers, 30 land → mineral pool would be at sweet (eff 1)
+    // gas pool sweet = 6, ratio = 30/(10*6) = 0.5 → eff 0.5
+    // 10 + 10 × 4 × 0.5 = 30
+    expect(workerIncome(10, 30, sweet, sco)).toBe(30)
+  })
+})
+
+describe('landPerWorker', () => {
+  it('returns NaN when there are no workers (so callers can render "—")', () => {
+    expect(landPerWorker(0, 100)).toBeNaN()
+  })
+
+  it('divides land by worker count', () => {
+    expect(landPerWorker(20, 60)).toBe(3)
+  })
+})

--- a/src/ReactClient/src/lib/economy.ts
+++ b/src/ReactClient/src/lib/economy.ts
@@ -1,0 +1,29 @@
+export interface EconomyFormula {
+  baseIncomePerTick: number
+  maxIncomePerWorker: number
+  mineralSweetSpotLandPerWorker: number
+  gasSweetSpotLandPerWorker: number
+  minEfficiency: number
+}
+
+/**
+ * Predicted income per tick for one worker pool. Mirrors
+ * ResourceGrowthSco.CalculateWorkerIncome on the server. Returns just the flat
+ * base income when there are no workers in this pool.
+ */
+export function workerIncome(
+  workers: number,
+  land: number,
+  sweetSpotLandPerWorker: number,
+  formula: EconomyFormula,
+): number {
+  if (workers <= 0) return formula.baseIncomePerTick
+  const ratio = land / (workers * sweetSpotLandPerWorker)
+  const eff = Math.min(1, Math.max(formula.minEfficiency, ratio))
+  return formula.baseIncomePerTick + workers * formula.maxIncomePerWorker * eff
+}
+
+export function landPerWorker(workers: number, land: number): number {
+  if (workers <= 0) return NaN
+  return land / workers
+}

--- a/src/ReactClient/src/lib/formatters.ts
+++ b/src/ReactClient/src/lib/formatters.ts
@@ -20,6 +20,12 @@ export function formatNumber(value: number): string {
   return Math.floor(value).toLocaleString()
 }
 
+/** Compact one-decimal ratio used for land/worker readouts. */
+export function formatRatio(value: number): string {
+  if (!isFinite(value)) return '—'
+  return value.toFixed(1)
+}
+
 export function formatDate(d: string): string {
   return new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/src/ReactClient/src/pages/Base.tsx
+++ b/src/ReactClient/src/pages/Base.tsx
@@ -22,7 +22,8 @@ import { WorkerAssignmentDialog } from '@/components/WorkerAssignmentDialog'
 import { ColonizeDialog } from '@/components/ColonizeDialog'
 import { AffordabilityChip } from '@/components/AffordabilityChip'
 import { relativeTime } from '@/lib/utils'
-import { formatNumber } from '@/lib/formatters'
+import { formatNumber, formatRatio } from '@/lib/formatters'
+import { landPerWorker } from '@/lib/economy'
 import { PageHeader } from '@/components/ui/page-header'
 import { Section } from '@/components/ui/section'
 import { Card, CardContent } from '@/components/ui/card'
@@ -206,7 +207,7 @@ function EconomyStat({
 	label: string
 	value: ReactNode
 	detail?: ReactNode
-	action?: { label: string; onClick: () => void; disabled?: boolean }
+	action?: { label: string; onClick: () => void; disabled?: boolean; title?: string }
 	iconClassName?: string
 	valueClassName?: string
 }) {
@@ -222,7 +223,14 @@ function EconomyStat({
 					{detail && <div className="text-xs text-muted-foreground mt-0.5">{detail}</div>}
 				</div>
 				{action && (
-					<Button size="sm" variant="outline" onClick={action.onClick} disabled={action.disabled} className="shrink-0">
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={action.onClick}
+						disabled={action.disabled}
+						title={action.title}
+						className="shrink-0"
+					>
 						{action.label}
 					</Button>
 				)}
@@ -358,6 +366,8 @@ export function Base({ gameId }: BaseProps) {
 	const queueCount = queueData?.entries.length ?? 0
 	const gasPercent = workers?.gasPercent ?? 0
 	const totalWorkers = workers?.totalWorkers ?? 0
+	const mineralWorkers = workers?.mineralWorkers ?? 0
+	const gasWorkers = workers?.gasWorkers ?? 0
 	// Land can be either the primary or secondary resource depending on the game definition;
 	// merge both to be robust across rulesets.
 	const land =
@@ -420,12 +430,19 @@ export function Base({ gameId }: BaseProps) {
 						resources
 							? (
 								<>
-									<span className="text-blue-400">{formatNumber(resources.colonizationCostPerLand)} minerals</span> per new tile
+									<span className="text-blue-400">{formatRatio(landPerWorker(mineralWorkers, land))}</span>
+									/mineral worker · <span className="text-green-400">{formatRatio(landPerWorker(gasWorkers, land))}</span>
+									/gas worker · sweet {formatRatio(resources.formula.mineralSweetSpotLandPerWorker)} / {formatRatio(resources.formula.gasSweetSpotLandPerWorker)}
 								</>
 							)
 							: undefined
 					}
-					action={{ label: 'Colonize', onClick: () => setColonizeOpen(true), disabled: isFinished }}
+					action={{
+						label: 'Colonize',
+						onClick: () => setColonizeOpen(true),
+						disabled: isFinished,
+						title: resources ? `${formatNumber(resources.colonizationCostPerLand)} minerals per new tile` : undefined,
+					}}
 				/>
 				<EconomyStat
 					icon={<HammerIcon className="h-5 w-5" />}


### PR DESCRIPTION
## Summary

- Land card on the Base page now shows current **land per mineral worker** and **land per gas worker** alongside the sweet-spot targets (3 / 6), replacing the single-purpose colonization-cost line. The cost moved to the Colonize button tooltip.
- Worker Assignment dialog gets a **live income preview** that updates as the gas-share slider moves, with a one-line tip when either pool is choking on too little land.
- Income formula constants extracted into `ResourceGrowthScoFormula` and exposed via `PlayerResourcesViewModel.Formula`, so the React client mirrors the server math without redeclaring values.

## Spec

`docs/superpowers/specs/2026-04-26-land-income-visualization-design.md`

## Test plan

- [x] `dotnet test` — 617 passing (incl. new `EconomyFormulaTest` guarding constants & sweet-spot derivation)
- [x] `npm test` in ReactClient — 42 passing (incl. new `economy.test.ts` truth table)
- [x] `npm run build` clean (TypeScript + Vite)
- [ ] Manual: open Base page in a running game; confirm Land card shows correct ratios; open Worker dialog and confirm income preview updates with the slider; verify low-land tip appears when sliding to extreme imbalance