### PR TITLE
feat(admin): add game selection to per-game admin pages

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/AdminController.cs
@@ -32,7 +32,8 @@ public class AdminController : ControllerBase
 	private readonly UnitRepositoryWrite unitRepositoryWrite;
 	private readonly ActionQueueRepository actionQueueRepository;
 	private readonly GameTickEngine gameTickEngine;
-	private readonly WorldState worldState;
+	private readonly IWorldStateAccessor worldStateAccessor;
+	private WorldState worldState => worldStateAccessor.WorldState;
 	private readonly GameStateJsonSerializer serializer;
 	private readonly IBlobStorage storage;
 	private readonly IActionLogger actionLogger;
@@ -53,7 +54,7 @@ public class AdminController : ControllerBase
 		UnitRepositoryWrite unitRepositoryWrite,
 		ActionQueueRepository actionQueueRepository,
 		GameTickEngine gameTickEngine,
-		WorldState worldState,
+		IWorldStateAccessor worldStateAccessor,
 		GameStateJsonSerializer serializer,
 		IBlobStorage storage,
 		IActionLogger actionLogger,
@@ -74,7 +75,7 @@ public class AdminController : ControllerBase
 		this.unitRepositoryWrite = unitRepositoryWrite;
 		this.actionQueueRepository = actionQueueRepository;
 		this.gameTickEngine = gameTickEngine;
-		this.worldState = worldState;
+		this.worldStateAccessor = worldStateAccessor;
 		this.serializer = serializer;
 		this.storage = storage;
 		this.actionLogger = actionLogger;

--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -210,8 +210,11 @@ const router = createBrowserRouter([
 
 			{ path: '/admin/games', element: <RouteWithBoundary><AdminGames /></RouteWithBoundary> },
 			{ path: '/admin/players', element: <RouteWithBoundary><AdminPlayers /></RouteWithBoundary> },
+			{ path: '/admin/players/:gameId', element: <RouteWithBoundary><AdminPlayers /></RouteWithBoundary> },
 			{ path: '/admin/ticks', element: <RouteWithBoundary><AdminTickControl /></RouteWithBoundary> },
+			{ path: '/admin/ticks/:gameId', element: <RouteWithBoundary><AdminTickControl /></RouteWithBoundary> },
 			{ path: '/admin/stats', element: <RouteWithBoundary><AdminStats /></RouteWithBoundary> },
+			{ path: '/admin/stats/:gameId', element: <RouteWithBoundary><AdminStats /></RouteWithBoundary> },
 			{ path: '/admin/metrics', element: <RouteWithBoundary><AdminMetrics /></RouteWithBoundary> },
 			{ path: '/admin/audit', element: <RouteWithBoundary><AdminAuditLog /></RouteWithBoundary> },
 			{ path: '/admin/reports', element: <RouteWithBoundary><AdminReports /></RouteWithBoundary> },

--- a/src/ReactClient/src/lib/gameIdFromPath.ts
+++ b/src/ReactClient/src/lib/gameIdFromPath.ts
@@ -1,7 +1,8 @@
 const GAME_PATH_PATTERN = /^\/games\/([^/]+)(?:\/|$)/
+const ADMIN_GAME_PATH_PATTERN = /^\/admin\/(?:players|ticks|stats)\/([^/]+)(?:\/|$)/
 
 export function gameIdFromPath(pathname: string): string | null {
-	const match = pathname.match(GAME_PATH_PATTERN)
+	const match = pathname.match(GAME_PATH_PATTERN) ?? pathname.match(ADMIN_GAME_PATH_PATTERN)
 	if (!match) return null
 	const id = match[1]
 	if (!id) return null

--- a/src/ReactClient/src/pages/admin/AdminGamePicker.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGamePicker.tsx
@@ -1,0 +1,117 @@
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+import apiClient from '@/api/client'
+import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
+
+export type AdminGameSection = 'players' | 'ticks' | 'stats'
+
+function pickDefaultGame(games: GameSummaryViewModel[]): GameSummaryViewModel | null {
+  return games.find((g) => g.status === 'Active')
+    ?? games.find((g) => g.status === 'Upcoming')
+    ?? games[0]
+    ?? null
+}
+
+interface PickerProps {
+  section: AdminGameSection
+  currentGameId: string | null
+}
+
+export function AdminGameSwitcher({ section, currentGameId }: PickerProps) {
+  const navigate = useNavigate()
+  const { data } = useQuery<GameListViewModel>({
+    queryKey: ['admin-game-switcher'],
+    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
+  })
+  const games = data?.games ?? []
+  const current = currentGameId ? games.find((g) => g.gameId === currentGameId) : null
+
+  return (
+    <div className="flex items-center gap-2 mb-4 text-sm">
+      <span className="text-muted-foreground">Game:</span>
+      <select
+        className="rounded border border-input bg-background px-2 py-1 text-sm"
+        value={currentGameId ?? ''}
+        onChange={(e) => {
+          const id = e.target.value
+          if (!id) return
+          navigate(`/admin/${section}/${id}`)
+        }}
+      >
+        {!current && <option value="">— select a game —</option>}
+        {games.map((g) => (
+          <option key={g.gameId} value={g.gameId}>
+            {g.name} ({g.status})
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export function AdminGamePickerPage({ section, title }: { section: AdminGameSection; title: string }) {
+  const { data, isLoading } = useQuery<GameListViewModel>({
+    queryKey: ['admin-game-picker'],
+    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
+  })
+  const games = data?.games ?? []
+  const defaultGame = pickDefaultGame(games)
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {title} are scoped per game. Pick a game to manage:
+      </p>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading games…</p>
+      ) : games.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No games found.</p>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th scope="col" className="px-3 py-2 text-left font-medium">Name</th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">Status</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Players</th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {games.map((g) => (
+                <tr key={g.gameId} className="border-b border-border/50">
+                  <td className="px-3 py-2 font-medium">{g.name}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded font-bold ${
+                        g.status === 'Active'
+                          ? 'bg-success text-success-foreground'
+                          : g.status === 'Upcoming'
+                          ? 'bg-warning text-warning-foreground'
+                          : 'bg-secondary text-secondary-foreground'
+                      }`}
+                    >
+                      {g.status}
+                    </span>
+                    {defaultGame?.gameId === g.gameId && (
+                      <span className="ml-2 text-xs text-muted-foreground">(default)</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right text-muted-foreground">{g.playerCount}</td>
+                  <td className="px-3 py-2 text-right">
+                    <a
+                      href={`/admin/${section}/${g.gameId}`}
+                      className="px-2 py-1 rounded border border-border text-xs hover:bg-muted"
+                    >
+                      Open
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ReactClient/src/pages/admin/AdminNav.tsx
+++ b/src/ReactClient/src/pages/admin/AdminNav.tsx
@@ -1,31 +1,42 @@
 import { useLocation } from 'react-router'
 
-const links = [
+interface NavLink {
+  path: string
+  label: string
+  perGame?: boolean
+}
+
+const links: NavLink[] = [
   { path: '/admin/games', label: 'Games' },
-  { path: '/admin/players', label: 'Players' },
-  { path: '/admin/ticks', label: 'Tick Control' },
+  { path: '/admin/players', label: 'Players', perGame: true },
+  { path: '/admin/ticks', label: 'Tick Control', perGame: true },
+  { path: '/admin/stats', label: 'Stats', perGame: true },
   { path: '/admin/metrics', label: 'Metrics' },
   { path: '/admin/audit', label: 'Audit Log' },
   { path: '/admin/reports', label: 'Reports' },
 ]
 
-export function AdminNav() {
+export function AdminNav({ currentGameId }: { currentGameId?: string | null } = {}) {
   const location = useLocation()
   return (
     <nav className="flex gap-1 mb-6 border-b border-border pb-2 flex-wrap">
-      {links.map(({ path, label }) => (
-        <a
-          key={path}
-          href={path}
-          className={`px-3 py-1.5 rounded text-sm ${
-            location.pathname === path
-              ? 'bg-primary text-primary-foreground'
-              : 'hover:bg-muted text-muted-foreground'
-          }`}
-        >
-          {label}
-        </a>
-      ))}
+      {links.map(({ path, label, perGame }) => {
+        const href = perGame && currentGameId ? `${path}/${currentGameId}` : path
+        const isActive = location.pathname === path || location.pathname.startsWith(`${path}/`)
+        return (
+          <a
+            key={path}
+            href={href}
+            className={`px-3 py-1.5 rounded text-sm ${
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'hover:bg-muted text-muted-foreground'
+            }`}
+          >
+            {label}
+          </a>
+        )
+      })}
     </nav>
   )
 }

--- a/src/ReactClient/src/pages/admin/AdminPlayers.tsx
+++ b/src/ReactClient/src/pages/admin/AdminPlayers.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
+import { useParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
+import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
 
 interface AdminPlayerEntry {
   playerId: string
@@ -27,20 +29,22 @@ interface AdminPlayerDetail extends AdminPlayerEntry {
 }
 
 export function AdminPlayers() {
+  const { gameId } = useParams<{ gameId: string }>()
   const queryClient = useQueryClient()
   const [selectedPlayer, setSelectedPlayer] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
 
   const { data: players, isLoading, error, refetch } = useQuery<AdminPlayerEntry[]>({
-    queryKey: ['admin-players'],
+    queryKey: ['admin-players', gameId ?? null],
     queryFn: () => apiClient.get('/api/admin/players-detail').then((r) => r.data),
+    enabled: !!gameId,
   })
 
   const { data: detail } = useQuery<AdminPlayerDetail>({
-    queryKey: ['admin-player-detail', selectedPlayer],
+    queryKey: ['admin-player-detail', gameId ?? null, selectedPlayer],
     queryFn: () => apiClient.get(`/api/admin/players/${selectedPlayer}`).then((r) => r.data),
-    enabled: !!selectedPlayer,
+    enabled: !!gameId && !!selectedPlayer,
   })
 
   const banMutation = useMutation({
@@ -83,6 +87,7 @@ export function AdminPlayers() {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       return (
         <div className="p-6 max-w-2xl mx-auto">
+          <AdminNav currentGameId={gameId ?? null} />
           <h1 className="text-2xl font-bold mb-4">Player Moderation</h1>
           <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
             You are not authorized to view the admin panel.
@@ -92,16 +97,28 @@ export function AdminPlayers() {
     }
     return (
       <div className="p-6 max-w-2xl mx-auto">
+        <AdminNav currentGameId={gameId ?? null} />
         <h1 className="text-2xl font-bold mb-4">Player Moderation</h1>
         <ApiError message="Failed to load players." onRetry={() => void refetch()} />
       </div>
     )
   }
 
+  if (!gameId) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <AdminNav />
+        <h1 className="text-2xl font-bold mb-6">Player Moderation</h1>
+        <AdminGamePickerPage section="players" title="Players" />
+      </div>
+    )
+  }
+
   return (
     <div className="p-6 max-w-6xl mx-auto">
-      <AdminNav />
+      <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Player Moderation</h1>
+      <AdminGameSwitcher section="players" currentGameId={gameId} />
 
       <div className="mb-4">
         <input

--- a/src/ReactClient/src/pages/admin/AdminStats.tsx
+++ b/src/ReactClient/src/pages/admin/AdminStats.tsx
@@ -1,9 +1,11 @@
+import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
+import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
 
 interface LiveStats {
   totalPlayers: number
@@ -17,16 +19,19 @@ interface LiveStats {
 }
 
 export function AdminStats() {
+  const { gameId } = useParams<{ gameId: string }>()
   const { data: stats, isLoading, error, refetch } = useQuery<LiveStats>({
-    queryKey: ['admin-live-stats'],
+    queryKey: ['admin-live-stats', gameId ?? null],
     queryFn: () => apiClient.get('/api/admin/live-stats').then((r) => r.data),
     refetchInterval: 10000,
+    enabled: !!gameId,
   })
 
   if (error) {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       return (
         <div className="p-6 max-w-2xl mx-auto">
+          <AdminNav currentGameId={gameId ?? null} />
           <h1 className="text-2xl font-bold mb-4">Live Stats</h1>
           <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
             You are not authorized to view the admin panel.
@@ -36,16 +41,28 @@ export function AdminStats() {
     }
     return (
       <div className="p-6 max-w-2xl mx-auto">
+        <AdminNav currentGameId={gameId ?? null} />
         <h1 className="text-2xl font-bold mb-4">Live Stats</h1>
         <ApiError message="Failed to load live stats." onRetry={() => void refetch()} />
       </div>
     )
   }
 
+  if (!gameId) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <AdminNav />
+        <h1 className="text-2xl font-bold mb-6">Live Stats</h1>
+        <AdminGamePickerPage section="stats" title="Live stats" />
+      </div>
+    )
+  }
+
   return (
     <div className="p-6 max-w-4xl mx-auto">
-      <AdminNav />
+      <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Live Stats</h1>
+      <AdminGameSwitcher section="stats" currentGameId={gameId} />
 
       {isLoading || !stats ? (
         <PageLoader message="Loading stats..." />

--- a/src/ReactClient/src/pages/admin/AdminTickControl.tsx
+++ b/src/ReactClient/src/pages/admin/AdminTickControl.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
+import { useParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
+import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
 
 interface TickStatus {
   currentTick: number
@@ -14,6 +16,7 @@ interface TickStatus {
 }
 
 export function AdminTickControl() {
+  const { gameId } = useParams<{ gameId: string }>()
   const queryClient = useQueryClient()
   const [tickCount, setTickCount] = useState(1)
   const [tickDuration, setTickDuration] = useState('')
@@ -21,9 +24,10 @@ export function AdminTickControl() {
   const [actionSuccess, setActionSuccess] = useState<string | null>(null)
 
   const { data: status, isLoading, error, refetch } = useQuery<TickStatus>({
-    queryKey: ['admin-tick-status'],
+    queryKey: ['admin-tick-status', gameId ?? null],
     queryFn: () => apiClient.get('/api/admin/tick-status').then((r) => r.data),
     refetchInterval: 5000,
+    enabled: !!gameId,
   })
 
   const pauseMutation = useMutation({
@@ -79,6 +83,7 @@ export function AdminTickControl() {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       return (
         <div className="p-6 max-w-2xl mx-auto">
+          <AdminNav currentGameId={gameId ?? null} />
           <h1 className="text-2xl font-bold mb-4">Game Tick Control</h1>
           <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
             You are not authorized to view the admin panel.
@@ -88,16 +93,28 @@ export function AdminTickControl() {
     }
     return (
       <div className="p-6 max-w-2xl mx-auto">
+        <AdminNav currentGameId={gameId ?? null} />
         <h1 className="text-2xl font-bold mb-4">Game Tick Control</h1>
         <ApiError message="Failed to load tick status." onRetry={() => void refetch()} />
       </div>
     )
   }
 
+  if (!gameId) {
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <AdminNav />
+        <h1 className="text-2xl font-bold mb-6">Game Tick Control</h1>
+        <AdminGamePickerPage section="ticks" title="Tick controls" />
+      </div>
+    )
+  }
+
   return (
     <div className="p-6 max-w-2xl mx-auto">
-      <AdminNav />
+      <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Game Tick Control</h1>
+      <AdminGameSwitcher section="ticks" currentGameId={gameId} />
 
       {actionError && (
         <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">


### PR DESCRIPTION
## Summary

`/admin/players`, `/admin/ticks`, and `/admin/stats` all operate on per-game `WorldState`, but they had no way to indicate or select which game they applied to — they silently always hit `GameRegistry.GetDefaultInstance()` (the first registered game).

The plumbing for multi-game requests already exists: `apiClient` extracts gameId from `/games/:gameId/...` URLs and sends `X-Game-Id`; `CurrentGameMiddleware` + `HttpContextWorldStateAccessor` resolve the right `WorldState`. But `AdminController` injected the singleton `WorldState` directly (bypassing the accessor) and admin URLs carried no gameId.

This PR closes both gaps for the per-game admin pages. Global admin pages (`/admin/games`, `/admin/metrics`, `/admin/audit`, `/admin/reports`) are unchanged.

### Changes

- **`AdminController`**: inject `IWorldStateAccessor` instead of `WorldState`. World-state dump, snapshots, live-stats, and tick-status now respect `X-Game-Id`. Repositories already used the accessor pattern, so they pick up the right game automatically.
- **Routes** (`App.tsx`): add `/admin/players/:gameId`, `/admin/ticks/:gameId`, `/admin/stats/:gameId`; bare paths render a game-picker landing page.
- **`gameIdFromPath`**: also extract gameId from `/admin/(players|ticks|stats)/:id` so `apiClient` automatically attaches `X-Game-Id` on admin requests.
- **`AdminGamePicker`** (new): inline switcher (dropdown) + full picker landing page.
- **`AdminNav`**: per-game links carry the current gameId; section is highlighted on `/admin/<section>/<id>`.

## Test plan

- [ ] CI build is green (`dotnet build` + `dotnet test`)
- [ ] `/admin/players` (no gameId) shows a game picker
- [ ] `/admin/players/:gameId` shows that game's players; switching games via dropdown navigates correctly
- [ ] Same for `/admin/ticks` and `/admin/stats`
- [ ] Tick controls (pause/resume/force) and player moderation operate on the selected game
- [ ] Global admin pages (`/admin/games`, `/admin/metrics`, `/admin/audit`, `/admin/reports`) still work

https://claude.ai/code/session_01PcNwos5Ceqf5D5Ug2kXkYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcNwos5Ceqf5D5Ug2kXkYT)_