### PR TITLE
fix(ticks): tick every game per-instance via ambient WorldState

### DIFF
--- a/src/BrowserGameEngine.FrontendServer/HttpContextWorldStateAccessor.cs
+++ b/src/BrowserGameEngine.FrontendServer/HttpContextWorldStateAccessor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using BrowserGameEngine.FrontendServer.Middleware;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer;
@@ -6,17 +8,20 @@ using BrowserGameEngine.StatefulGameServer.GameRegistry;
 
 namespace BrowserGameEngine.FrontendServer {
 	/// <summary>
-	/// Resolves the current request's WorldState dynamically. When the current
-	/// HttpContext has a GameId set by CurrentGameMiddleware, returns that
-	/// game's WorldState. Otherwise falls back to the default WorldState
-	/// captured at startup — preserving the previous singleton behaviour for
-	/// code paths that have no HttpContext (background hosted services, tick
-	/// engine).
+	/// Resolves the current request's WorldState dynamically. Resolution order:
+	/// 1) An ambient WorldState pushed via <see cref="PushAmbient"/> — used by
+	///    background services (game tick timer, lifecycle service) that have no
+	///    HttpContext but must direct singleton repositories at a specific game.
+	/// 2) The HttpContext's GameId set by CurrentGameMiddleware (the X-Game-Id
+	///    header) — used by HTTP-scoped requests.
+	/// 3) The default WorldState captured at startup — preserves singleton
+	///    behaviour for code paths with neither (e.g. early startup).
 	/// </summary>
 	public class HttpContextWorldStateAccessor : IWorldStateAccessor {
 		private readonly IHttpContextAccessor httpContextAccessor;
 		private readonly GameRegistry gameRegistry;
 		private readonly WorldState defaultWorldState;
+		private readonly AsyncLocal<WorldState?> ambient = new();
 
 		public HttpContextWorldStateAccessor(
 			IHttpContextAccessor httpContextAccessor,
@@ -29,12 +34,37 @@ namespace BrowserGameEngine.FrontendServer {
 
 		public WorldState WorldState {
 			get {
+				var ambientValue = ambient.Value;
+				if (ambientValue != null) return ambientValue;
 				var ctx = httpContextAccessor.HttpContext;
 				if (ctx != null && ctx.Items.TryGetValue(CurrentGameMiddleware.GameIdItemKey, out var raw) && raw is GameId gameId) {
 					var instance = gameRegistry.TryGetInstance(gameId);
 					if (instance != null) return instance.WorldState;
 				}
 				return defaultWorldState;
+			}
+		}
+
+		public IDisposable PushAmbient(WorldState worldState) {
+			var previous = ambient.Value;
+			ambient.Value = worldState;
+			return new AmbientScope(ambient, previous);
+		}
+
+		private sealed class AmbientScope : IDisposable {
+			private readonly AsyncLocal<WorldState?> slot;
+			private readonly WorldState? previous;
+			private bool disposed;
+
+			public AmbientScope(AsyncLocal<WorldState?> slot, WorldState? previous) {
+				this.slot = slot;
+				this.previous = previous;
+			}
+
+			public void Dispose() {
+				if (disposed) return;
+				disposed = true;
+				slot.Value = previous;
 			}
 		}
 	}

--- a/src/BrowserGameEngine.FrontendServer/Program.cs
+++ b/src/BrowserGameEngine.FrontendServer/Program.cs
@@ -13,7 +13,6 @@ using BrowserGameEngine.Persistence;
 using BrowserGameEngine.Persistence.S3;
 using BrowserGameEngine.StatefulGameServer;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
-using BrowserGameEngine.StatefulGameServer.GameTicks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
@@ -169,11 +168,10 @@ builder.Services.AddSingleton<BrowserGameEngine.StatefulGameServer.IWorldStateAc
  */
 var app = builder.Build();
 
-// Wire tick engine into game instances (Phase 1: single game)
-var tickEngine = app.Services.GetRequiredService<GameTickEngine>();
-foreach (var instance in app.Services.GetRequiredService<BrowserGameEngine.StatefulGameServer.GameRegistry.GameRegistry>().GetAllInstances()) {
-	instance.SetTickEngine(tickEngine);
-}
+// Tick orchestration is owned by GameTickTimerService — no per-instance
+// wiring required here. The hosted service iterates GameRegistry and pushes
+// each instance's WorldState as the ambient override before invoking the
+// shared GameTickEngine, so newly-created games tick automatically.
 
 var forwardedHeadersOptions = new ForwardedHeadersOptions {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto

--- a/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
+++ b/src/BrowserGameEngine.FrontendServer/Services/GameTickTimerService.cs
@@ -1,4 +1,6 @@
-﻿using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer;
+using BrowserGameEngine.StatefulGameServer.GameRegistry;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -7,16 +9,37 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace BrowserGameEngine.FrontendServer {
+	/// <summary>
+	/// Drives <see cref="GameTickEngine"/> for every registered game.
+	///
+	/// The tick engine and its modules are singletons that resolve the current
+	/// <see cref="BrowserGameEngine.StatefulGameServer.GameModelInternal.WorldState"/>
+	/// via <see cref="IWorldStateAccessor"/>. In an HTTP request the accessor
+	/// reads the per-game world from the X-Game-Id header; outside an HTTP
+	/// request (i.e. here) it falls back to the default world. So before
+	/// ticking a given instance we explicitly push that instance's WorldState
+	/// as the ambient override — otherwise every iteration would tick the same
+	/// default world and per-game progress would freeze (BGE: build queues
+	/// stuck at "ready in Nt" forever on non-default games).
+	/// </summary>
 	public class GameTickTimerService : IHostedService, IDisposable {
 		private int executionCount = 0;
 		private int isactive = 0;
 		private readonly ILogger<GameTickTimerService> logger;
 		private readonly GameRegistry gameRegistry;
+		private readonly GameTickEngine tickEngine;
+		private readonly IWorldStateAccessor worldStateAccessor;
 		private Timer? timer;
 
-		public GameTickTimerService(ILogger<GameTickTimerService> logger, GameRegistry gameRegistry) {
+		public GameTickTimerService(
+			ILogger<GameTickTimerService> logger,
+			GameRegistry gameRegistry,
+			GameTickEngine tickEngine,
+			IWorldStateAccessor worldStateAccessor) {
 			this.logger = logger;
 			this.gameRegistry = gameRegistry;
+			this.tickEngine = tickEngine;
+			this.worldStateAccessor = worldStateAccessor;
 		}
 
 		public Task StartAsync(CancellationToken stoppingToken) {
@@ -31,9 +54,11 @@ namespace BrowserGameEngine.FrontendServer {
 				var count = Interlocked.Increment(ref executionCount);
 				var totalSw = Stopwatch.StartNew();
 				foreach (var instance in gameRegistry.GetAllInstances()) {
+					if (instance.IsPaused) continue;
 					var sw = Stopwatch.StartNew();
 					try {
-						instance.TickEngine?.CheckAllTicks();
+						using var scope = worldStateAccessor.PushAmbient(instance.WorldState);
+						tickEngine.CheckAllTicks();
 					} catch (Exception ex) {
 						logger.LogError(ex, "GameTickFailure GameId={GameId}", instance.Record.GameId.Id);
 					} finally {

--- a/src/BrowserGameEngine.StatefulGameServer.Test/GameTickTimerServiceTest.cs
+++ b/src/BrowserGameEngine.StatefulGameServer.Test/GameTickTimerServiceTest.cs
@@ -1,0 +1,231 @@
+using BrowserGameEngine.FrontendServer;
+using BrowserGameEngine.GameDefinition;
+using BrowserGameEngine.GameDefinition.SCO;
+using BrowserGameEngine.GameModel;
+using BrowserGameEngine.StatefulGameServer.ActionFeed;
+using BrowserGameEngine.StatefulGameServer.Commands;
+using BrowserGameEngine.StatefulGameServer.Events;
+using BrowserGameEngine.StatefulGameServer.GameModelInternal;
+using BrowserGameEngine.StatefulGameServer.GameTicks;
+using BrowserGameEngine.StatefulGameServer.GameTicks.Modules;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using GameRegistryNs = BrowserGameEngine.StatefulGameServer.GameRegistry;
+
+namespace BrowserGameEngine.StatefulGameServer.Test {
+	/// <summary>
+	/// Regression coverage for the production bug where build queues on
+	/// non-default games stayed stuck (e.g. "Building · ready in 20t" forever
+	/// the day after the order was placed). Two layered defects caused it:
+	///
+	///   1) Program.cs only called <c>SetTickEngine</c> once at startup, so any
+	///      <see cref="GameRegistryNs.GameInstance"/> created at runtime by
+	///      <c>GamesController.Create</c> or <c>TournamentEngine</c> had a null
+	///      <c>TickEngine</c> and was silently skipped by the timer service.
+	///   2) Even with a wired engine, the singleton tick modules read their
+	///      <see cref="WorldState"/> through <see cref="HttpContextWorldStateAccessor"/>,
+	///      which falls back to <c>defaultWorldState</c> when no HttpContext
+	///      exists — so every iteration of the timer loop ticked the same
+	///      default game regardless of which instance was being processed.
+	///
+	/// The structural fix removes <c>GameInstance.TickEngine</c> entirely (no
+	/// field that can be forgotten) and makes <see cref="GameTickTimerService"/>
+	/// push each instance's <see cref="WorldState"/> as the ambient override on
+	/// the shared accessor before invoking the singleton engine. These tests
+	/// pin both behaviours.
+	/// </summary>
+	public class GameTickTimerServiceTest {
+		private static readonly GameDef TestGameDef = new TestGameDefFactory().CreateGameDef();
+
+		// Builds a self-contained tick stack — one accessor, one engine, one
+		// set of modules — that two GameInstances share, mirroring the
+		// production singleton DI graph that the bug surfaced under.
+		private sealed class SharedTickStack {
+			public HttpContextWorldStateAccessor Accessor { get; }
+			public GameTickEngine Engine { get; }
+			public GameRegistryNs.GameRegistry Registry { get; }
+
+			public SharedTickStack(WorldState defaultWorld, GameRegistryNs.GameRegistry registry) {
+				Registry = registry;
+				// No HttpContext available — mirrors the timer service's runtime context.
+				var httpContextAccessor = new HttpContextAccessor();
+				Accessor = new HttpContextWorldStateAccessor(httpContextAccessor, registry, defaultWorld);
+
+				// Construct modules and repositories against the SAME accessor
+				// the production DI uses, so this test catches regressions where
+				// modules bypass the ambient world-state push.
+				var resourceRepo = new ResourceRepository(Accessor, TestGameDef);
+				var resourceRepoWrite = new ResourceRepositoryWrite(Accessor, resourceRepo, TestGameDef);
+				var playerRepo = new PlayerRepository(Accessor, resourceRepo, new AllianceRepository(Accessor));
+				var actionQueueRepo = new ActionQueueRepository(Accessor);
+				var assetRepo = new AssetRepository(Accessor, playerRepo, actionQueueRepo);
+				var assetRepoWrite = new AssetRepositoryWrite(
+					NullLogger<AssetRepositoryWrite>.Instance, Accessor, assetRepo,
+					resourceRepo, resourceRepoWrite, actionQueueRepo, TestGameDef);
+				var unitRepo = new UnitRepository(Accessor, TestGameDef, playerRepo, assetRepo);
+				var unitRepoWrite = new UnitRepositoryWrite(
+					NullLogger<UnitRepositoryWrite>.Instance, Accessor, TestGameDef, unitRepo,
+					resourceRepoWrite, resourceRepo, playerRepo,
+					new BattleBehaviorScoOriginal(NullLogger<IBattleBehavior>.Instance),
+					new UpgradeRepository(Accessor));
+				var playerRepoWrite = new PlayerRepositoryWrite(Accessor, TimeProvider.System);
+
+				var services = new ServiceCollection();
+				services.AddSingleton<IGameTickModule>(new ActionQueueExecutor(assetRepoWrite));
+				services.AddSingleton<IGameTickModule>(new ResourceGrowthSco(
+					NullLogger<ResourceGrowthSco>.Instance, TestGameDef,
+					resourceRepo, resourceRepoWrite, playerRepo, unitRepo, unitRepoWrite,
+					new ActionLogger()));
+				var moduleRegistry = new GameTickModuleRegistry(
+					NullLogger<GameTickModuleRegistry>.Instance,
+					services.BuildServiceProvider(),
+					TestGameDef);
+
+				Engine = new GameTickEngine(
+					NullLogger<GameTickEngine>.Instance, Accessor, TestGameDef,
+					moduleRegistry, playerRepoWrite, TimeProvider.System,
+					NullGameEventPublisher.Instance);
+
+				BuildAssetWriter = assetRepoWrite;
+				AssetReader = assetRepo;
+			}
+
+			public AssetRepositoryWrite BuildAssetWriter { get; }
+			public AssetRepository AssetReader { get; }
+		}
+
+		private static GameRecordImmutable MakeRecord(string gameId) =>
+			new GameRecordImmutable(new GameId(gameId), gameId, "sco", GameStatus.Active,
+				DateTime.UtcNow, DateTime.UtcNow.AddDays(1), TimeSpan.FromSeconds(10));
+
+		private static GameRegistryNs.GameInstance MakeInstance(string gameId, WorldState world)
+			=> new GameRegistryNs.GameInstance(MakeRecord(gameId), world, TestGameDef);
+
+		// Captures Bug #1 + Bug #2 together: a build queued on the non-default
+		// game must complete when the timer service drives ticks, even though
+		// the singleton engine + accessor are pointed at the default world by
+		// default.
+		[Fact]
+		public void DoWork_TicksNonDefaultGame_AndCompletesQueuedBuild() {
+			var factory = new TestWorldStateFactory();
+			var game1World = (factory.CreateDevWorldState(1) with { GameId = new GameId("game1") }).ToMutable();
+			var game2World = (factory.CreateDevWorldState(1) with { GameId = new GameId("game2") }).ToMutable();
+
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			registry.Register(MakeInstance("game1", game1World)); // default (first registered)
+			registry.Register(MakeInstance("game2", game2World));
+
+			// defaultWorld for the accessor mirrors AddGameServer's startup wiring.
+			var stack = new SharedTickStack(defaultWorld: game1World, registry);
+
+			// Queue a build on game2 (non-default). Without the fix, the timer
+			// service would keep ticking game1's world while game2 stays frozen.
+			var player = factory.Player1;
+			using (var scope = stack.Accessor.PushAmbient(game2World)) {
+				stack.BuildAssetWriter.BuildAsset(new BuildAssetCommand(player, Id.AssetDef("asset2")));
+			}
+			Assert.False(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game2World));
+			Assert.False(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game1World));
+
+			// Drive the timer service. Force ticks via IncrementWorldTick to
+			// avoid the wall-clock wait.
+			var service = new GameTickTimerService(
+				NullLogger<GameTickTimerService>.Instance, registry, stack.Engine, stack.Accessor);
+			AdvanceWorldAndTick(stack, game2World, ticks: 10);
+			InvokeDoWork(service);
+
+			// Build (BuildTimeTicks=10 in TestGameDef) must now exist on game2,
+			// and game1 must be untouched.
+			Assert.True(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game2World),
+				"Build queued on game2 should complete after the timer service drives ticks.");
+			Assert.False(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game1World),
+				"game1 must be unaffected — ambient world-state push must isolate per-game state.");
+		}
+
+		// Pins Bug #3 (latent): GameLifecycleEngine.PauseTicks used to call
+		// PauseTicks on the singleton engine, which would freeze every game on
+		// the server. The fix moves pause to per-instance — verify the timer
+		// service honors it without affecting siblings.
+		[Fact]
+		public void DoWork_SkipsPausedInstance_ButTicksOthers() {
+			var factory = new TestWorldStateFactory();
+			var game1World = (factory.CreateDevWorldState(1) with { GameId = new GameId("game1") }).ToMutable();
+			var game2World = (factory.CreateDevWorldState(1) with { GameId = new GameId("game2") }).ToMutable();
+
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			var instance1 = MakeInstance("game1", game1World);
+			var instance2 = MakeInstance("game2", game2World);
+			registry.Register(instance1);
+			registry.Register(instance2);
+
+			var stack = new SharedTickStack(defaultWorld: game1World, registry);
+
+			// Pause game1; queue identical builds on both.
+			instance1.Pause();
+			var player = factory.Player1;
+			using (var scope = stack.Accessor.PushAmbient(game1World))
+				stack.BuildAssetWriter.BuildAsset(new BuildAssetCommand(player, Id.AssetDef("asset2")));
+			using (var scope = stack.Accessor.PushAmbient(game2World))
+				stack.BuildAssetWriter.BuildAsset(new BuildAssetCommand(player, Id.AssetDef("asset2")));
+
+			var service = new GameTickTimerService(
+				NullLogger<GameTickTimerService>.Instance, registry, stack.Engine, stack.Accessor);
+			AdvanceWorldAndTick(stack, game1World, ticks: 10);
+			AdvanceWorldAndTick(stack, game2World, ticks: 10);
+			InvokeDoWork(service);
+
+			Assert.False(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game1World),
+				"Paused game1 must not advance.");
+			Assert.True(stack.AssetReader.IsBuiltOnAmbient(player, "asset2", stack.Accessor, game2World),
+				"Unpaused game2 must still tick to completion.");
+		}
+
+		// Direct unit test of the ambient-scope mechanism the fix relies on.
+		[Fact]
+		public void HttpContextWorldStateAccessor_PushAmbient_OverridesDefault_AndPopsOnDispose() {
+			var factory = new TestWorldStateFactory();
+			var defaultWorld = factory.CreateDevWorldState(0).ToMutable();
+			var otherWorld = factory.CreateDevWorldState(0).ToMutable();
+			var registry = new GameRegistryNs.GameRegistry(new GlobalState());
+			var accessor = new HttpContextWorldStateAccessor(new HttpContextAccessor(), registry, defaultWorld);
+
+			Assert.Same(defaultWorld, accessor.WorldState);
+			using (var scope = accessor.PushAmbient(otherWorld)) {
+				Assert.Same(otherWorld, accessor.WorldState);
+			}
+			Assert.Same(defaultWorld, accessor.WorldState);
+		}
+
+		// CheckAllTicks is bounded by wall-clock: it loops while IsTickDue
+		// (LastUpdate stale) AND there are unprocessed players. Force enough
+		// world-tick increments per game so a single DoWork iteration drains
+		// the queued action.
+		private static void AdvanceWorldAndTick(SharedTickStack stack, WorldState world, int ticks) {
+			using var scope = stack.Accessor.PushAmbient(world);
+			stack.Engine.IncrementWorldTick(ticks);
+		}
+
+		private static void InvokeDoWork(GameTickTimerService service) {
+			// DoWork is private; reach it via reflection to avoid making it
+			// public solely for testing. The signature matches Timer's TimerCallback.
+			var method = typeof(GameTickTimerService).GetMethod("DoWork",
+				System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+			method.Invoke(service, new object?[] { null });
+		}
+	}
+
+	internal static class AssetRepositoryAmbientExtensions {
+		// HasAsset goes through the shared accessor — push the world we want
+		// to query so the assertion targets that game specifically.
+		internal static bool IsBuiltOnAmbient(this AssetRepository repo, PlayerId playerId, string assetId,
+				IWorldStateAccessor accessor, WorldState world) {
+			using var scope = accessor.PushAmbient(world);
+			return repo.HasAsset(playerId, Id.AssetDef(assetId));
+		}
+	}
+}

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameInstance.cs
@@ -1,7 +1,6 @@
 using BrowserGameEngine.GameDefinition;
 using BrowserGameEngine.GameModel;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
-using BrowserGameEngine.StatefulGameServer.GameTicks;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,7 +10,15 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 		public WorldState WorldState { get; }
 		public IWorldStateAccessor WorldStateAccessor { get; }
 		public GameDef GameDef { get; }
-		public GameTickEngine? TickEngine { get; private set; }
+
+		// Per-instance pause flag honored by GameTickTimerService. Set during
+		// finalization (and any other time we need to freeze a single game)
+		// without affecting the shared GameTickEngine — pre-fix, pausing one
+		// game paused them all.
+		private volatile bool isPaused;
+		public bool IsPaused => isPaused;
+		public void Pause() => isPaused = true;
+		public void Resume() => isPaused = false;
 
 		public GameInstance(GameRecordImmutable record, WorldState worldState, GameDef gameDef) {
 			Record = record;
@@ -41,7 +48,5 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				.Where(p => !p.IsBanned)
 				.Select(p => p.ToImmutable())
 				.ToList();
-
-		public void SetTickEngine(GameTickEngine tickEngine) { TickEngine = tickEngine; }
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/GameRegistry/GameLifecycleEngine.cs
@@ -128,8 +128,10 @@ namespace BrowserGameEngine.StatefulGameServer.GameRegistry {
 				return;
 			}
 
-			// Pause the tick engine so no more ticks run during finalization
-			instance.TickEngine?.PauseTicks();
+			// Pause this instance so no more ticks run during finalization.
+			// Per-instance (not engine-wide) so pausing one game doesn't freeze
+			// every other game on the server.
+			instance.Pause();
 
 			// Compute rankings: land desc, then minerals+gas desc, then by player id (stable tiebreaker)
 			var landRes = BrowserGameEngine.GameModel.Id.ResDef("land");

--- a/src/BrowserGameEngine.StatefulGameServer/IWorldStateAccessor.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/IWorldStateAccessor.cs
@@ -1,7 +1,19 @@
+using System;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public interface IWorldStateAccessor {
 		WorldState WorldState { get; }
+
+		/// <summary>
+		/// Pushes an ambient <see cref="WorldState"/> that overrides the default
+		/// resolution for the duration of the returned scope. Used by background
+		/// services (e.g. <c>GameTickTimerService</c>) to direct singleton
+		/// repositories at the correct per-game world while ticking. The scope
+		/// flows with <see cref="System.Threading.AsyncLocal{T}"/> so awaits and
+		/// continuations within the scope see the same override; disposing
+		/// restores the previous value.
+		/// </summary>
+		IDisposable PushAmbient(WorldState worldState);
 	}
 }

--- a/src/BrowserGameEngine.StatefulGameServer/SingletonWorldStateAccessor.cs
+++ b/src/BrowserGameEngine.StatefulGameServer/SingletonWorldStateAccessor.cs
@@ -1,11 +1,39 @@
+using System;
+using System.Threading;
 using BrowserGameEngine.StatefulGameServer.GameModelInternal;
 
 namespace BrowserGameEngine.StatefulGameServer {
 	public class SingletonWorldStateAccessor : IWorldStateAccessor {
-		public WorldState WorldState { get; }
+		private readonly WorldState defaultWorldState;
+		private readonly AsyncLocal<WorldState?> ambient = new();
 
 		public SingletonWorldStateAccessor(WorldState worldState) {
-			WorldState = worldState;
+			defaultWorldState = worldState;
+		}
+
+		public WorldState WorldState => ambient.Value ?? defaultWorldState;
+
+		public IDisposable PushAmbient(WorldState worldState) {
+			var previous = ambient.Value;
+			ambient.Value = worldState;
+			return new AmbientScope(ambient, previous);
+		}
+
+		private sealed class AmbientScope : IDisposable {
+			private readonly AsyncLocal<WorldState?> slot;
+			private readonly WorldState? previous;
+			private bool disposed;
+
+			public AmbientScope(AsyncLocal<WorldState?> slot, WorldState? previous) {
+				this.slot = slot;
+				this.previous = previous;
+			}
+
+			public void Dispose() {
+				if (disposed) return;
+				disposed = true;
+				slot.Value = previous;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Build queues on non-default games (e.g. user-reported "game1") sat frozen at "Building · ready in 20t" forever — the day after the order was placed. Two layered defects stopped any runtime-created game from ever advancing a tick:

1. **`Program.cs` only called `SetTickEngine` in a one-shot startup loop.** Every `GameInstance` later created by `GamesController.Create` or `TournamentEngine.CreateMatchGame` had a null `TickEngine`, so `GameTickTimerService.DoWork`'s `instance.TickEngine?.CheckAllTicks()` silently no-op'd for that game *forever*.

2. **Even with a wired engine, the singleton tick modules read their `WorldState` through `HttpContextWorldStateAccessor`**, which falls back to `defaultWorldState` (the first registered game) when no `HttpContext` exists. So every iteration of the timer loop was ticking the same default game regardless of which instance was being processed.

3. **Latent bug, would have surfaced as soon as #1 was naively fixed:** `instance.TickEngine?.PauseTicks()` in `GameLifecycleEngine` paused the *singleton* engine — i.e. it would freeze every game on the server during any single game's finalization. Hidden today only because #1 made the call a no-op.

## Structural fix — removes the "wire it or it dies" failure mode entirely

- **Drop `GameInstance.TickEngine` + `SetTickEngine`.** No per-instance field that can be forgotten.
- **`GameTickTimerService` injects the singleton `GameTickEngine` and shared `IWorldStateAccessor` directly.** Before each instance's tick it pushes that instance's `WorldState` as an ambient override on the accessor, so the singleton modules read the right game.
- **Add `IDisposable PushAmbient(WorldState)` to `IWorldStateAccessor`** backed by `AsyncLocal<WorldState?>`. Resolution order is now **ambient > HttpContext > default**, so HTTP scoping still wins for in-request code paths and background services can target any game without a context.
- **Move pause-during-finalization to a per-instance `bool` on `GameInstance`** (`Pause()`/`Resume()`/`IsPaused`). Timer service skips paused instances. Pausing one game no longer freezes its siblings.

## Regression coverage

`src/BrowserGameEngine.StatefulGameServer.Test/GameTickTimerServiceTest.cs`:

- `DoWork_TicksNonDefaultGame_AndCompletesQueuedBuild` — the actual reported bug: build queued on game2 (not the default game) completes after the timer service drives ticks on a shared engine + accessor.
- `DoWork_SkipsPausedInstance_ButTicksOthers` — pausing one game must not freeze its siblings.
- `HttpContextWorldStateAccessor_PushAmbient_OverridesDefault_AndPopsOnDispose` — direct unit test of the ambient-scope mechanism.

## Test plan

- [x] Regression test added covering both the wiring bug and the ambient-resolution bug.
- [ ] CI builds clean and tests pass (no local `dotnet` SDK in this environment — relying on CI to verify).
- [ ] Manual: existing stuck "Nexus build · ready in 20t" on game1 should fire on the very next tick once deployed (queued action's `DueTick=20` was set when world tick was 0; once ticks actually advance, it fires immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0157C47VqVQ1WtwaMYA2TAA9)_