### PR TITLE
fix: stop signup loop on freshly-created game's lobby

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs
@@ -241,7 +241,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		[ProducesResponseType(StatusCodes.Status409Conflict)]
 		public ActionResult Join(string gameId, [FromBody] JoinGameRequest request) {
-			if (!currentUserContext.IsValid) return Unauthorized();
+			// Use UserId (not IsValid) — a user joining a game they're not yet a
+			// player of has UserId set but IsValid=false in the per-game-scoped
+			// world state. TryCreatePlayer below enforces "one player per user".
+			if (currentUserContext.UserId == null) return Unauthorized();
 			if (string.IsNullOrWhiteSpace(request.PlayerName)) return BadRequest("Player name is required");
 			if (request.PlayerName.Length > 50) return BadRequest("Player name must be 50 characters or fewer.");
 

--- a/src/ReactClient/src/api/client.ts
+++ b/src/ReactClient/src/api/client.ts
@@ -19,8 +19,20 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      const returnUrl = encodeURIComponent(window.location.pathname + window.location.search)
-      window.location.href = `/signin?returnUrl=${returnUrl}`
+      // A 401 on a request scoped to a specific game (X-Game-Id header) usually
+      // means "you're authenticated but you have no player in this game" — not
+      // "your session is gone." Bouncing the user to /signin in that case
+      // produces an infinite signup loop on a freshly-created game's lobby.
+      const headers = error.config?.headers
+      const hadGameId = headers != null && (
+        typeof headers.get === 'function'
+          ? headers.get('X-Game-Id') != null
+          : Object.keys(headers).some((k) => k.toLowerCase() === 'x-game-id')
+      )
+      if (!hadGameId) {
+        const returnUrl = encodeURIComponent(window.location.pathname + window.location.search)
+        window.location.href = `/signin?returnUrl=${returnUrl}`
+      }
     }
     return Promise.reject(error)
   }


### PR DESCRIPTION
## Summary

User-reported bug: creating a new game ("game3"), opening it, and trying to register sent the user into an infinite signup loop. Two coupled bugs combined to cause it:

1. **Frontend axios interceptor blindly redirected to `/signin` on any 401.** After PR #341 scoped the API by `X-Game-Id`, per-game endpoints now legitimately return 401 when the caller has no player in *that* game's `WorldState` — even though the session is fine. `GameLayout`'s `usePlayerRace` / `TutorialOverlay` / `PlayerResources` queries all hit that 401, the interceptor force-navigated to `/signin?returnUrl=…`, and `/signin` sent the still-authenticated user straight back. Loop.

2. **`GamesController.Join` itself gated on `currentUserContext.IsValid`** — which is false in any game the caller hasn't joined yet. So even if the user reached the form, hitting *Register as terran* would 401 and re-trigger the redirect loop. Confirmed against `/ecs/bge` CloudWatch logs around 2026-04-26 19:15 UTC: `POST /api/games` 201 created game3, then `GET /api/playerprofile` returned 401 over and over with no `POST /join` ever landing.

## Fix

- `src/ReactClient/src/api/client.ts`: skip the `/signin` redirect when the failed request carried an `X-Game-Id` header. Truly unauth'd requests (which don't carry that header — `/api/profile`, `/api/games`, etc.) still redirect as before.
- `src/BrowserGameEngine.FrontendServer/Controllers/GamesController.cs`: `Join` now gates on `UserId == null` instead of `!IsValid`. `TryCreatePlayer` already enforces "one player per user per game" (`JoinGameResult.AlreadyJoined`), so this doesn't open up duplicate enrollment.

## Test plan

- [x] Frontend: `npm run lint` (no new warnings), `npm run build`, `npm test` (42 passed).
- [ ] CI: .NET build/test, React build/lint, e2e smoke (Playwright).
- [ ] Manual after deploy: create a brand-new game, open its lobby, register a race — should land on `/games/{id}/base` instead of bouncing through `/signin`.

https://claude.ai/code/session_01FuNg5m6SpSAKYrB8ZjxK52

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuNg5m6SpSAKYrB8ZjxK52)_