### PR TITLE
feat(admin): central game selector + per-game Metrics

### DIFF
--- a/src/ReactClient/src/App.tsx
+++ b/src/ReactClient/src/App.tsx
@@ -222,6 +222,7 @@ const router = createBrowserRouter([
 			{ path: '/admin/stats', element: <RouteWithBoundary><AdminStats /></RouteWithBoundary> },
 			{ path: '/admin/stats/:gameId', element: <RouteWithBoundary><AdminStats /></RouteWithBoundary> },
 			{ path: '/admin/metrics', element: <RouteWithBoundary><AdminMetrics /></RouteWithBoundary> },
+			{ path: '/admin/metrics/:gameId', element: <RouteWithBoundary><AdminMetrics /></RouteWithBoundary> },
 			{ path: '/admin/audit', element: <RouteWithBoundary><AdminAuditLog /></RouteWithBoundary> },
 			{ path: '/admin/reports', element: <RouteWithBoundary><AdminReports /></RouteWithBoundary> },
 		],

--- a/src/ReactClient/src/lib/gameIdFromPath.ts
+++ b/src/ReactClient/src/lib/gameIdFromPath.ts
@@ -1,5 +1,5 @@
 const GAME_PATH_PATTERN = /^\/games\/([^/]+)(?:\/|$)/
-const ADMIN_GAME_PATH_PATTERN = /^\/admin\/(?:players|ticks|stats)\/([^/]+)(?:\/|$)/
+const ADMIN_GAME_PATH_PATTERN = /^\/admin\/(?:players|ticks|stats|metrics)\/([^/]+)(?:\/|$)/
 
 export function gameIdFromPath(pathname: string): string | null {
 	const match = pathname.match(GAME_PATH_PATTERN) ?? pathname.match(ADMIN_GAME_PATH_PATTERN)

--- a/src/ReactClient/src/pages/admin/AdminGamePicker.tsx
+++ b/src/ReactClient/src/pages/admin/AdminGamePicker.tsx
@@ -1,9 +1,11 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
 import apiClient from '@/api/client'
 import type { GameListViewModel, GameSummaryViewModel } from '@/api/types'
+import { readRememberedAdminGameId, rememberAdminGameId } from './useAdminGameId'
 
-export type AdminGameSection = 'players' | 'ticks' | 'stats'
+export type AdminGameSection = 'players' | 'ticks' | 'stats' | 'metrics'
 
 function pickDefaultGame(games: GameSummaryViewModel[]): GameSummaryViewModel | null {
   return games.find((g) => g.status === 'Active')
@@ -12,50 +14,32 @@ function pickDefaultGame(games: GameSummaryViewModel[]): GameSummaryViewModel | 
     ?? null
 }
 
-interface PickerProps {
+interface PickerPageProps {
   section: AdminGameSection
-  currentGameId: string | null
+  title: string
+  /** When true, auto-redirects to the remembered game (or the default) so admins are not forced to re-pick on every navigation. */
+  autoSelect?: boolean
 }
 
-export function AdminGameSwitcher({ section, currentGameId }: PickerProps) {
+export function AdminGamePickerPage({ section, title, autoSelect = true }: PickerPageProps) {
   const navigate = useNavigate()
-  const { data } = useQuery<GameListViewModel>({
-    queryKey: ['admin-game-switcher'],
-    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
-  })
-  const games = data?.games ?? []
-  const current = currentGameId ? games.find((g) => g.gameId === currentGameId) : null
-
-  return (
-    <div className="flex items-center gap-2 mb-4 text-sm">
-      <span className="text-muted-foreground">Game:</span>
-      <select
-        className="rounded border border-input bg-background px-2 py-1 text-sm"
-        value={currentGameId ?? ''}
-        onChange={(e) => {
-          const id = e.target.value
-          if (!id) return
-          navigate(`/admin/${section}/${id}`)
-        }}
-      >
-        {!current && <option value="">— select a game —</option>}
-        {games.map((g) => (
-          <option key={g.gameId} value={g.gameId}>
-            {g.name} ({g.status})
-          </option>
-        ))}
-      </select>
-    </div>
-  )
-}
-
-export function AdminGamePickerPage({ section, title }: { section: AdminGameSection; title: string }) {
   const { data, isLoading } = useQuery<GameListViewModel>({
     queryKey: ['admin-game-picker'],
     queryFn: () => apiClient.get('/api/games').then((r) => r.data),
   })
   const games = data?.games ?? []
   const defaultGame = pickDefaultGame(games)
+
+  useEffect(() => {
+    if (!autoSelect || isLoading) return
+    if (games.length === 0) return
+    const remembered = readRememberedAdminGameId()
+    const target =
+      (remembered && games.find((g) => g.gameId === remembered)) ?? defaultGame
+    if (target) {
+      navigate(`/admin/${section}/${target.gameId}`, { replace: true })
+    }
+  }, [autoSelect, isLoading, games, defaultGame, navigate, section])
 
   return (
     <div className="space-y-4">
@@ -99,12 +83,15 @@ export function AdminGamePickerPage({ section, title }: { section: AdminGameSect
                   </td>
                   <td className="px-3 py-2 text-right text-muted-foreground">{g.playerCount}</td>
                   <td className="px-3 py-2 text-right">
-                    <a
-                      href={`/admin/${section}/${g.gameId}`}
+                    <button
+                      onClick={() => {
+                        rememberAdminGameId(g.gameId)
+                        navigate(`/admin/${section}/${g.gameId}`)
+                      }}
                       className="px-2 py-1 rounded border border-border text-xs hover:bg-muted"
                     >
                       Open
-                    </a>
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/src/ReactClient/src/pages/admin/AdminMetrics.tsx
+++ b/src/ReactClient/src/pages/admin/AdminMetrics.tsx
@@ -1,9 +1,11 @@
+import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
+import { AdminGamePickerPage } from './AdminGamePicker'
 
 interface LiveStats {
   totalPlayers: number
@@ -20,16 +22,19 @@ interface LiveStats {
 }
 
 export function AdminMetrics() {
+  const { gameId } = useParams<{ gameId: string }>()
   const { data: stats, isLoading, error, refetch } = useQuery<LiveStats>({
-    queryKey: ['admin-live-stats'],
+    queryKey: ['admin-live-stats', gameId ?? null],
     queryFn: () => apiClient.get('/api/admin/live-stats').then((r) => r.data),
     refetchInterval: 10000,
+    enabled: !!gameId,
   })
 
   if (error) {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       return (
         <div className="p-6 max-w-2xl mx-auto">
+          <AdminNav currentGameId={gameId ?? null} />
           <h1 className="text-2xl font-bold mb-4">Metrics</h1>
           <div className="rounded border border-warning/50 bg-warning/10 p-4 text-warning-foreground">
             You are not authorized to view the admin panel.
@@ -39,25 +44,55 @@ export function AdminMetrics() {
     }
     return (
       <div className="p-6 max-w-2xl mx-auto">
+        <AdminNav currentGameId={gameId ?? null} />
         <h1 className="text-2xl font-bold mb-4">Metrics</h1>
         <ApiError message="Failed to load metrics." onRetry={() => void refetch()} />
       </div>
     )
   }
 
+  if (!gameId) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <AdminNav />
+        <h1 className="text-2xl font-bold mb-6">Metrics</h1>
+        <AdminGamePickerPage section="metrics" title="Metrics" />
+      </div>
+    )
+  }
+
   return (
     <div className="p-6 max-w-4xl mx-auto">
-      <AdminNav />
+      <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Metrics</h1>
 
       {isLoading || !stats ? (
         <PageLoader message="Loading metrics..." />
       ) : (
         <div className="space-y-6">
+          {/* Across all games (truly global) */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-lg font-semibold mb-3">Across all games</h2>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold">{stats.totalGames}</div>
+                <div className="text-xs text-muted-foreground">Total games</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-success-foreground">{stats.runningGames}</div>
+                <div className="text-xs text-muted-foreground">Running</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-primary">{stats.dailyActiveUsers}</div>
+                <div className="text-xs text-muted-foreground">DAU (24h)</div>
+              </div>
+            </div>
+          </div>
+
           {/* Player Stats */}
           <div className="rounded-lg border border-border bg-card p-4">
             <h2 className="text-lg font-semibold mb-3">Players</h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-3 gap-4">
               <div className="text-center">
                 <div className="text-3xl font-bold">{stats.totalPlayers}</div>
                 <div className="text-xs text-muted-foreground">Total</div>
@@ -67,27 +102,8 @@ export function AdminMetrics() {
                 <div className="text-xs text-muted-foreground">Active (15m)</div>
               </div>
               <div className="text-center">
-                <div className="text-3xl font-bold text-primary">{stats.dailyActiveUsers}</div>
-                <div className="text-xs text-muted-foreground">DAU (24h)</div>
-              </div>
-              <div className="text-center">
                 <div className="text-3xl font-bold text-destructive">{stats.bannedPlayers}</div>
                 <div className="text-xs text-muted-foreground">Banned</div>
-              </div>
-            </div>
-          </div>
-
-          {/* Games */}
-          <div className="rounded-lg border border-border bg-card p-4">
-            <h2 className="text-lg font-semibold mb-3">Games</h2>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="text-center">
-                <div className="text-3xl font-bold">{stats.totalGames}</div>
-                <div className="text-xs text-muted-foreground">Total</div>
-              </div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-success-foreground">{stats.runningGames}</div>
-                <div className="text-xs text-muted-foreground">Running</div>
               </div>
             </div>
           </div>

--- a/src/ReactClient/src/pages/admin/AdminNav.tsx
+++ b/src/ReactClient/src/pages/admin/AdminNav.tsx
@@ -1,42 +1,118 @@
-import { useLocation } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useLocation, useNavigate } from 'react-router'
+import apiClient from '@/api/client'
+import type { GameListViewModel } from '@/api/types'
+import { rememberAdminGameId } from './useAdminGameId'
 
-interface NavLink {
+interface NavItem {
   path: string
   label: string
-  perGame?: boolean
 }
 
-const links: NavLink[] = [
+const globalLinks: NavItem[] = [
   { path: '/admin/games', label: 'Games' },
-  { path: '/admin/players', label: 'Players', perGame: true },
-  { path: '/admin/ticks', label: 'Tick Control', perGame: true },
-  { path: '/admin/stats', label: 'Stats', perGame: true },
-  { path: '/admin/metrics', label: 'Metrics' },
   { path: '/admin/audit', label: 'Audit Log' },
   { path: '/admin/reports', label: 'Reports' },
 ]
 
-export function AdminNav({ currentGameId }: { currentGameId?: string | null } = {}) {
+const perGameLinks: NavItem[] = [
+  { path: '/admin/players', label: 'Players' },
+  { path: '/admin/ticks', label: 'Tick Control' },
+  { path: '/admin/stats', label: 'Stats' },
+  { path: '/admin/metrics', label: 'Metrics' },
+]
+
+function isActive(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`)
+}
+
+interface AdminNavProps {
+  currentGameId?: string | null
+}
+
+export function AdminNav({ currentGameId = null }: AdminNavProps) {
   const location = useLocation()
+  const navigate = useNavigate()
+
+  const { data } = useQuery<GameListViewModel>({
+    queryKey: ['admin-games-nav'],
+    queryFn: () => apiClient.get('/api/games').then((r) => r.data),
+  })
+  const games = data?.games ?? []
+  const currentGame = currentGameId ? games.find((g) => g.gameId === currentGameId) : null
+
+  // If we're on a per-game admin page, derive the section so the selector can
+  // jump to the same section under the newly selected game.
+  const currentSection = perGameLinks.find((l) => isActive(location.pathname, l.path))
+
   return (
-    <nav className="flex gap-1 mb-6 border-b border-border pb-2 flex-wrap">
-      {links.map(({ path, label, perGame }) => {
-        const href = perGame && currentGameId ? `${path}/${currentGameId}` : path
-        const isActive = location.pathname === path || location.pathname.startsWith(`${path}/`)
-        return (
+    <nav className="mb-6 border-b border-border pb-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground mb-1">Admin</div>
+
+      {/* Global section */}
+      <div className="flex gap-1 flex-wrap mb-3">
+        {globalLinks.map(({ path, label }) => (
           <a
             key={path}
-            href={href}
+            href={path}
             className={`px-3 py-1.5 rounded text-sm ${
-              isActive
+              isActive(location.pathname, path)
                 ? 'bg-primary text-primary-foreground'
                 : 'hover:bg-muted text-muted-foreground'
             }`}
           >
             {label}
           </a>
-        )
-      })}
+        ))}
+      </div>
+
+      {/* Per-game section */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <label className="text-sm flex items-center gap-2">
+          <span className="text-muted-foreground">Game:</span>
+          <select
+            className="rounded border border-input bg-background px-2 py-1 text-sm min-w-[12rem]"
+            value={currentGameId ?? ''}
+            onChange={(e) => {
+              const id = e.target.value
+              if (!id) return
+              rememberAdminGameId(id)
+              const dest = currentSection?.path ?? '/admin/players'
+              navigate(`${dest}/${id}`)
+            }}
+          >
+            {!currentGame && <option value="">— select a game —</option>}
+            {games.map((g) => (
+              <option key={g.gameId} value={g.gameId}>
+                {g.name} ({g.status})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex gap-1 flex-wrap">
+          {perGameLinks.map(({ path, label }) => {
+            const active = isActive(location.pathname, path)
+            const href = currentGameId ? `${path}/${currentGameId}` : path
+            return (
+              <a
+                key={path}
+                href={href}
+                className={`px-3 py-1.5 rounded text-sm ${
+                  active
+                    ? 'bg-primary text-primary-foreground'
+                    : currentGameId
+                    ? 'hover:bg-muted text-muted-foreground'
+                    : 'text-muted-foreground/50 hover:bg-muted/50'
+                }`}
+                title={currentGameId ? undefined : 'Select a game first'}
+              >
+                {label}
+              </a>
+            )
+          })}
+        </div>
+      </div>
     </nav>
   )
 }

--- a/src/ReactClient/src/pages/admin/AdminPlayers.tsx
+++ b/src/ReactClient/src/pages/admin/AdminPlayers.tsx
@@ -6,7 +6,7 @@ import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
-import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
+import { AdminGamePickerPage } from './AdminGamePicker'
 
 interface AdminPlayerEntry {
   playerId: string
@@ -118,7 +118,6 @@ export function AdminPlayers() {
     <div className="p-6 max-w-6xl mx-auto">
       <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Player Moderation</h1>
-      <AdminGameSwitcher section="players" currentGameId={gameId} />
 
       <div className="mb-4">
         <input

--- a/src/ReactClient/src/pages/admin/AdminStats.tsx
+++ b/src/ReactClient/src/pages/admin/AdminStats.tsx
@@ -5,7 +5,7 @@ import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
-import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
+import { AdminGamePickerPage } from './AdminGamePicker'
 
 interface LiveStats {
   totalPlayers: number
@@ -62,7 +62,6 @@ export function AdminStats() {
     <div className="p-6 max-w-4xl mx-auto">
       <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Live Stats</h1>
-      <AdminGameSwitcher section="stats" currentGameId={gameId} />
 
       {isLoading || !stats ? (
         <PageLoader message="Loading stats..." />

--- a/src/ReactClient/src/pages/admin/AdminTickControl.tsx
+++ b/src/ReactClient/src/pages/admin/AdminTickControl.tsx
@@ -6,7 +6,7 @@ import apiClient from '@/api/client'
 import { PageLoader } from '@/components/PageLoader'
 import { ApiError } from '@/components/ApiError'
 import { AdminNav } from './AdminNav'
-import { AdminGameSwitcher, AdminGamePickerPage } from './AdminGamePicker'
+import { AdminGamePickerPage } from './AdminGamePicker'
 
 interface TickStatus {
   currentTick: number
@@ -114,7 +114,6 @@ export function AdminTickControl() {
     <div className="p-6 max-w-2xl mx-auto">
       <AdminNav currentGameId={gameId} />
       <h1 className="text-2xl font-bold mb-6">Game Tick Control</h1>
-      <AdminGameSwitcher section="ticks" currentGameId={gameId} />
 
       {actionError && (
         <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm mb-4">

--- a/src/ReactClient/src/pages/admin/useAdminGameId.ts
+++ b/src/ReactClient/src/pages/admin/useAdminGameId.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router'
+
+const STORAGE_KEY = 'bge-admin-game-id'
+
+/**
+ * Returns the currently selected admin game id.
+ *
+ * Prefers the route param when one is present (so the URL is the source of
+ * truth for the active page), and falls back to localStorage so the
+ * selection persists when the user navigates between admin pages without a
+ * gameId in the URL (e.g. from per-game Players to global Audit Log and
+ * back).
+ *
+ * Whenever a route gameId is observed, it is mirrored to localStorage so the
+ * "remembered" selection follows the user.
+ */
+export function useAdminGameId(): string | null {
+  const { gameId } = useParams<{ gameId: string }>()
+  const urlGameId = gameId ?? null
+
+  useEffect(() => {
+    if (urlGameId) {
+      try {
+        localStorage.setItem(STORAGE_KEY, urlGameId)
+      } catch {
+        // ignore storage errors (private mode etc.)
+      }
+    }
+  }, [urlGameId])
+
+  if (urlGameId) return urlGameId
+  try {
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function rememberAdminGameId(gameId: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, gameId)
+  } catch {
+    // ignore
+  }
+}
+
+export function readRememberedAdminGameId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}

--- a/src/ReactClient/test/lib/gameIdHeader.test.ts
+++ b/src/ReactClient/test/lib/gameIdHeader.test.ts
@@ -16,6 +16,15 @@ describe('gameIdFromPath', () => {
 		expect(gameIdFromPath('/games/')).toBeNull()
 		expect(gameIdFromPath('/profile')).toBeNull()
 		expect(gameIdFromPath('/admin/games')).toBeNull()
+		expect(gameIdFromPath('/admin/players')).toBeNull()
+		expect(gameIdFromPath('/admin/audit')).toBeNull()
+	})
+
+	it('extracts gameId from a per-game admin path', () => {
+		expect(gameIdFromPath('/admin/players/abc123')).toBe('abc123')
+		expect(gameIdFromPath('/admin/ticks/abc123')).toBe('abc123')
+		expect(gameIdFromPath('/admin/stats/abc123')).toBe('abc123')
+		expect(gameIdFromPath('/admin/metrics/abc123')).toBe('abc123')
 	})
 })
 


### PR DESCRIPTION
## Summary

Follow-up to #346. The admin menu had inline per-page game switchers and `/admin/metrics` was silently mixing global numbers with the default game's per-game numbers, making it unclear which game it referred to.

This PR replaces the ad-hoc switchers with one central, persistent game selector built into the admin nav, and makes Metrics fully per-game.

### Changes

- **`AdminNav`** — two-tier layout:
  - **Global**: Games, Audit Log, Reports
  - **Per-game**: Players, Tick Control, Stats, Metrics — driven by a single game selector
  - Per-game tabs are visually muted until a game is selected; the selector remembers the choice across admin pages.
- **`useAdminGameId` / `rememberAdminGameId`** — small persistence helper. Mirrors the URL gameId to `localStorage` and falls back to it when an admin lands on a per-game page without one.
- **`AdminGamePickerPage`** — auto-redirects to the remembered (or default Active/Upcoming) game so the picker is rare in practice.
- **`AdminMetrics`** — now per-game (`/admin/metrics/:gameId`). Truly global numbers (DAU, total games, running games) moved into a clearly-labelled **"Across all games"** section so the rest of the page is unambiguously about the selected game.
- **`gameIdFromPath`** — also matches `/admin/metrics/:id` so `apiClient` attaches `X-Game-Id`.
- **Tests** — extended `gameIdHeader.test.ts` to cover all per-game admin paths.

## Test plan

- [ ] CI build is green (`dotnet build`, `dotnet test`, react tests)
- [ ] Visiting `/admin/players` with no prior selection shows the picker; clicking a game stores the choice
- [ ] Subsequent visits to bare per-game admin paths auto-redirect to the remembered game
- [ ] Switching games via the nav dropdown navigates to the same section under the new game
- [ ] Global pages (`/admin/games`, `/admin/audit`, `/admin/reports`) still work without a game
- [ ] `/admin/metrics/:gameId` shows per-game data under the selected game; "Across all games" section shows DAU / running / total

https://claude.ai/code/session_01PcNwos5Ceqf5D5Ug2kXkYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcNwos5Ceqf5D5Ug2kXkYT)_