### PR TITLE
fix(workers): count all race workers in /api/workers, not just wbf

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
+++ b/src/BrowserGameEngine.FrontendServer/Controllers/WorkersController.cs
@@ -43,8 +43,10 @@ namespace BrowserGameEngine.FrontendServer.Controllers {
 		public ActionResult<WorkerAssignmentViewModel> Get() {
 			if (!currentUserContext.IsValid) return Unauthorized();
 			var playerId = currentUserContext.PlayerId!;
-			var workerUnit = Id.UnitDef("wbf");
-			int totalWorkers = unitRepository.CountByUnitDefId(playerId, workerUnit);
+			// Sum across every configured worker unit so Zerg (drone) and Protoss (probe)
+			// players see their workers, not just Terran (wbf).
+			int totalWorkers = 0;
+			foreach (var w in gameDef.GetWorkerUnitIds()) totalWorkers += unitRepository.CountByUnitDefId(playerId, w);
 			int gasPercent = playerRepository.GetGasPercent(playerId);
 			var (mineralWorkers, gasWorkers) = playerRepository.GetWorkerAssignment(playerId, totalWorkers);
 			return new WorkerAssignmentViewModel {

--- a/src/BrowserGameEngine.GameDefinition/GameDef.cs
+++ b/src/BrowserGameEngine.GameDefinition/GameDef.cs
@@ -35,6 +35,19 @@ namespace BrowserGameEngine.GameDefinition {
 			return gameDef.Units.Where(x => x.PlayerTypeRestriction.Equals(playerTypeId));
 		}
 
+		// Worker unit ids, sourced from the resource-growth-sco:1 module's "worker-units" property.
+		// Returns empty if the module or property isn't configured. The order matches the configured
+		// list (first entry is the canonical "primary" worker used by emergency respawn).
+		public static IEnumerable<UnitDefId> GetWorkerUnitIds(this GameDef gameDef) {
+			var module = gameDef.GameTickModules.FirstOrDefault(m => m.Name == "resource-growth-sco:1");
+			if (module == null) return Enumerable.Empty<UnitDefId>();
+			if (!module.Properties.TryGetValue("worker-units", out var raw)) return Enumerable.Empty<UnitDefId>();
+			return raw
+				.Split(',', StringSplitOptions.RemoveEmptyEntries)
+				.Select(x => new UnitDefId(x.Trim()))
+				.ToList();
+		}
+
 		public static IEnumerable<string> GetAssetNames(this GameDef gameDef, IList<AssetDefId> assetDefIds) {
 			return assetDefIds.Select(x => gameDef.GetAssetDef(x)).Where(x => x != null).Select(x => x!.Name);
 		}

--- a/src/BrowserGameEngine.StatefulGameServer.Test/WorkersControllerTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/WorkersControllerTest.cs
@@ -1,0 +1,91 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.FrontendServer.Controllers;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.Shared;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Linq;
+using Xunit;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	public class WorkersControllerTest {
+		private static WorkersController MakeController(TestGame game, CurrentUserContext userCtx) {
+			return new WorkersController(
+				NullLogger<WorkersController>.Instance,
+				userCtx,
+				game.PlayerRepository,
+				game.PlayerRepositoryWrite,
+				game.UnitRepository,
+				game.GameDef
+			);
+		}
+
+		private static CurrentUserContext AuthenticatedContext(PlayerId playerId) {
+			var ctx = new CurrentUserContext();
+			ctx.UserId = playerId.Id;
+			ctx.Activate(playerId);
+			return ctx;
+		}
+
+		[Fact]
+		public void Get_WhenUnauthorized_ReturnsUnauthorized() {
+			var game = new TestGame();
+			var controller = MakeController(game, new CurrentUserContext());
+
+			var result = controller.Get();
+
+			Assert.IsType<UnauthorizedResult>(result.Result);
+		}
+
+		// Regression: previously the controller hardcoded "wbf" and returned 0 for any
+		// worker unit not named "wbf". With the fix, it sums across every configured
+		// worker unit, so the TestGame's "unit1" workers (10 + 5 = 15) are now visible.
+		[Fact]
+		public void Get_CountsConfiguredWorkerUnit_NotHardcodedWbf() {
+			var game = new TestGame();
+			var ctx = AuthenticatedContext(game.Player1);
+			var controller = MakeController(game, ctx);
+
+			var result = controller.Get();
+
+			Assert.NotNull(result.Value);
+			Assert.Equal(15, result.Value!.TotalWorkers);
+		}
+
+		[Fact]
+		public void Get_ReturnsAssignmentDerivedFromTotalWorkers() {
+			var game = new TestGame();
+			var ctx = AuthenticatedContext(game.Player1);
+			game.PlayerRepositoryWrite.SetWorkerGasPercent(new SetWorkerGasPercentCommand(game.Player1, 40));
+			var controller = MakeController(game, ctx);
+
+			var result = controller.Get();
+
+			Assert.NotNull(result.Value);
+			Assert.Equal(15, result.Value!.TotalWorkers);
+			Assert.Equal(40, result.Value.GasPercent);
+			// 15 * 0.40 rounded = 6 gas, 9 minerals
+			Assert.Equal(6, result.Value.GasWorkers);
+			Assert.Equal(9, result.Value.MineralWorkers);
+		}
+
+		[Fact]
+		public void GetWorkerUnitIds_ReadsFromResourceGrowthScoConfig() {
+			var gameDef = new TestGameDefFactory().CreateGameDef();
+			var ids = gameDef.GetWorkerUnitIds().ToList();
+			Assert.Equal(new[] { Id.UnitDef("unit1") }, ids);
+		}
+
+		[Fact]
+		public void GetWorkerUnitIds_ScoGameDef_ReturnsAllRaceWorkers() {
+			var gameDef = new StarcraftOnlineGameDefFactory().CreateGameDef();
+			var ids = gameDef.GetWorkerUnitIds().ToList();
+			Assert.Contains(Id.UnitDef("wbf"), ids);
+			Assert.Contains(Id.UnitDef("drone"), ids);
+			Assert.Contains(Id.UnitDef("probe"), ids);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Zerg (drone) and Protoss (probe) players saw `TotalWorkers = 0` in the worker auto-assignment dialog and could not assign their drones for resource mining.
- `WorkersController.Get()` had drifted from `ResourceGrowthSco` during the gas-percent slider refactor: it hardcoded `Id.UnitDef("wbf")` while the tick module correctly summed across the comma-separated `worker-units` config.
- Added `GameDef.GetWorkerUnitIds()` extension that reads the `resource-growth-sco:1` module's `worker-units` property — same source of truth — and updated the controller to sum unit counts across that list.
- Income generation was already correct in `ResourceGrowthSco`; this purely fixes the UI/API view of the worker count for non-Terran races.

## Test plan

- [x] Added `WorkersControllerTest.Get_CountsConfiguredWorkerUnit_NotHardcodedWbf` — regression test that asserts the controller returns the configured worker count (15 in the test game) instead of 0
- [x] Added `WorkersControllerTest.Get_ReturnsAssignmentDerivedFromTotalWorkers` for the gas-split path
- [x] Added `GetWorkerUnitIds_ScoGameDef_ReturnsAllRaceWorkers` — verifies `wbf`, `drone`, `probe` are all returned for the SCO game def
- [x] Added `Get_WhenUnauthorized_ReturnsUnauthorized` for the auth path
- [ ] CI: `dotnet build` + `dotnet test` (no local dotnet available; CI will validate)
- [ ] Manual: Zerg player in dev game, verify drones now appear in worker assignment dialog

https://claude.ai/code/session_01S3CHaTyUxrtWryQLs7KJdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3CHaTyUxrtWryQLs7KJdg)_