### PR TITLE
fix(ui): scope playerprofile query cache by gameId — race header showed wrong race after switching games

### DIFF
--- a/src/ReactClient/src/components/TutorialOverlay.tsx
+++ b/src/ReactClient/src/components/TutorialOverlay.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { useParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { XIcon, ChevronRightIcon, ChevronLeftIcon, SkipForwardIcon } from 'lucide-react'
 import apiClient from '@/api/client'
@@ -51,19 +52,24 @@ const STEPS: TutorialStep[] = [
 
 export function TutorialOverlay() {
   const queryClient = useQueryClient()
+  const { gameId } = useParams<{ gameId: string }>()
   const [step, setStep] = useState(0)
   const [dismissed, setDismissed] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
 
+  // /api/playerprofile is scoped per-game via X-Game-Id, so the cache key
+  // must include gameId to avoid leaking another game's profile.
+  const tutorialQueryKey = ['player-profile-tutorial', gameId ?? null]
+
   const { data: profile } = useQuery<PlayerProfileViewModel>({
-    queryKey: ['player-profile-tutorial'],
+    queryKey: tutorialQueryKey,
     queryFn: () => apiClient.get('/api/playerprofile').then((r) => r.data),
   })
 
   const completeMut = useMutation({
     mutationFn: () => apiClient.post('/api/playerprofile/complete-tutorial'),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['player-profile-tutorial'] })
+      queryClient.invalidateQueries({ queryKey: tutorialQueryKey })
     },
   })
 

--- a/src/ReactClient/src/hooks/usePlayerRace.ts
+++ b/src/ReactClient/src/hooks/usePlayerRace.ts
@@ -1,12 +1,17 @@
 import { useEffect } from 'react'
+import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import apiClient from '@/api/client'
 import type { PlayerProfileViewModel } from '@/api/types'
 import { normalizeRace, type Race } from '@/lib/race'
 
 export function usePlayerRace(): Race | null {
+  // Scope the cache by gameId — /api/playerprofile is server-scoped per game
+  // via the X-Game-Id header, so a user playing different races in different
+  // games must not get a stale cached profile when navigating between them.
+  const { gameId } = useParams<{ gameId: string }>()
   const { data } = useQuery<PlayerProfileViewModel>({
-    queryKey: ['playerprofile'],
+    queryKey: ['playerprofile', gameId ?? null],
     queryFn: () => apiClient.get('/api/playerprofile').then((r) => r.data),
     staleTime: 60_000,
   })

--- a/src/ReactClient/test/hooks/usePlayerRace.test.tsx
+++ b/src/ReactClient/test/hooks/usePlayerRace.test.tsx
@@ -1,15 +1,27 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import type { ReactNode } from 'react'
 import { usePlayerRace } from '@/hooks/usePlayerRace'
 import apiClient from '@/api/client'
 
 vi.mock('@/api/client', () => ({ default: { get: vi.fn() } }))
 
-function wrapper({ children }: { children: ReactNode }) {
+function makeWrapper(initialPath = '/games/g1/units') {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/games/:gameId/*" element={<>{children}</>} />
+            <Route path="*" element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
 }
 
 describe('usePlayerRace', () => {
@@ -22,7 +34,7 @@ describe('usePlayerRace', () => {
     ;(apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: { playerType: 'terran', playerId: '1', playerName: 'x', land: 0, protectionTicksRemaining: 0, isOnline: true, lastOnline: null, tutorialCompleted: true },
     })
-    renderHook(() => usePlayerRace(), { wrapper })
+    renderHook(() => usePlayerRace(), { wrapper: makeWrapper() })
     await waitFor(() => {
       expect(document.documentElement.getAttribute('data-race')).toBe('terran')
     })
@@ -32,10 +44,50 @@ describe('usePlayerRace', () => {
     ;(apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: { playerType: 'alien', playerId: '1', playerName: 'x', land: 0, protectionTicksRemaining: 0, isOnline: true, lastOnline: null, tutorialCompleted: true },
     })
-    renderHook(() => usePlayerRace(), { wrapper })
+    renderHook(() => usePlayerRace(), { wrapper: makeWrapper() })
     await waitFor(() => {
       expect(apiClient.get).toHaveBeenCalled()
     })
     expect(document.documentElement.getAttribute('data-race')).toBeNull()
+  })
+
+  // Regression: usePlayerRace previously cached under ['playerprofile'] with no gameId,
+  // so navigating from a Zerg game to a Terran game showed stale Zerg in the header.
+  it('refetches the profile when gameId in the URL changes', async () => {
+    const get = apiClient.get as ReturnType<typeof vi.fn>
+    get.mockImplementation(() =>
+      Promise.resolve({
+        data: { playerType: 'zerg', playerId: '1', playerName: 'x', land: 0, protectionTicksRemaining: 0, isOnline: true, lastOnline: null, tutorialCompleted: true },
+      }),
+    )
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    function makeWrapperFor(path: string) {
+      return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+          <QueryClientProvider client={qc}>
+            <MemoryRouter initialEntries={[path]}>
+              <Routes>
+                <Route path="/games/:gameId/*" element={<>{children}</>} />
+              </Routes>
+            </MemoryRouter>
+          </QueryClientProvider>
+        )
+      }
+    }
+
+    const r1 = renderHook(() => usePlayerRace(), { wrapper: makeWrapperFor('/games/zergGame/units') })
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+    r1.unmount()
+
+    get.mockImplementation(() =>
+      Promise.resolve({
+        data: { playerType: 'terran', playerId: '2', playerName: 'y', land: 0, protectionTicksRemaining: 0, isOnline: true, lastOnline: null, tutorialCompleted: true },
+      }),
+    )
+    renderHook(() => usePlayerRace(), { wrapper: makeWrapperFor('/games/terranGame/units') })
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-race')).toBe('terran')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- The user reported "I am Zerg everywhere even though I was Terran before in other games."
- Verified directly in S3 (`bge-game-state` bucket) that the persisted `PlayerType` in each game's `state.json` is correct — most active games show `terran` for the user, with `zerg` only in the one game named "swarm" and `protoss` in another. So the data is fine; the bug is purely client-side.
- Since #341 made `/api/playerprofile` per-game (scoped via the `X-Game-Id` request header), the API correctly returns a different profile for each game. But `usePlayerRace` and `TutorialOverlay` were still keying their React Query cache as `['playerprofile']` / `['player-profile-tutorial']` with no `gameId`. Within `staleTime` (60s), navigating from one game to another reused the previously-fetched profile, so the race emblem, header label and `data-race` HTML attribute showed the wrong race in every game the user hadn't just refreshed. The screenshot the user attached (Land 404, 541 SCV, 166 Space Marine — clearly a Terran base) shows "Zerg" in the header for exactly this reason.
- Include `gameId` in the queryKey for both hooks so each game gets its own cached profile and switching games triggers a refetch.

## Test plan
- [x] `npm test` in `src/ReactClient` — 44 tests pass, including a new regression test that verifies the profile is refetched when the URL's `gameId` changes.
- [x] `npm run build` — TypeScript build succeeds.
- [ ] Manual: log in as a user with players of different races in multiple active games, navigate between games, confirm the header race updates immediately.

https://claude.ai/code/session_01HiRA7biMCSTTZPuhu8DKm8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiRA7biMCSTTZPuhu8DKm8)_