### PR TITLE
fix(ui): keep nav menu on alliance detail page

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -140,6 +140,11 @@ function AlliancesPage() {
   if (!gameId) return null
   return <Alliances gameId={gameId} />
 }
+function AllianceDetailPage() {
+  const { gameId } = useParams<{ gameId: string }>()
+  if (!gameId) return null
+  return <AllianceDetail />
+}
 function GameLiveViewPage() {
   const { gameId } = useParams<{ gameId: string }>()
   if (!gameId) return null
@@ -169,6 +174,7 @@ const router = createBrowserRouter([
 					{ path: 'messages', element: <RouteWithBoundary><MessagesPage /></RouteWithBoundary> },
 					{ path: 'ranking', element: <RouteWithBoundary><PlayerRankingPage /></RouteWithBoundary> },
 					{ path: 'alliances', element: <RouteWithBoundary><AlliancesPage /></RouteWithBoundary> },
+					{ path: 'alliances/:allianceId', element: <RouteWithBoundary><AllianceDetailPage /></RouteWithBoundary> },
 					{ path: 'allianceranking', element: <TodoPage name="Alliance Ranking" /> },
 					{ path: 'selectenemy/:unitId', element: <RouteWithBoundary><SelectEnemyPage /></RouteWithBoundary> },
 					{ path: 'unitdefinitions', element: <RouteWithBoundary><UnitDefinitions /></RouteWithBoundary> },
@@ -200,7 +206,7 @@ const router = createBrowserRouter([
 			{ path: '/profile', element: <BareRouteRedirect path="profile" /> },
 			{ path: '/profile/:userId', element: <RouteWithBoundary><PublicProfile /></RouteWithBoundary> },
 			{ path: '/players', element: <RouteWithBoundary><PlayersList /></RouteWithBoundary> },
-			{ path: '/alliances/:allianceId', element: <RouteWithBoundary><AllianceDetail /></RouteWithBoundary> },
+			{ path: '/alliances/:allianceId', element: <BareRouteRedirect path="alliances/:allianceId" /> },
 			{ path: '/history', element: <BareRouteRedirect path="history" /> },
 			{ path: '/replays/:gameId', element: <RouteWithBoundary><ReplayViewer /></RouteWithBoundary> },
 			{ path: '/stats', element: <BareRouteRedirect path="stats" /> },

--- a/src/ReactClient/src/components/BareRouteRedirect.tsx
+++ b/src/ReactClient/src/components/BareRouteRedirect.tsx
@@ -1,18 +1,21 @@
-import { Navigate } from 'react-router'
+import { Navigate, useParams } from 'react-router'
 import { useCurrentUser } from '@/contexts/CurrentUserContext'
 
 /**
  * Redirects bare routes (e.g. /base) to /games/:currentGameId/base.
+ * Substitutes :paramName tokens in path with values from the current route.
  * Falls back to /games if no current game is set.
  */
 export function BareRouteRedirect({ path }: { path: string }) {
   const { user, isLoading } = useCurrentUser()
+  const params = useParams()
 
   if (isLoading) return null
 
   const gameId = user?.currentGameId
   if (gameId) {
-    return <Navigate to={`/games/${gameId}/${path}`} replace />
+    const resolved = path.replace(/:([A-Za-z0-9_]+)/g, (_, key) => params[key] ?? '')
+    return <Navigate to={`/games/${gameId}/${resolved}`} replace />
   }
 
   return <Navigate to="/games" replace />

--- a/src/ReactClient/src/pages/AllianceDetail.tsx
+++ b/src/ReactClient/src/pages/AllianceDetail.tsx
@@ -27,7 +27,7 @@ import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 
 export function AllianceDetail() {
-	const { allianceId } = useParams<{ allianceId: string }>()
+	const { allianceId, gameId } = useParams<{ allianceId: string; gameId?: string }>()
 	const queryClient = useQueryClient()
 	const [error, setError] = useState<string | null>(null)
 	const [success, setSuccess] = useState<string | null>(null)
@@ -254,7 +254,7 @@ export function AllianceDetail() {
 		<div className="space-y-6 max-w-3xl">
 			{/* Header */}
 			<div>
-				<Link to="/alliances" className="text-xs text-muted-foreground hover:text-foreground">
+				<Link to={gameId ? `/games/${gameId}/alliances` : '/alliances'} className="text-xs text-muted-foreground hover:text-foreground">
 					← All Alliances
 				</Link>
 				<h1 className="text-2xl font-bold flex items-center gap-2 mt-1">

--- a/src/ReactClient/src/pages/Alliances.tsx
+++ b/src/ReactClient/src/pages/Alliances.tsx
@@ -150,7 +150,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 						<div>
 							<div className="text-sm text-muted-foreground">Your Alliance</div>
 							<Link
-								to={`/alliances/${myStatus.allianceId}`}
+								to={`/games/${gameId}/alliances/${myStatus.allianceId}`}
 								className="text-lg font-semibold text-primary hover:underline"
 							>
 								{myStatus.allianceName}
@@ -296,7 +296,7 @@ export function Alliances({ gameId }: AlliancesProps) {
 									<tr key={a.allianceId} className="border-b border-border hover:bg-secondary/30">
 										<td className="py-2 px-3">
 											<Link
-												to={`/alliances/${a.allianceId}`}
+												to={`/games/${gameId}/alliances/${a.allianceId}`}
 												className="font-medium text-primary hover:underline flex items-center gap-1.5"
 											>
 												<ShieldIcon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

The alliance detail page (`/alliances/:allianceId`) was rendered as a top-level route under `RootLayout`, so it lacked the sidebar nav menu that lives in `GameLayout`.

- Move alliance detail under `GameLayout` at `/games/:gameId/alliances/:allianceId`.
- Keep the legacy `/alliances/:allianceId` URL working by redirecting through `BareRouteRedirect`, which now substitutes `:param` tokens from the current route.
- Update internal links in `Alliances.tsx` and the back-link in `AllianceDetail.tsx` to use the game-scoped path.

## Test plan

- [x] `npm run build` (type-check + Vite build) passes
- [x] `npm test` (vitest) passes — 42 tests
- [ ] Manually verify nav menu shows on `/games/<gameId>/alliances/<id>`
- [ ] Manually verify legacy `/alliances/<id>` redirects to the game-scoped URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01HjNM6JUwbcVze5Wx1Dcu6T)_