### PR TITLE
fix(admin): sync starting-resource placeholders with new defaults

### DIFF
--- a/src/ReactClient/src/pages/admin/AdminGames.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGames.tsx
@@ -243,7 +243,7 @@ export function AdminGames() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1">Starting Minerals</label>
-                <input type="number" min={0} placeholder="5000 (default)"
+                <input type="number" min={0} placeholder="1500 (default)"
                   className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
                   value={createStartingMinerals ?? ''}
                   onChange={(e) => setCreateStartingMinerals(e.target.value ? Number(e.target.value) : undefined)}
@@ -251,7 +251,7 @@ export function AdminGames() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1">Starting Gas</label>
-                <input type="number" min={0} placeholder="3000 (default)"
+                <input type="number" min={0} placeholder="300 (default)"
                   className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
                   value={createStartingGas ?? ''}
                   onChange={(e) => setCreateStartingGas(e.target.value ? Number(e.target.value) : undefined)}


### PR DESCRIPTION
## Summary

Follow-up to #344. The Create Game form's Advanced Settings on `/admin/games` still showed `"5000 (default)"` for Starting Minerals and `"3000 (default)"` for Starting Gas in the input placeholders, even though #344 lowered the actual defaults to `1500` and `300`. This makes the admin UI lie about what value will be applied if the field is left blank.

## Files changed

- `src/ReactClient/src/pages/admin/AdminGames.tsx` — placeholder text only.

## Test plan

- [ ] Open `/admin/games`, expand Advanced Settings on the Create Game form, confirm Starting Minerals shows `1500 (default)` and Starting Gas shows `300 (default)`.

https://claude.ai/code/session_01PgvyGMmun1DFxHAqSTEVxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgvyGMmun1DFxHAqSTEVxU)_