### PR TITLE
fix: empty briefing page for finished games

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Middleware/CurrentGameMiddleware.cs
+++ b/src/BrowserGameEngine.FrontendServer/Middleware/CurrentGameMiddleware.cs
@@ -7,7 +7,11 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 	/// HttpContext.Items so HttpContextWorldStateAccessor can resolve the right
 	/// WorldState. Silently ignores missing headers (callers that don't need a
 	/// game context — e.g. /api/games or unauthenticated pages — work as before).
-	/// Returns 400 when the header is set but unknown.
+	/// Returns 400 when the header is set but the game id is unknown.
+	/// Validates against the persisted game catalog (GlobalState), not the in-memory
+	/// registry: finished games are evicted from the registry to free memory, but
+	/// their lobby/results endpoints must still be reachable for clients holding
+	/// URLs like /games/{id}/briefing or /games/{id}/results.
 	/// </summary>
 	public class CurrentGameMiddleware {
 		public const string GameIdHeader = "X-Game-Id";
@@ -22,14 +26,12 @@ namespace BrowserGameEngine.FrontendServer.Middleware {
 		public async Task InvokeAsync(HttpContext context, GameRegistry gameRegistry) {
 			var headerValue = context.Request.Headers[GameIdHeader].FirstOrDefault();
 			if (!string.IsNullOrEmpty(headerValue)) {
-				var gameId = new GameId(headerValue);
-				var instance = gameRegistry.TryGetInstance(gameId);
-				if (instance == null) {
+				if (!gameRegistry.GlobalState.GameExists(headerValue)) {
 					context.Response.StatusCode = StatusCodes.Status400BadRequest;
 					await context.Response.WriteAsync($"Unknown game id: {headerValue}");
 					return;
 				}
-				context.Items[GameIdItemKey] = gameId;
+				context.Items[GameIdItemKey] = new GameId(headerValue);
 			}
 			await next(context);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/CurrentGameMiddlewareTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/CurrentGameMiddlewareTest.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BrowserGameEngine.FrontendServer.Middleware;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class CurrentGameMiddlewareTest {
+		private static GameRecordImmutable MakeRecord(string gameId, GameStatus status) {
+			return new GameRecordImmutable(
+				new GameId(gameId),
+				"Test Game",
+				"sco",
+				status,
+				DateTime.UtcNow,
+				DateTime.UtcNow.AddDays(1),
+				TimeSpan.FromSeconds(30)
+			);
+		}
+
+		private static (CurrentGameMiddleware mw, HttpContext ctx, bool[] nextCalled) MakeMiddleware(string? headerValue) {
+			var nextCalled = new[] { false };
+			var mw = new CurrentGameMiddleware(_ => {
+				nextCalled[0] = true;
+				return Task.CompletedTask;
+			});
+			var ctx = new DefaultHttpContext();
+			ctx.Response.Body = new MemoryStream();
+			if (headerValue != null) ctx.Request.Headers[CurrentGameMiddleware.GameIdHeader] = headerValue;
+			return (mw, ctx, nextCalled);
+		}
+
+		[Fact]
+		public async Task InvokeAsync_NoHeader_PassesThrough() {
+			var globalState = new GlobalState();
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var (mw, ctx, nextCalled) = MakeMiddleware(headerValue: null);
+
+			await mw.InvokeAsync(ctx, registry);
+
+			Assert.True(nextCalled[0]);
+			Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
+			Assert.False(ctx.Items.ContainsKey(CurrentGameMiddleware.GameIdItemKey));
+		}
+
+		[Fact]
+		public async Task InvokeAsync_UnknownGameId_Returns400() {
+			var globalState = new GlobalState();
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var (mw, ctx, nextCalled) = MakeMiddleware(headerValue: "does-not-exist");
+
+			await mw.InvokeAsync(ctx, registry);
+
+			Assert.False(nextCalled[0]);
+			Assert.Equal(StatusCodes.Status400BadRequest, ctx.Response.StatusCode);
+		}
+
+		[Fact]
+		public async Task InvokeAsync_ActiveGameInGlobalState_PassesThrough() {
+			var globalState = new GlobalState();
+			globalState.AddGame(MakeRecord("active-game", GameStatus.Active));
+			var registry = new GameRegistry.GameRegistry(globalState);
+			var (mw, ctx, nextCalled) = MakeMiddleware(headerValue: "active-game");
+
+			await mw.InvokeAsync(ctx, registry);
+
+			Assert.True(nextCalled[0]);
+			Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
+			var stored = Assert.IsType<GameId>(ctx.Items[CurrentGameMiddleware.GameIdItemKey]!);
+			Assert.Equal("active-game", stored.Id);
+		}
+
+		[Fact]
+		public async Task InvokeAsync_FinishedGameNotInRegistry_PassesThrough() {
+			// Finished games are evicted from the in-memory registry to free memory,
+			// but their lobby/results endpoints (and any client navigation that sets the
+			// X-Game-Id header) must still succeed. The middleware must validate against
+			// the persisted game catalog (GlobalState), not the registry.
+			var globalState = new GlobalState();
+			globalState.AddGame(MakeRecord("finished-game", GameStatus.Finished));
+			var registry = new GameRegistry.GameRegistry(globalState);
+			// Intentionally do NOT register the instance — mirrors post-finalization state
+			var (mw, ctx, nextCalled) = MakeMiddleware(headerValue: "finished-game");
+
+			await mw.InvokeAsync(ctx, registry);
+
+			Assert.True(nextCalled[0]);
+			Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
+			var stored = Assert.IsType<GameId>(ctx.Items[CurrentGameMiddleware.GameIdItemKey]!);
+			Assert.Equal("finished-game", stored.Id);
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameModelInternal/GlobalState.cs
@@ -27,6 +27,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameModelInternal {
 			lock (_gamesLock) return _games.ToList();
 		}
 
+		public bool GameExists(string gameId) {
+			lock (_gamesLock) return _games.Any(g => g.GameId.Id == gameId);
+		}
+
 		public void AddGame(GameRecordImmutable record) {
 			lock (_gamesLock) _games.Add(record);
 		}


### PR DESCRIPTION
## Summary

The briefing page (e.g. `/games/eeaa7ff077c6/briefing`) renders empty for finished games. Root cause: `CurrentGameMiddleware` validated the `X-Game-Id` header against the in-memory `GameRegistry`, but finished games are evicted from the registry to free memory after finalization. Every API call from `/games/{finishedId}/*` therefore returned 400 "Unknown game id" — including `/api/games/{id}/lobby`, which the briefing page needs to detect a finished game and redirect to `/results`.

Validate against the persisted game catalog (`GlobalState`) instead, so finished games remain reachable for read endpoints (lobby, results) while still rejecting unknown ids.

## Changes

- `CurrentGameMiddleware`: validate against `GlobalState.GameExists` instead of `GameRegistry.TryGetInstance`
- `GlobalState`: add efficient `GameExists(string)` lookup
- New `CurrentGameMiddlewareTest` covering: missing header, unknown id (still 400), active game, finished-game-not-in-registry (the fix)

## Test plan

- [x] Unit tests for the four middleware paths
- [ ] CI: full build + test suite green
- [ ] Manual: visit `/games/{finishedGameId}/briefing` → page redirects to `/results` instead of showing an error


---
_Generated by [Claude Code](https://claude.ai/code/session_0147H5ryFkkEyx6J34Fz7ZiW)_